### PR TITLE
Fix some other mask delegations

### DIFF
--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -61,10 +61,6 @@ end)
   let get_bin mdb location bin_read =
     get_raw mdb location |> Option.map ~f:(fun v -> bin_read v ~pos_ref:(ref 0))
 
-  let get_generic mdb location =
-    assert (Location.is_generic location) ;
-    get_raw mdb location
-
   let get mdb location =
     assert (Location.is_account location) ;
     get_bin mdb location Account.bin_read_t
@@ -123,6 +119,10 @@ end)
   let make_space_for _t _tot = ()
 
   module Account_location = struct
+    let get_generic mdb location =
+      assert (Location.is_generic location) ;
+      get_raw mdb location
+
     let build_location key =
       Location.build_generic (Bigstring.of_string ("$" ^ Key.to_string key))
 

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -236,8 +236,8 @@ struct
       (* basically, the same code used for the database implementation *)
       let mask_maybe_accounts =
         let first_node, last_node = Addr.Range.subtree_range address in
-        Addr.Range.fold (first_node, last_node) ~init:[] ~f:
-          (fun bit_index acc ->
+        Addr.Range.fold (first_node, last_node) ~init:[]
+          ~f:(fun bit_index acc ->
             let account = find_account t (Location.Account bit_index) in
             account :: acc )
       in
@@ -245,11 +245,11 @@ struct
       mask_accounts @ parent_accounts
 
     (* set accounts in mask *)
-    let set_all_accounts_rooted_at_exn t address (accounts: Account.t list) =
+    let set_all_accounts_rooted_at_exn t address (accounts : Account.t list) =
       (* basically, the same code used for the database implementation *)
       let first_node, last_node = Addr.Range.subtree_range address in
-      Addr.Range.fold (first_node, last_node) ~init:accounts ~f:
-        (fun bit_index -> function
+      Addr.Range.fold (first_node, last_node) ~init:accounts
+        ~f:(fun bit_index -> function
         | head :: tail ->
             set t (Location.Account bit_index) head ;
             tail


### PR DESCRIPTION
There were some mask operations that delegated to the mask parent. Those operations are implemented here. 

There is still some work to be done for these operations. In particular, the allocation of account locations, as is done in the database implementation of Merkle ledgers, still needs some corresponding operation in the mask. The issue #1053 captures this work to be done.

Checklist:

- [x] Tests were added for the new behavior
- [x] All tests pass (CI will check this if you didn't)
