### PR TITLE
We included supply_increase for POS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Discord](https://discordapp.com/invite/cCYQbqN), for general OCaml help.
 * [Compiling from source and and running a node](docs/demo.md)
 
 # Learn more
-*  [directory structure](DIRECTORY_STRUCTURE.md)
-*  [lifecycle of a transaction](docs/lifecycle_of_a_transaction_lite.md)
+*  [Directory structure](DIRECTORY_STRUCTURE.md)
+*  [Lifecycle of a transaction](docs/lifecycle_of_a_transaction_lite.md)
 
 # License
 

--- a/src/lib/consensus/mechanism.ml
+++ b/src/lib/consensus/mechanism.ml
@@ -69,6 +69,7 @@ module type S = sig
     -> keypair:Signature_lib.Keypair.t
     -> transactions:Coda_base.Transaction.t list
     -> ledger:Coda_base.Ledger.t
+    -> supply_increase:Currency.Amount.t
     -> logger:Logger.t
     -> (Protocol_state.value * Consensus_transition_data.value) option
   (**

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -149,7 +149,8 @@ module Make (Inputs : Inputs_intf) :
     External_transition.Make (Ledger_builder_diff) (Protocol_state)
 
   let generate_transition ~previous_protocol_state ~blockchain_state
-      ~local_state:_ ~time:_ ~keypair:_ ~transactions:_ ~ledger:_ ~logger:_ =
+      ~local_state:_ ~time:_ ~keypair:_ ~transactions:_ ~ledger:_
+      ~supply_increase:_ ~logger:_ =
     let previous_consensus_state =
       Protocol_state.consensus_state previous_protocol_state
     in

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -873,11 +873,12 @@ module Make (Inputs : Inputs_intf) :
     let update ~(previous_consensus_state : value)
         ~(consensus_transition_data : Consensus_transition_data.value)
         ~(previous_protocol_state_hash : Coda_base.State_hash.t)
+        ~(supply_increase : Currency.Amount.t)
         ~(ledger_hash : Coda_base.Frozen_ledger_hash.t) : value Or_error.t =
       let open Or_error.Let_syntax in
       let open Consensus_transition_data in
       let%map total_currency =
-        Amount.add previous_consensus_state.total_currency Inputs.coinbase
+        Amount.add previous_consensus_state.total_currency supply_increase
         |> Option.map ~f:Or_error.return
         |> Option.value
              ~default:(Or_error.error_string "failed to add total_currency")
@@ -958,7 +959,7 @@ module Make (Inputs : Inputs_intf) :
   (* TODO: only track total currency from accounts > 1% of the currency using transactions *)
   let generate_transition ~(previous_protocol_state : Protocol_state.value)
       ~blockchain_state ~local_state ~time ~keypair ~transactions:_ ~ledger
-      ~logger =
+      ~supply_increase ~logger =
     let open Consensus_state in
     let open Epoch_data in
     let open Keypair in
@@ -989,6 +990,7 @@ module Make (Inputs : Inputs_intf) :
            ~consensus_transition_data
            ~previous_protocol_state_hash:
              (Protocol_state.hash previous_protocol_state)
+           ~supply_increase
            ~ledger_hash:
              ( Coda_base.Ledger.merkle_root ledger
              |> Coda_base.Frozen_ledger_hash.of_ledger_hash ))
@@ -1136,6 +1138,7 @@ module Make (Inputs : Inputs_intf) :
              Protocol_state.(consensus_state negative_one)
            ~previous_protocol_state_hash:Protocol_state.(hash negative_one)
            ~consensus_transition_data:Snark_transition.(consensus_data genesis)
+           ~supply_increase:Currency.Amount.zero
            ~ledger_hash:genesis_ledger_hash)
     in
     Protocol_state.create_value

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -155,6 +155,11 @@ module Make (Inputs : Inputs_intf) :
                 ( previous_protocol_state |> Protocol_state.blockchain_state
                 |> Blockchain_state.ledger_hash )
           in
+          let supply_increase =
+            Option.value_map ledger_proof_opt
+              ~f:(fun (_, stmt) -> stmt.supply_increase)
+              ~default:Currency.Amount.zero
+          in
           let blockchain_state =
             Blockchain_state.create_value ~timestamp:(Time.now time_controller)
               ~ledger_hash:next_ledger_hash
@@ -171,6 +176,7 @@ module Make (Inputs : Inputs_intf) :
                 .transactions diff
                 :> Transaction.t list )
             ~ledger:(Ledger_builder.ledger ledger_builder)
+            ~supply_increase
             ~logger )
     in
     Option.value

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -740,6 +740,7 @@ module type Consensus_mechanism_intf = sig
     -> keypair:keypair
     -> transactions:transaction list
     -> ledger:ledger
+    -> supply_increase:Currency.Amount.t
     -> logger:Logger.t
     -> (Protocol_state.value * Consensus_transition_data.value) option
 


### PR DESCRIPTION
Co-authored-by: Andrew Breckenridge <AndrewSB@users.noreply.github.com>
Co-authored-by: Avery Morin <schmavery@users.noreply.github.com>
Co-authored-by: RJ Rybarczyk <rrybarczyk@users.noreply.github.com>
Co-authored-by: Jonathon Hill <jcgh582@users.noreply.github.com>

Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

Include `supply_increase` to correctly compute total currency in Proof of Stake. We made the changes in `mechanism.ml` and `proof_of_stake.ml` and change it's corresponding dependencies to compile correctly in OCaml.

Checklist:

- [ ] Tests were added for the new behavior
- [X] All tests pass (CI will check this if you didn't)
- [X] Does this close issues? List them:

Closes #1021 
