### PR TITLE
No-op get_keys.sh if not master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ deb:
 provingkeys:
 	@if [ ! -f src/_build/coda_cache_dir_$(GITHASH).tar.bz2 ] ; then \
 		$(WRAP) tar -cvjf src/_build/coda_cache_dir_$(GITHASH).tar.bz2  /var/lib/coda ; \
-		@mkdir -p /tmp/artifacts ; \
-		@cp src/_build/coda_cache_dir*.tar.bz2 /tmp/artifacts/. ; \
+		mkdir -p /tmp/artifacts ; \
+		cp src/_build/coda_cache_dir*.tar.bz2 /tmp/artifacts/. ; \
 	else \
 		echo "Skipping because not on master" ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,13 @@ deb:
 	@cp src/_build/codaclient.deb /tmp/artifacts/.
 
 provingkeys:
-	$(WRAP) tar -cvjf src/_build/coda_cache_dir_$(GITHASH).tar.bz2  /var/lib/coda
-	@mkdir -p /tmp/artifacts
-	@cp src/_build/coda_cache_dir*.tar.bz2 /tmp/artifacts/.
+	@if [ ! -f src/_build/coda_cache_dir_$(GITHASH).tar.bz2 ] ; then \
+		$(WRAP) tar -cvjf src/_build/coda_cache_dir_$(GITHASH).tar.bz2  /var/lib/coda ; \
+		@mkdir -p /tmp/artifacts ; \
+		@cp src/_build/coda_cache_dir*.tar.bz2 /tmp/artifacts/. ; \
+	else \
+		echo "Skipping because not on master" ; \
+	fi
 
 genesiskeys:
 	@mkdir -p /tmp/artifacts

--- a/scripts/get_keys.sh
+++ b/scripts/get_keys.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euxo pipefail
 
+if [[ $CIRCLE_BRANCH == 'master' ]]; then
+
 # script to use in ci to pull down current proving and verificaiton keys
 # uses exising circleci GC creds
 # run as sudo
@@ -30,3 +32,5 @@ PINNED_KEY_COMMIT=c92e84c97abc239feb54b758de6cde98b9a6ef58
 mkdir -p /var/lib/coda
 cd /var/lib/coda
 tar --strip-components=2 -xvf /tmp/keys-$PINNED_KEY_COMMIT.tar.bz2
+
+fi


### PR DESCRIPTION
`get_keys.sh` only runs on master (so we can make ci pass on forks)

- [ ] Tests were added for the new behavior
- [x] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues?