### PR TITLE
Added supply_increase into checked methods of proof_of_stake

### DIFF
--- a/src/lib/consensus/mechanism.ml
+++ b/src/lib/consensus/mechanism.ml
@@ -93,6 +93,7 @@ module type S = sig
        Consensus_state.var
     -> Coda_base.State_hash.var
     -> Snark_transition.var
+    -> Currency.Amount.var
     -> (Consensus_state.var, _) Snark_params.Tick.Checked.t
   (**
    * Create a constrained, checked var for the next consensus state of

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -220,7 +220,8 @@ module Make (Inputs : Inputs_intf) :
     Snark_params.Tick.Boolean.(
       signature_verifies || previous_state_was_neg_one)
 
-  let next_state_checked (state : Consensus_state.var) _state_hash _block =
+  let next_state_checked (state : Consensus_state.var) _state_hash _block
+      _supply_increase =
     let open Consensus_state in
     let open Snark_params.Tick.Let_syntax in
     let%bind length = Length.increment_var state.length in

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -908,6 +908,7 @@ module Make (Inputs : Inputs_intf) :
     let update_var (previous_state : var)
         (transition_data : Consensus_transition_data.var)
         (previous_protocol_state_hash : Coda_base.State_hash.var)
+        (supply_increase : Currency.Amount.var)
         (ledger_hash : Coda_base.Frozen_ledger_hash.var) :
         (var, _) Snark_params.Tick.Checked.t =
       let open Snark_params.Tick.Let_syntax in
@@ -918,6 +919,9 @@ module Make (Inputs : Inputs_intf) :
       and total_currency =
         Amount.Checked.add previous_state.total_currency
           (Amount.var_of_t Inputs.coinbase)
+      in
+      let%bind total_currency =
+        Amount.Checked.add total_currency supply_increase
       in
       (* TODO: check vrf result from transition data *)
       let%map last_epoch_data, curr_epoch_data, epoch_length =
@@ -1007,10 +1011,11 @@ module Make (Inputs : Inputs_intf) :
   let is_transition_valid_checked _transition _ =
     Snark_params.Tick.(Let_syntax.return Boolean.true_)
 
-  let next_state_checked previous_state previous_state_hash transition =
+  let next_state_checked previous_state previous_state_hash transition
+      supply_increase =
     Consensus_state.update_var previous_state
       (Snark_transition.consensus_data transition)
-      previous_state_hash
+      previous_state_hash supply_increase
       ( transition |> Snark_transition.blockchain_state
       |> Blockchain_state.ledger_hash )
 


### PR DESCRIPTION
Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

Forgot to include `supply_increase` to checked methods of `proof_of_stake` in https://github.com/CodaProtocol/coda/pull/1065. This PR addresses that

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:

