### PR TITLE
Kill the daemon when kademlia dies

### DIFF
--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -124,7 +124,7 @@ module Haskell_process = struct
                {failure_response= ref `Die; process; lock_path} )
       with
       | Ok p ->
-          (* If the Kademlia process dies, kill the parent daemon process.   Fix
+          (* If the Kademlia process dies, kill the parent daemon process. Fix
            * for #550 *)
           Deferred.upon (Process.wait p.process) (fun code ->
               match (!(p.failure_response), code) with


### PR DESCRIPTION
`don't_wait_for @@ (exit 1)` was intentional, despite `Core.exit 1` being "cleaner". When Core's exit is used the file log line doesn't get printed out before the process dies, while the former method does allow this.

To detect the kademlia process dying, look for the following log message:

```
((attributes((module membership)(module-Gossip_net true)(module-membership true)))(path(membership Gossip_net))(level Fatal)(pid 23204)(host 2a76262a9d02)(time(2018-11-04 21:54:21.479253Z))(location())(message"Kademlia process died: (Signal sigterm)"))
```

and the daemon will exit with code 1.

- [ ] Tests were added for the new behavior

Tests weren't added, but I tested by `kill`-ing the child kademlia process and witnessing the daemon dying after printing the log message.

- [x] All tests pass (CI will check this if you didn't)
- [x] Does this close issues? List them:

Closes #550
