### PR TITLE
Remove shadowing empty_hash in Account

### DIFF
--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -73,11 +73,6 @@ let initialize public_key : t =
   ; nonce= Nonce.zero
   ; receipt_chain_hash= Receipt.Chain_hash.empty }
 
-let empty_hash =
-  Pedersen.digest_fold
-    (Pedersen.State.create Pedersen.params)
-    (Fold_lib.Fold.string_triples "nothing up my sleeve")
-
 let typ : (var, value) Typ.t =
   let spec =
     let open Data_spec in


### PR DESCRIPTION
There were two definitions of `empty_hash` in `Merkle_ledger.Account`. The second shadowed the first, so only the second was used.

Probably the first definition was the correct one, so this PR removes the second one. Maybe that's the wrong way around!

Checklist:

- [ ] Tests were added for the new behavior

No tests added, because unsure how to test.

- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? No.
