### PR TITLE
speed up sync ledger answering

### DIFF
--- a/src/lib/ledger_builder_controller/ledger_builder_controller.ml
+++ b/src/lib/ledger_builder_controller/ledger_builder_controller.ml
@@ -308,7 +308,7 @@ end = struct
       -> Ledger_hash.t * Sync_ledger.query
       -> (Ledger_hash.t * Sync_ledger.answer) Deferred.Or_error.t =
    fun t (hash, query) ->
-    (* TODO: We should cache, but in the future it will be free *)
+    (* TODO: this caching shouldn't be necessary *)
     let open Deferred.Or_error.Let_syntax in
     Logger.trace t.log
       !"Attempting to handle a sync-ledger query for %{sexp: Ledger_hash.t}"


### PR DESCRIPTION
we spend a surprising amount of time looking up
the local ledger for that hash. for now, cache
the most recent one you saw. this is good enough
to speed up the tests, and almost all cases with
posig (not postake).

tested by looking at a trace view (from my in-progress
tracer) and seeing that the slow bits went away.