### PR TITLE
make Lb.create_diff async

### DIFF
--- a/src/lib/ledger_builder/ledger_builder.ml
+++ b/src/lib/ledger_builder/ledger_builder.ml
@@ -1098,7 +1098,7 @@ end = struct
       @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
     in
     let%map new_data =
-      Deferred.List.mapi transactions ~f:(fun _ s ->
+      Deferred.List.map transactions ~f:(fun s ->
           let%map r = apply_transaction_and_get_witness t.ledger s in
           let _undo, t = Or_error.ok_exn r in
           t )

--- a/src/lib/ledger_builder/ledger_builder.ml
+++ b/src/lib/ledger_builder/ledger_builder.ml
@@ -1139,9 +1139,10 @@ end = struct
           let%map data, works, cb_works = apply_pre_diff_with_at_most_one d in
           (data, cb_works @ works) )
         ~second:(fun d ->
-          let%map data1, works1, cb_works1 =
+          let%bind data1, works1, cb_works1 =
             apply_pre_diff_with_at_most_two (fst d)
-          and data2, works2, cb_works2 =
+          in
+          let%map data2, works2, cb_works2 =
             apply_pre_diff_with_at_most_one (snd d)
           in
           (data1 @ data2, works1 @ cb_works1 @ cb_works2 @ works2) )

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -142,10 +142,10 @@ module Make (Inputs : Inputs_intf) :
     let%bind ( diff
              , `Hash_after_applying next_ledger_builder_hash
              , `Ledger_proof ledger_proof_opt ) =
-      lift_sync (fun () ->
-          Ledger_builder.create_diff ledger_builder
-            ~self:(Public_key.compress keypair.public_key)
-            ~logger ~transactions_by_fee:transactions ~get_completed_work )
+      Interruptible.uninterruptible
+        (Ledger_builder.create_diff ledger_builder
+           ~self:(Public_key.compress keypair.public_key)
+           ~logger ~transactions_by_fee:transactions ~get_completed_work)
     in
     let%bind transition_opt =
       lift_sync (fun () ->

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -555,9 +555,10 @@ module type Ledger_builder_intf = sig
     -> logger:Logger.t
     -> transactions_by_fee:user_command_with_valid_signature Sequence.t
     -> get_completed_work:(statement -> completed_work option)
-    -> valid_diff
+    -> ( valid_diff
        * [`Hash_after_applying of ledger_builder_hash]
-       * [`Ledger_proof of ledger_proof option]
+       * [`Ledger_proof of ledger_proof option] )
+       Deferred.t
 
   val all_work_pairs :
        t


### PR DESCRIPTION
Sparse_ledger.of_ledger_subset_exn is slow, and synchronous.
So is apply_transaction_and_get_statement. Yield immediately
after each of these to give the scheduler a chance to run some
other code.

This makes `create_diff` async.

Tested by looking at the tracing output (PR forthcoming) and
noticing that the large "proposer" block gets split into three pieces.
