### PR TITLE
Implement remove_accounts_exn for database and mask

### DIFF
--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -297,6 +297,26 @@ let%test_module "test functor on in memory databases" =
               assert (
                 List.equal ~equal:Account.equal accounts retrieved_accounts )
           )
+
+      let%test_unit "removing accounts restores Merkle root" =
+        Test.with_instance (fun mdb ->
+            let num_accounts = 5 in
+            let keys = Key.gen_keys num_accounts in
+            let balances =
+              Quickcheck.random_value
+                (Quickcheck.Generator.list_with_length num_accounts Balance.gen)
+            in
+            let accounts = List.map2_exn keys balances ~f:Account.create in
+            let merkle_root0 = MT.merkle_root mdb in
+            List.iter accounts ~f:(fun account ->
+                ignore @@ create_new_account_exn mdb account ) ;
+            let merkle_root1 = MT.merkle_root mdb in
+            (* adding accounts should change the Merkle root *)
+            assert (not (Hash.equal merkle_root0 merkle_root1)) ;
+            MT.remove_accounts_exn mdb keys ;
+            (* should see original Merkle root after removing the accounts *)
+            let merkle_root2 = MT.merkle_root mdb in
+            assert (Hash.equal merkle_root2 merkle_root0) )
     end
 
     module Make_db (Depth : sig

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -86,14 +86,6 @@ struct
       Location.Table.set t.account_tbl ~key:location ~data:account ;
       set_location t (Account.public_key account) location
 
-    let remove_account t location =
-      let account = Option.value_exn (find_account t location) in
-      Location.Table.remove t.account_tbl location ;
-      (* TODO : use stack database to save unused location, which can be 
-        used when allocating a location
-      *)
-      Key.Table.remove t.location_tbl (Account.public_key account)
-
     (* a read does a lookup in the account_tbl; if that fails, delegate to parent *)
     let get t location =
       match find_account t location with
@@ -172,6 +164,25 @@ struct
       | Some hash -> hash
       | None -> Base.merkle_root (get_parent t)
 
+    let remove_account_and_update_hashes t location =
+      (* remove account and key from tables *)
+      let account = Option.value_exn (find_account t location) in
+      Location.Table.remove t.account_tbl location ;
+      (* TODO : use stack database to save unused location, which can be
+        used when allocating a location
+      *)
+      Key.Table.remove t.location_tbl (Account.public_key account) ;
+      (* update hashes *)
+      let account_address = Location.to_path_exn location in
+      let account_hash = Hash.empty_account in
+      let merkle_path = merkle_path t location in
+      let addresses_and_hashes =
+        addresses_and_hashes_from_merkle_path_exn merkle_path account_address
+          account_hash
+      in
+      List.iter addresses_and_hashes ~f:(fun (addr, hash) ->
+          set_hash t addr hash )
+
     (* a write writes only to the mask, parent is not involved 
      need to update both account and hash pieces of the mask
        *)
@@ -193,19 +204,9 @@ struct
     let parent_set_notify t location account =
       match find_account t location with
       | Some existing_account ->
-          if Account.equal account existing_account then (
+          if Account.equal account existing_account then
             (* optimization: remove from account table *)
-            remove_account t location ;
-            (* update hashes *)
-            let account_address = Location.to_path_exn location in
-            let account_hash = Hash.empty_account in
-            let merkle_path = merkle_path t location in
-            let addresses_and_hashes =
-              addresses_and_hashes_from_merkle_path_exn merkle_path
-                account_address account_hash
-            in
-            List.iter addresses_and_hashes ~f:(fun (addr, hash) ->
-                set_hash t addr hash ) )
+            remove_account_and_update_hashes t location
       | None -> ()
 
     (* as for accounts, we see if we have it in the mask, else delegate to parent *)
@@ -295,9 +296,25 @@ struct
       assert (Addr.depth address <= Base.depth) ;
       get_hash t address |> Option.value_exn
 
-    (* database also does not implement remove_accounts_exn *)
-    let remove_accounts_exn _t _accounts =
-      failwith "remove_accounts_exn: not implemented"
+    let remove_accounts_exn t keys =
+      let rec loop keys parent_keys mask_locations =
+        match keys with
+        | [] -> (parent_keys, mask_locations)
+        | key :: rest -> (
+          match find_location t key with
+          | None -> loop rest (key :: parent_keys) mask_locations
+          | Some loc -> loop rest parent_keys (loc :: mask_locations) )
+      in
+      (* parent_keys not in mask, may be in parent
+         mask_locations definitely in mask
+       *)
+      let parent_keys, mask_locations = loop keys [] [] in
+      (* allow call to parent to raise an exception
+         if raised, the parent hasn't removed any accounts,
+          and we don't try to remove any accounts from mask *)
+      Base.remove_accounts_exn t.parent parent_keys ;
+      (* removing accounts in parent succeeded, so proceed with removing accounts from mask *)
+      List.iter mask_locations ~f:(remove_account_and_update_hashes t)
 
     let destroy t =
       Location.Table.iteri t.account_tbl ~f:(fun ~key ~data:_ ->


### PR DESCRIPTION
`remove_accounts_exn` had not been implemented for the database Merkle ledger and for the Merkle mask.

In the database, each public key has two entries. The first is an encoding of the key, whose value is an account location. The second is the account location, whose value is the account. Those are removed, and the affected hashes in the database are updated. A possible optimization, removing hashes no longer needed in the database, was not implemented. If any of the keys does not map to a location, no changes to the database are made.

For the mask, we partition the keys into two lists, those that have an entry in the mask, and the rest. We try to remove the non-mask keys from the mask parent. If that raises an exception, we're done, and no changes have been made to the mask or parent. Otherwise, we remove the accounts known to be in the parent.

The tests check whether a Merkle root is the same before and after adding, then removing accounts. For the mask, we make that check by adding, removing accounts to just the mask, just the parent, and both mask and parent.

This PR is needed to allow integration of the database and mask as a Merkle ledger, since some tests use `remove_accounts_exn`.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? No. 
