### PR TITLE
Feature/nohaskeltoolchain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,15 +4,12 @@ jobs:
     build:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
             - run:
                 name: Lint
                 command: eval `opam config env` && make check-format
-            - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=dev make build 2>&1 | tee /tmp/buildocaml.log
@@ -34,12 +31,9 @@ jobs:
     build_withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
-            - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet make build 2>&1 | tee /tmp/buildocaml.log
@@ -61,12 +55,9 @@ jobs:
     build_public:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
-            - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet_public make build 2>&1 | tee /tmp/buildocaml.log
@@ -82,12 +73,9 @@ jobs:
     test-unit-test:
        resource_class: large
        docker:
-       - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+       - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
        steps:
            - checkout
-           - run:
-               name: Build Haskell
-               command: source ~/.profile && make kademlia
            - run:
               name: Test make test-runtest
               command: source ~/.profile && make test-runtest
@@ -95,12 +83,9 @@ jobs:
     test-withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
-            - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=test_snark make build 2>&1 | tee /tmp/buildocaml.log
@@ -112,15 +97,12 @@ jobs:
     test-all_sig_integration_tests:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+      - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
       steps:
           - checkout
           - run:
               name: Check .circleci Render
               command: make check-render-circleci
-          - run:
-              name: Build Haskell
-              command: source ~/.profile && make kademlia
           - run:
               name: Build OCaml
               command: eval `opam config env` && DUNE_PROFILE=test make build 2>&1 | tee /tmp/buildocaml.log
@@ -156,15 +138,12 @@ jobs:
     test-all_stake_integration_tests:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+      - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
       steps:
           - checkout
           - run:
               name: Check .circleci Render
               command: make check-render-circleci
-          - run:
-              name: Build Haskell
-              command: source ~/.profile && make kademlia
           - run:
               name: Build OCaml
               command: eval `opam config env` && DUNE_PROFILE=test make build 2>&1 | tee /tmp/buildocaml.log
@@ -212,7 +191,8 @@ workflows:
             
             - test-withsnark
             - test-unit-test
-    # NOTES: Save this idea for later (nightly/scheduled workflows)
+
+# NOTES: Save this idea for later (nightly/scheduled workflows)
     # nightly:
     #     triggers:
     #         - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     build:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -31,7 +31,7 @@ jobs:
     build_withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -55,7 +55,7 @@ jobs:
     build_public:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -73,7 +73,7 @@ jobs:
     test-unit-test:
        resource_class: large
        docker:
-       - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+       - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
        steps:
            - checkout
            - run:
@@ -83,7 +83,7 @@ jobs:
     test-withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -97,7 +97,7 @@ jobs:
     test-all_sig_integration_tests:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+      - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
       steps:
           - checkout
           - run:
@@ -138,7 +138,7 @@ jobs:
     test-all_stake_integration_tests:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+      - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
       steps:
           - checkout
           - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -4,7 +4,7 @@ jobs:
     build:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
             - run:
@@ -31,7 +31,7 @@ jobs:
     build_withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
             - run:
@@ -55,7 +55,7 @@ jobs:
     build_public:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
             - run:
@@ -73,7 +73,7 @@ jobs:
     test-unit-test:
        resource_class: large
        docker:
-       - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+       - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
        steps:
            - checkout
            - run:
@@ -83,7 +83,7 @@ jobs:
     test-withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
         steps:
             - checkout
             - run:
@@ -97,7 +97,7 @@ jobs:
     test-{{test.name}}:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+      - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
       steps:
           - checkout
           - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -11,9 +11,6 @@ jobs:
                 name: Lint
                 command: eval `opam config env` && make check-format
             - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
-            - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=dev make build 2>&1 | tee /tmp/buildocaml.log
             - run:
@@ -37,9 +34,6 @@ jobs:
         - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
         steps:
             - checkout
-            - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet make build 2>&1 | tee /tmp/buildocaml.log
@@ -65,9 +59,6 @@ jobs:
         steps:
             - checkout
             - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
-            - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet_public make build 2>&1 | tee /tmp/buildocaml.log
             - run:
@@ -86,9 +77,6 @@ jobs:
        steps:
            - checkout
            - run:
-               name: Build Haskell
-               command: source ~/.profile && make kademlia
-           - run:
               name: Test make test-runtest
               command: source ~/.profile && make test-runtest
 
@@ -98,9 +86,6 @@ jobs:
         - image: codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
         steps:
             - checkout
-            - run:
-                name: Build Haskell
-                command: source ~/.profile && make kademlia
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=test_snark make build 2>&1 | tee /tmp/buildocaml.log
@@ -118,9 +103,6 @@ jobs:
           - run:
               name: Check .circleci Render
               command: make check-render-circleci
-          - run:
-              name: Build Haskell
-              command: source ~/.profile && make kademlia
           - run:
               name: Build OCaml
               command: eval `opam config env` && DUNE_PROFILE=test make build 2>&1 | tee /tmp/buildocaml.log
@@ -142,7 +124,8 @@ workflows:
             {%endfor%}
             - test-withsnark
             - test-unit-test
-    # NOTES: Save this idea for later (nightly/scheduled workflows)
+
+# NOTES: Save this idea for later (nightly/scheduled workflows)
     # nightly:
     #     triggers:
     #         - schedule:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -4,7 +4,7 @@ jobs:
     build:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -31,7 +31,7 @@ jobs:
     build_withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -55,7 +55,7 @@ jobs:
     build_public:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -73,7 +73,7 @@ jobs:
     test-unit-test:
        resource_class: large
        docker:
-       - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+       - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
        steps:
            - checkout
            - run:
@@ -83,7 +83,7 @@ jobs:
     test-withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+        - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
         steps:
             - checkout
             - run:
@@ -97,7 +97,7 @@ jobs:
     test-{{test.name}}:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+      - image: codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
       steps:
           - checkout
           - run:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM codaprotocol/coda:toolchain-90509bec114a4bbe4e676765c21118f403e86452
+FROM codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
 
 ENV OPAM_DIR             "/home/opam/.opam/4.07"
 ENV PATH                 "${OPAM_DIR}/bin:$PATH"

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM codaprotocol/coda:toolchain-0464742a84137aaba0070161513d5b7d52905343
+FROM codaprotocol/coda:toolchain-6c30528b108af08d559d08edec04d6db4f654f50
 
 ENV OPAM_DIR             "/home/opam/.opam/4.07"
 ENV PATH                 "${OPAM_DIR}/bin:$PATH"

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -46,6 +46,7 @@ ADD /src/external/ocaml-sodium /ocaml-sodium
 RUN cd /ocaml-sodium && yes | opam pin add .
 
 # Get coda-kademlia from packages repo
-RUN echo "deb [trusted=yes] https://packages.o1test.net unstable main" | sudo tee -a /etc/apt/sources.list.d/coda.list && \
+RUN sudo apt-get install --yes apt-transport-https ca-certificates && \
+      echo "deb [trusted=yes] https://packages.o1test.net unstable main" | sudo tee -a /etc/apt/sources.list.d/coda.list && \
       sudo apt-get update && \
       sudo apt-get install --yes coda-kademlia

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -46,6 +46,6 @@ ADD /src/external/ocaml-sodium /ocaml-sodium
 RUN cd /ocaml-sodium && yes | opam pin add .
 
 # Get coda-kademlia from packages repo
-RUN echo "deb [trusted=yes] https://packages.o1test.net unstable main" >> /etc/apt/sources.list.d/coda.list && \
-      apt-get update && \
-      apt-get install --yes coda-kademlia
+RUN sudo echo "deb [trusted=yes] https://packages.o1test.net unstable main" >> /etc/apt/sources.list.d/coda.list && \
+      sudo apt-get update && \
+      sudo apt-get install --yes coda-kademlia

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -45,16 +45,7 @@ RUN opam switch import opam.export ; rm opam.export
 ADD /src/external/ocaml-sodium /ocaml-sodium
 RUN cd /ocaml-sodium && yes | opam pin add .
 
-
-# nix for haskell for kademlia
-# fixme: break in to it's own container
-RUN sudo mkdir -p /nix
-RUN sudo chown opam /nix
-RUN sudo mkdir -p /etc/nix
-RUN sudo bash  -c 'echo "build-users-group =" > /etc/nix/nix.conf'
-ENV USER opam
-RUN cd /home/opam && curl https://nixos.org/nix/install | sh
-
-ADD /src/app/kademlia-haskell/prefetch /prefetch
-RUN sudo chown -R opam /prefetch
-RUN cd /prefetch && . /home/opam/.nix-profile/etc/profile.d/nix.sh && nix-build prefetch.nix
+# Get coda-kademlia from packages repo
+RUN echo "deb [trusted=yes] https://packages.o1test.net unstable main" >> /etc/apt/sources.list.d/coda.list && \
+      apt-get update && \
+      apt-get install --yes coda-kademlia

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -46,6 +46,6 @@ ADD /src/external/ocaml-sodium /ocaml-sodium
 RUN cd /ocaml-sodium && yes | opam pin add .
 
 # Get coda-kademlia from packages repo
-RUN sudo echo "deb [trusted=yes] https://packages.o1test.net unstable main" >> /etc/apt/sources.list.d/coda.list && \
+RUN echo "deb [trusted=yes] https://packages.o1test.net unstable main" | sudo tee -a /etc/apt/sources.list.d/coda.list && \
       sudo apt-get update && \
       sudo apt-get install --yes coda-kademlia


### PR DESCRIPTION
Changes toolchain to remove kademlia build.
(instead pulls down previously built deb stored in deb repo)

Reduces toolchain image build from 7.9GB to 5.3GB. (should reduce CI 'Setup Env' time)
Reduces each CI run by ~20s as there's no longer a 'build haskell'.

On non-debian systems, kademlia can be built using 'make docker-toolchain-haskell' or in old/native method:" 'make kademlia'

