### PR TITLE
Update docker SHA in README-dev.md

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -40,7 +40,7 @@ Now you'll have a `src/_build/codaclient.deb` ready to install on Ubuntu or Debi
 
 * Pull down developer container image  (~2GB download, go stretch your legs)
 
-`docker pull codaprotocol/coda:toolchain-e11592718bee89d2a4facfa7ca209844fa7b140c`
+`docker pull codaprotocol/coda:toolchain-9aea9e820e487fabb79e3c8c27372a50fbf77289`
 
 * Apply local customizations
 

--- a/scripts/update-toolchain-references.sh
+++ b/scripts/update-toolchain-references.sh
@@ -17,5 +17,5 @@ filenames="
 for filename in $filenames
 do
   echo "Updating $filename with new toolchain reference: $1"
-  sed -i "s/toolchain-.*/toolchain-$1/g" $filename
+  sed -i "s/toolchain-[\`]*/toolchain-$1/g" $filename
 done

--- a/scripts/update-toolchain-references.sh
+++ b/scripts/update-toolchain-references.sh
@@ -11,6 +11,7 @@ fi
 filenames="
   $SCRIPTPATH/../dockerfiles/Dockerfile
   $SCRIPTPATH/../.circleci/config.yml.jinja
+  $SCRIPTPATH/../README-dev.md
 "
 
 for filename in $filenames


### PR DESCRIPTION
The `update-toolchain-references` script wasn't updating `README-dev.md`, which uses a SHA in the docker image name.

In that file, the image name ends with a backtick, so the regexp for `sed` in the script needs to exclude that character.

I ran `make update-deps` to confirm the SHA was updated, and the backtick preserved.

Checklist:

- [ ] Tests were added for the new behavior. No.
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? No.
