### PR TITLE
Merkle masks per maskable instance, not per Maskable module

### DIFF
--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -186,7 +186,7 @@ let%test_module "Test mask connected to underlying Merkle tree" =
             in
             try
               let (_unattached_mask : Mask.t) =
-                Maskable.unregister_mask_exn attached_mask
+                Maskable.unregister_mask_exn maskable attached_mask
               in
               true
             with Failure _ -> false )

--- a/src/lib/merkle_mask/maskable_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree_intf.ml
@@ -15,6 +15,6 @@ module type S = sig
 
   val register_mask : t -> unattached_mask -> attached_mask
 
-  val unregister_mask_exn : attached_mask -> unattached_mask
+  val unregister_mask_exn : t -> attached_mask -> unattached_mask
   (** raises an exception if mask is not registered *)
 end


### PR DESCRIPTION
The functor to create a Maskable ledger contained a list of mask children. Instead, the children should be associated with created instances.

A way to do that would be to associate the children in the type `t` for the Maskable -- but that type `t` comes from the `Base` ledger and can't be redefined. Instead, the functor contains an assoc list where the maskable instances are the key, and lists of masks are the values.

It would have been simpler to use a hash table than an assoc list, but that requires `hash` and `compare` for databases in the `Base` module. Deriving those didn't seem to work for the database in the test stubs.

Checklist:

- [ X ] Tests were added for the new behavior : more accurately, updated to use the new signature for `unregister_mask_exn`
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? No.
