### PR TITLE
Ledger builder `create_diff` doesn't apply it too

### DIFF
--- a/src/lib/ledger_builder/ledger_builder.ml
+++ b/src/lib/ledger_builder/ledger_builder.ml
@@ -2212,7 +2212,7 @@ let%test_module "test" =
         Lb.create_diff lb ~self:self_pk ~logger ~transactions_by_fee:txns
           ~get_completed_work:stmt_to_work
       in
-      let%map (_, `Ledger_proof ledger_proof) =
+      let%map _, `Ledger_proof ledger_proof =
         Lb.apply lb (Test_input1.Ledger_builder_diff.forget diff) ~logger
       in
       (ledger_proof, Test_input1.Ledger_builder_diff.forget diff)
@@ -2262,11 +2262,12 @@ let%test_module "test" =
               in
               let%map proof, diff =
                 create_and_apply lb logger (Sequence.of_list all_ts)
-                  stmt_to_work |> Deferred.Or_error.ok_exn
+                  stmt_to_work
+                |> Deferred.Or_error.ok_exn
               in
               let fee_excess =
-                Option.value_map ~default:Currency.Fee.Signed.zero
-                  proof ~f:(fun proof ->
+                Option.value_map ~default:Currency.Fee.Signed.zero proof
+                  ~f:(fun proof ->
                     let stmt = Test_input1.Ledger_proof.statement proof in
                     stmt.fee_excess )
               in
@@ -2300,11 +2301,12 @@ let%test_module "test" =
               let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
               let ts = List.take all_ts i in
               let%map proof, diff =
-                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work |> Deferred.Or_error.ok_exn
+                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
+                |> Deferred.Or_error.ok_exn
               in
               let fee_excess =
-                Option.value_map ~default:Currency.Fee.Signed.zero
-                  proof ~f:(fun proof ->
+                Option.value_map ~default:Currency.Fee.Signed.zero proof
+                  ~f:(fun proof ->
                     let stmt = Test_input1.Ledger_proof.statement proof in
                     stmt.fee_excess )
               in
@@ -2345,11 +2347,12 @@ let%test_module "test" =
               let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
               let ts = List.take all_ts i in
               let%map proof, diff =
-                create_and_apply lb logger (Sequence.of_list ts) get_work |> Deferred.Or_error.ok_exn
+                create_and_apply lb logger (Sequence.of_list ts) get_work
+                |> Deferred.Or_error.ok_exn
               in
               let fee_excess =
-                Option.value_map ~default:Currency.Fee.Signed.zero
-                  proof ~f:(fun proof ->
+                Option.value_map ~default:Currency.Fee.Signed.zero proof
+                  ~f:(fun proof ->
                     let stmt = Test_input1.Ledger_proof.statement proof in
                     stmt.fee_excess )
               in
@@ -2388,7 +2391,8 @@ let%test_module "test" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Deferred.List.fold ~init:() txns ~f:(fun _ ts ->
               let%map _ =
-                create_and_apply lb logger (Sequence.of_list ts) get_work |> Deferred.Or_error.ok_exn
+                create_and_apply lb logger (Sequence.of_list ts) get_work
+                |> Deferred.Or_error.ok_exn
               in
               () ) )
 
@@ -2407,7 +2411,8 @@ let%test_module "test" =
               let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
               let ts = List.take all_ts i in
               let%map proof, _ =
-                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work |> Deferred.Or_error.ok_exn
+                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
+                |> Deferred.Or_error.ok_exn
               in
               let last_snarked_ledger, snarked_ledger_hash =
                 Option.value_map

--- a/src/lib/ledger_builder/ledger_builder.ml
+++ b/src/lib/ledger_builder/ledger_builder.ml
@@ -1074,7 +1074,7 @@ end = struct
       "Block info: No of transactions included:%d Coinbase parts:%d Work \
        count:%d"
       user_commands_count cb_parts_count (List.length works) ;
-    res_opt
+    (`Hash_after_applying (hash t), `Ledger_proof res_opt)
 
   let apply t witness ~logger =
     Result_with_rollback.run (apply_diff t witness ~logger)
@@ -1160,7 +1160,7 @@ end = struct
     in
     Or_error.ok_exn (Parallel_scan.enqueue_data ~state:t.scan_state ~data) ;
     Or_error.ok_exn (verify_scan_state_after_apply t.ledger t.scan_state) ;
-    res_opt
+    (`Hash_after_applying (hash t), `Ledger_proof res_opt)
 
   let work_to_do scan_state : Completed_work.Statement.t Sequence.t =
     let work_seq = Parallel_scan.next_jobs_sequence ~state:scan_state in
@@ -1662,14 +1662,9 @@ end = struct
         get_completed_work ledger self partitions
     in
     trace_event "prediffs done" ;
-    let diff =
-      { Ledger_builder_diff.With_valid_signatures_and_proofs.pre_diffs
-      ; creator= self
-      ; prev_hash= curr_hash }
-    in
-    let%map ledger_proof = apply_diff_unchecked t' diff in
-    trace_event "applied diff" ;
-    (diff, `Hash_after_applying (hash t'), `Ledger_proof ledger_proof)
+    { Ledger_builder_diff.With_valid_signatures_and_proofs.pre_diffs
+    ; creator= self
+    ; prev_hash= curr_hash }
 end
 
 let%test_module "test" =
@@ -2212,11 +2207,12 @@ let%test_module "test" =
         ; prover }
 
     let create_and_apply lb logger txns stmt_to_work =
-      let%bind diff, _, _ =
+      let open Deferred.Or_error.Let_syntax in
+      let diff =
         Lb.create_diff lb ~self:self_pk ~logger ~transactions_by_fee:txns
           ~get_completed_work:stmt_to_work
       in
-      let%map ledger_proof =
+      let%map (_, `Ledger_proof ledger_proof) =
         Lb.apply lb (Test_input1.Ledger_builder_diff.forget diff) ~logger
       in
       (ledger_proof, Test_input1.Ledger_builder_diff.forget diff)
@@ -2266,11 +2262,11 @@ let%test_module "test" =
               in
               let%map proof, diff =
                 create_and_apply lb logger (Sequence.of_list all_ts)
-                  stmt_to_work
+                  stmt_to_work |> Deferred.Or_error.ok_exn
               in
               let fee_excess =
                 Option.value_map ~default:Currency.Fee.Signed.zero
-                  (Or_error.ok_exn proof) ~f:(fun proof ->
+                  proof ~f:(fun proof ->
                     let stmt = Test_input1.Ledger_proof.statement proof in
                     stmt.fee_excess )
               in
@@ -2304,11 +2300,11 @@ let%test_module "test" =
               let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
               let ts = List.take all_ts i in
               let%map proof, diff =
-                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
+                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work |> Deferred.Or_error.ok_exn
               in
               let fee_excess =
                 Option.value_map ~default:Currency.Fee.Signed.zero
-                  (Or_error.ok_exn proof) ~f:(fun proof ->
+                  proof ~f:(fun proof ->
                     let stmt = Test_input1.Ledger_proof.statement proof in
                     stmt.fee_excess )
               in
@@ -2349,11 +2345,11 @@ let%test_module "test" =
               let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
               let ts = List.take all_ts i in
               let%map proof, diff =
-                create_and_apply lb logger (Sequence.of_list ts) get_work
+                create_and_apply lb logger (Sequence.of_list ts) get_work |> Deferred.Or_error.ok_exn
               in
               let fee_excess =
                 Option.value_map ~default:Currency.Fee.Signed.zero
-                  (Or_error.ok_exn proof) ~f:(fun proof ->
+                  proof ~f:(fun proof ->
                     let stmt = Test_input1.Ledger_proof.statement proof in
                     stmt.fee_excess )
               in
@@ -2392,7 +2388,7 @@ let%test_module "test" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           Deferred.List.fold ~init:() txns ~f:(fun _ ts ->
               let%map _ =
-                create_and_apply lb logger (Sequence.of_list ts) get_work
+                create_and_apply lb logger (Sequence.of_list ts) get_work |> Deferred.Or_error.ok_exn
               in
               () ) )
 
@@ -2411,7 +2407,7 @@ let%test_module "test" =
               let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
               let ts = List.take all_ts i in
               let%map proof, _ =
-                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
+                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work |> Deferred.Or_error.ok_exn
               in
               let last_snarked_ledger, snarked_ledger_hash =
                 Option.value_map
@@ -2419,7 +2415,7 @@ let%test_module "test" =
                     ( !expected_snarked_ledger
                     , Int.to_string !expected_snarked_ledger )
                   ~f:(fun p -> (Int.of_string p.target, p.target))
-                  (Or_error.ok_exn proof)
+                  proof
               in
               expected_snarked_ledger := last_snarked_ledger ;
               let materialized_ledger =

--- a/src/lib/ledger_builder_controller/inputs.ml
+++ b/src/lib/ledger_builder_controller/inputs.ml
@@ -139,7 +139,8 @@ module Base = struct
       Protocols.Coda_pow.Ledger_builder_base_intf
       with type ledger_builder_hash := Ledger_builder_hash.t
        and type frozen_ledger_hash := Frozen_ledger_hash.t
-       and type valid_diff := Ledger_builder_diff.With_valid_signatures_and_proofs.t
+       and type valid_diff :=
+                  Ledger_builder_diff.With_valid_signatures_and_proofs.t
        and type diff := Ledger_builder_diff.t
        and type ledger_proof := Ledger_proof.t
        and type ledger := Ledger.t

--- a/src/lib/ledger_builder_controller/inputs.ml
+++ b/src/lib/ledger_builder_controller/inputs.ml
@@ -34,6 +34,10 @@ module Base = struct
 
     module Ledger_builder_diff : sig
       type t [@@deriving sexp, bin_io]
+
+      module With_valid_signatures_and_proofs : sig
+        type t
+      end
     end
 
     module Ledger : sig
@@ -135,6 +139,7 @@ module Base = struct
       Protocols.Coda_pow.Ledger_builder_base_intf
       with type ledger_builder_hash := Ledger_builder_hash.t
        and type frozen_ledger_hash := Frozen_ledger_hash.t
+       and type valid_diff := Ledger_builder_diff.With_valid_signatures_and_proofs.t
        and type diff := Ledger_builder_diff.t
        and type ledger_proof := Ledger_proof.t
        and type ledger := Ledger.t

--- a/src/lib/ledger_builder_controller/ledger_builder_controller.ml
+++ b/src/lib/ledger_builder_controller/ledger_builder_controller.ml
@@ -45,10 +45,10 @@ end = struct
     module Step = struct
       let apply' t diff logger =
         let open Deferred.Or_error.Let_syntax in
-        let%map (_, `Ledger_proof proof) = Ledger_builder.apply t diff ~logger in
-        (Option.map proof ~f:(fun proof ->
-             ( Ledger_proof.statement proof |> Ledger_proof_statement.target
-             , proof ) ))
+        let%map _, `Ledger_proof proof = Ledger_builder.apply t diff ~logger in
+        Option.map proof ~f:(fun proof ->
+            ( Ledger_proof.statement proof |> Ledger_proof_statement.target
+            , proof ) )
 
       let step logger {With_hash.data= tip; hash= tip_hash}
           {With_hash.data= transition; hash= transition_target_hash} =
@@ -417,6 +417,7 @@ let%test_module "test" =
         (* A ledger_builder transition will just add to a "ledger" integer *)
         module Ledger_builder_diff = struct
           type t = int [@@deriving bin_io, sexp]
+
           module With_valid_signatures_and_proofs = struct
             type t = int
           end

--- a/src/lib/ledger_builder_controller/ledger_builder_controller.ml
+++ b/src/lib/ledger_builder_controller/ledger_builder_controller.ml
@@ -44,12 +44,11 @@ end = struct
 
     module Step = struct
       let apply' t diff logger =
-        Deferred.Or_error.map
-          (Ledger_builder.apply t diff ~logger)
-          ~f:
-            (Option.map ~f:(fun proof ->
-                 ( Ledger_proof.statement proof |> Ledger_proof_statement.target
-                 , proof ) ))
+        let open Deferred.Or_error.Let_syntax in
+        let%map (_, `Ledger_proof proof) = Ledger_builder.apply t diff ~logger in
+        (Option.map proof ~f:(fun proof ->
+             ( Ledger_proof.statement proof |> Ledger_proof_statement.target
+             , proof ) ))
 
       let step logger {With_hash.data= tip; hash= tip_hash}
           {With_hash.data= transition; hash= transition_target_hash} =
@@ -416,7 +415,12 @@ let%test_module "test" =
         end
 
         (* A ledger_builder transition will just add to a "ledger" integer *)
-        module Ledger_builder_diff = Int
+        module Ledger_builder_diff = struct
+          type t = int [@@deriving bin_io, sexp]
+          module With_valid_signatures_and_proofs = struct
+            type t = int
+          end
+        end
 
         module Ledger = struct
           include Int
@@ -456,7 +460,10 @@ let%test_module "test" =
 
           let apply (t : t) (x : Ledger_builder_diff.t) ~logger:_ =
             t := x ;
-            return (Ok (Some x))
+            return (Ok (`Hash_after_applying (hash t), `Ledger_proof (Some x)))
+
+          let apply_diff_unchecked (_t : t) (_x : 'a) =
+            failwith "Unimplemented"
 
           let snarked_ledger :
                  t

--- a/src/lib/ledger_builder_controller/tip_ops.ml
+++ b/src/lib/ledger_builder_controller/tip_ops.ml
@@ -34,8 +34,8 @@ module Make (Inputs : Inputs.Base.S) = struct
           (External_transition.ledger_builder_diff transition)
           ~logger
       with
-      | Ok None -> ()
-      | Ok (Some _) -> ()
+      | Ok (_, `Ledger_proof None) -> ()
+      | Ok (_, `Ledger_proof (Some _)) -> ()
       (* We've already verified that all the patches can be
         applied successfully before we added to the ktree, so we
         can force-unwrap here *)

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -141,19 +141,20 @@ module Make (Inputs : Inputs_intf) :
       ~ledger_builder ~transactions ~get_completed_work ~logger
       ~(keypair : Keypair.t) ~proposal_data =
     let open Interruptible.Let_syntax in
-    let%bind ( diff
-             , next_ledger_builder_hash
-             , ledger_proof_opt ) =
+    let%bind diff, next_ledger_builder_hash, ledger_proof_opt =
       Interruptible.uninterruptible
         (let open Deferred.Let_syntax in
-         let diff =
-            Ledger_builder.create_diff ledger_builder
-             ~self:(Public_key.compress keypair.public_key)
-             ~logger ~transactions_by_fee:transactions ~get_completed_work
-         in
-         let lb2 = Ledger_builder.copy ledger_builder in
-         let%map (`Hash_after_applying next_ledger_builder_hash, `Ledger_proof ledger_proof_opt ) = Ledger_builder.apply_diff_unchecked lb2 diff in
-         (diff, next_ledger_builder_hash, ledger_proof_opt))
+        let diff =
+          Ledger_builder.create_diff ledger_builder
+            ~self:(Public_key.compress keypair.public_key)
+            ~logger ~transactions_by_fee:transactions ~get_completed_work
+        in
+        let lb2 = Ledger_builder.copy ledger_builder in
+        let%map ( `Hash_after_applying next_ledger_builder_hash
+                , `Ledger_proof ledger_proof_opt ) =
+          Ledger_builder.apply_diff_unchecked lb2 diff
+        in
+        (diff, next_ledger_builder_hash, ledger_proof_opt))
     in
     let%bind protocol_state, consensus_transition_data =
       lift_sync (fun () ->

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -142,12 +142,18 @@ module Make (Inputs : Inputs_intf) :
       ~(keypair : Keypair.t) ~proposal_data =
     let open Interruptible.Let_syntax in
     let%bind ( diff
-             , `Hash_after_applying next_ledger_builder_hash
-             , `Ledger_proof ledger_proof_opt ) =
+             , next_ledger_builder_hash
+             , ledger_proof_opt ) =
       Interruptible.uninterruptible
-        (Ledger_builder.create_diff ledger_builder
-           ~self:(Public_key.compress keypair.public_key)
-           ~logger ~transactions_by_fee:transactions ~get_completed_work)
+        (let open Deferred.Let_syntax in
+         let diff =
+            Ledger_builder.create_diff ledger_builder
+             ~self:(Public_key.compress keypair.public_key)
+             ~logger ~transactions_by_fee:transactions ~get_completed_work
+         in
+         let lb2 = Ledger_builder.copy ledger_builder in
+         let%map (`Hash_after_applying next_ledger_builder_hash, `Ledger_proof ledger_proof_opt ) = Ledger_builder.apply_diff_unchecked lb2 diff in
+         (diff, next_ledger_builder_hash, ledger_proof_opt))
     in
     let%bind protocol_state, consensus_transition_data =
       lift_sync (fun () ->

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -480,6 +480,8 @@ module type Ledger_builder_base_intf = sig
 
   type diff
 
+  type valid_diff
+
   type ledger_builder_aux_hash
 
   type ledger_builder_hash
@@ -515,7 +517,10 @@ module type Ledger_builder_base_intf = sig
   val aux : t -> Aux.t
 
   val apply :
-    t -> diff -> logger:Logger.t -> ledger_proof option Deferred.Or_error.t
+    t -> diff -> logger:Logger.t -> ([`Hash_after_applying of ledger_builder_hash] * [`Ledger_proof of ledger_proof option]) Deferred.Or_error.t
+
+  val apply_diff_unchecked :
+    t -> valid_diff -> ( [`Hash_after_applying of ledger_builder_hash] * [`Ledger_proof of ledger_proof option] ) Deferred.t
 
   val snarked_ledger :
     t -> snarked_ledger_hash:frozen_ledger_hash -> ledger Or_error.t
@@ -523,8 +528,6 @@ end
 
 module type Ledger_builder_intf = sig
   include Ledger_builder_base_intf
-
-  type valid_diff
 
   type ledger_hash
 
@@ -556,10 +559,7 @@ module type Ledger_builder_intf = sig
     -> logger:Logger.t
     -> transactions_by_fee:user_command_with_valid_signature Sequence.t
     -> get_completed_work:(statement -> completed_work option)
-    -> ( valid_diff
-       * [`Hash_after_applying of ledger_builder_hash]
-       * [`Ledger_proof of ledger_proof option] )
-       Deferred.t
+    -> valid_diff
 
   val all_work_pairs :
        t

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -517,10 +517,19 @@ module type Ledger_builder_base_intf = sig
   val aux : t -> Aux.t
 
   val apply :
-    t -> diff -> logger:Logger.t -> ([`Hash_after_applying of ledger_builder_hash] * [`Ledger_proof of ledger_proof option]) Deferred.Or_error.t
+       t
+    -> diff
+    -> logger:Logger.t
+    -> ( [`Hash_after_applying of ledger_builder_hash]
+       * [`Ledger_proof of ledger_proof option] )
+       Deferred.Or_error.t
 
   val apply_diff_unchecked :
-    t -> valid_diff -> ( [`Hash_after_applying of ledger_builder_hash] * [`Ledger_proof of ledger_proof option] ) Deferred.t
+       t
+    -> valid_diff
+    -> ( [`Hash_after_applying of ledger_builder_hash]
+       * [`Ledger_proof of ledger_proof option] )
+       Deferred.t
 
   val snarked_ledger :
     t -> snarked_ledger_hash:frozen_ledger_hash -> ledger Or_error.t


### PR DESCRIPTION
Step one of Staged_ledger world domination

These are the minimum required changes to make `create_diff` of ledger-builder not auto-apply a diff afterwards (as we're moving towards isolating diff creation)

Unit tests change guided by types