### PR TITLE
Use db ledger

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -413,7 +413,7 @@ struct
       { protocol_state: Protocol_state.value
       ; proof: Protocol_state_proof.t
       ; ledger_builder: Ledger_builder.t }
-    [@@deriving sexp, bin_io, fields]
+    [@@deriving sexp, fields]
 
     let of_transition_and_lb transition ledger_builder =
       { protocol_state=
@@ -786,7 +786,7 @@ module type Main_intf = sig
     module Time : Protocols.Coda_pow.Time_intf
 
     module Ledger : sig
-      type t [@@deriving sexp]
+      type t
 
       type account
 

--- a/src/lib/coda_base/jbuild
+++ b/src/lib/coda_base/jbuild
@@ -8,6 +8,7 @@
   (library_flags (-linkall))
   (libraries
     ( lite_base
+      rocksdb_database
       hash_prefixes
       base64
       signature_lib

--- a/src/lib/coda_base/jbuild
+++ b/src/lib/coda_base/jbuild
@@ -8,6 +8,7 @@
   (library_flags (-linkall))
   (libraries
     ( lite_base
+      merkle_mask
       rocksdb_database
       hash_prefixes
       base64

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -452,10 +452,17 @@ module Hash = struct
 end
 
 module Ledger = struct
-  include Merkle_ledger.Database.Make (Public_key.Compressed) (Account) (Hash)
-            (Depth)
+  module Base_db =
+    Merkle_ledger.Database.Make (Public_key.Compressed) (Account) (Hash)
+      (Depth)
+      (Location0)
+      (Rocksdb_database)
+  include Merkle_mask.Masking_merkle_tree.Make
+            (Public_key.Compressed)
+            (Account)
+            (Hash)
             (Location0)
-            (Rocksdb_database)
+            (Base_db)
 end
 
 module Any_ledger =

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -444,11 +444,7 @@ module Storage_locations : Merkle_ledger.Intf.Storage_locations = struct
   (* TODO: The name of this value should be dynamically generated per test run*)
   let key_value_db_dir = ""
 end
-module Ledger = struct
-  include Merkle_ledger.Database.Make
-    (Public_key.Compressed)
-    (Account)
-    (struct
+module Hash = struct
       type t = Ledger_hash.t [@@deriving sexp, hash, compare, bin_io]
 
       let merge = Ledger_hash.merge
@@ -457,10 +453,23 @@ module Ledger = struct
         Fn.compose Ledger_hash.of_digest Account.digest
 
       let empty_account = hash_account Account.empty
-    end)
+end
+module Ledger = struct
+  include Merkle_ledger.Database.Make
+    (Public_key.Compressed)
+    (Account)
+    (Hash)
     (Depth)
     (Location0)
     (In_memory_kvdb)
     (Storage_locations)
 end
+module Any_ledger =
+  Merkle_ledger.Any_ledger.Make_base
+    (Public_key.Compressed)
+    (Account)
+    (Hash)
+    (Location0)
+    (Depth)
+module Any = Any_ledger.M
 include Make (Ledger)

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -2,7 +2,7 @@ open Core
 open Import
 
 include
-  Merkle_ledger.Merkle_ledger_intf.S
+  Merkle_ledger.Database_intf.S
   with type root_hash := Ledger_hash.t
    and type hash := Ledger_hash.t
    and type account := Account.t

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -15,8 +15,6 @@ include
    and type account := Account.t
    and type key := Public_key.Compressed.t
 
-val create : unit -> t
-
 type account = Account.t
 
 module Undo : sig

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -1,6 +1,13 @@
 open Core
 open Import
 
+module Any :
+  Merkle_ledger.Base_ledger_intf.S
+  with type root_hash := Ledger_hash.t
+   and type hash := Ledger_hash.t
+   and type account := Account.t
+   and type key := Public_key.Compressed.t
+
 include
   Merkle_ledger.Database_intf.S
   with type root_hash := Ledger_hash.t

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -53,7 +53,9 @@ let%test_unit "of_ledger_subset_exn with keys that don't exist works" =
     let privkey = Private_key.create () in
     (privkey, Public_key.of_private_key_exn privkey |> Public_key.compress)
   in
-  let ledger = Ledger.create () in
+  let ledger =
+    Ledger.create ~directory:(Filename.temp_dir "coda-test-db" "")
+  in
   let _, pub1 = keygen () in
   let _, pub2 = keygen () in
   let sl = of_ledger_subset_exn ledger [pub1; pub2] in

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -144,8 +144,8 @@ module Make (Inputs : Inputs_intf) :
 
   module Local_state = struct
     type t =
-      { mutable last_epoch_ledger: Coda_base.Ledger.t option
-      ; mutable curr_epoch_ledger: Coda_base.Ledger.t option
+      { mutable last_epoch_ledger: Coda_base.Ledger.t option sexp_opaque
+      ; mutable curr_epoch_ledger: Coda_base.Ledger.t option sexp_opaque
       ; mutable delegators: Currency.Balance.t Coda_base.Account.Index.Table.t
       }
     [@@deriving sexp]

--- a/src/lib/genesis_ledger/functor.ml
+++ b/src/lib/genesis_ledger/functor.ml
@@ -15,7 +15,9 @@ module Make_from_base (Base : Base_intf) : Intf.S = struct
   include Base
 
   let t =
-    let ledger = Ledger.create () in
+    let ledger =
+      Ledger.create ~directory:(Core.Filename.temp_dir "coda-test-db" "")
+    in
     List.iter accounts ~f:(fun (_, account) ->
         let open Account in
         Ledger.create_new_account_exn ledger account.public_key account ) ;

--- a/src/lib/ledger_builder/ledger_builder.ml
+++ b/src/lib/ledger_builder/ledger_builder.ml
@@ -512,8 +512,8 @@ end = struct
         scan_state
         (* Invariant: this is the ledger after having applied all the transactions in
     the above state. *)
-    ; ledger: Ledger.t }
-  [@@deriving sexp, bin_io]
+    ; ledger: Ledger.t sexp_opaque }
+  [@@deriving sexp]
 
   let chunks_of xs ~n = List.groupi xs ~break:(fun i _ _ -> i mod n = 0)
 

--- a/src/lib/ledger_builder_controller/ledger_builder_controller.ml
+++ b/src/lib/ledger_builder_controller/ledger_builder_controller.ml
@@ -122,13 +122,12 @@ end = struct
 
   let ledger_builder_io {ledger_builder_io; _} = ledger_builder_io
 
-  let load_tip_and_genesis_hash
-      {Config.genesis_tip; _} log =
+  let load_tip_and_genesis_hash {Config.genesis_tip; _} log =
     let genesis_state_hash =
       Protocol_state.hash genesis_tip.Tip.protocol_state
     in
     Logger.warn log
-          "TODO: Re-enable serialization, for now we're genesis tipping";
+      "TODO: Re-enable serialization, for now we're genesis tipping" ;
     return {With_hash.data= genesis_tip; hash= genesis_state_hash}
 
   let create (config : Config.t) =
@@ -239,9 +238,7 @@ end = struct
     let load_tip t config =
       let open With_hash in
       let open Deferred.Let_syntax in
-      let%map {data= tip; _} =
-        load_tip_and_genesis_hash config t.log
-      in
+      let%map {data= tip; _} = load_tip_and_genesis_hash config t.log in
       tip
   end
 

--- a/src/lib/lite_params/gen/dune
+++ b/src/lib/lite_params/gen/dune
@@ -11,6 +11,7 @@
      coda_base
      lite_compat
      precomputed_values)
+   (link_flags (-cclib -lrocksdb))
    (preprocessor_deps "../../../config.mlh")
    (preprocess (pps ppx_jane ppxlib.metaquot ppxlib.runner))
    (modes native))

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -56,8 +56,6 @@ struct
 
     module Addr = Location.Addr
 
-    let copy (T ((module Base), t)) = T ((module Base), Base.copy t)
-
     let remove_accounts_exn (T ((module Base), t)) = Base.remove_accounts_exn t
 
     let merkle_path_at_index_exn (T ((module Base), t)) =

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -74,6 +74,4 @@ module type S = sig
   val merkle_path_at_index_exn : t -> int -> Path.t
 
   val remove_accounts_exn : t -> key list -> unit
-
-  val copy : t -> t
 end

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -9,8 +9,7 @@ end)
 (Hash : Intf.Hash with type account := Account.t)
 (Depth : Intf.Depth)
 (Location : Location_intf.S)
-(Kvdb : Intf.Key_value_database)
-(Storage_locations : Intf.Storage_locations) :
+(Kvdb : Intf.Key_value_database) :
   Database_intf.S
   with module Location = Location
    and module Addr = Location.Addr
@@ -44,8 +43,8 @@ end)
 
   let get_uuid t = t.uuid
 
-  let create () =
-    let kvdb = Kvdb.create ~directory:Storage_locations.key_value_db_dir in
+  let create ~directory =
+    let kvdb = Kvdb.create ~directory in
     {uuid= Uuid.create (); kvdb}
 
   let destroy {uuid= _; kvdb} = Kvdb.destroy kvdb
@@ -308,9 +307,6 @@ end)
   let fold_until = C.fold_until
 
   let merkle_root mdb = get_hash mdb Location.root_hash
-
-  (* for a copy, the uuid is fresh *)
-  let copy {uuid= _; kvdb} = {uuid= Uuid.create (); kvdb= Kvdb.copy kvdb}
 
   let remove_accounts_exn t keys =
     let locations =

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -3,7 +3,7 @@ open Core
 module Make (Key : sig
   include Intf.Key
 
-  val to_string : t -> string
+  val to_base64 : t -> string
 end)
 (Account : Intf.Account with type key := Key.t)
 (Hash : Intf.Hash with type account := Account.t)
@@ -135,7 +135,7 @@ end)
       get_raw mdb location
 
     let build_location key =
-      Location.build_generic (Bigstring.of_string ("$" ^ Key.to_string key))
+      Location.build_generic (Bigstring.of_string ("$" ^ Key.to_base64 key))
 
     let get mdb key =
       match get_generic mdb (build_location key) with

--- a/src/lib/merkle_ledger/database_intf.ml
+++ b/src/lib/merkle_ledger/database_intf.ml
@@ -1,7 +1,7 @@
 module type S = sig
   include Base_ledger_intf.S
 
-  val create : unit -> t
+  val create : directory:string -> t
 
   module For_tests : sig
     val gen_account_location : Location.t Core.Quickcheck.Generator.t

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -43,8 +43,6 @@ end
 module type Key_value_database = sig
   type t
 
-  val copy : t -> t
-
   val create : directory:string -> t
 
   val get_uuid : t -> Uuid.t

--- a/src/lib/merkle_ledger/ledger_extras_intf.ml
+++ b/src/lib/merkle_ledger/ledger_extras_intf.ml
@@ -10,4 +10,8 @@ module type S = sig
   val key_of_index_exn : t -> index -> key
 
   val recompute_tree : t -> unit
+
+  val create : unit -> t
+
+  val copy : t -> t
 end

--- a/src/lib/merkle_ledger_tests/jbuild
+++ b/src/lib/merkle_ledger_tests/jbuild
@@ -6,6 +6,6 @@
   (flags (:standard -short-paths -warn-error -6-33-27-9-58))
   (library_flags (-linkall))
   (inline_tests)
-  (libraries (core merkle_ledger merkle_mask signature_lib extlib))
+  (libraries (core coda_base merkle_ledger merkle_mask signature_lib extlib))
   (preprocess (pps (ppx_jane ppx_deriving.eq ppx_deriving.show)))
   (synopsis "Testing account databases")))

--- a/src/lib/merkle_ledger_tests/test.ml
+++ b/src/lib/merkle_ledger_tests/test.ml
@@ -12,7 +12,6 @@ let%test_module "Database integration test" =
     module Location = Merkle_ledger.Location.Make (Depth)
     module DB =
       Database.Make (Key) (Account) (Hash) (Depth) (Location) (In_memory_kvdb)
-        (Storage_locations)
     module Ledger = Ledger.Make (Key) (Account) (Hash) (Depth)
     module Binary_tree = Binary_tree.Make (Account) (Hash) (Depth)
 
@@ -69,7 +68,9 @@ let%test_module "Database integration test" =
           let accounts =
             List.map2_exn public_keys balances ~f:Account.create
           in
-          let db = DB.create () in
+          let db =
+            DB.create ~directory:Filename.(temp_dir "coda-test-db" "")
+          in
           let ledger = Ledger.create () in
           let enumerate_dir_combinations max_depth =
             Sequence.range 0 (max_depth - 1)

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -426,7 +426,6 @@ let%test_module "Test mask connected to underlying Merkle tree" =
          and type key := Key.t =
         Database.Make (Key) (Account) (Hash) (Depth) (Location)
           (In_memory_kvdb)
-          (Storage_locations)
 
       module Any_base =
         Merkle_ledger.Any_ledger.Make_base (Key) (Account) (Hash) (Location)
@@ -465,9 +464,11 @@ let%test_module "Test mask connected to underlying Merkle tree" =
           (Base)
           (Mask)
 
+      let tmp_dir () = Filename.(temp_dir "coda-db-test" "")
+
       (* test runner *)
       let with_instances f =
-        let db = Base_db.create () in
+        let db = Base_db.create ~directory:(tmp_dir ()) in
         let maskable = Any_base.T ((module Base_db), db) in
         let mask = Mask.create () in
         f maskable mask

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -142,6 +142,7 @@ module Key = struct
   let empty = Account.empty.public_key
 
   let to_string = Format.sprintf !"%{sexp: T.t}"
+  let to_base64 = to_string
 
   let gen_keys num_keys =
     (* TODO : the Quickcheck generator for Public_key.Compressed produces duplicates

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -122,9 +122,6 @@ module In_memory_kvdb : Intf.Key_value_database = struct
     List.iter key_data_pairs ~f:(fun (key, data) -> set tbl ~key ~data)
 
   let delete t ~key = Bigstring_frozen.Table.remove t.table key
-
-  let copy (t : t) =
-    {uuid= Uuid.create (); table= Bigstring_frozen.Table.copy t.table}
 end
 
 module Storage_locations : Intf.Storage_locations = struct
@@ -142,6 +139,7 @@ module Key = struct
   let empty = Account.empty.public_key
 
   let to_string = Format.sprintf !"%{sexp: T.t}"
+
   let to_base64 = to_string
 
   let gen_keys num_keys =

--- a/src/lib/merkle_mask/jbuild
+++ b/src/lib/merkle_mask/jbuild
@@ -5,6 +5,6 @@
   (public_name merkle_mask)
   (flags (:standard -short-paths -warn-error -6-33-27-9-58))
   (library_flags (-linkall))
-  (libraries (core bitstring integers extlib immutable_array dyn_array coda_base merkle_ledger merkle_address))
+  (libraries (core bitstring integers extlib immutable_array dyn_array merkle_ledger merkle_address))
   (preprocess (pps (ppx_jane ppx_deriving.eq ppx_deriving.show)))
   (synopsis "Implementation of Merkle tree masks")))

--- a/src/lib/precomputed_values/gen_values/jbuild
+++ b/src/lib/precomputed_values/gen_values/jbuild
@@ -16,6 +16,7 @@
       ledger_builder
       global_signer_private_key
     ))
+   (link_flags (-cclib -lrocksdb))
    (preprocessor_deps ("../../../config.mlh"))
    (preprocess (pps (ppx_jane ppxlib.metaquot ppxlib.runner)))
    (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61))

--- a/src/lib/rocksdb_database/jbuild
+++ b/src/lib/rocksdb_database/jbuild
@@ -5,5 +5,6 @@
   (public_name rocksdb_database)
   (flags (:standard -short-paths -warn-error -58))
   (library_flags (-linkall))
+  (c_library_flags (-lrocksdb))
   (libraries (core rocks))
   (synopsis "RocksDB Database module")))

--- a/src/lib/rocksdb_database/rocksdb_database.ml
+++ b/src/lib/rocksdb_database/rocksdb_database.ml
@@ -2,27 +2,34 @@
 
 open Core
 
-type t = Rocks.t
+type t = {rocks: Rocks.t; uuid: Uuid.t}
 
 let create ~directory =
   let opts = Rocks.Options.create () in
   Rocks.Options.set_create_if_missing opts true ;
-  Rocks.open_db ~opts directory
+  {rocks= Rocks.open_db ~opts directory; uuid= Uuid.create ()}
 
-let destroy = Rocks.close
+let destroy t = Rocks.close t.rocks
 
-let get = Rocks.get ?pos:None ?len:None ?opts:None
+let get t ~(key : Bigstring.t_frozen) : Bigstring.t_frozen option =
+  Rocks.get ?pos:None ?len:None ?opts:None t.rocks (Obj.magic key)
+  (* TODO: Fix *)
+  |> Obj.magic
 
-let set =
+let get_uuid t = t.uuid
+
+let set t ~(key : Bigstring.t_frozen) ~(data : Bigstring.t_frozen) : unit =
   Rocks.put ?key_pos:None ?key_len:None ?value_pos:None ?value_len:None
-    ?opts:None
+    ?opts:None t.rocks (Obj.magic key) (Obj.magic data)
 
-let set_batch t ~key_data_pairs =
+let set_batch t
+    ~(key_data_pairs : (Bigstring.t_frozen * Bigstring.t_frozen) list) =
   let batch = Rocks.WriteBatch.create () in
   (* write to batch *)
   List.iter key_data_pairs ~f:(fun (key, data) ->
-      Rocks.WriteBatch.put batch key data ) ;
+      Rocks.WriteBatch.put batch (Obj.magic key) (Obj.magic data) ) ;
   (* commit batch *)
-  Rocks.write t batch
+  Rocks.write t.rocks batch
 
-let delete = Rocks.delete ?pos:None ?len:None ?opts:None
+let delete t ~(key : Bigstring.t_frozen) =
+  Rocks.delete ?pos:None ?len:None ?opts:None t.rocks (Obj.magic key)

--- a/src/lib/snark_keys/gen_keys/jbuild
+++ b/src/lib/snark_keys/gen_keys/jbuild
@@ -14,6 +14,7 @@
       core
       ledger_builder
     ))
+   (link_flags (-cclib -lrocksdb))
    (preprocessor_deps ("../../../config.mlh"))
    (preprocess (pps (ppx_jane ppxlib.metaquot ppxlib.runner)))
    (flags (-w -40 -g -warn-error +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61))

--- a/src/lib/syncable_ledger/test_db.ml
+++ b/src/lib/syncable_ledger/test_db.ml
@@ -25,7 +25,6 @@ struct
     module MT =
       Merkle_ledger.Database.Make (Key) (Account) (Hash) (Depth) (Location)
         (In_memory_kvdb)
-        (Storage_locations)
     module Addr = MT.Addr
 
     type root_hash = Hash.t
@@ -61,7 +60,9 @@ struct
     let make_space_for = MT.make_space_for
 
     let load_ledger num_accounts (balance : int) =
-      let ledger = MT.create () in
+      let ledger =
+        MT.create ~directory:Filename.(temp_dir "coda-test-db" "")
+      in
       let keys = Key.gen_keys num_accounts in
       let currency_balance = Currency.Balance.of_int balance in
       List.iter keys ~f:(fun key ->

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1307,7 +1307,9 @@ let%test_module "transaction_snark" =
     let%test_unit "new_account" =
       Test_util.with_randomness 123456789 (fun () ->
           let wallets = random_wallets () in
-          let ledger = Ledger.create () in
+          let ledger =
+            Ledger.create ~directory:(Filename.temp_dir "coda-test-db" "")
+          in
           Array.iter
             (Array.sub wallets ~pos:1 ~len:(Array.length wallets - 1))
             ~f:(fun {account; private_key= _} ->
@@ -1340,7 +1342,9 @@ let%test_module "transaction_snark" =
     let%test "base_and_merge" =
       Test_util.with_randomness 123456789 (fun () ->
           let wallets = random_wallets () in
-          let ledger = Ledger.create () in
+          let ledger =
+            Ledger.create ~directory:(Filename.temp_dir "coda-test-db" "")
+          in
           Array.iter wallets ~f:(fun {account; private_key= _} ->
               Ledger.create_new_account_exn ledger account.public_key account
           ) ;

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -132,7 +132,7 @@ module type Proof_intf = sig
 end
 
 module type Ledger_intf = sig
-  type t [@@deriving sexp, bin_io]
+  type t
 
   type transaction
 
@@ -481,7 +481,7 @@ module type Ledger_builder_transition_intf = sig
 end
 
 module type Ledger_builder_base_intf = sig
-  type t [@@deriving sexp, bin_io]
+  type t [@@deriving sexp]
 
   type diff
 
@@ -629,7 +629,7 @@ module type Tip_intf = sig
     { protocol_state: protocol_state
     ; proof: protocol_state_proof
     ; ledger_builder: ledger_builder }
-  [@@deriving sexp, bin_io, fields]
+  [@@deriving sexp, fields]
 
   val of_transition_and_lb : external_transition -> ledger_builder -> t
 


### PR DESCRIPTION
Use the DB ledger instead of the in-memory ledger throughout the codebase. This is the first step towards swapping in the masked ledger in ledger-builder (soon to be "staged-ledger")

There is a question of whether this is even a good approach to integrating the mask things. I'm down with throwing this away if we can come up with a better approach. I tried a few things and this seemed to be the leaf of a dependency graph of hellish tasks toward integrating the mask things.

As a side-effect, I'm intentionally breaking the "tip-saving" feature in the existing ledger-builder-controller. As we're rewriting that code anyway, it shouldn't be a huge problem.

I think tests will need some massaging to pass now that the ledger is a DB one.