### PR TITLE
Add a stop-daemon command

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -110,6 +110,17 @@ module Args = struct
     return (fun a b c d -> (a, b, c, d)) <*> arg1 <*> arg2 <*> arg3 <*> arg4
 end
 
+let stop_daemon =
+  let open Deferred.Let_syntax in
+  let open Client_lib in
+  let open Command.Param in
+  Command.async ~summary:"Stop the daemon"
+    (Daemon_cli.init (return ()) ~f:(fun port () ->
+         match%map dispatch Stop_daemon.rpc () port with
+         | Ok () -> printf "Daemon stopping\n"
+         | Error e ->
+             printf "Daemon likely stopped: %s\n" (Error.to_string_hum e) ))
+
 let get_balance =
   let open Command.Param in
   let open Deferred.Let_syntax in
@@ -494,6 +505,7 @@ let command =
     ; ("prove-payment", prove_payment)
     ; ("get-nonce", get_nonce_cmd)
     ; ("send-payment", send_payment)
+    ; ("stop-daemon", stop_daemon)
     ; ("batch-send-payments", batch_send_payments)
     ; ("status", status)
     ; ("status-clear-hist", status_clear_hist)

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1215,7 +1215,9 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
       ; Rpc.Rpc.implement Client_lib.Clear_hist_status.rpc (fun () () ->
             return (clear_hist_status coda) )
       ; Rpc.Rpc.implement Client_lib.Get_ledger.rpc (fun () lh ->
-            get_ledger coda lh ) ]
+            get_ledger coda lh )
+      ; Rpc.Rpc.implement Client_lib.Stop_daemon.rpc (fun () () ->
+            Shutdown.exit 0 ) ]
     in
     let snark_worker_impls =
       [ Rpc.Rpc.implement Snark_worker.Rpcs.Get_work.rpc (fun () () ->

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1217,7 +1217,8 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
       ; Rpc.Rpc.implement Client_lib.Get_ledger.rpc (fun () lh ->
             get_ledger coda lh )
       ; Rpc.Rpc.implement Client_lib.Stop_daemon.rpc (fun () () ->
-            Shutdown.exit 0 ) ]
+            Scheduler.yield () >>= (fun () -> exit 0) |> don't_wait_for ;
+            Deferred.unit ) ]
     in
     let snark_worker_impls =
       [ Rpc.Rpc.implement Snark_worker.Rpcs.Get_work.rpc (fun () () ->

--- a/src/lib/client_lib/client_lib.ml
+++ b/src/lib/client_lib/client_lib.ml
@@ -292,4 +292,15 @@ module Get_public_keys = struct
     Rpc.Rpc.create ~name:"Get_public_keys" ~version:0 ~bin_query ~bin_response
 end
 
+module Stop_daemon = struct
+  type query = unit [@@deriving bin_io]
+
+  type response = unit [@@deriving bin_io]
+
+  type error = unit
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Stop_daemon" ~version:0 ~bin_query ~bin_response
+end
+
 module Git_sha = Git_sha


### PR DESCRIPTION
Adds a basic RPC for stopping the daemon approximately graceful.

Tested by spinning up a daemon and then running `coda client stop-daemon` and watching the daemon process die.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Does this close issues? List them:

Closes #673

