### PR TITLE
Fix failing signature check in testnets

### DIFF
--- a/src/config/testnet_posig.mlh
+++ b/src/config/testnet_posig.mlh
@@ -4,6 +4,6 @@
 [%%define debug_logs true]
 [%%define call_logger false]
 [%%define force_updates false]
-[%%define global_signer_real true]
+[%%define global_signer_real false]
 [%%define tracing false]
 [%%define consensus_mechanism "proof_of_signature"]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -4,6 +4,6 @@
 [%%define debug_logs true]
 [%%define call_logger false]
 [%%define force_updates false]
-[%%define global_signer_real true]
+[%%define global_signer_real false]
 [%%define tracing false]
 [%%define consensus_mechanism "proof_of_stake"]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -4,6 +4,6 @@
 [%%define debug_logs true]
 [%%define call_logger false]
 [%%define force_updates true]
-[%%define global_signer_real true]
+[%%define global_signer_real false]
 [%%define tracing false]
 [%%define consensus_mechanism "proof_of_signature"]

--- a/src/lib/genesis_ledger/testnet_posig_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_posig_ledger.ml
@@ -25,5 +25,7 @@ include Make (struct
       ; 1_000 ]
     in
     List.mapi balances ~f:(fun i b ->
-      {balance= b; pk= fst Coda_base.Sample_keypairs.keypairs.(i); sk = snd Coda_base.Sample_keypairs.keypairs.(i)} )
+        { balance= b
+        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
+        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
 end)

--- a/src/lib/genesis_ledger/testnet_posig_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_posig_ledger.ml
@@ -1,4 +1,4 @@
-open Functor.Without_private
+open Functor.With_private
 open Core
 
 (* TODO: generate new keypairs before public testnet *)
@@ -25,5 +25,5 @@ include Make (struct
       ; 1_000 ]
     in
     List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst Coda_base.Sample_keypairs.keypairs.(i)} )
+      {balance= b; pk= fst Coda_base.Sample_keypairs.keypairs.(i); sk = snd Coda_base.Sample_keypairs.keypairs.(i)} )
 end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -1,4 +1,4 @@
-open Functor.Without_private
+open Functor.With_private
 open Core
 
 (* TODO: generate new keypairs before public testnet *)
@@ -25,5 +25,5 @@ include Make (struct
       ; 1_000 ]
     in
     List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst Coda_base.Sample_keypairs.keypairs.(i)} )
+      {balance= b; pk= fst Coda_base.Sample_keypairs.keypairs.(i); sk= snd Coda_base.Sample_keypairs.keypairs.(i)} )
 end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -25,5 +25,7 @@ include Make (struct
       ; 1_000 ]
     in
     List.mapi balances ~f:(fun i b ->
-      {balance= b; pk= fst Coda_base.Sample_keypairs.keypairs.(i); sk= snd Coda_base.Sample_keypairs.keypairs.(i)} )
+        { balance= b
+        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
+        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
 end)


### PR DESCRIPTION
Since we auto-generate keypairs anyway in SampleKeypairs and we're using
these to seed all our genesis ledgers, there's no point hiding behind a
global_signer_private_key.ml file.

For now, global_signer_real is set to false on all profiles, and we use
the secret-key exposing genesis ledgers everywhere.

I didn't test the changes manually, but seeing as this goes through the same code-path now as the working genesis ledgers, we should be good.