### PR TITLE
Fix bad copy comment

### DIFF
--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -47,7 +47,7 @@ module type S = sig
     (** called when parent sets an account; update local state *)
 
     val copy : t -> t
-    (* makes new mask instance with empty tables, re-use parent *)
+    (* makes new mask instance with copied tables, re-use parent *)
 
     (** already have module For_testing from include above *)
     module For_testing : sig


### PR DESCRIPTION
Noticed an inaccurate comment in #1225. Corrected here.

- [ ] Tests were added for the new behavior: No
- [ ] All tests pass: just a comment change
- [ ] Does this close issues? No.
