### PR TITLE
use vrf eval as a tie breaker

### DIFF
--- a/src/lib/coda_base/user_command_memo.ml
+++ b/src/lib/coda_base/user_command_memo.ml
@@ -7,7 +7,7 @@ let max_size_in_bytes = 1000
 
 let create_exn s =
   let max_size = 1000 in
-  if String.length s > max_size_in_bytes then
+  if Int.(String.length s > max_size_in_bytes) then
     failwithf !"Memo data too long. Max size = %d" max_size ()
   else Sha256.digest_string s
 


### PR DESCRIPTION
This PR closes https://github.com/CodaProtocol/coda/issues/1127. It uses the last VRF evaluation as a tie breaker when choosing between equal-length chains.