### PR TITLE
add command for printing out constraint system digests

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -410,6 +410,20 @@ let dump_ledger =
          | Ok (Error e) -> printf !"Ledger not found: %{sexp:Error.t}\n" e
          | Ok (Ok accounts) -> printf !"%{sexp:Account.t list}\n" accounts ))
 
+let constraint_system_digests =
+  Command.async ~summary:"Print the md5 digest of each SNARK constraint system"
+    (Command.Param.return (fun () ->
+         let all =
+           Transaction_snark.constraint_system_digests ()
+           @ Blockchain_snark.Blockchain_transition.constraint_system_digests
+               ()
+         in
+         let all =
+           List.sort (fun (k1, _) (k2, _) -> String.compare k1 k2) all
+         in
+         List.iter all ~f:(fun (k, v) -> printf "%s\t%s\n" k (Md5.to_hex v)) ;
+         Deferred.unit ))
+
 let command =
   Command.group ~summary:"Lightweight client process"
     [ ("get-balance", get_balance)
@@ -424,4 +438,5 @@ let command =
     ; ("wrap-key", wrap_key)
     ; ("dump-keypair", dump_keypair)
     ; ("dump-ledger", dump_ledger)
+    ; ("constraint-system-digests", constraint_system_digests)
     ; ("generate-keypair", generate_keypair) ]

--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -260,3 +260,21 @@ struct
       (location, t, checksum)
   end
 end
+
+let constraint_system_digests () =
+  let module M =
+    Make
+      (Consensus.Mechanism)
+      (Transaction_snark.Verification.Make (struct
+        let keys = Transaction_snark.Keys.Verification.dummy
+      end))
+  in
+  let module W = M.Wrap_base (struct
+    let verification_key = Dummy_values.Tick.verification_key
+  end) in
+  let digest = Tick.R1CS_constraint_system.digest in
+  let digest' = Tock.R1CS_constraint_system.digest in
+  [ ( "blockchain-step"
+    , digest M.Step_base.(Tick.constraint_system ~exposing:(input ()) main) )
+  ; ("blockchain-wrap", digest' W.(Tock.constraint_system ~exposing:input main))
+  ]

--- a/src/lib/snarky/src/jbuild
+++ b/src/lib/snarky/src/jbuild
@@ -5,7 +5,7 @@
   (public_name snarky)
   (flags (:standard -short-paths -safe-string -warn-error -27-32-9-33-39-6-34))
   (inline_tests)
-  (libraries (core_kernel fold_lib tuple_lib bitstring_lib interval_union bignum camlsnark_c coda_debug))
+  (libraries (core_kernel o1trace fold_lib tuple_lib bitstring_lib interval_union bignum camlsnark_c coda_debug))
   (c_library_flags (:standard -lstdc++ -lpthread))
   (cxx_flags
     (

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1415,3 +1415,18 @@ let%test_module "transaction_snark" =
                   ~supply_increase:Amount.zero ~fee_excess:total_fees
                   wrap_vk_bits)) )
   end )
+
+let constraint_system_digests () =
+  let module W = Wrap (struct
+    let merge = Dummy_values.Tick.verification_key
+
+    let base = Dummy_values.Tick.verification_key
+  end) in
+  let digest = Tick.R1CS_constraint_system.digest in
+  let digest' = Tock.R1CS_constraint_system.digest in
+  [ ( "transaction-merge"
+    , digest Merge.(Tick.constraint_system ~exposing:(input ()) main) )
+  ; ( "transaction-base"
+    , digest Base.(Tick.constraint_system ~exposing:(tick_input ()) main) )
+  ; ( "transaction-wrap"
+    , digest' W.(Tock.constraint_system ~exposing:wrap_input main) ) ]

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -159,3 +159,5 @@ end
 module Make (K : sig
   val keys : Keys.t
 end) : S
+
+val constraint_system_digests : unit -> (string * Md5.t) list


### PR DESCRIPTION
This is step 1 of more robust SNARK key handling.

Tested by running `coda client constraint-system-digests` and noting the output.