### PR TITLE
Fix/revert frontier hash stuff

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -785,12 +785,6 @@ struct
     include Ledger_builder_controller.Make (Inputs)
   end
 
-  module Transition_frontier = struct
-    type t
-
-    let root_successor _ = failwith "TODO"
-  end
-
   module Proposer = Proposer.Make (struct
     include Inputs0
     module Ledger_builder_diff = Ledger_builder_diff
@@ -807,7 +801,6 @@ struct
     module Keypair = Keypair
     module Compressed_public_key = Public_key.Compressed
     module Consensus_mechanism = Consensus.Mechanism
-    module Transition_frontier = Transition_frontier
 
     module Prover = struct
       let prove ~prev_state ~prev_state_proof ~next_state

--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -11,7 +11,6 @@ module type S = sig
        protocol_state:Protocol_state.value
     -> protocol_state_proof:Proof.t
     -> ledger_builder_diff:Ledger_builder_diff.t
-    -> transition_frontier_root_hash:State_hash.t
     -> t
 
   val protocol_state : t -> Protocol_state.value
@@ -19,8 +18,6 @@ module type S = sig
   val protocol_state_proof : t -> Proof.t
 
   val ledger_builder_diff : t -> Ledger_builder_diff.t
-
-  val transition_frontier_root_hash : t -> State_hash.t
 
   val timestamp : t -> Block_time.t
 end
@@ -39,8 +36,7 @@ end)
   type t =
     { protocol_state: Protocol_state.value
     ; protocol_state_proof: Proof.Stable.V1.t
-    ; ledger_builder_diff: Ledger_builder_diff.t
-    ; transition_frontier_root_hash: State_hash.t }
+    ; ledger_builder_diff: Ledger_builder_diff.t }
   [@@deriving sexp, fields, bin_io]
 
   (* TODO: Important for bkase to review *)
@@ -50,12 +46,8 @@ end)
   let equal t1 t2 =
     Protocol_state.equal_value t1.protocol_state t2.protocol_state
 
-  let create ~protocol_state ~protocol_state_proof ~ledger_builder_diff
-      ~transition_frontier_root_hash =
-    { protocol_state
-    ; protocol_state_proof
-    ; ledger_builder_diff
-    ; transition_frontier_root_hash }
+  let create ~protocol_state ~protocol_state_proof ~ledger_builder_diff =
+    {protocol_state; protocol_state_proof; ledger_builder_diff}
 
   let timestamp {protocol_state; _} =
     Protocol_state.blockchain_state protocol_state

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -251,8 +251,6 @@ module type Proposer_intf = sig
 
   type keypair
 
-  type transition_frontier
-
   module Tip : sig
     type t =
       { protocol_state: protocol_state * protocol_state_proof
@@ -270,7 +268,6 @@ module type Proposer_intf = sig
     -> time_controller:time_controller
     -> keypair:keypair
     -> consensus_local_state:consensus_local_state
-    -> transition_frontier:transition_frontier
     -> (external_transition * Unix_timestamp.t) Linear_pipe.Reader.t
 end
 
@@ -391,10 +388,6 @@ module type Inputs_intf = sig
      and type public_key_compressed := Public_key.Compressed.t
      and type maskable_ledger := Ledger.maskable_ledger
 
-  module Transition_frontier : sig
-    type t
-  end
-
   module Proposer :
     Proposer_intf
     with type ledger_hash := Ledger_hash.t
@@ -408,7 +401,6 @@ module type Inputs_intf = sig
      and type external_transition := External_transition.t
      and type time_controller := Time.Controller.t
      and type keypair := Keypair.t
-     and type transition_frontier := Transition_frontier.t
 
   module Genesis : sig
     val state : Consensus_mechanism.Protocol_state.value
@@ -632,7 +624,6 @@ module Make (Inputs : Inputs_intf) = struct
                 ~get_completed_work:(Snark_pool.get_completed_work snark_pool)
                 ~time_controller:config.time_controller ~keypair
                 ~consensus_local_state
-                ~transition_frontier:(failwith "to be wired in")
             in
             don't_wait_for
               (Linear_pipe.transfer_id transitions external_transitions_writer)

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -6,12 +6,6 @@ open O1trace
 module type Inputs_intf = sig
   include Protocols.Coda_pow.Inputs_intf
 
-  module Transition_frontier : sig
-    type t
-
-    val root_successor : t -> Protocol_state_hash.t -> Protocol_state_hash.t
-  end
-
   module Prover : sig
     val prove :
          prev_state:Consensus_mechanism.Protocol_state.value
@@ -100,8 +94,7 @@ module Make (Inputs : Inputs_intf) :
    and type completed_work_statement := Inputs.Completed_work.Statement.t
    and type completed_work_checked := Inputs.Completed_work.Checked.t
    and type time_controller := Inputs.Time.Controller.t
-   and type keypair := Inputs.Keypair.t
-   and type transition_frontier := Inputs.Transition_frontier.t = struct
+   and type keypair := Inputs.Keypair.t = struct
   open Inputs
   open Consensus_mechanism
 
@@ -240,7 +233,7 @@ module Make (Inputs : Inputs_intf) :
   let transition_capacity = 64
 
   let create ~parent_log ~get_completed_work ~change_feeder:tip_reader
-      ~time_controller ~keypair ~consensus_local_state ~transition_frontier =
+      ~time_controller ~keypair ~consensus_local_state =
     trace_task "proposer" (fun () ->
         let logger = Logger.child parent_log "proposer" in
         let transition_reader, transition_writer = Linear_pipe.create () in
@@ -293,11 +286,6 @@ module Make (Inputs : Inputs_intf) :
                              ~ledger_builder_diff:
                                (Internal_transition.ledger_builder_diff
                                   internal_transition)
-                             ~transition_frontier_root_hash:
-                               (Transition_frontier.root_successor
-                                  transition_frontier
-                                  (Protocol_state.previous_state_hash
-                                     protocol_state))
                          in
                          let time =
                            Time.now time_controller |> Time.to_span_since_epoch

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -791,22 +791,17 @@ module type External_transition_intf = sig
 
   type ledger_builder_diff
 
-  type state_hash
-
   type t [@@deriving sexp]
 
   val create :
        protocol_state:protocol_state
     -> protocol_state_proof:protocol_state_proof
     -> ledger_builder_diff:ledger_builder_diff
-    -> transition_frontier_root_hash:state_hash
     -> t
 
   val protocol_state : t -> protocol_state
 
   val protocol_state_proof : t -> protocol_state_proof
-
-  val transition_frontier_root_hash : t -> state_hash
 
   val ledger_builder_diff : t -> ledger_builder_diff
 end
@@ -1180,7 +1175,6 @@ Merge Snark:
     with type protocol_state := Consensus_mechanism.Protocol_state.value
      and type ledger_builder_diff := Ledger_builder_diff.t
      and type protocol_state_proof := Protocol_state_proof.t
-     and type state_hash := Protocol_state_hash.t
 
   module Tip :
     Tip_intf

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -13,12 +13,6 @@ module type Transition_frontier_intf = sig
 
   type staged_ledger
 
-  type protocol_state
-
-  type protocol_state_proof
-
-  type ledger_builder_diff
-
   exception
     Parent_not_found of ([`Parent of state_hash] * [`Target of state_hash])
 
@@ -66,8 +60,6 @@ module type Transition_frontier_intf = sig
 
   val add_exn :
     t -> (external_transition, state_hash) With_hash.t -> Breadcrumb.t
-
-  val root_successor : t -> state_hash -> state_hash
 end
 
 module type Catchup_intf = sig


### PR DESCRIPTION
This reverts the work related to the frontier hash being in external transition because we thought of another better way to accomplish the same thing.