### PR TITLE
Feature/protocol state hash separation

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1109,12 +1109,14 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
               Lite_compat.digest
                 ( Consensus.Mechanism.Protocol_state.previous_state_hash state
                   :> Snark_params.Tick.Pedersen.Digest.t )
-          ; blockchain_state=
-              Lite_compat.blockchain_state
-                (Consensus.Mechanism.Protocol_state.blockchain_state state)
-          ; consensus_state=
-              consensus_state_to_lite
-                (Consensus.Mechanism.Protocol_state.consensus_state state) }
+          ; body=
+              { blockchain_state=
+                  Lite_compat.blockchain_state
+                    (Consensus.Mechanism.Protocol_state.blockchain_state state)
+              ; consensus_state=
+                  consensus_state_to_lite
+                    (Consensus.Mechanism.Protocol_state.consensus_state state)
+              } }
         in
         let proof = Lite_compat.proof proof in
         {Lite_base.Lite_chain.proof; ledger; protocol_state} )

--- a/src/app/lite/main.ml
+++ b/src/app/lite/main.ml
@@ -106,7 +106,7 @@ module State = struct
     ; tooltip_stage= None }
 
   let chain_length chain =
-    chain.Lite_chain.protocol_state.consensus_state.length
+    chain.Lite_chain.protocol_state.body.consensus_state.length
 
   let should_update state (new_chain : Lite_chain.t) =
     Length.compare (chain_length new_chain) (chain_length state.chain) > 0
@@ -545,8 +545,8 @@ let merkle_tree num_layers_to_show =
         match List.last_exn specs with
         | Spec.Node _ -> None
         | Spec.Account
-            {pos= _; account= {public_key; balance; nonce; receipt_chain_hash}}
-          ->
+            { pos= _
+            ; account= {public_key; balance; nonce; receipt_chain_hash; _} } ->
             let record =
               let open Html.Record in
               create None
@@ -709,7 +709,7 @@ let state_html state =
       ; tooltip_stage= _
       ; chain=
           { protocol_state=
-              {previous_state_hash; blockchain_state; consensus_state}
+              {previous_state_hash; body= {blockchain_state; consensus_state}}
           ; ledger
           ; proof } } =
     state

--- a/src/app/lite/verifier_main.ml
+++ b/src/app/lite/verifier_main.ml
@@ -12,9 +12,15 @@ let state_and_instance_hash ~wrap_vk =
       (Proof_system.Verification_key.fold wrap_vk)
   in
   let hash_state s =
+    let fold_body b =
+      Pedersen.digest_fold
+        (salt Hash_prefixes.protocol_state_body)
+        (Lite_base.Protocol_state.Body.fold b)
+      |> Lite_base.Pedersen.Digest.fold
+    in
     Pedersen.digest_fold
       (salt Hash_prefixes.protocol_state)
-      (Lite_base.Protocol_state.fold s)
+      (Lite_base.Protocol_state.fold ~fold_body s)
   in
   stage (fun state ->
       let state_hash = hash_state state in
@@ -32,7 +38,7 @@ let verify_chain pvk state_and_instance_hash
   let check b lab = if b then Ok () else Or_error.error_string lab in
   let open Or_error.Let_syntax in
   let lb_ledger_hash =
-    protocol_state.blockchain_state.ledger_builder_hash.ledger_hash
+    protocol_state.body.blockchain_state.ledger_builder_hash.ledger_hash
   in
   let%bind () =
     check

--- a/src/lib/coda_base/hash_prefix.ml
+++ b/src/lib/coda_base/hash_prefix.ml
@@ -7,6 +7,8 @@ let salt (s : t) = Snark_params.Tick.Pedersen.(State.salt params (s :> string))
 
 let protocol_state = salt protocol_state
 
+let protocol_state_body = salt protocol_state_body
+
 let account = salt account
 
 let merkle_tree =

--- a/src/lib/coda_base/hash_prefix.mli
+++ b/src/lib/coda_base/hash_prefix.mli
@@ -4,6 +4,8 @@ val length_in_triples : int
 
 val protocol_state : Tick.Pedersen.State.t
 
+val protocol_state_body : Tick.Pedersen.State.t
+
 val signature : Tick.Pedersen.State.t
 
 val account : Tick.Pedersen.State.t

--- a/src/lib/coda_base/state_body_hash.ml
+++ b/src/lib/coda_base/state_body_hash.ml
@@ -1,0 +1,1 @@
+include Data_hash.Make_full_size ()

--- a/src/lib/coda_base/state_body_hash.mli
+++ b/src/lib/coda_base/state_body_hash.mli
@@ -1,0 +1,1 @@
+include Data_hash.Full_size

--- a/src/lib/hash_prefixes/hash_prefixes.ml
+++ b/src/lib/hash_prefixes/hash_prefixes.ml
@@ -24,6 +24,8 @@ include T
 
 let protocol_state = create "CodaProtoState"
 
+let protocol_state_body = create "CodaProtoStateBody"
+
 let account = create "CodaAccount"
 
 let merkle_tree i = create (Printf.sprintf "CodaMklTree%03d" i)

--- a/src/lib/lite_base/protocol_state.ml
+++ b/src/lib/lite_base/protocol_state.ml
@@ -1,13 +1,19 @@
 open Fold_lib
 
-type t =
-  { previous_state_hash: Pedersen.Digest.t
-  ; blockchain_state: Blockchain_state.t
-  ; consensus_state: Consensus_state.t }
+module Body = struct
+  type t =
+    {blockchain_state: Blockchain_state.t; consensus_state: Consensus_state.t}
+  [@@deriving eq, bin_io, sexp]
+
+  let fold {blockchain_state; consensus_state} =
+    let open Fold in
+    Blockchain_state.fold blockchain_state
+    +> Consensus_state.fold consensus_state
+end
+
+type t = {previous_state_hash: Pedersen.Digest.t; body: Body.t}
 [@@deriving eq, bin_io, sexp]
 
-let fold {previous_state_hash; blockchain_state; consensus_state} =
+let fold ~fold_body {previous_state_hash; body} =
   let open Fold in
-  State_hash.fold previous_state_hash
-  +> Blockchain_state.fold blockchain_state
-  +> Consensus_state.fold consensus_state
+  State_hash.fold previous_state_hash +> fold_body body

--- a/src/lib/lite_params/gen/gen.ml
+++ b/src/lib/lite_params/gen/gen.ml
@@ -92,10 +92,11 @@ let protocol_state (s : Proof_of_signature.Protocol_state.value) :
       Lite_compat.digest
         ( Protocol_state.previous_state_hash s
           :> Snark_params.Tick.Pedersen.Digest.t )
-  ; blockchain_state=
-      Lite_compat.blockchain_state
-        (Proof_of_signature.Protocol_state.blockchain_state s)
-  ; consensus_state }
+  ; body=
+      { blockchain_state=
+          Lite_compat.blockchain_state
+            (Proof_of_signature.Protocol_state.blockchain_state s)
+      ; consensus_state } }
 
 let genesis ~loc =
   let module E = Ppxlib.Ast_builder.Make (struct
@@ -107,7 +108,7 @@ let genesis ~loc =
   in
   let ledger =
     Sparse_ledger_lib.Sparse_ledger.of_hash ~depth:0
-      protocol_state.blockchain_state.ledger_builder_hash.ledger_hash
+      protocol_state.body.blockchain_state.ledger_builder_hash.ledger_hash
   in
   let proof = Lite_compat.proof Precomputed_values.base_proof in
   let chain = {Lite_base.Lite_chain.protocol_state; ledger; proof} in


### PR DESCRIPTION
This pulls the meat of the protocol state into a sub-record (the "body") which is hashed separately so that we can give shorter ancestor proofs for protocol states.