### PR TITLE
SIMPLE: use stable keys (workaround)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,9 @@ jobs:
         - image: codaprotocol/coda:toolchain-956136e7b621813f03881a1c2ab29b9ca24b539c
         steps:
             - checkout
+	    - run:
+	        name: Download Stable Proving Keys
+		command: scripts/getkeys.sh
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet_posig make build 2>&1 | tee /tmp/buildocaml.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,9 @@ jobs:
         - image: codaprotocol/coda:toolchain-956136e7b621813f03881a1c2ab29b9ca24b539c
         steps:
             - checkout
-	    - run:
-	        name: Download Stable Proving Keys
-		command: scripts/getkeys.sh
+            - run:
+                name: Download Stable Proving Keys
+                command: scripts/getkeys.sh
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet_posig make build 2>&1 | tee /tmp/buildocaml.log

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -43,6 +43,9 @@ jobs:
         - image: codaprotocol/coda:toolchain-956136e7b621813f03881a1c2ab29b9ca24b539c
         steps:
             - checkout
+	    - run:
+	        name: Download Stable Proving Keys
+		command: scripts/getkeys.sh
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet_posig make build 2>&1 | tee /tmp/buildocaml.log

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -43,9 +43,9 @@ jobs:
         - image: codaprotocol/coda:toolchain-956136e7b621813f03881a1c2ab29b9ca24b539c
         steps:
             - checkout
-	    - run:
-	        name: Download Stable Proving Keys
-		command: scripts/getkeys.sh
+            - run:
+                name: Download Stable Proving Keys
+                command: scripts/getkeys.sh
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=testnet_posig make build 2>&1 | tee /tmp/buildocaml.log

--- a/scripts/getkeys.sh
+++ b/scripts/getkeys.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euxo pipefail
+
+if [[ $CIRCLE_BRANCH == 'master' ]]; then
+
+    # GC credentials
+    echo $JSON_GCLOUD_CREDENTIALS > google_creds.json
+    /usr/bin/gcloud auth activate-service-account --key-file=google_creds.json
+    /usr/bin/gcloud config set project $(cat google_creds.json | jq -r .project_id)
+
+    # Get cached keys
+    PINNED_KEY_COMMIT=temporary_hack
+    /usr/bin/gsutil cp gs://proving-keys-stable/keys-$PINNED_KEY_COMMIT.tar.bz2 /tmp/.
+
+    # Unpack keys
+    sudo mkdir -p /var/lib/coda
+    cd /var/lib/coda
+    sudo tar --strip-components=2 -xvf /tmp/keys-$PINNED_KEY_COMMIT.tar.bz2
+    rm /tmp/keys-$PINNED_KEY_COMMIT.tar.bz2
+fi

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -119,7 +119,8 @@ let apply_fee_transfer_exn =
   fun t transfer ->
     List.fold (Fee_transfer.to_list transfer) ~f:apply_single ~init:t
 
-let apply_coinbase_exn t ({proposer; fee_transfer} : Coinbase.t) =
+let apply_coinbase_exn t
+    ({proposer; fee_transfer; amount= coinbase_amount} : Coinbase.t) =
   let open Currency in
   let add_to_balance t pk amount =
     let idx = find_index_exn t pk in
@@ -129,13 +130,10 @@ let apply_coinbase_exn t ({proposer; fee_transfer} : Coinbase.t) =
   in
   let proposer_reward, t =
     match fee_transfer with
-    | None -> (Protocols.Coda_praos.coinbase_amount, t)
+    | None -> (coinbase_amount, t)
     | Some (receiver, fee) ->
         let fee = Amount.of_fee fee in
-        let reward =
-          Amount.sub Protocols.Coda_praos.coinbase_amount fee
-          |> Option.value_exn
-        in
+        let reward = Amount.sub coinbase_amount fee |> Option.value_exn in
         (reward, add_to_balance t receiver fee)
   in
   add_to_balance t proposer proposer_reward


### PR DESCRIPTION
Work around for non-deterministic proving/verifying keys being built for every build.

TODO: Generate a hash signature of snark codes to determine when this key set is invalid.