### PR TITLE
Remove unneeded type definition

### DIFF
--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -21,8 +21,6 @@ let%test_module "Test mask connected to underlying Merkle tree" =
          and type hash := Hash.t
          and type key := Key.t
 
-      type base = Base.t
-
       module Mask :
         Merkle_mask.Masking_merkle_tree_intf.S
         with module Addr = Location.Addr
@@ -44,11 +42,12 @@ let%test_module "Test mask connected to underlying Merkle tree" =
          and type hash := Hash.t
          and type unattached_mask := Mask.t
          and type attached_mask := Mask.Attached.t
-         and type t := base
+         and type t := Base.t
 
-      val with_instances : (base -> Mask.t -> 'a) -> 'a
+      val with_instances : (Base.t -> Mask.t -> 'a) -> 'a
 
-      val with_chain : (base -> Mask.Attached.t -> Mask.Attached.t -> 'a) -> 'a
+      val with_chain :
+        (Base.t -> Mask.Attached.t -> Mask.Attached.t -> 'a) -> 'a
       (** Here we provide a base ledger and two layers of attached masks
        * one ontop another *)
     end


### PR DESCRIPTION
> Explain your changes here.

Removed a type definition that wasn't needed.

> Explain how you tested your changes here.

`dune b` still builds without error.

Checklist:

- [ ] Tests were added for the new behavior: no
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? no
