### PR TITLE
SIMPLE: include transition_snark_profiler in regular binary

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -413,7 +413,8 @@ let coda_commands log =
   [ (Parallel.worker_command_name, Parallel.worker_command)
   ; ("internal", Command.group ~summary:"Internal commands" internal_commands)
   ; ("daemon", daemon log)
-  ; ("client", Client.command) ]
+  ; ("client", Client.command)
+  ; ("transaction-snark-profiler", Transaction_snark_profiler.command) ]
 
 [%%if
 integration_tests]


### PR DESCRIPTION
Include transition_snark_profiler in regular binaries for testing/benchmarking

```
./src/_build/default/app/cli/src/coda.exe transaction-snark-profiler
(...LOTS OF INFO...)
Total time was: 50.4734s
```
