### PR TITLE
Fix/receipt chain signature

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -107,7 +107,7 @@ let prove_payment =
     flag "address" ~doc:"PUBLICKEY Public-key address of sender"
       (required public_key)
   in
-  Command.async ~summary:"Generate a proof of a payment"
+  Command.async ~summary:"Generate a proof of a sent payment"
     (Cli_lib.Background_daemon.init (Args.zip2 receipt_hash_flag address_flag)
        ~f:(fun port (receipt_chain_hash, pk) ->
          dispatch_with_message Prove_receipt.rpc

--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -107,7 +107,7 @@ let prove_payment =
     flag "address" ~doc:"PUBLICKEY Public-key address of sender"
       (required public_key)
   in
-  Command.async ~summary:"Generate a proof of a payment as a merkle list"
+  Command.async ~summary:"Generate a proof of a payment"
     (Cli_lib.Background_daemon.init (Args.zip2 receipt_hash_flag address_flag)
        ~f:(fun port (receipt_chain_hash, pk) ->
          dispatch_with_message Prove_receipt.rpc
@@ -141,7 +141,7 @@ let verify_payment =
     flag "address" ~doc:"PUBLICKEY Public-key address of sender"
       (required public_key)
   in
-  Command.async ~summary:"Generate a proof of a payment as a merkle list"
+  Command.async ~summary:"Verify a proof of a sent payment"
     (Cli_lib.Background_daemon.init
        (Args.zip3 payment_path_flag proof_path_flag address_flag)
        ~f:(fun port (payment_path, proof_path, pk) ->

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -991,7 +991,7 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
     let open Or_error.Let_syntax in
     let%bind () = Payment_verifier.verify ~resulting_receipt proof in
     if
-      List.exists proof ~f:(fun (_, txn) ->
+      List.exists (Payment_proof.payments proof) ~f:(fun txn ->
           User_command.equal verifying_txn txn )
     then Ok ()
     else

--- a/src/app/cli/src/coda_receipt_chain_test.ml
+++ b/src/app/cli/src/coda_receipt_chain_test.ml
@@ -40,12 +40,12 @@ let main () =
       Coda_worker_testnet.Api.send_payment_with_receipt testnet 0 sender_sk
         receiver_pk send_amount fee
     in
-    let%map merkle_list =
+    let%map proof =
       Coda_worker_testnet.Api.prove_receipt testnet 0 receipt_chain_hash
         receipt_chain_hash
     in
     Receipt.Chain_hash.equal
-      (merkle_list |> List.hd_exn |> fst)
+      (Payment_proof.initial_receipt proof)
       receipt_chain_hash
   in
   assert (Option.value ~default:false result)

--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -31,10 +31,10 @@ end
 module Prove_receipt = struct
   type t = Coda_base.Payment_proof.t [@@deriving yojson]
 
-  let to_text merkle_list =
+  let to_text proof =
     sprintf
       !"Merkle List of transactions:\n%s"
-      (to_yojson merkle_list |> Yojson.Safe.pretty_to_string)
+      (to_yojson proof |> Yojson.Safe.pretty_to_string)
 end
 
 module Public_key_with_balances = struct

--- a/src/lib/coda_base/payment_proof.ml
+++ b/src/lib/coda_base/payment_proof.ml
@@ -1,42 +1,26 @@
 open Core_kernel
+open Receipt_chain_database_lib
 
-type t = (Receipt.Chain_hash.t * User_command.t) list
-[@@deriving eq, sexp, bin_io]
+module T = struct
+  type t = (Receipt.Chain_hash.t, User_command.t) Payment_proof.t
+  [@@deriving eq, sexp, bin_io, yojson]
+end
 
-include Codable.Make (struct
-  type original = t
+include T
 
-  type merkle_node =
-    {receipt_chain_hash: Receipt.Chain_hash.t; payment: User_command.t}
-  [@@deriving yojson]
+let initial_receipt = Payment_proof.initial_receipt
 
-  type standardized = merkle_node list [@@deriving yojson]
-
-  let encode =
-    List.map ~f:(fun (receipt_chain_hash, payment) ->
-        {receipt_chain_hash; payment} )
-
-  let decode =
-    List.map ~f:(fun {receipt_chain_hash; payment} ->
-        (receipt_chain_hash, payment) )
-end)
+let payments = Payment_proof.payments
 
 let gen ~keys ~max_amount ~max_fee =
   let open Quickcheck.Generator.Let_syntax in
   let%bind list_size = Int.gen_incl 0 20 in
-  let%bind initial_receipt_chain = Receipt.Chain_hash.gen in
+  let%bind initial_receipt = Receipt.Chain_hash.gen in
   let%map payments =
     Quickcheck.Generator.list_with_length list_size
       (User_command.gen ~keys ~max_amount ~max_fee)
   in
-  let hashes =
-    List.folding_map payments ~init:initial_receipt_chain
-      ~f:(fun acc_hash payment ->
-        let {User_command.payload; _} = payment in
-        let new_hash = Receipt.Chain_hash.cons payload acc_hash in
-        (new_hash, new_hash) )
-  in
-  List.zip_exn hashes payments
+  {Payment_proof.initial_receipt; payments}
 
 let gen_test =
   let keys = Array.init 2 ~f:(fun _ -> Signature_lib.Keypair.create ()) in
@@ -44,4 +28,4 @@ let gen_test =
 
 let%test_unit "json" =
   Quickcheck.test ~trials:20 gen_test ~sexp_of:sexp_of_t ~f:(fun t ->
-      assert (For_tests.check_encoding ~equal t) )
+      assert (Codable.For_tests.check_encoding (module T) ~equal t) )

--- a/src/lib/coda_base/payment_proof.mli
+++ b/src/lib/coda_base/payment_proof.mli
@@ -1,2 +1,8 @@
-type t = (Receipt.Chain_hash.t * User_command.t) list
-[@@deriving yojson, eq, sexp, bin_io]
+open Receipt_chain_database_lib
+
+type t = (Receipt.Chain_hash.t, User_command.t) Payment_proof.t
+[@@deriving eq, sexp, bin_io, yojson]
+
+val initial_receipt : t -> Receipt.Chain_hash.t
+
+val payments : t -> User_command.t list

--- a/src/lib/receipt_chain_database_lib/database.ml
+++ b/src/lib/receipt_chain_database_lib/database.ml
@@ -149,8 +149,8 @@ let%test_module "receipt_database" =
             ( Receipt_db.prove db ~proving_receipt ~resulting_receipt
             |> Or_error.ok_exn ) )
 
-    let%test_unit "There exists a valid proof if a path exists in a \
-                   tree of payments" =
+    let%test_unit "There exists a valid proof if a path exists in a tree of \
+                   payments" =
       Quickcheck.test
         ~sexp_of:[%sexp_of: Receipt_chain_hash.t * Payment.t * Payment.t list]
         Quickcheck.Generator.(
@@ -179,17 +179,17 @@ let%test_module "receipt_database" =
               ~f:(Fn.compose not (String.equal prev_receipt_chain))
             |> List.random_element_exn
           in
-          let merkle_list =
+          let proof =
             Receipt_db.prove db ~proving_receipt:initial_receipt_chain
               ~resulting_receipt:random_receipt_chain
             |> Or_error.ok_exn
           in
           assert (
-            Verifier.verify merkle_list ~resulting_receipt:random_receipt_chain
+            Verifier.verify proof ~resulting_receipt:random_receipt_chain
             |> Result.is_ok ) )
 
-    let%test_unit "A proof should not exist if a proving receipt does \
-                   not exist in the database" =
+    let%test_unit "A proof should not exist if a proving receipt does not \
+                   exist in the database" =
       Quickcheck.test
         ~sexp_of:[%sexp_of: Receipt_chain_hash.t * Payment.t * Payment.t list]
         Quickcheck.Generator.(

--- a/src/lib/receipt_chain_database_lib/dune
+++ b/src/lib/receipt_chain_database_lib/dune
@@ -1,9 +1,10 @@
 (library
  (name receipt_chain_database_lib)
   (public_name receipt_chain_database_lib)
+  (flags (:standard -short-paths -warn-error -39))
   (library_flags (-linkall))
-  (libraries core key_value_database)
+  (libraries core key_value_database ppx_deriving_yojson.runtime yojson)
   (inline_tests)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
-  (synopsis "A library that contains a database that records sent payments for an individual account and generates a merkle list of a payment. 
-  Also, the library contains a verifier that proves the correctness of a merkle list of payments"))
+  (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson ppx_fields_conv))
+  (synopsis "A library that contains a database that records sent payments for an individual account and generates a proof of a payment. 
+  Also, the library contains a verifier that proves the correctness of the proof of payments"))

--- a/src/lib/receipt_chain_database_lib/intf.ml
+++ b/src/lib/receipt_chain_database_lib/intf.ml
@@ -35,9 +35,9 @@ module type Database = sig
     -> proving_receipt:receipt_chain_hash
     -> resulting_receipt:receipt_chain_hash
     -> (receipt_chain_hash, payment) Payment_proof.t Or_error.t
-  (** Prove will provide a proof of a proving_receipt hash up to an underlying 
-      resulting_receipt hash. The proof will consist of a initial_receipt as
-      proving_receipt and a list of payments leading to resulting_receipt *)
+  (** Prove will provide a proof of a `proving_receipt` hash up to an underlying 
+      `resulting_receipt` hash. The proof will consist of an initial proving_receipt
+       and a list of payments leading to resulting_receipt *)
 
   val get_payment : t -> receipt:receipt_chain_hash -> payment option
 

--- a/src/lib/receipt_chain_database_lib/payment_proof.ml
+++ b/src/lib/receipt_chain_database_lib/payment_proof.ml
@@ -1,0 +1,5 @@
+open Core_kernel
+
+type ('receipt_chain_hash, 'payment) t =
+  {initial_receipt: 'receipt_chain_hash; payments: 'payment list}
+[@@deriving eq, sexp, bin_io, yojson, compare, fields]


### PR DESCRIPTION
Changed 

```ocaml
type t = (Receipt.Chain_hash.t * User_command.t) list
```

to

```ocaml
type t = {initial_receipt: Receipt.Chain_hash.t; payments: User_command.t list}
```

After refactoring the code, the build compiles and passes all the tests

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Does this close issues? List them:

Closes #1222
