### PR TITLE
Remove deferreds from ledger-builder

### DIFF
--- a/src/lib/ledger_builder/ledger_builder.ml
+++ b/src/lib/ledger_builder/ledger_builder.ml
@@ -487,7 +487,16 @@ end = struct
     end
 
     module Statement_scanner_with_proofs =
-      Make_statement_scanner (Deferred) (Inputs.Ledger_proof_verifier)
+      Make_statement_scanner (struct
+          include Monad.Ident
+          module Or_error = Or_error
+        end)
+        (struct
+          include Inputs.Ledger_proof_verifier
+
+          let verify p s ~message =
+            Async.Thread_safe.block_on_async_exn (fun () -> verify p s ~message)
+        end)
 
     let is_valid t =
       Parallel_scan.parallelism ~state:t
@@ -645,7 +654,7 @@ end = struct
     | Error (`Error e) -> failwithf !"statement_exn: %{sexp:Error.t}" e ()
 
   let of_aux_and_ledger ~snarked_ledger_hash ~ledger ~aux =
-    let open Deferred.Or_error.Let_syntax in
+    let open Or_error.Let_syntax in
     let verify_snarked_ledger t snarked_ledger_hash =
       match snarked_ledger t ~snarked_ledger_hash with
       | Ok _ -> Ok ()
@@ -659,9 +668,7 @@ end = struct
       Aux.Statement_scanner_with_proofs.check_invariants aux
         "Ledger_hash.of_aux_and_ledger" ledger (Some snarked_ledger_hash)
     in
-    let%map () =
-      Deferred.return @@ verify_snarked_ledger t snarked_ledger_hash
-    in
+    let%map () = verify_snarked_ledger t snarked_ledger_hash in
     t
 
   let copy {scan_state; ledger} =
@@ -743,11 +750,13 @@ end = struct
           ( Ledger_proof.create ~statement ~sok_digest ~proof
           , Sok_message.create ~fee ~prover )
 
-  let verify ~message job proof =
+  let verify ~message job proof : bool =
     match statement_of_job job with
-    | None -> return false
+    | None -> false
     | Some statement ->
-        Inputs.Ledger_proof_verifier.verify proof statement ~message
+        (* TODO: This is synchronous for now -- we'll need to figure out how to make it async again long term *)
+        Async.Thread_safe.block_on_async_exn (fun () ->
+            Inputs.Ledger_proof_verifier.verify proof statement ~message )
 
   let total_proofs (works : Completed_work.t list) =
     List.sum (module Int) works ~f:(fun w -> List.length w.proofs)
@@ -809,17 +818,14 @@ end = struct
           in
           c.proposer :: ft_receivers
     in
-    let open Deferred.Let_syntax in
     let witness =
       measure "sparse ledger" (fun () ->
           Sparse_ledger.of_ledger_subset_exn ledger (public_keys s) )
     in
-    let%bind () = Async.Scheduler.yield () in
     let r =
       measure "apply+stmt" (fun () ->
           apply_transaction_and_get_statement ledger s )
     in
-    let%map () = Async.Scheduler.yield () in
     let open Or_error.Let_syntax in
     let%map undo, statement = r in
     ( undo
@@ -832,36 +838,34 @@ end = struct
     in
     let rec go processed acc = function
       | [] ->
-          Deferred.return
-            { Result_with_rollback.result= Ok (List.rev acc)
-            ; rollback= Call (fun () -> undo_transactions processed) }
+          { Result_with_rollback.result= Ok (List.rev acc)
+          ; rollback= Call (fun () -> undo_transactions processed) }
       | t :: ts -> (
-          match%bind apply_transaction_and_get_witness ledger t with
-          | Error e ->
-              undo_transactions processed ;
-              Result_with_rollback.error e
-          | Ok (undo, res) -> go (undo :: processed) (res :: acc) ts )
+        match apply_transaction_and_get_witness ledger t with
+        | Error e ->
+            undo_transactions processed ;
+            Result_with_rollback.error e
+        | Ok (undo, res) -> go (undo :: processed) (res :: acc) ts )
     in
     go [] [] ts
 
   let check_completed_works t (completed_works : Completed_work.t list) =
     Result_with_rollback.with_no_rollback
-      (let open Deferred.Or_error.Let_syntax in
+      (let open Or_error.Let_syntax in
       let%bind jobses =
-        Deferred.return
-          (let open Or_error.Let_syntax in
-          let%map jobs =
-            Parallel_scan.next_k_jobs ~state:t.scan_state
-              ~k:(total_proofs completed_works)
-          in
-          chunks_of jobs ~n:Completed_work.proofs_length)
+        let open Or_error.Let_syntax in
+        let%map jobs =
+          Parallel_scan.next_k_jobs ~state:t.scan_state
+            ~k:(total_proofs completed_works)
+        in
+        chunks_of jobs ~n:Completed_work.proofs_length
       in
-      Deferred.List.for_all (List.zip_exn jobses completed_works)
+      List.for_all (List.zip_exn jobses completed_works)
         ~f:(fun (jobs, work) ->
           let message = Sok_message.create ~fee:work.fee ~prover:work.prover in
-          Deferred.List.for_all (List.zip_exn jobs work.proofs)
-            ~f:(fun (job, proof) -> verify ~message job proof ) )
-      |> Deferred.map ~f:(check_or_error "proofs did not verify"))
+          List.for_all (List.zip_exn jobs work.proofs) ~f:(fun (job, proof) ->
+              verify ~message job proof ) )
+      |> check_or_error "proofs did not verify")
 
   let create_fee_transfers completed_works delta public_key =
     let singles =
@@ -1121,9 +1125,9 @@ end = struct
       @ List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
       @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
     in
-    let%map new_data =
-      Deferred.List.map transactions ~f:(fun s ->
-          let%map r = apply_transaction_and_get_witness t.ledger s in
+    let new_data =
+      List.map transactions ~f:(fun s ->
+          let r = apply_transaction_and_get_witness t.ledger s in
           let _undo, t = Or_error.ok_exn r in
           t )
     in
@@ -1157,16 +1161,16 @@ end = struct
       in
       apply_pre_diff_unchecked t coinbase_added diff.creator pre_diff2.diff
     in
-    let%map data, works =
+    let data, works =
       Either.value_map diff.pre_diffs
         ~first:(fun d ->
-          let%map data, works, cb_works = apply_pre_diff_with_at_most_one d in
+          let data, works, cb_works = apply_pre_diff_with_at_most_one d in
           (data, cb_works @ works) )
         ~second:(fun d ->
-          let%bind data1, works1, cb_works1 =
+          let data1, works1, cb_works1 =
             apply_pre_diff_with_at_most_two (fst d)
           in
-          let%map data2, works2, cb_works2 =
+          let data2, works2, cb_works2 =
             apply_pre_diff_with_at_most_one (snd d)
           in
           (data1 @ data2, works1 @ cb_works1 @ cb_works2 @ works2) )
@@ -2240,7 +2244,7 @@ let%test_module "test" =
           -> Completed_work.Checked.t option Deferred.t =
        fun {fee= f; proofs= p; prover= pr} _ ->
         Deferred.return
-        @@ Some {Completed_work.Checked.fee= f; proofs= p; prover= pr}
+          (Some {Completed_work.Checked.fee= f; proofs= p; prover= pr})
     end
 
     module Lb = Make (Test_input1)
@@ -2258,7 +2262,7 @@ let%test_module "test" =
         ; prover }
 
     let create_and_apply lb logger txns stmt_to_work =
-      let open Deferred.Or_error.Let_syntax in
+      let open Or_error.Let_syntax in
       let diff =
         Lb.create_diff lb ~self:self_pk ~logger ~transactions_by_fee:txns
           ~get_completed_work:stmt_to_work
@@ -2305,37 +2309,29 @@ let%test_module "test" =
       let initial_ledger = ref 0 in
       let lb = Lb.create ~ledger:initial_ledger in
       Quickcheck.test g ~trials:1000 ~f:(fun _ ->
-          Async.Thread_safe.block_on_async_exn (fun () ->
-              let open Deferred.Let_syntax in
-              let old_ledger = !(Lb.ledger lb) in
-              let all_ts =
-                txns (p / 2) (fun x -> (x + 1) * 100) (fun _ -> 4)
-              in
-              let%map proof, diff =
-                create_and_apply lb logger (Sequence.of_list all_ts)
-                  stmt_to_work
-                |> Deferred.Or_error.ok_exn
-              in
-              let fee_excess =
-                Option.value_map ~default:Currency.Fee.Signed.zero proof
-                  ~f:(fun proof ->
-                    let stmt = Test_input1.Ledger_proof.statement proof in
-                    stmt.fee_excess )
-              in
-              (*fee_excess at the top should always be zero*)
-              assert (
-                Currency.Fee.Signed.equal fee_excess Currency.Fee.Signed.zero
-              ) ;
-              let cb = coinbase_added diff in
-              (*At worst case number of provers coinbase should not be split more than two times*)
-              assert (cb > 0 && cb < 3) ;
-              let x =
-                List.length
-                  (Test_input1.Ledger_builder_diff.user_commands diff)
-              in
-              assert_at_least_coinbase_added x cb ;
-              let expected_value = expected_ledger x all_ts old_ledger in
-              assert (!(Lb.ledger lb) = expected_value) ) )
+          let old_ledger = !(Lb.ledger lb) in
+          let all_ts = txns (p / 2) (fun x -> (x + 1) * 100) (fun _ -> 4) in
+          let proof, diff =
+            create_and_apply lb logger (Sequence.of_list all_ts) stmt_to_work
+            |> Or_error.ok_exn
+          in
+          let fee_excess =
+            Option.value_map ~default:Currency.Fee.Signed.zero proof
+              ~f:(fun proof ->
+                let stmt = Test_input1.Ledger_proof.statement proof in
+                stmt.fee_excess )
+          in
+          (*fee_excess at the top should always be zero*)
+          assert (Currency.Fee.Signed.equal fee_excess Currency.Fee.Signed.zero) ;
+          let cb = coinbase_added diff in
+          (*At worst case number of provers coinbase should not be split more than two times*)
+          assert (cb > 0 && cb < 3) ;
+          let x =
+            List.length (Test_input1.Ledger_builder_diff.user_commands diff)
+          in
+          assert_at_least_coinbase_added x cb ;
+          let expected_value = expected_ledger x all_ts old_ledger in
+          assert (!(Lb.ledger lb) = expected_value) )
 
     let%test_unit "Be able to include random number of user_commands" =
       (*Always at worst case number of provers*)
@@ -2346,35 +2342,30 @@ let%test_module "test" =
       let initial_ledger = ref 0 in
       let lb = Lb.create ~ledger:initial_ledger in
       Quickcheck.test g ~trials:1000 ~f:(fun i ->
-          Async.Thread_safe.block_on_async_exn (fun () ->
-              let open Deferred.Let_syntax in
-              let old_ledger = !(Lb.ledger lb) in
-              let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
-              let ts = List.take all_ts i in
-              let%map proof, diff =
-                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
-                |> Deferred.Or_error.ok_exn
-              in
-              let fee_excess =
-                Option.value_map ~default:Currency.Fee.Signed.zero proof
-                  ~f:(fun proof ->
-                    let stmt = Test_input1.Ledger_proof.statement proof in
-                    stmt.fee_excess )
-              in
-              (*fee_excess at the top should always be zero*)
-              assert (
-                Currency.Fee.Signed.equal fee_excess Currency.Fee.Signed.zero
-              ) ;
-              let cb = coinbase_added diff in
-              (*At worst case number of provers coinbase should not be split more than two times*)
-              assert (cb > 0 && cb < 3) ;
-              let x =
-                List.length
-                  (Test_input1.Ledger_builder_diff.user_commands diff)
-              in
-              assert_at_least_coinbase_added x cb ;
-              let expected_value = expected_ledger x all_ts old_ledger in
-              assert (!(Lb.ledger lb) = expected_value) ) )
+          let old_ledger = !(Lb.ledger lb) in
+          let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
+          let ts = List.take all_ts i in
+          let proof, diff =
+            create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
+            |> Or_error.ok_exn
+          in
+          let fee_excess =
+            Option.value_map ~default:Currency.Fee.Signed.zero proof
+              ~f:(fun proof ->
+                let stmt = Test_input1.Ledger_proof.statement proof in
+                stmt.fee_excess )
+          in
+          (*fee_excess at the top should always be zero*)
+          assert (Currency.Fee.Signed.equal fee_excess Currency.Fee.Signed.zero) ;
+          let cb = coinbase_added diff in
+          (*At worst case number of provers coinbase should not be split more than two times*)
+          assert (cb > 0 && cb < 3) ;
+          let x =
+            List.length (Test_input1.Ledger_builder_diff.user_commands diff)
+          in
+          assert_at_least_coinbase_added x cb ;
+          let expected_value = expected_ledger x all_ts old_ledger in
+          assert (!(Lb.ledger lb) = expected_value) )
 
     let%test_unit "Be able to include random number of user_commands (One \
                    prover)" =
@@ -2392,35 +2383,30 @@ let%test_module "test" =
       let initial_ledger = ref 0 in
       let lb = Lb.create ~ledger:initial_ledger in
       Quickcheck.test g ~trials:1000 ~f:(fun i ->
-          Async.Thread_safe.block_on_async_exn (fun () ->
-              let open Deferred.Let_syntax in
-              let old_ledger = !(Lb.ledger lb) in
-              let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
-              let ts = List.take all_ts i in
-              let%map proof, diff =
-                create_and_apply lb logger (Sequence.of_list ts) get_work
-                |> Deferred.Or_error.ok_exn
-              in
-              let fee_excess =
-                Option.value_map ~default:Currency.Fee.Signed.zero proof
-                  ~f:(fun proof ->
-                    let stmt = Test_input1.Ledger_proof.statement proof in
-                    stmt.fee_excess )
-              in
-              (*fee_excess at the top should always be zero*)
-              assert (
-                Currency.Fee.Signed.equal fee_excess Currency.Fee.Signed.zero
-              ) ;
-              let cb = coinbase_added diff in
-              (*With just one prover, coinbase should never be split*)
-              assert (cb = 1) ;
-              let x =
-                List.length
-                  (Test_input1.Ledger_builder_diff.user_commands diff)
-              in
-              assert_at_least_coinbase_added x cb ;
-              let expected_value = expected_ledger x all_ts old_ledger in
-              assert (!(Lb.ledger lb) = expected_value) ) )
+          let old_ledger = !(Lb.ledger lb) in
+          let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
+          let ts = List.take all_ts i in
+          let proof, diff =
+            create_and_apply lb logger (Sequence.of_list ts) get_work
+            |> Or_error.ok_exn
+          in
+          let fee_excess =
+            Option.value_map ~default:Currency.Fee.Signed.zero proof
+              ~f:(fun proof ->
+                let stmt = Test_input1.Ledger_proof.statement proof in
+                stmt.fee_excess )
+          in
+          (*fee_excess at the top should always be zero*)
+          assert (Currency.Fee.Signed.equal fee_excess Currency.Fee.Signed.zero) ;
+          let cb = coinbase_added diff in
+          (*With just one prover, coinbase should never be split*)
+          assert (cb = 1) ;
+          let x =
+            List.length (Test_input1.Ledger_builder_diff.user_commands diff)
+          in
+          assert_at_least_coinbase_added x cb ;
+          let expected_value = expected_ledger x all_ts old_ledger in
+          assert (!(Lb.ledger lb) = expected_value) )
 
     let%test_unit "Reproduce invalid statement error" =
       (*Always at worst case number of provers*)
@@ -2439,13 +2425,12 @@ let%test_module "test" =
       in
       let ledger = ref 0 in
       let lb = Lb.create ~ledger in
-      Async.Thread_safe.block_on_async_exn (fun () ->
-          Deferred.List.fold ~init:() txns ~f:(fun _ ts ->
-              let%map _ =
-                create_and_apply lb logger (Sequence.of_list ts) get_work
-                |> Deferred.Or_error.ok_exn
-              in
-              () ) )
+      List.fold ~init:() txns ~f:(fun _ ts ->
+          let _ =
+            create_and_apply lb logger (Sequence.of_list ts) get_work
+            |> Or_error.ok_exn
+          in
+          () )
 
     let%test_unit "Snarked ledger" =
       Backtrace.elide := false ;
@@ -2456,26 +2441,24 @@ let%test_module "test" =
       let lb = Lb.create ~ledger:initial_ledger in
       let expected_snarked_ledger = ref 0 in
       Quickcheck.test g ~trials:50 ~f:(fun i ->
-          Async.Thread_safe.block_on_async_exn (fun () ->
-              let open Deferred.Let_syntax in
-              let _old_ledger = !(Lb.ledger lb) in
-              let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
-              let ts = List.take all_ts i in
-              let%map proof, _ =
-                create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
-                |> Deferred.Or_error.ok_exn
-              in
-              let last_snarked_ledger, snarked_ledger_hash =
-                Option.value_map
-                  ~default:
-                    ( !expected_snarked_ledger
-                    , Int.to_string !expected_snarked_ledger )
-                  ~f:(fun p -> (Int.of_string p.target, p.target))
-                  proof
-              in
-              expected_snarked_ledger := last_snarked_ledger ;
-              let materialized_ledger =
-                Or_error.ok_exn @@ Lb.snarked_ledger lb ~snarked_ledger_hash
-              in
-              assert (!expected_snarked_ledger = !materialized_ledger) ) )
+          let _old_ledger = !(Lb.ledger lb) in
+          let all_ts = txns p (fun x -> (x + 1) * 100) (fun _ -> 4) in
+          let ts = List.take all_ts i in
+          let proof, _ =
+            create_and_apply lb logger (Sequence.of_list ts) stmt_to_work
+            |> Or_error.ok_exn
+          in
+          let last_snarked_ledger, snarked_ledger_hash =
+            Option.value_map
+              ~default:
+                ( !expected_snarked_ledger
+                , Int.to_string !expected_snarked_ledger )
+              ~f:(fun p -> (Int.of_string p.target, p.target))
+              proof
+          in
+          expected_snarked_ledger := last_snarked_ledger ;
+          let materialized_ledger =
+            Or_error.ok_exn @@ Lb.snarked_ledger lb ~snarked_ledger_hash
+          in
+          assert (!expected_snarked_ledger = !materialized_ledger) )
   end )

--- a/src/lib/ledger_builder/result_with_rollback.mli
+++ b/src/lib/ledger_builder/result_with_rollback.mli
@@ -1,5 +1,4 @@
 open Core
-open Async
 
 module Rollback : sig
   type t = Do_nothing | Call of (unit -> unit)
@@ -7,14 +6,14 @@ end
 
 type 'a result = {result: 'a Or_error.t; rollback: Rollback.t}
 
-type 'a t = 'a result Deferred.t
+type 'a t = 'a result
 
 include Monad.S with type 'a t := 'a t
 
-val run : 'a t -> 'a Or_error.t Deferred.t
+val run : 'a t -> 'a Or_error.t
 
 val error : Error.t -> 'a t
 
 val of_or_error : 'a Or_error.t -> 'a t
 
-val with_no_rollback : 'a Or_error.t Deferred.t -> 'a t
+val with_no_rollback : 'a Or_error.t -> 'a t

--- a/src/lib/ledger_builder_controller/catchup.ml
+++ b/src/lib/ledger_builder_controller/catchup.ml
@@ -50,7 +50,7 @@ struct
         let build_lb ~aux ~ledger =
           let open Interruptible.Let_syntax in
           match%bind
-            Interruptible.uninterruptible
+            Interruptible.return
               (Ledger_builder.of_aux_and_ledger ~snarked_ledger_hash ~ledger
                  ~aux)
           with

--- a/src/lib/ledger_builder_controller/ledger_builder_controller.ml
+++ b/src/lib/ledger_builder_controller/ledger_builder_controller.ml
@@ -48,7 +48,9 @@ end = struct
     module Step = struct
       let apply' t diff logger =
         let open Deferred.Or_error.Let_syntax in
-        let%map _, `Ledger_proof proof = Ledger_builder.apply t diff ~logger in
+        let%map _, `Ledger_proof proof =
+          Deferred.return @@ Ledger_builder.apply t diff ~logger
+        in
         Option.map proof ~f:(fun proof ->
             ( Ledger_proof.statement proof |> Ledger_proof_statement.target
             , proof ) )
@@ -433,13 +435,13 @@ let%test_module "test" =
             create ~ledger
 
           let of_aux_and_ledger ~snarked_ledger_hash:_ ~ledger ~aux:_ =
-            Deferred.return (Ok (create ~ledger))
+            Ok (create ~ledger)
 
           let aux t = !t
 
           let apply (t : t) (x : Ledger_builder_diff.t) ~logger:_ =
             t := x ;
-            return (Ok (`Hash_after_applying (hash t), `Ledger_proof (Some x)))
+            Ok (`Hash_after_applying (hash t), `Ledger_proof (Some x))
 
           let apply_diff_unchecked (_t : t) (_x : 'a) =
             failwith "Unimplemented"

--- a/src/lib/ledger_builder_controller/tip_ops.ml
+++ b/src/lib/ledger_builder_controller/tip_ops.ml
@@ -29,13 +29,13 @@ module Make (Inputs : Inputs.Base.S) = struct
       transition_with_hash ) logger =
     let%map () =
       let open Deferred.Let_syntax in
-      match%map
+      match
         Ledger_builder.apply t.Tip.ledger_builder
           (External_transition.ledger_builder_diff transition)
           ~logger
       with
-      | Ok (_, `Ledger_proof None) -> ()
-      | Ok (_, `Ledger_proof (Some _)) -> ()
+      | Ok (_, `Ledger_proof None) -> return ()
+      | Ok (_, `Ledger_proof (Some _)) -> return ()
       (* We've already verified that all the patches can be
         applied successfully before we added to the ktree, so we
         can force-unwrap here *)

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -150,11 +150,11 @@ module Make (Inputs : Inputs_intf) :
             ~logger ~transactions_by_fee:transactions ~get_completed_work
         in
         let lb2 = Ledger_builder.copy ledger_builder in
-        let%map ( `Hash_after_applying next_ledger_builder_hash
-                , `Ledger_proof ledger_proof_opt ) =
+        let ( `Hash_after_applying next_ledger_builder_hash
+            , `Ledger_proof ledger_proof_opt ) =
           Ledger_builder.apply_diff_unchecked lb2 diff
         in
-        (diff, next_ledger_builder_hash, ledger_proof_opt))
+        return (diff, next_ledger_builder_hash, ledger_proof_opt))
     in
     let%bind protocol_state, consensus_transition_data =
       lift_sync (fun () ->

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -50,7 +50,7 @@ module Make (Inputs : Inputs.S) :
                        ~timeout_duration:catchup_timeout_duration ~transition
                  | Some _ ->
                      ignore
-                       (Transition_frontier.add_transition_exn ~logger frontier
+                       (Transition_frontier.add_transition_exn frontier
                           transition) ;
                      Catchup_monitor.notify catchup_monitor ~time_controller
                        ~transition ) ) ))

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -574,7 +574,7 @@ module type Ledger_builder_base_intf = sig
        snarked_ledger_hash:frozen_ledger_hash
     -> ledger:ledger
     -> aux:Aux.t
-    -> t Or_error.t Deferred.t
+    -> t Or_error.t
 
   val of_serialized_and_unserialized :
     serialized:serializable -> unserialized:ledger -> t
@@ -593,14 +593,13 @@ module type Ledger_builder_base_intf = sig
     -> logger:Logger.t
     -> ( [`Hash_after_applying of ledger_builder_hash]
        * [`Ledger_proof of ledger_proof option] )
-       Deferred.Or_error.t
+       Or_error.t
 
   val apply_diff_unchecked :
        t
     -> valid_diff
-    -> ( [`Hash_after_applying of ledger_builder_hash]
-       * [`Ledger_proof of ledger_proof option] )
-       Deferred.t
+    -> [`Hash_after_applying of ledger_builder_hash]
+       * [`Ledger_proof of ledger_proof option]
 
   val snarked_ledger :
     t -> snarked_ledger_hash:frozen_ledger_hash -> ledger Or_error.t

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -66,10 +66,7 @@ module type Transition_frontier_intf = sig
   val attach_breadcrumb_exn : t -> Breadcrumb.t -> unit
 
   val add_transition_exn :
-       t
-    -> logger:Logger.t
-    -> (external_transition, state_hash) With_hash.t
-    -> Breadcrumb.t
+    t -> (external_transition, state_hash) With_hash.t -> Breadcrumb.t
 end
 
 module type Catchup_intf = sig


### PR DESCRIPTION
Let the slowness wash over yourself.

This is temporary while we wait for @deepthiskumar's change to get in.

The intent here is to only Async.Thread_safe over the part of the code that doesn't do mutations as the OCaml compiler will incorrectly optimize away mutations.