### PR TITLE
Fix link formatting

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -88,7 +88,7 @@ let g:syntastic_ocaml_checkers=['merlin']
 ```
 
 Emacs has a built-in autocomplete, via `M-x completion-at-point`, or simply `M-tab`. There are other
-Emacs autocompletion packages; see [Emacs from scratch] (https://github.com/ocaml/merlin/wiki/emacs-from-scratch).
+Emacs autocompletion packages; see [Emacs from scratch](https://github.com/ocaml/merlin/wiki/emacs-from-scratch).
 
 ## Using the makefile
 


### PR DESCRIPTION
> Explain your changes here.

Trivial: Removed space, fixing link formatting.

> Explain how you tested your changes here.

In Emacs markdown mode, link appears correctly now.

- [ ] Tests were added for the new behavior: No
- [X] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues?: No.
