### PR TITLE
Transition frontier genesis initialization

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -221,6 +221,8 @@ module type Main_intf = sig
 
     module Protocol_state_proof : sig
       type t
+
+      val dummy : t
     end
 
     module Ledger_builder_hash : sig
@@ -414,6 +416,8 @@ struct
     include Proof.Stable.V1
 
     type input = Protocol_state.value
+
+    let dummy = Coda_base.Proof.dummy
 
     let verify state_proof state =
       match%map
@@ -813,6 +817,7 @@ struct
 
   module Proposer = Proposer.Make (struct
     include Inputs0
+    module Genesis_ledger = Genesis_ledger
     module State_hash = State_hash
     module Ledger_builder_diff = Ledger_builder_diff
     module Ledger_proof_verifier = Ledger_proof_verifier
@@ -927,6 +932,7 @@ module Make_coda (Init : Init_intf) = struct
 
   module Inputs = struct
     include Make_inputs (Init) (Ledger_proof_verifier) (Storage.Disk)
+    module Genesis_ledger = Genesis_ledger
     module Ledger_proof_statement = Ledger_proof_statement
     module Snark_worker = Snark_worker_lib.Debug.Worker
     module Consensus_mechanism = Consensus.Mechanism

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -515,7 +515,20 @@ module Make (Inputs : Inputs_intf) = struct
           Consensus_mechanism.Local_state.create config.propose_keypair
         in
         let first_transition =
-          failwith "TODO: Bootstrap should emit this transition"
+          External_transition.create
+            ~protocol_state:Consensus_mechanism.genesis_protocol_state
+            ~protocol_state_proof:Protocol_state_proof.dummy
+            ~ledger_builder_diff:
+              { Ledger_builder_diff.pre_diffs =
+                  Either.First
+                    { diff=
+                        {completed_works= []; user_commands= []}
+                    ; coinbase_added= Ledger_builder_diff.At_most_one.Zero }
+              ; prev_hash=
+                  Ledger_builder_hash.of_aux_and_ledger_hash
+                    (Ledger_builder_aux_hash.of_bytes "")
+                    (Ledger.merkle_root Genesis_ledger.t)
+              ; creator= Account.public_key (snd (List.hd_exn Genesis_ledger.accounts)) }
         in
         let transition_frontier =
           Transition_frontier.create ~logger:config.log

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -119,6 +119,8 @@ end
 
 module type Protocol_state_proof_intf = sig
   type t
+
+  val dummy : t
 end
 
 module type Ledger_builder_aux_hash_intf = sig
@@ -1067,6 +1069,8 @@ module type Inputs_intf = sig
 
   module Account : sig
     type t
+
+    val public_key : t -> Public_key.Compressed.t
   end
 
   module Ledger :
@@ -1075,6 +1079,12 @@ module type Inputs_intf = sig
      and type transaction := Transaction.t
      and type ledger_hash := Ledger_hash.t
      and type account := Account.t
+
+  module Genesis_ledger : sig
+    val t : Ledger.t
+
+    val accounts : (Private_key.t option * Account.t) list
+  end
 
   module Ledger_builder_aux_hash : Ledger_builder_aux_hash_intf
 


### PR DESCRIPTION
This adds a stubbed genesis transition for initializing the transition frontier at the genesis state.

It's difficult to test and see if this will work as of right now, so there may be changes that need to be made in the logic for ledger builder diff application to handle applying "empty" ledger builder diffs.