### PR TITLE
Created ancestor_prove within sync_handler

### DIFF
--- a/src/lib/sync_handler/dune
+++ b/src/lib/sync_handler/dune
@@ -2,4 +2,4 @@
   (name sync_handler)
   (public_name sync_handler)
   (preprocess (pps ppx_jane))
-  (libraries async_kernel core_kernel protocols coda_base syncable_ledger merkle_address))
+  (libraries async_kernel core_kernel protocols coda_base syncable_ledger merkle_address consensus))

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -37,7 +37,7 @@ module Make (Inputs : Inputs_intf) :
    and type syncable_ledger_query := Inputs.Syncable_ledger.query
    and type syncable_ledger_answer := Inputs.Syncable_ledger.answer
    and type transition_frontier := Inputs.Transition_frontier.t
-   and type proof := State_body_hash.t list = struct
+   and type ancestor_proof := State_body_hash.t list = struct
   open Inputs
 
   let answer_query ~frontier (hash, query) =
@@ -48,7 +48,7 @@ module Make (Inputs : Inputs_intf) :
     let answer = Syncable_ledger.Responder.answer_query responder query in
     (hash, answer)
 
-  let prove ~frontier generations descendants =
+  let prove_ancestory ~frontier generations descendants =
     let open Option.Let_syntax in
     let rec go acc iter_traversal state_hash =
       if iter_traversal = 0 then Some (state_hash, acc)

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -5,8 +5,6 @@ open Coda_base
 open Pipe_lib
 
 module type Inputs_intf = sig
-  module Consensus_mechanism : Consensus_mechanism_intf
-
   module Merkle_address : Merkle_address.S
 
   module Staged_ledger : sig
@@ -19,18 +17,27 @@ module type Inputs_intf = sig
      and type hash := Ledger_hash.t
      and type merkle_tree := Staged_ledger.t
 
+  module Protocol_state : Protocol_state.S
+
+  module External_transition :
+    External_transition_intf with type protocol_state := Protocol_state.value
+
   module Transition_frontier :
-    Transition_frontier_intf with type staged_ledger := Staged_ledger.t
+    Transition_frontier_intf
+    with type staged_ledger := Staged_ledger.t
+     and type external_transition := External_transition.t
+     and type state_hash := State_hash.t
 end
 
 module Make (Inputs : Inputs_intf) :
   Sync_handler_intf
   with type addr := Inputs.Merkle_address.t
-   and type hash := Inputs.Transition_frontier.state_hash
+   and type hash := State_hash.t
    and type syncable_ledger := Inputs.Syncable_ledger.t
    and type syncable_ledger_query := Inputs.Syncable_ledger.query
    and type syncable_ledger_answer := Inputs.Syncable_ledger.answer
-   and type transition_frontier := Inputs.Transition_frontier.t = struct
+   and type transition_frontier := Inputs.Transition_frontier.t
+   and type proof := State_body_hash.t list = struct
   open Inputs
 
   let answer_query ~frontier (hash, query) =
@@ -40,6 +47,28 @@ module Make (Inputs : Inputs_intf) :
     let responder = Syncable_ledger.Responder.create ledger ignore in
     let answer = Syncable_ledger.Responder.answer_query responder query in
     (hash, answer)
+
+  let prove ~frontier generations descendants =
+    let open Option.Let_syntax in
+    let rec go acc iter_traversal state_hash =
+      if iter_traversal = 0 then Some (state_hash, acc)
+      else
+        let%bind breadcrumb = Transition_frontier.find frontier state_hash in
+        let transition_with_hash =
+          Transition_frontier.Breadcrumb.transition_with_hash breadcrumb
+        in
+        let external_transition = With_hash.data transition_with_hash in
+        let protocol_state =
+          External_transition.protocol_state external_transition
+        in
+        let body = Protocol_state.body protocol_state in
+        let state_body_hash = Protocol_state.Body.hash body in
+        let previous_state_hash =
+          Protocol_state.previous_state_hash protocol_state
+        in
+        go (state_body_hash :: acc) (iter_traversal - 1) previous_state_hash
+    in
+    go [] generations descendants
 
   let run ~frontier ~sync_query_reader ~sync_answer_writer =
     let answer_broadcaster =

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -119,6 +119,8 @@ module type Sync_handler_intf = sig
 
   type transition_frontier
 
+  type proof
+
   val run :
        frontier:transition_frontier
     -> sync_query_reader:(hash * syncable_ledger_query) Reader.t
@@ -127,6 +129,9 @@ module type Sync_handler_intf = sig
                           , unit Async.Deferred.t )
                           Writer.t
     -> unit
+
+  val prove :
+    frontier:transition_frontier -> int -> hash -> (hash * proof) option
 end
 
 module type Transition_frontier_controller_intf = sig

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -119,7 +119,7 @@ module type Sync_handler_intf = sig
 
   type transition_frontier
 
-  type proof
+  type ancestor_proof
 
   val run :
        frontier:transition_frontier
@@ -130,8 +130,8 @@ module type Sync_handler_intf = sig
                           Writer.t
     -> unit
 
-  val prove :
-    frontier:transition_frontier -> int -> hash -> (hash * proof) option
+  val prove_ancestory :
+    frontier:transition_frontier -> int -> hash -> (hash * ancestor_proof) option
 end
 
 module type Transition_frontier_controller_intf = sig


### PR DESCRIPTION
Since the proofs for Ancestor proof can be retrieved in the
transition_frontier, a prove implementation was created to specifically
interact with transtion_frontier

Finishing https://github.com/CodaProtocol/coda/pull/1248

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:
