### PR TITLE
Transition frontier controller hooked in with holes

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -801,12 +801,18 @@ struct
     module Syncable_ledger = Sync_ledger
   end)
 
-  module Transition_handler = struct
-    type t = TODO
-  end
+  module Ledger_catchup = Ledger_catchup.Make (struct
+    include (
+      Inputs0 :
+        module type of Inputs0
+        with module Ledger_builder := Patched_ledger_builder )
+  end)
 
-  module Catchup = struct
-    type t = TODO
+  module Transition_handler = struct
+    include (
+      Inputs0 :
+        module type of Inputs0
+        with module Ledger_builder := Patched_ledger_builder )
   end
 
   module Transition_frontier_controller =
@@ -815,7 +821,7 @@ struct
     module Syncable_ledger = Sync_ledger
     module Sync_handler = Sync_handler
     module Merkle_address = Ledger.Addr
-    module Catchup = Catchup
+    module Catchup = Ledger_catchup
     module Transition_handler = Transition_handler
     module Ledger_builder_diff = Ledger_builder_diff
     module Ledger_diff = Ledger_builder_diff

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -457,8 +457,7 @@ struct
 
   module Ledger = Ledger
   module Ledger_db = Ledger.Db
-  module Ledger_transfer =
-    Ledger_transfer.Make(Ledger)(Ledger_db)
+  module Ledger_transfer = Ledger_transfer.Make (Ledger) (Ledger_db)
 
   module Transaction_snark = struct
     include Ledger_proof
@@ -492,8 +491,7 @@ struct
      and type sparse_ledger := Sparse_ledger.t
      and type ledger_proof_statement := Ledger_proof_statement.t
      and type ledger_proof_statement_set := Ledger_proof_statement.Set.t
-     and type transaction := Transaction.t
-  = struct
+     and type transaction := Transaction.t = struct
     module Inputs = struct
       module Sok_message = Sok_message
       module Account = Account
@@ -577,13 +575,12 @@ struct
     type ledger_builder_aux_hash = Ledger_builder_aux_hash.t
   end
 
-  module Transition_frontier =
-    Transition_frontier.Make (struct
-      module Completed_work = Completed_work
-      module Ledger_builder_diff = Ledger_builder_diff
-      module External_transition = External_transition
-      module Ledger_builder = Patched_ledger_builder
-    end)
+  module Transition_frontier = Transition_frontier.Make (struct
+    module Completed_work = Completed_work
+    module Ledger_builder_diff = Ledger_builder_diff
+    module External_transition = External_transition
+    module Ledger_builder = Patched_ledger_builder
+  end)
 
   module Transaction_pool = struct
     module Pool = Transaction_pool.Make (User_command)
@@ -792,38 +789,38 @@ struct
     module Blockchain_state = Consensus.Mechanism.Blockchain_state
   end)
 
-  module Sync_handler =
-    Sync_handler.Make(struct
-      include (
-        Inputs0 :
-          module type of Inputs0
-          with module Ledger_builder := Patched_ledger_builder )
+  module Sync_handler = Sync_handler.Make (struct
+    include (
+      Inputs0 :
+        module type of Inputs0
+        with module Ledger_builder := Patched_ledger_builder )
 
-      module Ledger_builder = Patched_ledger_builder
-      module Ledger_builder_diff = Ledger_builder_diff
-      module Completed_work = Completed_work
-      module Syncable_ledger = Sync_ledger
-    end)
+    module Ledger_builder = Patched_ledger_builder
+    module Ledger_builder_diff = Ledger_builder_diff
+    module Completed_work = Completed_work
+    module Syncable_ledger = Sync_ledger
+  end)
 
   module Transition_handler = struct
     type t = TODO
   end
+
   module Catchup = struct
     type t = TODO
   end
 
   module Transition_frontier_controller =
-    Transition_frontier_controller.Make (struct
-      include Inputs0
-      module Syncable_ledger = Sync_ledger
-      module Sync_handler = Sync_handler
-      module Merkle_address = Ledger.Addr
-      module Catchup = Catchup
-      module Transition_handler = Transition_handler
-      module Ledger_builder_diff = Ledger_builder_diff
-      module Ledger_diff = Ledger_builder_diff
-      module Consensus_mechanism = Consensus.Mechanism
-    end)
+  Transition_frontier_controller.Make (struct
+    include Inputs0
+    module Syncable_ledger = Sync_ledger
+    module Sync_handler = Sync_handler
+    module Merkle_address = Ledger.Addr
+    module Catchup = Catchup
+    module Transition_handler = Transition_handler
+    module Ledger_builder_diff = Ledger_builder_diff
+    module Ledger_diff = Ledger_builder_diff
+    module Consensus_mechanism = Consensus.Mechanism
+  end)
 
   module Ledger_builder_controller = struct
     module Inputs = struct

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -398,6 +398,7 @@ struct
       Block_time.Span.( < ) (Block_time.diff t now) limit
   end
 
+  module Masked_ledger = Ledger.Mask.Attached
   module Sok_message = Sok_message
 
   module Amount = struct
@@ -806,18 +807,36 @@ struct
       Inputs0 :
         module type of Inputs0
         with module Ledger_builder := Patched_ledger_builder )
+
+    module Ledger_builder_diff = Ledger_builder_diff
+    module Completed_work = Completed_work
+    module Ledger_builder = Patched_ledger_builder
   end)
 
-  module Transition_handler = struct
+  module Transition_handler = Transition_handler.Make (struct
+    module Hack_proof = Inputs0.Proof
+
+    include (
+      Inputs0 :
+        module type of Inputs0
+        with module Ledger_builder := Patched_ledger_builder
+         and module Proof := Hack_proof )
+
+    module Proof = Protocol_state_proof
+    module Completed_work = Completed_work
+    module Ledger_builder_diff = Ledger_builder_diff
+    module Ledger_builder = Patched_ledger_builder
+  end)
+
+  module Transition_frontier_controller =
+  Transition_frontier_controller.Make (struct
     include (
       Inputs0 :
         module type of Inputs0
         with module Ledger_builder := Patched_ledger_builder )
-  end
 
-  module Transition_frontier_controller =
-  Transition_frontier_controller.Make (struct
-    include Inputs0
+    module Ledger_builder = Patched_ledger_builder
+    module Completed_work = Completed_work
     module Syncable_ledger = Sync_ledger
     module Sync_handler = Sync_handler
     module Merkle_address = Ledger.Addr
@@ -850,6 +869,7 @@ struct
       module Ledger_proof_statement = Ledger_proof_statement
       module Ledger_builder_hash = Ledger_builder_hash
       module Ledger = Ledger
+      module Ledger_builder = Ledger_builder
       module Ledger_builder_diff = Ledger_builder_diff
       module Ledger_builder_aux_hash = Ledger_builder_aux_hash
       module Blockchain_state = Blockchain_state

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -457,6 +457,8 @@ struct
 
   module Ledger = Ledger
   module Ledger_db = Ledger.Db
+  module Ledger_transfer =
+    Ledger_transfer.Make(Ledger)(Ledger_db)
 
   module Transaction_snark = struct
     include Ledger_proof

--- a/src/app/cli/src/jbuild
+++ b/src/app/cli/src/jbuild
@@ -39,6 +39,8 @@
       transition_frontier
       transition_frontier_controller
       sync_handler
+      ledger_catchup
+      transition_handler
       async
       async_extra
       rpc_parallel

--- a/src/app/cli/src/jbuild
+++ b/src/app/cli/src/jbuild
@@ -37,6 +37,8 @@
       storage
       logger
       transition_frontier
+      transition_frontier_controller
+      sync_handler
       async
       async_extra
       rpc_parallel

--- a/src/lib/coda_base/ledger_transfer.ml
+++ b/src/lib/coda_base/ledger_transfer.ml
@@ -1,0 +1,20 @@
+open Core_kernel
+open Signature_lib
+
+module type Base_ledger_intf =
+  Merkle_ledger.Base_ledger_intf.S
+  with type account := Account.t
+   and type key := Public_key.Compressed.t
+   and type hash := Ledger_hash.t
+   and type root_hash := Ledger_hash.t
+
+module Make (Source : Base_ledger_intf) (Dest : Base_ledger_intf) :
+  Protocols.Coda_pow.Ledger_transfer_intf
+  with type src := Source.t
+   and type dest := Dest.t = struct
+  let transfer_accounts ~src ~dest =
+    Source.foldi src ~init:dest ~f:(fun _addr dest account ->
+        let key = Account.public_key account in
+        ignore (Dest.get_or_create_account_exn dest key account) ;
+        dest )
+end

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -396,6 +396,17 @@ module type Inputs_intf = sig
      and type external_transition := External_transition.t
      and type ledger_database := Ledger_db.t
 
+  module Syncable_ledger : sig type query type answer end
+
+  module Transition_frontier_controller :
+    Protocols.Coda_transition_frontier.Transition_frontier_controller_intf
+    with type time_controller := Time.Controller.t
+     and type external_transition := External_transition.t
+     and type syncable_ledger_query := Syncable_ledger.query
+     and type syncable_ledger_answer := Syncable_ledger.answer
+     and type transition_frontier := Transition_frontier.t
+     and type state_hash := Protocol_state_hash.t
+
   module Proposer :
     Proposer_intf
     with type ledger_hash := Ledger_hash.t
@@ -438,7 +449,7 @@ module Make (Inputs : Inputs_intf) = struct
         (* TODO: Is this the best spot for the transaction_pool ref? *)
     ; transaction_pool: Transaction_pool.t
     ; snark_pool: Snark_pool.t
-    ; ledger_builder: Ledger_builder_controller.t
+    ; transition_frontier: Transition_frontier.t
     ; strongest_ledgers:
         (Ledger_builder.t * External_transition.t) Linear_pipe.Reader.t
     ; log: Logger.t
@@ -452,19 +463,16 @@ module Make (Inputs : Inputs_intf) = struct
   let propose_keypair t = t.propose_keypair
 
   let best_ledger_builder t =
-    (Ledger_builder_controller.strongest_tip t.ledger_builder).ledger_builder
+    (failwith "TODO: Use transition frontier to get best lb out; you'll need to update the signature")
 
   let best_protocol_state t =
-    (Ledger_builder_controller.strongest_tip t.ledger_builder).state
+    (failwith "TODO: Use transition frontier to get best lb out; you'll need to update the signature")
 
   let best_tip t =
-    let tip = Ledger_builder_controller.strongest_tip t.ledger_builder in
-    (Ledger_builder.ledger tip.ledger_builder, tip.state, tip.proof)
+    (failwith "TODO: Use transition frontier to get best lb out; you'll need to update the signature")
 
   let get_ledger t lh =
-    Ledger_builder_controller.local_get_ledger t.ledger_builder lh
-    |> Deferred.Or_error.map ~f:(fun (lb, _) ->
-           Ledger_builder.ledger lb |> Ledger.to_list )
+    (failwith "TODO: Use transition frontier to find an arbitrary ledger based on a hash")
 
   let best_ledger t = Ledger_builder.ledger (best_ledger_builder t)
 
@@ -512,7 +520,7 @@ module Make (Inputs : Inputs_intf) = struct
 
   let create (config : Config.t) =
     trace_task "coda" (fun () ->
-        let external_transitions_reader, external_transitions_writer =
+        let _external_transitions_reader, external_transitions_writer =
           Linear_pipe.create ()
         in
         let net_ivar = Ivar.create () in
@@ -552,41 +560,21 @@ module Make (Inputs : Inputs_intf) = struct
                    (Ledger_db.create ?directory_name:config.ledger_db_location
                       ()))
         in
-        let lbc_deferred =
-          Ledger_builder_controller.create
-            (Ledger_builder_controller.Config.make
-               ?proposer_public_key:
-                 (Option.map config.propose_keypair ~f:(fun k ->
-                      k.public_key |> Public_key.compress ))
-               ~parent_log:config.log ~net_deferred:(Ivar.read net_ivar)
-               ~genesis_tip:
-                 { ledger_builder=
-                     Ledger_builder.create
-                       ~ledger:
-                         (Ledger.register_mask Genesis.ledger
-                            (Ledger.Mask.create ()))
-                 ; state= Genesis.state
-                 ; proof= Genesis.proof }
-               ~consensus_local_state ~ledger:Genesis.ledger
-               ~longest_tip_location:config.ledger_builder_persistant_location
-               ~external_transitions:external_transitions_reader ())
+        let () =
+          Transition_frontier_controller.run
+            ~logger:config.log
+            ~time_controller:config.time_controller
+            ~frontier:transition_frontier
+            ~transition_reader:(failwith "Turn external_transitions_reader into a strict pipe")
+            ~sync_query_reader:(failwith "TODO")
+            ~sync_answer_writer:(failwith "TODO")
         in
         let%bind net =
           Net.create config.net_config
-            ~get_ledger_builder_aux_at_hash:(fun hash ->
-              let%bind lbc = lbc_deferred in
-              (* TODO: Just make lbc do this *)
-              match%map
-                Ledger_builder_controller.local_get_ledger lbc hash
-              with
-              | Ok (lb, _state) ->
-                  Some
-                    ( Ledger_builder.aux lb
-                    , Ledger.merkle_root (Ledger_builder.ledger lb) )
-              | _ -> None )
-            ~answer_sync_ledger_query:(fun query ->
-              let%bind lbc = lbc_deferred in
-              Ledger_builder_controller.handle_sync_ledger_queries lbc query )
+            ~get_ledger_builder_aux_at_hash:(fun _hash ->
+              failwith "TODO: replace with new net" )
+            ~answer_sync_ledger_query:(fun _query ->
+              failwith "TODO: replace with new net" )
         in
         let%bind transaction_pool =
           Transaction_pool.load ~parent_log:config.log
@@ -599,7 +587,6 @@ module Make (Inputs : Inputs_intf) = struct
                Net.broadcast_transaction_pool_diff net x ;
                Deferred.unit )) ;
         Ivar.fill net_ivar net ;
-        let%bind ledger_builder = lbc_deferred in
         don't_wait_for
           (Linear_pipe.transfer_id (Net.states net) external_transitions_writer) ;
         let%bind snark_pool =
@@ -615,7 +602,7 @@ module Make (Inputs : Inputs_intf) = struct
             , strongest_ledgers_for_network
             , strongest_ledgers_for_api ) =
           Linear_pipe.fork3
-            (Ledger_builder_controller.strongest_ledgers ledger_builder)
+            (failwith "TODO: Broadcast \"best tips\" from transition frontier")
         in
         Linear_pipe.iter strongest_ledgers_for_network ~f:(fun (_, t) ->
             Net.broadcast_state net t ; Deferred.unit )
@@ -670,7 +657,7 @@ module Make (Inputs : Inputs_intf) = struct
           ; external_transitions= external_transitions_writer
           ; transaction_pool
           ; snark_pool
-          ; ledger_builder
+          ; transition_frontier
           ; strongest_ledgers= strongest_ledgers_for_api
           ; log= config.log
           ; seen_jobs= Work_selector.State.init

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -414,8 +414,8 @@ module type Inputs_intf = sig
 
   module Ledger_transfer :
     Coda_pow.Ledger_transfer_intf
-      with type src := Ledger.t
-       and type dest := Ledger_db.t
+    with type src := Ledger.t
+     and type dest := Ledger_db.t
 
   module Genesis : sig
     val state : Consensus_mechanism.Protocol_state.value
@@ -547,9 +547,10 @@ module Make (Inputs : Inputs_intf) = struct
               Transition_frontier.Transaction_snark_scan_state.empty
             ~root_staged_ledger_diff:None
             ~root_snarked_ledger:
-              (Ledger_transfer.transfer_accounts
-                ~src:Genesis.ledger
-                ~dest:(Ledger_db.create ?directory_name:config.ledger_db_location ()))
+              (Ledger_transfer.transfer_accounts ~src:Genesis.ledger
+                 ~dest:
+                   (Ledger_db.create ?directory_name:config.ledger_db_location
+                      ()))
         in
         let lbc_deferred =
           Ledger_builder_controller.create

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -412,6 +412,11 @@ module type Inputs_intf = sig
      and type transition_frontier := Transition_frontier.t
      and type transaction_pool := Transaction_pool.t
 
+  module Ledger_transfer :
+    Coda_pow.Ledger_transfer_intf
+      with type src := Ledger.t
+       and type dest := Ledger_db.t
+
   module Genesis : sig
     val state : Consensus_mechanism.Protocol_state.value
 
@@ -542,7 +547,9 @@ module Make (Inputs : Inputs_intf) = struct
               Transition_frontier.Transaction_snark_scan_state.empty
             ~root_staged_ledger_diff:None
             ~root_snarked_ledger:
-              (Ledger_db.create ?directory_name:config.ledger_db_location ())
+              (Ledger_transfer.transfer_accounts
+                ~src:Genesis.ledger
+                ~dest:(Ledger_db.create ?directory_name:config.ledger_db_location ()))
         in
         let lbc_deferred =
           Ledger_builder_controller.create

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -390,22 +390,26 @@ module type Inputs_intf = sig
 
   module Ledger_db : Coda_pow.Ledger_creatable_intf
 
+  module Masked_ledger : sig
+    type t
+  end
+
   module Transition_frontier :
     Protocols.Coda_transition_frontier.Transition_frontier_base_intf
     with type state_hash := Protocol_state_hash.t
      and type external_transition := External_transition.t
      and type ledger_database := Ledger_db.t
-
-  module Syncable_ledger : sig type query type answer end
+     and type masked_ledger := Masked_ledger.t
 
   module Transition_frontier_controller :
     Protocols.Coda_transition_frontier.Transition_frontier_controller_intf
     with type time_controller := Time.Controller.t
      and type external_transition := External_transition.t
-     and type syncable_ledger_query := Syncable_ledger.query
-     and type syncable_ledger_answer := Syncable_ledger.answer
+     and type syncable_ledger_query := Sync_ledger.query
+     and type syncable_ledger_answer := Sync_ledger.answer
      and type transition_frontier := Transition_frontier.t
      and type state_hash := Protocol_state_hash.t
+     and type time := Time.t
 
   module Proposer :
     Proposer_intf
@@ -463,16 +467,24 @@ module Make (Inputs : Inputs_intf) = struct
   let propose_keypair t = t.propose_keypair
 
   let best_ledger_builder t =
-    (failwith "TODO: Use transition frontier to get best lb out; you'll need to update the signature")
+    failwith
+      "TODO: Use transition frontier to get best lb out; you'll need to \
+       update the signature"
 
   let best_protocol_state t =
-    (failwith "TODO: Use transition frontier to get best lb out; you'll need to update the signature")
+    failwith
+      "TODO: Use transition frontier to get best lb out; you'll need to \
+       update the signature"
 
   let best_tip t =
-    (failwith "TODO: Use transition frontier to get best lb out; you'll need to update the signature")
+    failwith
+      "TODO: Use transition frontier to get best lb out; you'll need to \
+       update the signature"
 
   let get_ledger t lh =
-    (failwith "TODO: Use transition frontier to find an arbitrary ledger based on a hash")
+    failwith
+      "TODO: Use transition frontier to find an arbitrary ledger based on a \
+       hash"
 
   let best_ledger t = Ledger_builder.ledger (best_ledger_builder t)
 
@@ -561,11 +573,11 @@ module Make (Inputs : Inputs_intf) = struct
                       ()))
         in
         let () =
-          Transition_frontier_controller.run
-            ~logger:config.log
+          Transition_frontier_controller.run ~logger:config.log
             ~time_controller:config.time_controller
             ~frontier:transition_frontier
-            ~transition_reader:(failwith "Turn external_transitions_reader into a strict pipe")
+            ~transition_reader:
+              (failwith "Turn external_transitions_reader into a strict pipe")
             ~sync_query_reader:(failwith "TODO")
             ~sync_answer_writer:(failwith "TODO")
         in

--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -1,4 +1,4 @@
 (library
   (name ledger_catchup)
   (public_name ledger_catchup)
-  (libraries async_kernel core_kernel protocols pipe_lib syncable_ledger merkle_address coda_base))
+  (libraries async_kernel transition_frontier consensus core_kernel protocols pipe_lib syncable_ledger merkle_address coda_base))

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -1,18 +1,19 @@
 open Core_kernel
 open Async_kernel
-open Protocols.Coda_pow
+open Protocols.Coda_transition_frontier
 open Pipe_lib
+open Coda_base
 
 module type Inputs_intf = sig
-  module Consensus_mechanism : Consensus_mechanism_intf
+  include Transition_frontier.Inputs_intf
 
-  module Transition_frontier : Transition_frontier_intf
-
-  module External_transition :
-    External_transition_intf
-    with type protocol_state := Consensus_mechanism.Protocol_state.value
-     and type ledger_builder_diff := Consensus_mechanism.ledger_builder_diff
-     and type protocol_state_proof := Consensus_mechanism.protocol_state_proof
+  module Transition_frontier :
+    Transition_frontier_intf
+    with type state_hash := State_hash.t
+     and type external_transition := External_transition.t
+     and type ledger_database := Ledger.Db.t
+     and type ledger_builder := Ledger_builder.t
+     and type masked_ledger := Ledger.Mask.Attached.t
 end
 
 module Make (Inputs : Inputs_intf) :
@@ -21,7 +22,7 @@ module Make (Inputs : Inputs_intf) :
    and type transition_frontier := Inputs.Transition_frontier.t
    and type transition_frontier_breadcrumb :=
               Inputs.Transition_frontier.Breadcrumb.t
-   and type state_hash := Coda_base.State_hash.t = struct
+   and type state_hash := State_hash.t = struct
   let run ~frontier:_ ~catchup_job_reader ~catchup_breadcrumbs_writer:_ =
     don't_wait_for
       (Strict_pipe.Reader.iter catchup_job_reader ~f:(fun _ ->

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -14,12 +14,17 @@ module type Inputs_intf = sig
     type t
   end
 
+  module Masked_ledger : sig
+    type t
+  end
+
   module Transition_frontier :
     Protocols.Coda_transition_frontier.Transition_frontier_intf
     with type state_hash := State_hash.t
      and type external_transition := External_transition.t
      and type ledger_database := Ledger_db.t
      and type ledger_builder := Ledger_builder.t
+     and type masked_ledger := Masked_ledger.t
 
   module Transaction_pool :
     Coda_lib.Transaction_pool_read_intf

--- a/src/lib/sync_handler/dune
+++ b/src/lib/sync_handler/dune
@@ -2,4 +2,4 @@
   (name sync_handler)
   (public_name sync_handler)
   (preprocess (pps ppx_jane))
-  (libraries async_kernel core_kernel protocols coda_base syncable_ledger merkle_address))
+  (libraries async_kernel core_kernel protocols coda_base transition_frontier syncable_ledger merkle_address))

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -16,13 +16,13 @@ module type Inputs_intf = sig
      and type masked_ledger := Ledger.Mask.Attached.t
 
   module Syncable_ledger :
-      Syncable_ledger.S
-      with type addr := Ledger.Addr.t
-       and type hash := Ledger_hash.t
-       and type merkle_tree := Ledger.Mask.Attached.t
-       and type merkle_path := Ledger.path
-       and type root_hash := Ledger_hash.t
-       and type account := Account.t
+    Syncable_ledger.S
+    with type addr := Ledger.Addr.t
+     and type hash := Ledger_hash.t
+     and type merkle_tree := Ledger.Mask.Attached.t
+     and type merkle_path := Ledger.path
+     and type root_hash := Ledger_hash.t
+     and type account := Account.t
 end
 
 module Make (Inputs : Inputs_intf) :
@@ -38,7 +38,9 @@ module Make (Inputs : Inputs_intf) :
   let answer_query ~frontier (hash, query) =
     let open Option.Let_syntax in
     let%map breadcrumb = Transition_frontier.find frontier hash in
-    let staged_ledger = Transition_frontier.Breadcrumb.staged_ledger breadcrumb in
+    let staged_ledger =
+      Transition_frontier.Breadcrumb.staged_ledger breadcrumb
+    in
     let ledger = Transition_frontier.Staged_ledger.ledger staged_ledger in
     let responder = Syncable_ledger.Responder.create ledger ignore in
     let answer = Syncable_ledger.Responder.answer_query responder query in

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -9,52 +9,53 @@ module Max_length = struct
 end
 
 module type Inputs_intf = sig
-module Completed_work : sig
-  type t
-
-  module Checked : sig
+  module Completed_work : sig
     type t
+
+    module Checked : sig
+      type t
+    end
   end
+
+  module Ledger_builder_diff :
+    Ledger_builder_diff_intf
+    with type user_command := User_command.t
+     and type user_command_with_valid_signature :=
+                User_command.With_valid_signature.t
+     and type ledger_builder_hash := Ledger_builder_hash.t
+     and type public_key := Public_key.Compressed.t
+     and type completed_work := Completed_work.t
+     and type completed_work_checked := Completed_work.Checked.t
+
+  module External_transition :
+    External_transition.S
+    with module Protocol_state = Consensus.Mechanism.Protocol_state
+     and module Ledger_builder_diff := Ledger_builder_diff
+
+  module Ledger_builder :
+    Ledger_builder_intf
+    with type diff := Ledger_builder_diff.t
+     and type valid_diff :=
+                Ledger_builder_diff.With_valid_signatures_and_proofs.t
+     and type ledger_builder_hash := Ledger_builder_hash.t
+     and type ledger_hash := Ledger_hash.t
+     and type frozen_ledger_hash := Frozen_ledger_hash.t
+     and type public_key := Public_key.Compressed.t
+     and type ledger := Ledger.t
+     and type user_command_with_valid_signature :=
+                User_command.With_valid_signature.t
+     and type completed_work := Completed_work.Checked.t
 end
-module Ledger_builder_diff : Ledger_builder_diff_intf
-                       with type user_command := User_command.t
-                        and type user_command_with_valid_signature :=
-                                   User_command.With_valid_signature.t
-                        and type ledger_builder_hash := Ledger_builder_hash.t
-                        and type public_key := Public_key.Compressed.t
-                        and type completed_work := Completed_work.t
-                        and type completed_work_checked :=
-                                   Completed_work.Checked.t
 
-module External_transition : External_transition.S
-                       with module Protocol_state = Consensus.Mechanism
-                                                    .Protocol_state
-                        and module Ledger_builder_diff := Ledger_builder_diff
-
-module Ledger_builder : Ledger_builder_intf
-                  with type diff := Ledger_builder_diff.t
-                   and type valid_diff :=
-                              Ledger_builder_diff
-                              .With_valid_signatures_and_proofs
-                              .t
-                   and type ledger_builder_hash := Ledger_builder_hash.t
-                   and type ledger_hash := Ledger_hash.t
-                   and type frozen_ledger_hash := Frozen_ledger_hash.t
-                   and type public_key := Public_key.Compressed.t
-                   and type ledger := Ledger.t
-                   and type user_command_with_valid_signature :=
-                              User_command.With_valid_signature.t
-                   and type completed_work := Completed_work.Checked.t
-end
-
-module Make (Inputs: Inputs_intf) :
+module Make (Inputs : Inputs_intf) :
   Transition_frontier_intf
   with type state_hash := State_hash.t
    and type external_transition := Inputs.External_transition.t
    and type ledger_database := Ledger.Db.t
    and type masked_ledger := Ledger.Mask.Attached.t
    and type ledger_builder := Inputs.Ledger_builder.t = struct
-     open Inputs
+  open Inputs
+
   type ledger_diff = Ledger_builder_diff.t
 
   (* Transaction_snark_scan_state and Staged_ledger long-term will not live in

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -8,14 +8,15 @@ module Max_length = struct
   let length = 2160
 end
 
-module Make (Completed_work : sig
+module type Inputs_intf = sig
+module Completed_work : sig
   type t
 
   module Checked : sig
     type t
   end
-end)
-(Ledger_builder_diff : Ledger_builder_diff_intf
+end
+module Ledger_builder_diff : Ledger_builder_diff_intf
                        with type user_command := User_command.t
                         and type user_command_with_valid_signature :=
                                    User_command.With_valid_signature.t
@@ -23,12 +24,14 @@ end)
                         and type public_key := Public_key.Compressed.t
                         and type completed_work := Completed_work.t
                         and type completed_work_checked :=
-                                   Completed_work.Checked.t)
-(External_transition : External_transition.S
+                                   Completed_work.Checked.t
+
+module External_transition : External_transition.S
                        with module Protocol_state = Consensus.Mechanism
                                                     .Protocol_state
-                        and module Ledger_builder_diff := Ledger_builder_diff)
-(Ledger_builder : Ledger_builder_intf
+                        and module Ledger_builder_diff := Ledger_builder_diff
+
+module Ledger_builder : Ledger_builder_intf
                   with type diff := Ledger_builder_diff.t
                    and type valid_diff :=
                               Ledger_builder_diff
@@ -41,12 +44,17 @@ end)
                    and type ledger := Ledger.t
                    and type user_command_with_valid_signature :=
                               User_command.With_valid_signature.t
-                   and type completed_work := Completed_work.Checked.t) :
+                   and type completed_work := Completed_work.Checked.t
+end
+
+module Make (Inputs: Inputs_intf) :
   Transition_frontier_intf
   with type state_hash := State_hash.t
-   and type external_transition := External_transition.t
+   and type external_transition := Inputs.External_transition.t
    and type ledger_database := Ledger.Db.t
-   and type ledger_builder := Ledger_builder.t = struct
+   and type masked_ledger := Ledger.Mask.Attached.t
+   and type ledger_builder := Inputs.Ledger_builder.t = struct
+     open Inputs
   type ledger_diff = Ledger_builder_diff.t
 
   (* Transaction_snark_scan_state and Staged_ledger long-term will not live in

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -1,4 +1,4 @@
 (library
   (name transition_frontier_controller)
   (public_name transition_frontier_controller)
-  (libraries core_kernel protocols coda_base syncable_ledger merkle_address merkle_mask genesis_ledger))
+  (libraries core_kernel consensus protocols coda_base syncable_ledger merkle_address merkle_mask sync_handler genesis_ledger))

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -1,4 +1,4 @@
 (library
   (name transition_frontier_controller)
   (public_name transition_frontier_controller)
-  (libraries core_kernel consensus protocols coda_base syncable_ledger merkle_address merkle_mask sync_handler genesis_ledger))
+  (libraries core_kernel consensus protocols coda_base syncable_ledger merkle_address merkle_mask sync_handler transition_handler genesis_ledger))

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -8,13 +8,14 @@ module type Inputs_intf = sig
 
   module Time : Time_intf
 
-  module Sync_handler : Sync_handler_intf
-  with type addr := Ledger.Addr.t
-   and type hash := State_hash.t
-   and type syncable_ledger := Syncable_ledger.t
-   and type syncable_ledger_query := Syncable_ledger.query
-   and type syncable_ledger_answer := Syncable_ledger.answer
-   and type transition_frontier := Transition_frontier.t
+  module Sync_handler :
+    Sync_handler_intf
+    with type addr := Ledger.Addr.t
+     and type hash := State_hash.t
+     and type syncable_ledger := Syncable_ledger.t
+     and type syncable_ledger_query := Syncable_ledger.query
+     and type syncable_ledger_answer := Syncable_ledger.answer
+     and type transition_frontier := Transition_frontier.t
 
   module Transition_handler :
     Transition_handler_intf

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -23,6 +23,7 @@ module type Inputs_intf = sig
      and type external_transition := External_transition.t
      and type state_hash := State_hash.t
      and type transition_frontier := Transition_frontier.t
+     and type time := Time.t
      and type transition_frontier_breadcrumb :=
                 Transition_frontier.Breadcrumb.t
 
@@ -42,6 +43,7 @@ module Make (Inputs : Inputs_intf) :
    and type syncable_ledger_query := Inputs.Syncable_ledger.query
    and type syncable_ledger_answer := Inputs.Syncable_ledger.answer
    and type transition_frontier := Inputs.Transition_frontier.t
+   and type time := Inputs.Time.t
    and type state_hash := State_hash.t = struct
   open Inputs
 
@@ -58,7 +60,7 @@ module Make (Inputs : Inputs_intf) :
       Strict_pipe.create (Buffered (`Capacity 3, `Overflow Crash))
     in
     Transition_handler.Validator.run ~frontier ~transition_reader
-      ~valid_transition_writer ;
+      ~valid_transition_writer ~logger ;
     Transition_handler.Processor.run ~logger ~time_controller ~frontier
       ~valid_transition_reader ~catchup_job_writer ~catchup_breadcrumbs_reader ;
     Catchup.run ~frontier ~catchup_job_reader ~catchup_breadcrumbs_writer ;

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -5,6 +5,7 @@ open Pipe_lib
 
 module type Inputs_intf = sig
   include Sync_handler.Inputs_intf
+  include Transition_handler.Inputs.S
 
   module Time : Time_intf
 

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -1,62 +1,20 @@
 open Protocols.Coda_pow
+open Protocols.Coda_transition_frontier
 open Coda_base
 open Pipe_lib
-open Signature_lib
 
 module type Inputs_intf = sig
+  include Sync_handler.Inputs_intf
+
   module Time : Time_intf
 
-  module Consensus_mechanism :
-    Consensus_mechanism_intf with type protocol_state_hash := State_hash.t
-
-  module External_transition :
-    External_transition_intf
-    with type protocol_state := Consensus_mechanism.Protocol_state.value
-     and type ledger_builder_diff := Consensus_mechanism.ledger_builder_diff
-     and type protocol_state_proof := Consensus_mechanism.protocol_state_proof
-
-  module Ledger_builder_diff : Ledger_builder_diff_intf
-
-  module Merkle_address : Merkle_address.S
-
-  module Syncable_ledger :
-    Syncable_ledger.S
-    with type addr := Merkle_address.t
-     and type hash := Ledger_hash.t
-
-  module Ledger_builder :
-    Ledger_builder_intf
-    with type diff := Ledger_builder_diff.t
-     and type valid_diff :=
-                Ledger_builder_diff.With_valid_signatures_and_proofs.t
-     and type ledger_builder_hash := Ledger_builder_hash.t
-     and type ledger_hash := Ledger_hash.t
-     and type frozen_ledger_hash := Frozen_ledger_hash.t
-     and type public_key := Public_key.Compressed.t
-     and type ledger := Ledger.t
-     and type user_command_with_valid_signature :=
-                User_command.With_valid_signature.t
-
-  module Ledger_diff : sig
-    type t
-
-    val empty : t
-  end
-
-  module Transition_frontier :
-    Transition_frontier_intf
-    with type external_transition := External_transition.t
-     and type state_hash := State_hash.t
-     and type ledger_database := Ledger.Db.t
-     and type ledger_diff := Ledger_diff.t
-
-  type ledger_database
-
-  type transaction_snark_scan_state
-
-  type ledger_diff
-
-  type staged_ledger
+  module Sync_handler : Sync_handler_intf
+  with type addr := Ledger.Addr.t
+   and type hash := State_hash.t
+   and type syncable_ledger := Syncable_ledger.t
+   and type syncable_ledger_query := Syncable_ledger.query
+   and type syncable_ledger_answer := Syncable_ledger.answer
+   and type transition_frontier := Transition_frontier.t
 
   module Transition_handler :
     Transition_handler_intf
@@ -74,15 +32,6 @@ module type Inputs_intf = sig
      and type transition_frontier := Transition_frontier.t
      and type transition_frontier_breadcrumb :=
                 Transition_frontier.Breadcrumb.t
-
-  module Sync_handler :
-    Sync_handler_intf
-    with type addr := Merkle_address.t
-     and type hash := State_hash.t
-     and type syncable_ledger := Ledger.t
-     and type transition_frontier := Transition_frontier.t
-     and type syncable_ledger_query := Syncable_ledger.query
-     and type syncable_ledger_answer := Syncable_ledger.answer
 end
 
 module Make (Inputs : Inputs_intf) :

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -5,7 +5,6 @@ open Pipe_lib
 
 module type Inputs_intf = sig
   include Sync_handler.Inputs_intf
-  include Transition_handler.Inputs.S
 
   module Time : Time_intf
 

--- a/src/lib/transition_handler/catchup_monitor.ml
+++ b/src/lib/transition_handler/catchup_monitor.ml
@@ -1,11 +1,11 @@
 open Core_kernel
 open Pipe_lib.Strict_pipe
 open With_hash
-module State_hash = Coda_base.State_hash
+open Coda_base
 
 module Make (Inputs : Inputs.S) = struct
   open Inputs
-  open Consensus_mechanism
+  open Consensus.Mechanism
 
   type t =
     { catchup_job_writer:

--- a/src/lib/transition_handler/dune
+++ b/src/lib/transition_handler/dune
@@ -1,5 +1,5 @@
 (library
   (name transition_handler)
   (public_name transition_handler)
-  (libraries core_kernel protocols coda_base)
+  (libraries core_kernel transition_frontier consensus protocols coda_base)
   (preprocess (pps ppx_jane)))

--- a/src/lib/transition_handler/inputs.ml
+++ b/src/lib/transition_handler/inputs.ml
@@ -1,27 +1,22 @@
 open Protocols.Coda_pow
+open Coda_base
 
 module type S = sig
   module Time : Time_intf
-
-  module Consensus_mechanism :
-    Consensus_mechanism_intf
-    with type protocol_state_hash := Coda_base.State_hash.t
-     and type protocol_state_proof := Coda_base.Proof.t
-
-  module External_transition :
-    External_transition_intf
-    with type protocol_state := Consensus_mechanism.Protocol_state.value
-     and type protocol_state_proof := Coda_base.Proof.t
+  include Transition_frontier.Inputs_intf
 
   module Proof :
     Proof_intf
-    with type input := Consensus_mechanism.Protocol_state.value
-     and type t := Coda_base.Proof.t
+    with type input := Consensus.Mechanism.Protocol_state.value
+     and type t := Proof.t
 
   module Transition_frontier :
     Transition_frontier_intf
-    with type state_hash := Coda_base.State_hash.t
+    with type state_hash := State_hash.t
      and type external_transition := External_transition.t
+     and type ledger_database := Ledger.Db.t
+     and type ledger_builder := Ledger_builder.t
+     and type masked_ledger := Ledger.Mask.Attached.t
 end
 
 (*

--- a/src/lib/transition_handler/inputs.ml
+++ b/src/lib/transition_handler/inputs.ml
@@ -3,6 +3,7 @@ open Coda_base
 
 module type S = sig
   module Time : Time_intf
+
   include Transition_frontier.Inputs_intf
 
   module Proof :

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -1,18 +1,19 @@
 open Core_kernel
 open Protocols.Coda_pow
 open Pipe_lib.Strict_pipe
+open Coda_base
 open O1trace
 
 module Make (Inputs : Inputs.S) :
   Transition_handler_processor_intf
-  with type state_hash := Coda_base.State_hash.t
+  with type state_hash := State_hash.t
    and type time_controller := Inputs.Time.Controller.t
    and type external_transition := Inputs.External_transition.t
    and type transition_frontier := Inputs.Transition_frontier.t
    and type transition_frontier_breadcrumb :=
               Inputs.Transition_frontier.Breadcrumb.t = struct
   open Inputs
-  open Consensus_mechanism
+  open Consensus.Mechanism
   module Catchup_monitor = Catchup_monitor.Make (Inputs)
 
   (* TODO: calculate a sensible value from postake consensus arguments *)

--- a/src/lib/transition_handler/transition_handler.ml
+++ b/src/lib/transition_handler/transition_handler.ml
@@ -5,7 +5,8 @@ module Inputs = Inputs
 
 module Make (Inputs : Inputs.S) :
   Transition_handler_intf
-  with type time_controller := Inputs.Time.Controller.t
+  with type time := Inputs.Time.t
+   and type time_controller := Inputs.Time.Controller.t
    and type external_transition := Inputs.External_transition.t
    and type state_hash := State_hash.t
    and type transition_frontier := Inputs.Transition_frontier.t

--- a/src/lib/transition_handler/transition_handler.ml
+++ b/src/lib/transition_handler/transition_handler.ml
@@ -1,6 +1,18 @@
-(*
-module Make (Inputs : Inputs_intf) : Transaction_handler_intf = struct
+open Protocols.Coda_transition_frontier
+open Coda_base
+
+module Inputs = Inputs
+
+module Make (Inputs : Inputs.S) :
+  Transition_handler_intf
+  with type time_controller := Inputs.Time.Controller.t
+   and type external_transition := Inputs.External_transition.t
+   and type state_hash := State_hash.t
+   and type transition_frontier := Inputs.Transition_frontier.t
+   and type transition_frontier_breadcrumb :=
+              Inputs.Transition_frontier.Breadcrumb.t
+= struct
   module Validator = Validator.Make (Inputs)
   module Processor = Processor.Make (Inputs)
 end
- *)
+

--- a/src/lib/transition_handler/transition_handler.ml
+++ b/src/lib/transition_handler/transition_handler.ml
@@ -1,6 +1,5 @@
 open Protocols.Coda_transition_frontier
 open Coda_base
-
 module Inputs = Inputs
 
 module Make (Inputs : Inputs.S) :
@@ -11,9 +10,7 @@ module Make (Inputs : Inputs.S) :
    and type state_hash := State_hash.t
    and type transition_frontier := Inputs.Transition_frontier.t
    and type transition_frontier_breadcrumb :=
-              Inputs.Transition_frontier.Breadcrumb.t
-= struct
+              Inputs.Transition_frontier.Breadcrumb.t = struct
   module Validator = Validator.Make (Inputs)
   module Processor = Processor.Make (Inputs)
 end
-

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -4,7 +4,7 @@ open Pipe_lib.Strict_pipe
 
 module Make (Inputs : Inputs.S) = struct
   open Inputs
-  open Consensus_mechanism
+  open Consensus.Mechanism
   open Deferred.Let_syntax
 
   let validate_transition ~logger ~frontier ~time_received t =
@@ -30,10 +30,10 @@ module Make (Inputs : Inputs.S) = struct
     in
     if
       log_assert
-        (Consensus_mechanism.is_valid (consensus_state t) ~time_received)
+        (Consensus.Mechanism.is_valid (consensus_state t) ~time_received)
         "failed consensus validation"
       && log_assert
-           ( Consensus_mechanism.select ~logger
+           ( Consensus.Mechanism.select ~logger
                ~existing:(consensus_state root) ~candidate:(consensus_state t)
                ~time_received
            = `Take )

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -65,7 +65,12 @@ module Make (Inputs : Inputs.S) = struct
          ~f:(fun (`Transition transition, `Time_received time_received) ->
            if%map
              validate_transition ~logger ~frontier ~time_received transition
-           then Writer.write valid_transition_writer (With_hash.of_data transition ~hash_data:(Fn.compose Protocol_state.hash External_transition.protocol_state))
+           then
+             Writer.write valid_transition_writer
+               (With_hash.of_data transition
+                  ~hash_data:
+                    (Fn.compose Protocol_state.hash
+                       External_transition.protocol_state))
            else
              (* TODO: punish *)
              Logger.warn logger "failed to verify transition from the network!"

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -65,7 +65,7 @@ module Make (Inputs : Inputs.S) = struct
          ~f:(fun (`Transition transition, `Time_received time_received) ->
            if%map
              validate_transition ~logger ~frontier ~time_received transition
-           then Writer.write valid_transition_writer transition
+           then Writer.write valid_transition_writer (With_hash.of_data transition ~hash_data:(Fn.compose Protocol_state.hash External_transition.protocol_state))
            else
              (* TODO: punish *)
              Logger.warn logger "failed to verify transition from the network!"

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -179,6 +179,7 @@ end
 
 module type Ledger_transfer_intf = sig
   type src
+
   type dest
 
   val transfer_accounts : src:src -> dest:dest -> dest

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -177,6 +177,13 @@ module type Ledger_creatable_intf = sig
   val create : ?directory_name:string -> unit -> t
 end
 
+module type Ledger_transfer_intf = sig
+  type src
+  type dest
+
+  val transfer_accounts : src:src -> dest:dest -> dest
+end
+
 module type Ledger_intf = sig
   include Ledger_creatable_intf
 

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -107,6 +107,8 @@ module type Catchup_intf = sig
 end
 
 module type Transition_handler_validator_intf = sig
+  type time
+
   type state_hash
 
   type external_transition
@@ -114,11 +116,12 @@ module type Transition_handler_validator_intf = sig
   type transition_frontier
 
   val run :
-       frontier:transition_frontier
-    -> transition_reader:external_transition Reader.t
+       logger:Logger.t
+    -> frontier:transition_frontier
+    -> transition_reader:([`Transition of external_transition] * [`Time_received of time]) Reader.t
     -> valid_transition_writer:( (external_transition, state_hash) With_hash.t
                                , drop_head buffered
-                               , _ )
+                               , unit )
                                Writer.t
     -> unit
 end
@@ -151,6 +154,8 @@ end
 module type Transition_handler_intf = sig
   type time_controller
 
+  type time
+
   type state_hash
 
   type external_transition
@@ -161,7 +166,8 @@ module type Transition_handler_intf = sig
 
   module Validator :
     Transition_handler_validator_intf
-    with type state_hash := state_hash
+    with type time := time
+     and type state_hash := state_hash
      and type external_transition := external_transition
      and type transition_frontier := transition_frontier
 

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -5,10 +5,20 @@ module type Transition_frontier_base_intf = sig
 
   type external_transition
 
+  type masked_ledger
+
+  type staged_ledger
+
   module Transaction_snark_scan_state : sig
     type t
 
     val empty : t
+  end
+
+  module Staged_ledger : sig
+    type t = staged_ledger
+
+    val ledger : t -> masked_ledger
   end
 
   type ledger_database
@@ -28,8 +38,6 @@ end
 
 module type Transition_frontier_intf = sig
   include Transition_frontier_base_intf
-
-  type staged_ledger
 
   type ledger_builder
 

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -118,7 +118,9 @@ module type Transition_handler_validator_intf = sig
   val run :
        logger:Logger.t
     -> frontier:transition_frontier
-    -> transition_reader:([`Transition of external_transition] * [`Time_received of time]) Reader.t
+    -> transition_reader:( [`Transition of external_transition]
+                         * [`Time_received of time] )
+                         Reader.t
     -> valid_transition_writer:( (external_transition, state_hash) With_hash.t
                                , drop_head buffered
                                , unit )
@@ -216,11 +218,15 @@ module type Transition_frontier_controller_intf = sig
 
   type transition_frontier
 
+  type time
+
   val run :
        logger:Logger.t
     -> time_controller:time_controller
     -> frontier:transition_frontier
-    -> transition_reader:external_transition Reader.t
+    -> transition_reader:( [`Transition of external_transition]
+                         * [`Time_received of time] )
+                         Reader.t
     -> sync_query_reader:(state_hash * syncable_ledger_query) Reader.t
     -> sync_answer_writer:( state_hash * syncable_ledger_answer
                           , synchronous

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -198,14 +198,14 @@ module type Transition_frontier_controller_intf = sig
 
   type syncable_ledger_answer
 
-  type transition_frontier
-
   type state_hash
+
+  type transition_frontier
 
   val run :
        logger:Logger.t
     -> time_controller:time_controller
-    -> genesis_transition:external_transition
+    -> frontier:transition_frontier
     -> transition_reader:external_transition Reader.t
     -> sync_query_reader:(state_hash * syncable_ledger_query) Reader.t
     -> sync_answer_writer:( state_hash * syncable_ledger_answer


### PR DESCRIPTION
Transition frontier controller is entirely hooked in but there are failwith holes present (see `coda_lib.ml`). These holes can be filled in by people in parallel.

For reviewers: You should be able to read the commits chronologically and it should make sense.

It compiles

Thanks @nholland94 for fixing up the transition_handler stuff