### PR TITLE
remove constraint system from proving key

### DIFF
--- a/src/app/cli/src/prover.ml
+++ b/src/app/cli/src/prover.ml
@@ -55,6 +55,13 @@ module Worker_state = struct
     Deferred.return
       (let module Keys = Keys_lib.Keys.Make (Consensus_mechanism) in
       let%map (module Keys) = Keys.create () in
+      (let open Snark_params in
+      Tock.prepare_proving_key
+        (Tock.Keypair.pk Keys.Wrap.keys)
+        Keys.Wrap.input Keys.Wrap.main ;
+      Tick.prepare_proving_key
+        (Tick.Keypair.pk Keys.Step.keys)
+        (Keys.Step.input ()) Keys.Step.main) ;
       let module Transaction_snark =
       Transaction_snark.Verification.Make (struct
         let keys = Keys.transaction_snark_keys

--- a/src/lib/snarky/src/backend_intf.ml
+++ b/src/lib/snarky/src/backend_intf.ml
@@ -38,39 +38,6 @@ module type S = sig
     val set_is_square : t -> bool -> unit
   end
 
-  module Proving_key : sig
-    type t [@@deriving bin_io]
-
-    val to_string : t -> string
-
-    val of_string : string -> t
-
-    val to_bigstring : t -> Bigstring.t
-
-    val of_bigstring : Bigstring.t -> t
-  end
-
-  module Verification_key : sig
-    type t
-
-    include Stringable.S with type t := t
-
-    val to_bigstring : t -> Bigstring.t
-
-    val of_bigstring : Bigstring.t -> t
-  end
-
-  module Proof : sig
-    type t
-
-    include Stringable.S with type t := t
-
-    val create :
-      Proving_key.t -> primary:Field.Vector.t -> auxiliary:Field.Vector.t -> t
-
-    val verify : t -> Verification_key.t -> Field.Vector.t -> bool
-  end
-
   module R1CS_constraint_system : sig
     type t
 
@@ -100,6 +67,41 @@ module type S = sig
       -> bool
 
     val digest : t -> Md5.t
+  end
+
+  module Proving_key : sig
+    type t [@@deriving bin_io]
+
+    val r1cs_constraint_system : t -> R1CS_constraint_system.t
+
+    val to_string : t -> string
+
+    val of_string : string -> t
+
+    val to_bigstring : t -> Bigstring.t
+
+    val of_bigstring : Bigstring.t -> t
+  end
+
+  module Verification_key : sig
+    type t
+
+    include Stringable.S with type t := t
+
+    val to_bigstring : t -> Bigstring.t
+
+    val of_bigstring : Bigstring.t -> t
+  end
+
+  module Proof : sig
+    type t
+
+    include Stringable.S with type t := t
+
+    val create :
+      Proving_key.t -> primary:Field.Vector.t -> auxiliary:Field.Vector.t -> t
+
+    val verify : t -> Verification_key.t -> Field.Vector.t -> bool
   end
 
   module Keypair : sig

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
@@ -455,6 +455,13 @@ r1cs_constraint_system<FieldT>* camlsnark_bn128_r1cs_constraint_system_create() 
   return new r1cs_constraint_system<FieldT>();
 }
 
+void camlsnark_bn128_r1cs_constraint_system_clear(r1cs_constraint_system<FieldT>* sys) {
+  sys->primary_input_size = 0;
+  sys->auxiliary_input_size = 0;
+  sys->num_square_constraints = 0;
+  sys->constraints.clear();
+}
+
 void camlsnark_bn128_linear_combination_update_digest(
     linear_combination<FieldT>& lc,
     MD5_CTX* ctx) {

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
@@ -455,6 +455,13 @@ r1cs_constraint_system<FieldT>* camlsnark_mnt4_r1cs_constraint_system_create() {
   return new r1cs_constraint_system<FieldT>();
 }
 
+void camlsnark_mnt4_r1cs_constraint_system_clear(r1cs_constraint_system<FieldT>* sys) {
+  sys->primary_input_size = 0;
+  sys->auxiliary_input_size = 0;
+  sys->num_square_constraints = 0;
+  sys->constraints.clear();
+}
+
 void camlsnark_mnt4_linear_combination_update_digest(
     linear_combination<FieldT>& lc,
     MD5_CTX* ctx) {

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
@@ -455,6 +455,13 @@ r1cs_constraint_system<FieldT>* camlsnark_mnt6_r1cs_constraint_system_create() {
   return new r1cs_constraint_system<FieldT>();
 }
 
+void camlsnark_mnt6_r1cs_constraint_system_clear(r1cs_constraint_system<FieldT>* sys) {
+  sys->primary_input_size = 0;
+  sys->auxiliary_input_size = 0;
+  sys->num_square_constraints = 0;
+  sys->constraints.clear();
+}
+
 void camlsnark_mnt6_linear_combination_update_digest(
     linear_combination<FieldT>& lc,
     MD5_CTX* ctx) {

--- a/src/lib/snarky/src/libsnark.ml
+++ b/src/lib/snarky/src/libsnark.ml
@@ -541,6 +541,8 @@ struct
 
     val create : unit -> t
 
+    val clear : t -> unit
+
     val delete : t -> unit
 
     val report_statistics : t -> unit
@@ -577,6 +579,8 @@ struct
     let func_name s = with_prefix prefix s
 
     let delete = foreign (func_name "delete") (typ @-> returning void)
+
+    let clear = foreign (func_name "clear") (typ @-> returning void)
 
     let report_statistics =
       foreign (func_name "report_statistics") (typ @-> returning void)
@@ -1016,6 +1020,8 @@ module Make_proof_system (M : sig
     type t
 
     val typ : t Ctypes.typ
+
+    val clear : t -> unit
   end
 
   module Field : sig
@@ -1033,6 +1039,8 @@ struct
     val typ : t Ctypes.typ
 
     val delete : t -> unit
+
+    val r1cs_constraint_system : t -> M.R1CS_constraint_system.t
 
     val to_string : t -> string
 
@@ -1052,8 +1060,18 @@ struct
 
     let delete = foreign (with_prefix prefix "delete") (typ @-> returning void)
 
+    let r1cs_constraint_system =
+      foreign
+        (with_prefix prefix "r1cs_constraint_system")
+        (typ @-> returning M.R1CS_constraint_system.typ)
+
     let to_cpp_string_stub : t -> Cpp_string.t =
-      foreign (func_name "to_string") (typ @-> returning Cpp_string.typ)
+     fun t ->
+      let stub =
+        foreign (func_name "to_string") (typ @-> returning Cpp_string.typ)
+      in
+      M.R1CS_constraint_system.clear (r1cs_constraint_system t) ;
+      stub t
 
     let to_string : t -> string =
      fun t ->

--- a/src/lib/snarky/src/snark_intf.ml
+++ b/src/lib/snarky/src/snark_intf.ml
@@ -497,6 +497,12 @@ module type Basic = sig
     -> 'k_var
     -> Keypair.t
 
+  val prepare_proving_key :
+       Proving_key.t
+    -> ((unit, 's) Checked.t, _, 'k_var, _) Data_spec.t
+    -> 'k_var
+    -> unit
+
   val prove :
        Proving_key.t
     -> ((unit, 's) Checked.t, Proof.t, 'k_var, 'k_value) Data_spec.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -963,6 +963,11 @@ struct
     let base = keys.verification.base
   end)
 
+  let () =
+    Tock.prepare_proving_key keys.proving.wrap wrap_input Wrap.main ;
+    Tick.prepare_proving_key keys.proving.base (tick_input ()) Base.main ;
+    Tick.prepare_proving_key keys.proving.merge (tick_input ()) Merge.main
+
   let wrap proof_type proof input =
     let prover_state = {Wrap.Prover_state.proof; proof_type} in
     Tock.prove keys.proving.wrap wrap_input prover_state Wrap.main


### PR DESCRIPTION
This removes the constraint system from the proving key so that the serialized key is much smaller (we recompute the constraint system from scratch the first time we prove). This is kind of a gross hack and has some bad attributes. Namely that the latency of the first proof will be significantly higher than subsequent ones.