### PR TITLE
Rip out old pipes from coda_lib

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -295,8 +295,10 @@ let daemon log =
          let banlist =
            Coda_base.Banlist.create ~suspicious_dir ~punished_dir
          in
+         let time_controller = Inputs.Time.Controller.create () in
          let net_config =
            { Inputs.Net.Config.parent_log= log
+           ; time_controller
            ; gossip_net_params=
                { timeout= Time.Span.of_sec 1.
                ; parent_log= log
@@ -322,8 +324,8 @@ let daemon log =
                 ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")
                 ~ledger_db_location:(conf_dir ^/ "ledger_db")
                 ~snark_work_fee:snark_work_fee_flag ~receipt_chain_database
-                ~time_controller:(Inputs.Time.Controller.create ())
-                ?propose_keypair:Config0.propose_keypair () ~banlist)
+                ~time_controller ?propose_keypair:Config0.propose_keypair ()
+                ~banlist)
          in
          let web_service = Web_pipe.get_service () in
          Web_pipe.run_service (module Run) coda web_service ~conf_dir ~log ;

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -183,6 +183,7 @@ module type Main_intf = sig
       module Config :
         Coda_networking.Config_intf
         with type gossip_config := Gossip_net.Config.t
+         and type time_controller := Time.Controller.t
     end
 
     module Sparse_ledger : sig

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -212,8 +212,10 @@ module T = struct
           ~directory:receipt_chain_dir_name
       in
       let banlist = Coda_base.Banlist.create ~suspicious_dir ~punished_dir in
+      let time_controller = Main.Inputs.Time.Controller.create () in
       let net_config =
         { Main.Inputs.Net.Config.parent_log= log
+        ; time_controller
         ; gossip_net_params=
             { Main.Inputs.Net.Gossip_net.Config.timeout= Time.Span.of_sec 1.
             ; target_peer_count= 8
@@ -234,8 +236,8 @@ module T = struct
              ~transaction_pool_disk_location:
                (conf_temp_dir ^/ "transaction_pool")
              ~snark_pool_disk_location:(conf_temp_dir ^/ "snark_pool")
-             ~time_controller:(Main.Inputs.Time.Controller.create ())
-             ~receipt_chain_database ~snark_work_fee:(Currency.Fee.of_int 0)
+             ~time_controller ~receipt_chain_database
+             ~snark_work_fee:(Currency.Fee.of_int 0)
              ?propose_keypair:Config.propose_keypair () ~banlist)
       in
       Option.iter snark_worker_config ~f:(fun config ->

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -65,8 +65,10 @@ let run_test () : unit Deferred.t =
   let receipt_chain_database =
     Coda_base.Receipt_chain_database.create ~directory:receipt_chain_dir_name
   in
+  let time_controller = Inputs.Time.Controller.create () in
   let net_config =
     { Inputs.Net.Config.parent_log= log
+    ; time_controller
     ; gossip_net_params=
         { Inputs.Net.Gossip_net.Config.timeout= Time.Span.of_sec 1.
         ; parent_log= log
@@ -83,8 +85,7 @@ let run_test () : unit Deferred.t =
          ~ledger_builder_persistant_location:(temp_conf_dir ^/ "ledger_builder")
          ~transaction_pool_disk_location:(temp_conf_dir ^/ "transaction_pool")
          ~snark_pool_disk_location:(temp_conf_dir ^/ "snark_pool")
-         ~time_controller:(Inputs.Time.Controller.create ())
-         ~receipt_chain_database () ~banlist
+         ~time_controller ~receipt_chain_database () ~banlist
          ~snark_work_fee:(Currency.Fee.of_int 0))
   in
   don't_wait_for (Linear_pipe.drain (Main.strongest_ledgers coda)) ;

--- a/src/lib/pipe_lib/strict_pipe.ml
+++ b/src/lib/pipe_lib/strict_pipe.ml
@@ -26,6 +26,13 @@ type (_, _) type_ =
 module Reader = struct
   type 't t = {reader: 't Pipe.Reader.t; mutable has_reader: bool}
 
+  (* TODO: See #1281 *)
+  let to_linear_pipe {reader= pipe; has_reader} =
+    {Linear_pipe.Reader.pipe; has_reader}
+
+  let of_linear_pipe {Linear_pipe.Reader.pipe= reader; has_reader} =
+    {reader; has_reader}
+
   let assert_not_read reader =
     if reader.has_reader then raise Multiple_reads_attempted
 
@@ -124,6 +131,9 @@ module Writer = struct
     { type_: ('type_, 'write_return) type_
     ; reader: 't Pipe.Reader.t
     ; writer: 't Pipe.Writer.t }
+
+  (* TODO: See #1281 *)
+  let to_linear_pipe {writer= pipe; reader= _; type_= _} = pipe
 
   let handle_overflow : type b.
       ('t, b buffered, unit) t -> 't -> b overflow_behavior -> unit =

--- a/src/lib/pipe_lib/strict_pipe.mli
+++ b/src/lib/pipe_lib/strict_pipe.mli
@@ -25,6 +25,10 @@ type (_, _) type_ =
 module Reader : sig
   type 't t
 
+  val to_linear_pipe : 't t -> 't Linear_pipe.Reader.t
+
+  val of_linear_pipe : 't Linear_pipe.Reader.t -> 't t
+
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
   val filter_map : 'a t -> f:('a -> 'b option) -> 'b t
@@ -74,6 +78,8 @@ end
 
 module Writer : sig
   type ('t, 'behavior, 'return) t
+
+  val to_linear_pipe : ('t, 'behavior, 'return) t -> 't Linear_pipe.Writer.t
 
   val write : ('t, _, 'return) t -> 't -> 'return
 end

--- a/src/lib/proposer/jbuild
+++ b/src/lib/proposer/jbuild
@@ -11,6 +11,7 @@
       async
       coda_lib
       coda_base
+      envelope
       protocols
       async_extra
       unix_timestamp

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -121,7 +121,8 @@ module Make (Inputs : Inputs_intf) :
    and type time_controller := Inputs.Time.Controller.t
    and type keypair := Inputs.Keypair.t
    and type transition_frontier := Inputs.Transition_frontier.t
-   and type transaction_pool := Inputs.Transaction_pool.t = struct
+   and type transaction_pool := Inputs.Transaction_pool.t
+   and type time := Inputs.Time.t = struct
   open Inputs
   open Consensus_mechanism
 
@@ -305,13 +306,10 @@ module Make (Inputs : Inputs_intf) :
                            (Internal_transition.ledger_builder_diff
                               internal_transition)
                      in
-                     let time =
-                       Time.now time_controller |> Time.to_span_since_epoch
-                       |> Time.Span.to_ms
-                     in
+                     let time = Time.now time_controller in
                      Linear_pipe.write_or_exn ~capacity:transition_capacity
                        transition_writer transition_reader
-                       (external_transition, time)) )
+                       (Envelope.Incoming.local external_transition, time)) )
         in
         let proposal_supervisor = Singleton_supervisor.create ~task:propose in
         let scheduler = Singleton_scheduler.create time_controller in


### PR DESCRIPTION
Rips out old pipes from coda_lib, and makes transition frontier controller return a pipe