### PR TITLE
No failwiths for pipes except network

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -297,7 +297,9 @@ module type Main_intf = sig
   val peers : t -> Kademlia.Peer.t list
 
   val strongest_ledgers :
-    t -> Inputs.External_transition.t Linear_pipe.Reader.t
+       t
+    -> (Inputs.External_transition.t, State_hash.t) With_hash.t
+       Strict_pipe.Reader.t
 
   val transaction_pool : t -> Inputs.Transaction_pool.t
 

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -281,15 +281,14 @@ module T = struct
       let coda_strongest_ledgers () =
         let r, w = Linear_pipe.create () in
         don't_wait_for
-          (Linear_pipe.iter (Main.strongest_ledgers coda) ~f:(fun t ->
-               let p = Main.Inputs.External_transition.protocol_state t in
+          (Strict_pipe.Reader.iter (Main.strongest_ledgers coda) ~f:(fun t ->
+               let open Main.Inputs in
+               let p = External_transition.protocol_state (With_hash.data t) in
                let prev_state_hash =
                  Main.Inputs.Consensus_mechanism.Protocol_state
                  .previous_state_hash p
                in
-               let state_hash =
-                 Main.Inputs.Consensus_mechanism.Protocol_state.hash p
-               in
+               let state_hash = With_hash.hash t in
                let prev_state_hash = State_hash.to_bits prev_state_hash in
                let state_hash = State_hash.to_bits state_hash in
                Linear_pipe.write w (prev_state_hash, state_hash) )) ;

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -88,7 +88,10 @@ let run_test () : unit Deferred.t =
          ~time_controller ~receipt_chain_database () ~banlist
          ~snark_work_fee:(Currency.Fee.of_int 0))
   in
-  don't_wait_for (Linear_pipe.drain (Main.strongest_ledgers coda)) ;
+  don't_wait_for
+    (Strict_pipe.Reader.iter_without_pushback
+       (Main.strongest_ledgers coda)
+       ~f:ignore) ;
   let wait_until_cond ~(f : t -> bool) ~(timeout : Float.t) =
     let rec go () =
       if f coda then return ()

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -467,7 +467,8 @@ module Make (Inputs : Inputs_intf) = struct
     ; snark_pool: Snark_pool.t
     ; transition_frontier: Transition_frontier.t
     ; strongest_ledgers:
-        (Ledger_builder.t * External_transition.t) Linear_pipe.Reader.t
+        (External_transition.t, Protocol_state_hash.t) With_hash.t
+        Strict_pipe.Reader.t
     ; log: Logger.t
     ; mutable seen_jobs: Work_selector.State.t
     ; receipt_chain_database: Coda_base.Receipt_chain_database.t
@@ -518,8 +519,7 @@ module Make (Inputs : Inputs_intf) = struct
     let lb = best_ledger_builder t in
     Ledger_builder.current_ledger_proof lb
 
-  let strongest_ledgers t =
-    Linear_pipe.map t.strongest_ledgers ~f:(fun (_, x) -> x)
+  let strongest_ledgers t = t.strongest_ledgers
 
   module Config = struct
     (** If ledger_db_location is None, will auto-generate a db based on a UUID *)
@@ -680,11 +680,7 @@ module Make (Inputs : Inputs_intf) = struct
           ; transaction_pool
           ; snark_pool
           ; transition_frontier
-          ; strongest_ledgers=
-              (let _ =
-                 Strict_pipe.Reader.to_linear_pipe valid_transitions_for_api
-               in
-               failwith "fixup integration tests")
+          ; strongest_ledgers= valid_transitions_for_api
           ; log= config.log
           ; seen_jobs= Work_selector.State.init
           ; ledger_builder_transition_backup_capacity=


### PR DESCRIPTION
Removes the last failwiths in coda_lib that are independent of hooking sync ledger into network (which @cmr is working on) and the "best_ledgers" set of failwiths (which @nholland94 is working on)