### PR TITLE
Feature/transition frontier best tip hack

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -250,6 +250,14 @@ module type Main_intf = sig
       Coda_base.External_transition.S
       with module Protocol_state = Consensus.Mechanism.Protocol_state
        and module Ledger_builder_diff := Ledger_builder_diff
+
+    module Transition_frontier :
+      Protocols.Coda_pow.Transition_frontier_intf
+      with type state_hash := State_hash.t
+       and type external_transition := External_transition.t
+       and type ledger_database := Coda_base.Ledger.Db.t
+       and type masked_ledger := Coda_base.Ledger.t
+       and type ledger_builder := Ledger_builder.t
   end
 
   module Config : sig
@@ -283,16 +291,9 @@ module type Main_intf = sig
 
   val best_ledger : t -> Inputs.Ledger.t
 
-  val best_tip :
-       t
-    -> Inputs.Ledger.t
-       * Consensus.Mechanism.Protocol_state.value
-       * Inputs.Protocol_state_proof.t
-
   val best_protocol_state : t -> Consensus.Mechanism.Protocol_state.value
 
-  val best_tip :
-    t -> Inputs.Ledger.t * Consensus.Mechanism.Protocol_state.value * Proof.t
+  val best_tip : t -> Inputs.Transition_frontier.Breadcrumb.t
 
   val peers : t -> Kademlia.Peer.t list
 
@@ -1223,7 +1224,10 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
       (t -> Public_key.Compressed.t list -> Lite_base.Lite_chain.t) option =
     Option.map Consensus.Mechanism.Consensus_state.to_lite
       ~f:(fun consensus_state_to_lite t pks ->
-        let ledger, state, proof = best_tip t in
+        let ledger = best_ledger t in
+        let transition = With_hash.data (Transition_frontier.Breadcrumb.transition_with_hash (best_tip t)) in
+        let state = External_transition.protocol_state transition in
+        let proof = External_transition.protocol_state_proof transition in
         let ledger =
           List.fold pks
             ~f:(fun acc key ->

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1225,7 +1225,10 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
     Option.map Consensus.Mechanism.Consensus_state.to_lite
       ~f:(fun consensus_state_to_lite t pks ->
         let ledger = best_ledger t in
-        let transition = With_hash.data (Transition_frontier.Breadcrumb.transition_with_hash (best_tip t)) in
+        let transition =
+          With_hash.data
+            (Transition_frontier.Breadcrumb.transition_with_hash (best_tip t))
+        in
         let state = External_transition.protocol_state transition in
         let proof = External_transition.protocol_state_proof transition in
         let ledger =

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -487,25 +487,30 @@ module Make (Inputs : Inputs_intf) = struct
 
   let best_protocol_state t =
     Transition_frontier.Breadcrumb.transition_with_hash (best_tip t)
-    |> With_hash.data
-    |> External_transition.protocol_state
+    |> With_hash.data |> External_transition.protocol_state
 
   let best_ledger t = Ledger_builder.ledger (best_ledger_builder t)
 
   let get_ledger t ledger_builder_hash =
     match
-      List.find_map (Transition_frontier.all_breadcrumbs t.transition_frontier) ~f:(fun b ->
+      List.find_map (Transition_frontier.all_breadcrumbs t.transition_frontier)
+        ~f:(fun b ->
           let ledger_builder =
             Transition_frontier.Breadcrumb.staged_ledger b
-            |> Transition_frontier.hack_temporary_ledger_builder_of_staged_ledger
+            |> Transition_frontier
+               .hack_temporary_ledger_builder_of_staged_ledger
           in
-          if Ledger_builder_hash.equal (Ledger_builder.hash ledger_builder) ledger_builder_hash then
-            Some (Ledger.to_list (Ledger_builder.ledger ledger_builder))
-          else
-            None)
+          if
+            Ledger_builder_hash.equal
+              (Ledger_builder.hash ledger_builder)
+              ledger_builder_hash
+          then Some (Ledger.to_list (Ledger_builder.ledger ledger_builder))
+          else None )
     with
     | Some x -> Deferred.return (Ok x)
-    | None   -> Deferred.Or_error.error_string "ledger builder hash not found in transition frontier"
+    | None ->
+        Deferred.Or_error.error_string
+          "ledger builder hash not found in transition frontier"
 
   let seen_jobs t = t.seen_jobs
 

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -407,7 +407,7 @@ module type Inputs_intf = sig
   end
 
   module Transition_frontier :
-    Protocols.Coda_transition_frontier.Transition_frontier_base_intf
+    Protocols.Coda_transition_frontier.Transition_frontier_intf
     with type state_hash := Protocol_state_hash.t
      and type external_transition := External_transition.t
      and type ledger_database := Ledger_db.t
@@ -479,27 +479,33 @@ module Make (Inputs : Inputs_intf) = struct
 
   let propose_keypair t = t.propose_keypair
 
+  let best_tip t = Transition_frontier.best_tip t.transition_frontier
+
   let best_ledger_builder t =
-    failwith
-      "TODO: Use transition frontier to get best lb out; you'll need to \
-       update the signature"
+    Transition_frontier.Breadcrumb.staged_ledger (best_tip t)
+    |> Transition_frontier.hack_temporary_ledger_builder_of_staged_ledger
 
   let best_protocol_state t =
-    failwith
-      "TODO: Use transition frontier to get best lb out; you'll need to \
-       update the signature"
-
-  let best_tip t =
-    failwith
-      "TODO: Use transition frontier to get best lb out; you'll need to \
-       update the signature"
-
-  let get_ledger t lh =
-    failwith
-      "TODO: Use transition frontier to find an arbitrary ledger based on a \
-       hash"
+    Transition_frontier.Breadcrumb.transition_with_hash (best_tip t)
+    |> With_hash.data
+    |> External_transition.protocol_state
 
   let best_ledger t = Ledger_builder.ledger (best_ledger_builder t)
+
+  let get_ledger t ledger_builder_hash =
+    match
+      List.find_map (Transition_frontier.all_breadcrumbs t.transition_frontier) ~f:(fun b ->
+          let ledger_builder =
+            Transition_frontier.Breadcrumb.staged_ledger b
+            |> Transition_frontier.hack_temporary_ledger_builder_of_staged_ledger
+          in
+          if Ledger_builder_hash.equal (Ledger_builder.hash ledger_builder) ledger_builder_hash then
+            Some (Ledger.to_list (Ledger_builder.ledger ledger_builder))
+          else
+            None)
+    with
+    | Some x -> Deferred.return (Ok x)
+    | None   -> Deferred.Or_error.error_string "ledger builder hash not found in transition frontier"
 
   let seen_jobs t = t.seen_jobs
 

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -247,6 +247,9 @@ module Make (Inputs : Inputs_intf) :
         ; best_tip= root_hash
         ; table }
 
+  let all_breadcrumbs t =
+    List.map (Hashtbl.data t.table) ~f:(fun {breadcrumb;_} -> breadcrumb)
+
   let hack_temporary_ledger_builder_of_staged_ledger = Fn.id
 
   let find t hash =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -248,7 +248,7 @@ module Make (Inputs : Inputs_intf) :
         ; table }
 
   let all_breadcrumbs t =
-    List.map (Hashtbl.data t.table) ~f:(fun {breadcrumb;_} -> breadcrumb)
+    List.map (Hashtbl.data t.table) ~f:(fun {breadcrumb; _} -> breadcrumb)
 
   let hack_temporary_ledger_builder_of_staged_ledger = Fn.id
 

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -62,6 +62,8 @@ module type Transition_frontier_intf = sig
 
   val max_length : int
 
+  val all_breadcrumbs : t -> Breadcrumb.t list
+
   val root : t -> Breadcrumb.t
 
   val best_tip : t -> Breadcrumb.t


### PR DESCRIPTION
Quick and dirty way to get the transition frontier plugged into the existing interface for coda_lib. I have another branch that does this in a better, less hacky way, but this will unblock the integration tests and deployments for now.