### PR TITLE
Fix Rocksdb_database.to_alist

### DIFF
--- a/src/lib/coda_base/ledger_transfer.ml
+++ b/src/lib/coda_base/ledger_transfer.ml
@@ -13,8 +13,22 @@ module Make (Source : Base_ledger_intf) (Dest : Base_ledger_intf) :
   with type src := Source.t
    and type dest := Dest.t = struct
   let transfer_accounts ~src ~dest =
-    Source.foldi src ~init:dest ~f:(fun _addr dest account ->
+    let l = Ledger.create () in
+    [%test_result: Ledger_hash.t]
+      ~message:
+        "Merkle root of an empty ledger is different from merkle root of the \
+         fresh dest"
+      ~expect:(Ledger.merkle_root l) (Dest.merkle_root dest) ;
+    let sorted =
+      Source.foldi src ~init:[] ~f:(fun addr acc account ->
+          (addr, account) :: acc )
+      |> List.sort ~compare:(fun (addr1, _) (addr2, _) ->
+             Source.Addr.compare addr1 addr2 )
+    in
+    List.iter sorted ~f:(fun (addr, account) ->
         let key = Account.public_key account in
-        ignore (Dest.get_or_create_account_exn dest key account) ;
-        dest )
+        ignore (Dest.get_or_create_account_exn dest key account) ) ;
+    [%test_result: Ledger_hash.t] ~message:"Merkle roots differ after transfer"
+      ~expect:(Source.merkle_root src) (Dest.merkle_root dest) ;
+    dest
 end

--- a/src/lib/coda_base/ledger_transfer.ml
+++ b/src/lib/coda_base/ledger_transfer.ml
@@ -13,19 +13,13 @@ module Make (Source : Base_ledger_intf) (Dest : Base_ledger_intf) :
   with type src := Source.t
    and type dest := Dest.t = struct
   let transfer_accounts ~src ~dest =
-    let l = Ledger.create () in
-    [%test_result: Ledger_hash.t]
-      ~message:
-        "Merkle root of an empty ledger is different from merkle root of the \
-         fresh dest"
-      ~expect:(Ledger.merkle_root l) (Dest.merkle_root dest) ;
     let sorted =
       Source.foldi src ~init:[] ~f:(fun addr acc account ->
           (addr, account) :: acc )
       |> List.sort ~compare:(fun (addr1, _) (addr2, _) ->
              Source.Addr.compare addr1 addr2 )
     in
-    List.iter sorted ~f:(fun (addr, account) ->
+    List.iter sorted ~f:(fun (_addr, account) ->
         let key = Account.public_key account in
         ignore (Dest.get_or_create_account_exn dest key account) ) ;
     [%test_result: Ledger_hash.t] ~message:"Merkle roots differ after transfer"

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -633,9 +633,7 @@ module Make (Inputs : Inputs_intf) = struct
             ~root_staged_ledger_diff:None
             ~root_snarked_ledger:
               (Ledger_transfer.transfer_accounts ~src:Genesis.ledger
-                 ~dest:
-                   (Ledger_db.create ?directory_name:config.ledger_db_location
-                      ()))
+                 ~dest:(Ledger_db.create ()))
         in
         let%bind net =
           Net.create config.net_config

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -55,13 +55,21 @@ let to_alist t : (Bigstring.t * Bigstring.t) list =
   loop []
 
 let%test_unit "to_alist (of_alist l) = l" =
-  Quickcheck.test Quickcheck.Generator.(tuple2 String.gen String.gen |> list) ~f:(fun kvs ->
-    File_system.with_temp_dir "/tmp/coda-test"  ~f:(fun directory ->
-    let s = Bigstring.of_string in
-    let sorted = List.sort kvs ~compare:[%compare : string*string] |> List.map ~f:(fun (k, v) -> (s k, s v)) in
-    let db = create ~directory in
-    List.iter sorted ~f:(fun (key, data) -> set db ~key ~data) ;
-    let alist = List.sort (to_alist db) ~compare:[%compare : Bigstring.t * Bigstring.t] in
-    [%test_result : (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
-    Async.Deferred.unit
-  ) |> Async.don't_wait_for)
+  Quickcheck.test
+    Quickcheck.Generator.(tuple2 String.gen String.gen |> list)
+    ~f:(fun kvs ->
+      File_system.with_temp_dir "/tmp/coda-test" ~f:(fun directory ->
+          let s = Bigstring.of_string in
+          let sorted =
+            List.sort kvs ~compare:[%compare: string * string]
+            |> List.map ~f:(fun (k, v) -> (s k, s v))
+          in
+          let db = create ~directory in
+          List.iter sorted ~f:(fun (key, data) -> set db ~key ~data) ;
+          let alist =
+            List.sort (to_alist db)
+              ~compare:[%compare: Bigstring.t * Bigstring.t]
+          in
+          [%test_result: (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
+          Async.Deferred.unit )
+      |> Async.don't_wait_for )

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -38,10 +38,16 @@ let to_alist t : (Bigstring.t * Bigstring.t) list =
   let iterator = Rocks.Iterator.create t.db in
   Rocks.Iterator.seek_to_last iterator ;
   (* iterate backwards and cons, to build list sorted by key *)
+  let copy t =
+    let tlen = Bigstring.length t in
+    let new_t = Bigstring.create tlen in
+    Bigstring.blit ~src:t ~dst:new_t ~src_pos:0 ~dst_pos:0 ~len:tlen ;
+    new_t
+  in
   let rec loop accum =
     if Rocks.Iterator.is_valid iterator then (
-      let key = Rocks.Iterator.get_key iterator in
-      let value = Rocks.Iterator.get_value iterator in
+      let key = copy (Rocks.Iterator.get_key iterator) in
+      let value = copy (Rocks.Iterator.get_value iterator) in
       Rocks.Iterator.prev iterator ;
       loop ((key, value) :: accum) )
     else accum

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -53,3 +53,15 @@ let to_alist t : (Bigstring.t * Bigstring.t) list =
     else accum
   in
   loop []
+
+let%test_unit "to_alist (of_alist l) = l" =
+  Quickcheck.test Quickcheck.Generator.(tuple2 String.gen String.gen |> list) ~f:(fun kvs ->
+    File_system.with_temp_dir "/tmp/coda-test"  ~f:(fun directory ->
+    let s = Bigstring.of_string in
+    let sorted = List.sort kvs ~compare:[%compare : string*string] |> List.map ~f:(fun (k, v) -> (s k, s v)) in
+    let db = create ~directory in
+    List.iter sorted ~f:(fun (key, data) -> set db ~key ~data) ;
+    let alist = List.sort (to_alist db) ~compare:[%compare : Bigstring.t * Bigstring.t] in
+    [%test_result : (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
+    Async.Deferred.unit
+  ) |> Async.don't_wait_for)

--- a/src/lib/rocksdb/jbuild
+++ b/src/lib/rocksdb/jbuild
@@ -6,6 +6,7 @@
   (flags (:standard -short-paths -warn-error -58))
   (library_flags (-linkall))
   (c_library_flags (-lrocksdb))
-  (libraries (core rocks key_value_database))
+  (inline_tests)
+  (libraries (core rocks key_value_database file_system))
   (preprocess (pps (ppx_jane)))
   (synopsis "RocksDB Database module")))


### PR DESCRIPTION
The bigarrays it was returning referenced unowned memory, which was getting invalidated by the call to `Iterator.prev`. Classic iterator invalidation bug!