### PR TITLE
Bad assert + bool flip

### DIFF
--- a/src/lib/pipe_lib/strict_pipe.ml
+++ b/src/lib/pipe_lib/strict_pipe.ml
@@ -77,7 +77,7 @@ module Reader = struct
 
   module Merge = struct
     let iter readers ~f =
-      let not_empty r = Pipe.is_empty r.reader in
+      let not_empty r = not @@ Pipe.is_empty r.reader in
       let rec read_deferred () =
         let%bind ready_reader =
           match List.find readers ~f:not_empty with

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -138,12 +138,6 @@ struct
       Frozen_ledger_hash.of_ledger_hash
       @@ Ledger.merkle_root (Ledger.of_database root_snarked_ledger)
     in
-    assert (
-      Ledger_hash.equal
-        (Ledger.Mask.Attached.merkle_root root_masked_ledger)
-        (Staged_ledger_hash.ledger_hash
-           (Consensus.Mechanism.Protocol_state.Blockchain_state
-            .staged_ledger_hash root_blockchain_state)) ) ;
     match
       Inputs.Staged_ledger.of_scan_state_and_ledger
         ~scan_state:root_transaction_snark_scan_state


### PR DESCRIPTION
* Not empty should be "not @@ is_empty"
* The assertion that the initial staged ledger is the same as the staged
ledger in the blockchain state is incorrect at the genesis ledger, so
I've removed that assertion

When applied on top of #1296 full test attempts to apply a transition