### PR TITLE
make external transition sexps smaller

### DIFF
--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -1,3 +1,5 @@
+open Core
+
 module type S = sig
   module Protocol_state : Protocol_state.S
 
@@ -35,7 +37,7 @@ end)
 
   type t =
     { protocol_state: Protocol_state.value
-    ; protocol_state_proof: Proof.Stable.V1.t
+    ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
     ; staged_ledger_diff: Staged_ledger_diff.t }
   [@@deriving sexp, fields, bin_io]
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -42,9 +42,7 @@ module Compressed = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = (Field.t, bool) t_
-        [@@deriving bin_io, eq, compare, hash]
-
+        type t = (Field.t, bool) t_ [@@deriving bin_io, eq, compare, hash]
       end
 
       include T

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -43,7 +43,8 @@ module Compressed = struct
     module V1 = struct
       module T = struct
         type t = (Field.t, bool) t_
-        [@@deriving bin_io, sexp, eq, compare, hash]
+        [@@deriving bin_io, eq, compare, hash]
+
       end
 
       include T
@@ -51,6 +52,14 @@ module Compressed = struct
       let to_base64 t = Binable.to_string (module T) t |> B64.encode
 
       let of_base64_exn s = B64.decode s |> Binable.of_string (module T)
+
+      include Sexpable.Of_stringable (struct
+        type nonrec t = t
+
+        let to_string = to_base64
+
+        let of_string = of_base64_exn
+      end)
 
       include Codable.Make_of_string (struct
         type nonrec t = t
@@ -67,10 +76,6 @@ module Compressed = struct
   include Hashable.Make_binable (Stable.V1)
 
   let compress (x, y) : t = {x; is_odd= parity y}
-
-  let to_base64 t = Binable.to_string (module Stable.V1) t |> B64.encode
-
-  let of_base64_exn s = B64.decode s |> Binable.of_string (module Stable.V1)
 
   let empty = {x= Field.zero; is_odd= false}
 


### PR DESCRIPTION
Makes the protocol state proof opaque, sexps public keys (well, any Non_zero_curve_point) as b64 instead of decimal.