### PR TITLE
SIMPLE:do not log traces

### DIFF
--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -207,9 +207,8 @@ module Haskell_process = struct
           | "DBUG" ->
               Logger.debug log "%s" line_no_prefix ;
               None
-          | "TRAC" ->
-              Logger.trace log "%s" line_no_prefix ;
-              None
+          | "TRAC" -> (* trace is 99% ping/pong checks, omit *)
+                      None
           | "EROR" ->
               Logger.error log "%s" line_no_prefix ;
               None


### PR DESCRIPTION
~50% of all logging messages are PING/PONG traces coming from Kademlia.

Let's omit them from logging output.

Example:

```
((attributes((module membership)(module-Gossip_net true)(module-membership true)))(path(membership Gossip_net))(level Trace)(pid 3720)(host closet)(time(2018-12-11 23:07:32.445821Z))(location())(message"Register chan: reply Answer (Signal {source = 127.0.0.1:8503 (HashId \"\\v\\252\\205\\153f-:X\\227\\t\\141\\223_\\163p\\217\\DC2\\r3\\189\\147G\\USV\\214\\223\\168 >g>e\"), command = PING})"))
``` 
