### PR TITLE
SIMPLE: add random to worker delay, BSD compat inplace for sed

### DIFF
--- a/scripts/merlin-fixup.sh
+++ b/scripts/merlin-fixup.sh
@@ -10,7 +10,7 @@ OCAML_VERSION=4.07
 for file in `find src -name .merlin`
 do
     cp -p $file $file.SAVE
-    sed --in-place s+.opam/$OCAML_VERSION/+.opam/$OPAM_SWITCH/+g $file
-    sed --in-place s+/home/opam/.opam/+$HOME/.opam/+g $file
-    sed --in-place s+/home/opam/app/src/_build/+$(git rev-parse --show-toplevel)/src/_build/+g $file
+    sed -i.bak s+.opam/$OCAML_VERSION/+.opam/$OPAM_SWITCH/+g $file
+    sed -i.bak s+/home/opam/.opam/+$HOME/.opam/+g $file
+    sed -i.bak s+/home/opam/app/src/_build/+$(git rev-parse --show-toplevel)/src/_build/+g $file
 done

--- a/src/lib/snark_worker_lib/worker.ml
+++ b/src/lib/snark_worker_lib/worker.ml
@@ -87,9 +87,12 @@ module Make (Inputs : Intf.Inputs_intf) :
       with
       | Error e -> log_and_retry "getting work" e
       | Ok None ->
-          Logger.info log "No work; waiting %.2fs"
-            Worker_state.worker_wait_time ;
-          let%bind () = wait ~sec:Worker_state.worker_wait_time () in
+          let random_delay =
+            Worker_state.worker_wait_time
+            +. (0.2 *. Random.float Worker_state.worker_wait_time)
+          in
+          Logger.info log "No work; waiting %.3fs" random_delay ;
+          let%bind () = wait ~sec:random_delay () in
           go ()
       | Ok (Some work) -> (
           Logger.info log !"Received work." ;


### PR DESCRIPTION
adds a random extra delay when workers do not connect. (max 20% of usual delay)

fixes GNU-SED-ism with BSD-SED-ism-compat way to perform inplace edits


