### PR TITLE
Stabalize nodes before starting tests

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -328,6 +328,7 @@ let daemon log =
                 ~time_controller ?propose_keypair:Config0.propose_keypair ()
                 ~banlist)
          in
+         M.start coda ;
          let web_service = Web_pipe.get_service () in
          Web_pipe.run_service (module Run) coda web_service ~conf_dir ~log ;
          Run.setup_local_server ?client_whitelist ?rest_server_port ~coda

--- a/src/app/cli/src/coda_process.ml
+++ b/src/app/cli/src/coda_process.ml
@@ -70,3 +70,6 @@ let strongest_ledgers_exn (conn, proc, _) =
       ~f:Coda_worker.functions.strongest_ledgers ~arg:()
   in
   Linear_pipe.wrap_reader r
+
+let start_exn (conn, proc, _) =
+  Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.start ~arg:()

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -79,6 +79,7 @@ module T = struct
 
   type 'worker functions =
     { peers: ('worker, unit, Peers.t) Rpc_parallel.Function.t
+    ; start: ('worker, unit, unit) Rpc_parallel.Function.t
     ; get_balance:
         ( 'worker
         , Public_key.Compressed.t
@@ -99,6 +100,7 @@ module T = struct
 
   type coda_functions =
     { coda_peers: unit -> Peers.t Deferred.t
+    ; coda_start: unit -> unit Deferred.t
     ; coda_get_balance: Public_key.Compressed.t -> Maybe_currency.t Deferred.t
     ; coda_send_payment:
         Send_payment_input.t -> Receipt.Chain_hash.t Deferred.t
@@ -137,8 +139,14 @@ module T = struct
     let prove_receipt_impl ~worker_state ~conn_state:() input =
       worker_state.coda_prove_receipt input
 
+    let start_impl ~worker_state ~conn_state:() () = worker_state.coda_start ()
+
     let peers =
       C.create_rpc ~f:peers_impl ~bin_input:Unit.bin_t ~bin_output:Peers.bin_t
+        ()
+
+    let start =
+      C.create_rpc ~f:start_impl ~bin_input:Unit.bin_t ~bin_output:Unit.bin_t
         ()
 
     let get_balance =
@@ -158,7 +166,12 @@ module T = struct
         ~bin_output:State_hashes.bin_t ()
 
     let functions =
-      {peers; strongest_ledgers; get_balance; send_payment; prove_receipt}
+      { peers
+      ; start
+      ; strongest_ledgers
+      ; get_balance
+      ; send_payment
+      ; prove_receipt }
 
     let init_worker_state
         { host
@@ -243,6 +256,7 @@ module T = struct
           Run.run_snark_worker ~log ~client_port:config.port run_snark_worker
       ) ;
       let coda_peers () = return (Main.peers coda) in
+      let coda_start () = return (Main.start coda) in
       let coda_get_balance pk = return (Run.get_balance coda pk) in
       let coda_send_payment (sk, pk, amount, fee, memo) =
         let pk_of_sk sk =
@@ -296,7 +310,8 @@ module T = struct
         ; coda_strongest_ledgers
         ; coda_get_balance
         ; coda_send_payment
-        ; coda_prove_receipt }
+        ; coda_prove_receipt
+        ; coda_start }
 
     let init_connection_state ~connection:_ ~worker_state:_ = return
   end

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -88,6 +88,7 @@ let run_test () : unit Deferred.t =
          ~time_controller ~receipt_chain_database () ~banlist
          ~snark_work_fee:(Currency.Fee.of_int 0))
   in
+  Main.start coda ;
   don't_wait_for
     (Strict_pipe.Reader.iter_without_pushback
        (Main.strongest_ledgers coda)


### PR DESCRIPTION
Stabilization of nodes currently means all nodes see all other nodes in
the kademlia network. This ensures that we don't have late joiners.
Eventually when we want late joiners in tests, we can make this
configurable.

This is achieved by breaking coda_lib's create into `create` and
`start`. `start` currently only begins proposing, `create` still does
all other initialization. If we ever add new modules that send
information across the network, we should put that initialization into
`start` as well.

The following test which triggered catchup most of the time:

```
$ CODA_PROPOSAL_INTERVAL=8000 dune exec --profile=test_sigs coda -- integration-tests coda-shared-prefix-test -who-proposes 0
```

Now never triggers the catchup path.