### PR TITLE
Clean up libsnark bindings and move bin io into libsnark.ml

### DIFF
--- a/src/lib/snarky/src/field_intf.ml
+++ b/src/lib/snarky/src/field_intf.ml
@@ -1,5 +1,5 @@
 module type S = sig
-  type t [@@deriving sexp]
+  type t [@@deriving sexp, bin_io]
 
   val of_int : int -> t
 

--- a/src/lib/snarky/src/libsnark.ml
+++ b/src/lib/snarky/src/libsnark.ml
@@ -30,6 +30,20 @@ module type Deletable_intf = sig
   val delete : t -> unit
 end
 
+module type Prefix_intf = sig
+  val prefix : string
+end
+
+module Make_foreign (M : Prefix_intf) = struct
+  type t = unit ptr
+
+  let typ = ptr void
+
+  let func_name = with_prefix M.prefix
+
+  let delete = foreign (func_name "delete") (typ @-> returning void)
+end
+
 let set_profiling = foreign "camlsnark_set_profiling" (bool @-> returning void)
 
 let () = set_profiling false
@@ -45,7 +59,7 @@ end) (Bigint_r : sig
 
   val typ : t Ctypes.typ
 end) (Fq : sig
-  type t
+  type t [@@deriving bin_io]
 
   val typ : t Ctypes.typ
 
@@ -53,7 +67,7 @@ end) (Fq : sig
 end) =
 struct
   module Group : sig
-    type t
+    type t [@@deriving bin_io]
 
     val typ : t Ctypes.typ
 
@@ -85,13 +99,12 @@ struct
 
     module Vector : Vector.S with type elt := t
   end = struct
-    type t = unit ptr
+    module P = struct
+      let prefix = with_prefix M.prefix "g1"
+    end
 
-    let typ = ptr void
-
-    let prefix = with_prefix M.prefix "g1"
-
-    let func_name s = with_prefix prefix s
+    include P
+    include Make_foreign (P)
 
     let zero =
       let stub = foreign (func_name "zero") (void @-> returning typ) in
@@ -179,6 +192,29 @@ struct
         Fq.schedule_delete x ;
         let y = stub_y t in
         Fq.schedule_delete y ; (x, y)
+
+    module Repr = struct
+      type t = Zero | Non_zero of {x: Fq.t; y: Fq.t} [@@deriving bin_io]
+    end
+
+    let to_repr t : Repr.t =
+      if equal zero t then Zero
+      else
+        let x, y = to_coords t in
+        Non_zero {x; y}
+
+    let of_repr (r : Repr.t) =
+      match r with Zero -> zero | Non_zero {x; y} -> of_coords (x, y)
+
+    include Binable.Of_binable
+              (Repr)
+              (struct
+                type nonrec t = t
+
+                let to_binable = to_repr
+
+                let of_binable = of_repr
+              end)
   end
 end
 
@@ -195,8 +231,173 @@ struct
 
   let () = init ()
 
+  module Field0 = struct
+    module F = Make_foreign (struct
+      let prefix = with_prefix prefix "field"
+    end)
+
+    type t = F.t sexp_opaque [@@deriving sexp]
+
+    include (F : module type of F with type t := t)
+  end
+
+  module Bigint : sig
+    module R : sig
+      type t [@@deriving bin_io]
+
+      val typ : t Ctypes.typ
+
+      val of_decimal_string : string -> t
+
+      val of_numeral : string -> base:int -> t
+
+      val of_field : Field0.t -> t
+
+      val div : t -> t -> t
+
+      val to_field : t -> Field0.t
+
+      val compare : t -> t -> int
+
+      val test_bit : t -> int -> bool
+
+      val find_wnaf : Unsigned.Size_t.t -> t -> Long_vector.t
+    end
+
+    module Q : sig
+      type t
+
+      val typ : t Ctypes.typ
+
+      val test_bit : t -> int -> bool
+
+      val find_wnaf : Unsigned.Size_t.t -> t -> Long_vector.t
+    end
+  end = struct
+    module Common (N : sig
+      val prefix : string
+    end) =
+    struct
+      include Make_foreign (struct
+        let prefix = with_prefix (with_prefix M.prefix "bigint") N.prefix
+      end)
+
+      let test_bit =
+        foreign (func_name "test_bit") (typ @-> int @-> returning bool)
+
+      let find_wnaf =
+        let stub =
+          foreign (func_name "find_wnaf")
+            (size_t @-> typ @-> returning Long_vector.typ)
+        in
+        fun x y ->
+          let v = stub x y in
+          Caml.Gc.finalise Long_vector.delete v ;
+          v
+    end
+
+    module R = struct
+      let prefix = "r"
+
+      include Common (struct
+        let prefix = prefix
+      end)
+
+      let func_name =
+        with_prefix (with_prefix (with_prefix M.prefix "bigint") prefix)
+
+      let div =
+        let stub = foreign (func_name "div") (typ @-> typ @-> returning typ) in
+        fun x y ->
+          let z = stub x y in
+          Caml.Gc.finalise delete z ; z
+
+      let of_numeral =
+        let stub =
+          foreign (func_name "of_numeral")
+            (string @-> int @-> int @-> returning typ)
+        in
+        fun s ~base ->
+          let n = stub s (String.length s) base in
+          Caml.Gc.finalise delete n ; n
+
+      let of_decimal_string =
+        let stub =
+          foreign (func_name "of_decimal_string") (string @-> returning typ)
+        in
+        fun s ->
+          let n = stub s in
+          Caml.Gc.finalise delete n ; n
+
+      let compare =
+        foreign (func_name "compare") (typ @-> typ @-> returning int)
+
+      let of_field =
+        let stub =
+          foreign (func_name "of_field") (Field0.typ @-> returning typ)
+        in
+        fun x ->
+          let n = stub x in
+          Caml.Gc.finalise delete n ; n
+
+      let num_limbs =
+        let stub = foreign (func_name "num_limbs") (void @-> returning int) in
+        stub ()
+
+      let bytes_per_limb =
+        let stub =
+          foreign (func_name "bytes_per_limb") (void @-> returning int)
+        in
+        let res = stub () in
+        assert (res = 8) ;
+        res
+
+      let length_in_bytes = num_limbs * bytes_per_limb
+
+      let to_bigstring =
+        let stub =
+          foreign (func_name "to_data") (typ @-> returning (ptr char))
+        in
+        fun t ->
+          let limbs = stub t in
+          Bigstring.init length_in_bytes ~f:(fun i -> Ctypes.(!@(limbs +@ i)))
+
+      let of_bigstring =
+        let stub =
+          foreign (func_name "of_data") (ptr char @-> returning typ)
+        in
+        fun s ->
+          let ptr = Ctypes.bigarray_start Ctypes.array1 s in
+          let t = stub ptr in
+          Caml.Gc.finalise delete t ; t
+
+      include Binable.Of_binable
+                (Bigstring)
+                (struct
+                  type nonrec t = t
+
+                  let to_binable = to_bigstring
+
+                  let of_binable = of_bigstring
+                end)
+
+      let to_field =
+        let stub =
+          foreign (func_name "to_field") (typ @-> returning Field0.typ)
+        in
+        fun n ->
+          let x = stub n in
+          Caml.Gc.finalise Field0.delete x ;
+          x
+    end
+
+    module Q = Common (struct
+      let prefix = "q"
+    end)
+  end
+
   module Field : sig
-    type t [@@deriving sexp]
+    type t = Field0.t [@@deriving sexp, bin_io]
 
     val typ : t Ctypes.typ
 
@@ -235,13 +436,7 @@ struct
     module Vector : Vector.S with type elt = t
   end = struct
     module T = struct
-      type t = unit ptr sexp_opaque [@@deriving sexp]
-
-      let typ = ptr void
-
-      let prefix = with_prefix M.prefix "field"
-
-      let func_name s = with_prefix prefix s
+      include Field0
 
       let size_in_bits =
         let stub =
@@ -323,6 +518,16 @@ struct
     end)
 
     include T
+
+    include Binable.Of_binable
+              (Bigint.R)
+              (struct
+                type t = T.t
+
+                let to_binable = Bigint.R.of_field
+
+                let of_binable = Bigint.R.to_field
+              end)
   end
 
   module Var : sig
@@ -334,13 +539,9 @@ struct
 
     val create : int -> t
   end = struct
-    type t = unit ptr
-
-    let func_name = with_prefix (with_prefix M.prefix "var")
-
-    let typ = ptr void
-
-    let delete = foreign (func_name "delete") (typ @-> returning void)
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "var"
+    end)
 
     let create =
       (* TODO: Use size_t *)
@@ -389,24 +590,16 @@ struct
 
     val add_term : t -> Field.t -> Var.t -> unit
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
-
     let prefix = with_prefix M.prefix "linear_combination"
 
-    let func_name = with_prefix prefix
+    include Make_foreign (struct
+      let prefix = prefix
+    end)
 
     module Term = struct
-      type t = unit ptr
-
-      let typ = ptr void
-
-      let prefix = with_prefix prefix "term"
-
-      let func_name = with_prefix prefix
-
-      let delete = foreign (func_name "delete") (typ @-> returning void)
+      include Make_foreign (struct
+        let prefix = with_prefix prefix "term"
+      end)
 
       let create =
         let stub =
@@ -437,8 +630,6 @@ struct
         let schedule_delete = Caml.Gc.finalise delete
       end)
     end
-
-    let delete = foreign (func_name "delete") (typ @-> returning void)
 
     let schedule_delete t = Caml.Gc.finalise delete t
 
@@ -510,15 +701,9 @@ struct
 
     val set_is_square : t -> bool -> unit
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
-
-    let prefix = with_prefix M.prefix "r1cs_constraint"
-
-    let func_name = with_prefix prefix
-
-    let delete = foreign (func_name "delete") (typ @-> returning void)
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "r1cs_constraint"
+    end)
 
     let create =
       let stub =
@@ -568,15 +753,9 @@ struct
 
     val digest : t -> Md5.t
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
-
-    let prefix = with_prefix M.prefix "r1cs_constraint_system"
-
-    let func_name s = with_prefix prefix s
-
-    let delete = foreign (func_name "delete") (typ @-> returning void)
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "r1cs_constraint_system"
+    end)
 
     let report_statistics =
       foreign (func_name "report_statistics") (typ @-> returning void)
@@ -693,9 +872,9 @@ struct
 
     val augment_variable_annotation : t -> Variable.t -> string -> unit
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "protoboard"
+    end)
 
     module Variable : sig
       type t
@@ -708,58 +887,37 @@ struct
 
       val index : t -> int
     end = struct
-      type t = unit ptr
-
-      let typ = ptr void
-
-      let delete =
-        foreign
-          (with_prefix M.prefix "protoboard_variable_delete")
-          (typ @-> returning void)
+      include Make_foreign (struct
+        let prefix = with_prefix M.prefix "protoboard_variable"
+      end)
 
       let of_int =
-        let stub =
-          foreign
-            (with_prefix M.prefix "protoboard_variable_of_int")
-            (int @-> returning typ)
-        in
+        let stub = foreign (func_name "of_int") (int @-> returning typ) in
         fun i ->
           let t = stub i in
           Caml.Gc.finalise delete t ; t
 
-      let index =
-        foreign
-          (with_prefix M.prefix "protoboard_variable_index")
-          (typ @-> returning int)
+      let index = foreign (func_name "index") (typ @-> returning int)
     end
 
     module Variable_array = struct
-      type t = unit ptr
-
-      let typ = ptr void
-
-      let prefix = with_prefix M.prefix "protoboard_variable_array"
-
-      let delete =
-        foreign (with_prefix prefix "delete") (typ @-> returning void)
+      include Make_foreign (struct
+        let prefix = with_prefix M.prefix "protoboard_variable_array"
+      end)
 
       let create =
-        let stub =
-          foreign (with_prefix prefix "create") (void @-> returning typ)
-        in
+        let stub = foreign (func_name "create") (void @-> returning typ) in
         fun () ->
           let t = stub () in
           Caml.Gc.finalise delete t ; t
 
       let emplace_back =
-        foreign
-          (with_prefix prefix "emplace_back")
+        foreign (func_name "emplace_back")
           (typ @-> Variable.typ @-> returning void)
 
       let get =
         let stub =
-          foreign (with_prefix prefix "get")
-            (typ @-> int @-> returning Variable.typ)
+          foreign (func_name "get") (typ @-> int @-> returning Variable.typ)
         in
         fun t i ->
           let v = stub t i in
@@ -767,15 +925,11 @@ struct
           v
     end
 
-    let func_name = with_prefix (with_prefix M.prefix "protoboard")
-
     let renumber_and_append_constraints =
       foreign
         (func_name "renumber_and_append_constraints")
         ( typ @-> R1CS_constraint_system.typ @-> Linear_combination.Vector.typ
         @-> int @-> returning void )
-
-    let delete = foreign (func_name "delete") (typ @-> returning void)
 
     let augment_variable_annotation =
       foreign
@@ -840,166 +994,6 @@ struct
         v
   end
 
-  module Bigint : sig
-    module R : sig
-      type t [@@deriving bin_io]
-
-      val typ : t Ctypes.typ
-
-      val of_decimal_string : string -> t
-
-      val of_numeral : string -> base:int -> t
-
-      val of_field : Field.t -> t
-
-      val div : t -> t -> t
-
-      val to_field : t -> Field.t
-
-      val compare : t -> t -> int
-
-      val test_bit : t -> int -> bool
-
-      val find_wnaf : Unsigned.Size_t.t -> t -> Long_vector.t
-    end
-
-    module Q : sig
-      type t
-
-      val typ : t Ctypes.typ
-
-      val test_bit : t -> int -> bool
-
-      val find_wnaf : Unsigned.Size_t.t -> t -> Long_vector.t
-    end
-  end = struct
-    module Common (N : sig
-      val prefix : string
-    end) =
-    struct
-      type t = unit ptr
-
-      let typ = ptr void
-
-      let func_name =
-        with_prefix (with_prefix (with_prefix M.prefix "bigint") N.prefix)
-
-      let delete = foreign (func_name "delete") (typ @-> returning void)
-
-      let test_bit =
-        foreign (func_name "test_bit") (typ @-> int @-> returning bool)
-
-      let find_wnaf =
-        let stub =
-          foreign (func_name "find_wnaf")
-            (size_t @-> typ @-> returning Long_vector.typ)
-        in
-        fun x y ->
-          let v = stub x y in
-          Caml.Gc.finalise Long_vector.delete v ;
-          v
-    end
-
-    module R = struct
-      let prefix = "r"
-
-      include Common (struct
-        let prefix = prefix
-      end)
-
-      let func_name =
-        with_prefix (with_prefix (with_prefix M.prefix "bigint") prefix)
-
-      let div =
-        let stub = foreign (func_name "div") (typ @-> typ @-> returning typ) in
-        fun x y ->
-          let z = stub x y in
-          Caml.Gc.finalise delete z ; z
-
-      let of_numeral =
-        let stub =
-          foreign (func_name "of_numeral")
-            (string @-> int @-> int @-> returning typ)
-        in
-        fun s ~base ->
-          let n = stub s (String.length s) base in
-          Caml.Gc.finalise delete n ; n
-
-      let of_decimal_string =
-        let stub =
-          foreign (func_name "of_decimal_string") (string @-> returning typ)
-        in
-        fun s ->
-          let n = stub s in
-          Caml.Gc.finalise delete n ; n
-
-      let compare =
-        foreign (func_name "compare") (typ @-> typ @-> returning int)
-
-      let of_field =
-        let stub =
-          foreign (func_name "of_field") (Field.typ @-> returning typ)
-        in
-        fun x ->
-          let n = stub x in
-          Caml.Gc.finalise delete n ; n
-
-      let num_limbs =
-        let stub = foreign (func_name "num_limbs") (void @-> returning int) in
-        stub ()
-
-      let bytes_per_limb =
-        let stub =
-          foreign (func_name "bytes_per_limb") (void @-> returning int)
-        in
-        let res = stub () in
-        assert (res = 8) ;
-        res
-
-      let length_in_bytes = num_limbs * bytes_per_limb
-
-      let to_bigstring =
-        let stub =
-          foreign (func_name "to_data") (typ @-> returning (ptr char))
-        in
-        fun t ->
-          let limbs = stub t in
-          Bigstring.init length_in_bytes ~f:(fun i -> Ctypes.(!@(limbs +@ i)))
-
-      let of_bigstring =
-        let stub =
-          foreign (func_name "of_data") (ptr char @-> returning typ)
-        in
-        fun s ->
-          let ptr = Ctypes.bigarray_start Ctypes.array1 s in
-          let t = stub ptr in
-          Caml.Gc.finalise delete t ; t
-
-      include Binable.Of_binable
-                (Bigstring)
-                (struct
-                  type nonrec t = t
-
-                  let to_binable = to_bigstring
-
-                  let of_binable = of_bigstring
-                end)
-
-      let to_field =
-        let stub =
-          foreign (func_name "to_field") (typ @-> returning Field.typ)
-        in
-        fun n ->
-          let x = stub n in
-          Caml.Gc.finalise Field.delete x ;
-          x
-    end
-
-    module Q = Common (struct
-      let prefix = "q"
-    end)
-  end
-
   let field_size =
     let stub =
       foreign
@@ -1042,15 +1036,9 @@ struct
 
     val of_bigstring : Bigstring.t -> t
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
-
-    let prefix = with_prefix M.prefix "proving_key"
-
-    let func_name = with_prefix prefix
-
-    let delete = foreign (with_prefix prefix "delete") (typ @-> returning void)
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "proving_key"
+    end)
 
     let to_cpp_string_stub : t -> Cpp_string.t =
       foreign (func_name "to_string") (typ @-> returning Cpp_string.typ)
@@ -1160,15 +1148,9 @@ struct
 
     val size_in_bits : t -> int
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
-
-    let prefix = with_prefix M.prefix "verification_key"
-
-    let func_name = with_prefix prefix
-
-    let delete = foreign (with_prefix prefix "delete") (typ @-> returning void)
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "verification_key"
+    end)
 
     let size_in_bits =
       foreign (func_name "size_in_bits") (typ @-> returning int)
@@ -1233,15 +1215,9 @@ struct
 
     val create : M.R1CS_constraint_system.t -> t
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
-
-    let prefix = with_prefix M.prefix "keypair"
-
-    let func_name s = with_prefix prefix s
-
-    let delete = foreign (func_name "delete") (typ @-> returning void)
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "keypair"
+    end)
 
     let pk =
       let stub =
@@ -1288,15 +1264,9 @@ struct
 
     val of_string : string -> t
   end = struct
-    type t = unit ptr
-
-    let typ = ptr void
-
-    let prefix = with_prefix M.prefix "proof"
-
-    let func_name = with_prefix prefix
-
-    let delete = foreign (func_name "delete") (typ @-> returning void)
+    include Make_foreign (struct
+      let prefix = with_prefix M.prefix "proof"
+    end)
 
     let to_string : t -> string =
       let stub =
@@ -1451,15 +1421,9 @@ end) (Fq : sig
   module Vector : Deletable_intf
 end) =
 struct
-  type t = unit ptr
-
-  let typ = ptr void
-
-  let prefix = with_prefix Prefix.prefix "g2"
-
-  let func_name = with_prefix prefix
-
-  let delete = foreign (func_name "delete") (typ @-> returning void)
+  include Make_foreign (struct
+    let prefix = with_prefix Prefix.prefix "g2"
+  end)
 
   let to_coords =
     let coord name =

--- a/src/lib/snarky/src/libsnark.ml
+++ b/src/lib/snarky/src/libsnark.ml
@@ -597,8 +597,10 @@ struct
     end)
 
     module Term = struct
+      let prefix = with_prefix prefix "term"
+
       include Make_foreign (struct
-        let prefix = with_prefix prefix "term"
+        let prefix = prefix
       end)
 
       let create =

--- a/src/lib/snarky/src/snark0.ml
+++ b/src/lib/snarky/src/snark0.ml
@@ -134,16 +134,6 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     let of_string = Fn.compose of_bignum_bigint Bignum_bigint.of_string
 
-    include Binable.Of_binable
-              (Bigint)
-              (struct
-                type t = Field.t
-
-                let to_binable = Bigint.of_field
-
-                let of_binable = Bigint.to_field
-              end)
-
     module Infix = struct
       let ( + ) = add
 


### PR DESCRIPTION
This PR

- refactors the libsnark bindings a little
- moves the bin_io instance for field into libsnark.ml
- adds a bin_io instance for G1