### PR TITLE
fix create_empty in mask

### DIFF
--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -188,6 +188,18 @@ let%test_module "test functor on in memory databases" =
                 let result = MT.get_all_accounts_rooted_at_exn mdb address in
                 assert (List.equal ~equal:Account.equal accounts result) ) )
 
+      let%test_unit "create_empty doesn't modify the hash" =
+        Test.with_instance (fun ledger ->
+            let open MT in
+            let key = List.nth_exn (Key.gen_keys 1) 0 in
+            let start_hash = merkle_root ledger in
+            match get_or_create_account_exn ledger key Account.empty with
+            | `Existed, _ ->
+                failwith
+                  "create_empty with empty ledger somehow already has that key?"
+            | `Added, new_loc ->
+                [%test_eq: Hash.t] start_hash (merkle_root ledger) )
+
       let%test "get_at_index_exn t (index_of_key_exn t public_key) = account" =
         Test.with_instance (fun mdb ->
             let max_height = Int.min MT.depth 5 in

--- a/src/lib/merkle_ledger_tests/test_ledger.ml
+++ b/src/lib/merkle_ledger_tests/test_ledger.ml
@@ -273,6 +273,17 @@ let%test_module "test functor on in memory databases" =
           res ) ;
       assert (mr_start = L16.merkle_root ledger)
 
+    let%test_unit "create_empty doesn't modify the hash" =
+      let open L3 in
+      let key = List.nth_exn (Key.gen_keys 1) 0 in
+      let ledger = create () in
+      let start_hash = merkle_root ledger in
+      match get_or_create_account_exn ledger key Account.empty with
+      | `Existed, _ ->
+          failwith
+            "create_empty with empty ledger somehow already has that key?"
+      | `Added, new_loc -> [%test_eq: Hash.t] start_hash (merkle_root ledger)
+
     let%test_unit "remove last two accounts is as if they were never there" =
       (* NB: because of the issue with duplicates in public _key generation,
          given numbers of accounts n and m, where m > n, the key list produced by load_ledger on n

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -445,6 +445,19 @@ let%test_module "Test mask connected to underlying Merkle tree" =
             in
             assert (Int.equal retrieved_total total) )
 
+      let%test_unit "create_empty doesn't modify the hash" =
+        Test.with_instances (fun maskable mask ->
+            let open Mask.Attached in
+            let ledger = Maskable.register_mask maskable mask in
+            let key = List.nth_exn (Key.gen_keys 1) 0 in
+            let start_hash = merkle_root ledger in
+            match get_or_create_account_exn ledger key Account.empty with
+            | `Existed, _ ->
+                failwith
+                  "create_empty with empty ledger somehow already has that key?"
+            | `Added, new_loc ->
+                [%test_eq: Hash.t] start_hash (merkle_root ledger) )
+
       let%test_unit "reuse of locations for removed accounts" =
         Test.with_instances (fun maskable mask ->
             let attached_mask = Maskable.register_mask maskable mask in


### PR DESCRIPTION
These unit tests (hopefully) expose a bug. In theory, associating a key with an empty account should do nothing -- the merkle trees are supposed to use (hash Account.empty) when an account isn't present, and when `get_or_create_account l k Account.empty = `Added` the root hash of `l` shouldn't change. I haven't made much headway debugging this yet, any insight @psteckler ?