### PR TITLE
Verify transitions in validator

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -242,6 +242,10 @@ module type Main_intf = sig
 
     module Staged_ledger_diff : sig
       type t [@@deriving sexp, bin_io]
+
+      module Verified : sig
+        type t [@@deriving sexp, bin_io]
+      end
     end
 
     module Internal_transition :
@@ -258,12 +262,12 @@ module type Main_intf = sig
     module Transition_frontier :
       Protocols.Coda_pow.Transition_frontier_intf
       with type state_hash := State_hash.t
-       and type external_transition := External_transition.t
+       and type external_transition_verified := External_transition.Verified.t
        and type ledger_database := Coda_base.Ledger.Db.t
+       and type ledger_diff_verified := Staged_ledger_diff.Verified.t
        and type masked_ledger := Coda_base.Ledger.t
        and type staged_ledger := Staged_ledger.t
        and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
-       and type ledger_diff := Staged_ledger_diff.t
   end
 
   module Config : sig
@@ -305,7 +309,7 @@ module type Main_intf = sig
 
   val strongest_ledgers :
        t
-    -> (Inputs.External_transition.t, State_hash.t) With_hash.t
+    -> (Inputs.External_transition.Verified.t, State_hash.t) With_hash.t
        Strict_pipe.Reader.t
 
   val transaction_pool : t -> Inputs.Transaction_pool.t
@@ -522,6 +526,8 @@ struct
     end
 
     include Staged_ledger.Make (Inputs)
+
+    type verified_diff = Staged_ledger_diff.Verified.t
   end
 
   module Staged_ledger_aux = Staged_ledger.Scan_state
@@ -538,7 +544,7 @@ struct
     end
 
     let forget {With_valid_signatures_and_proofs.old; diff} =
-      {old; diff= Staged_ledger_diff.forget diff}
+      {old; diff= Staged_ledger_diff.forget_validated diff}
   end
 
   module Internal_transition =
@@ -585,9 +591,11 @@ struct
       ; staged_ledger: Staged_ledger.t sexp_opaque }
     [@@deriving sexp, fields]
 
-    let of_transition_and_staged_ledger transition staged_ledger =
-      { state= External_transition.protocol_state transition
-      ; proof= External_transition.protocol_state_proof transition
+    type external_transition_verified = External_transition.Verified.t
+
+    let of_verified_transition_and_staged_ledger transition staged_ledger =
+      { state= External_transition.Verified.protocol_state transition
+      ; proof= External_transition.Verified.protocol_state_proof transition
       ; staged_ledger }
 
     let bin_tip =
@@ -777,15 +785,6 @@ struct
     module Staged_ledger_aux_hash = Staged_ledger_aux_hash
   end)
 
-  module Ledger_catchup = Ledger_catchup.Make (struct
-    include Inputs0
-    module Staged_ledger_diff = Staged_ledger_diff
-    module Transaction_snark_work = Transaction_snark_work
-    module Ledger_proof_statement = Ledger_proof_statement
-    module Staged_ledger_aux_hash = Staged_ledger_aux_hash
-    module Network = Net
-  end)
-
   module Transition_handler = Transition_handler.Make (struct
     include Inputs0
     module State_proof = Protocol_state_proof
@@ -793,6 +792,16 @@ struct
     module Staged_ledger_diff = Staged_ledger_diff
     module Ledger_proof_statement = Ledger_proof_statement
     module Staged_ledger_aux_hash = Staged_ledger_aux_hash
+  end)
+
+  module Ledger_catchup = Ledger_catchup.Make (struct
+    include Inputs0
+    module Staged_ledger_diff = Staged_ledger_diff
+    module Transaction_snark_work = Transaction_snark_work
+    module Transition_handler_validator = Transition_handler.Validator
+    module Ledger_proof_statement = Ledger_proof_statement
+    module Staged_ledger_aux_hash = Staged_ledger_aux_hash
+    module Network = Net
   end)
 
   module Transition_frontier_controller =
@@ -1189,8 +1198,10 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
           With_hash.data
             (Transition_frontier.Breadcrumb.transition_with_hash (best_tip t))
         in
-        let state = External_transition.protocol_state transition in
-        let proof = External_transition.protocol_state_proof transition in
+        let state = External_transition.Verified.protocol_state transition in
+        let proof =
+          External_transition.Verified.protocol_state_proof transition
+        in
         let ledger =
           List.fold pks
             ~f:(fun acc key ->

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -294,7 +294,9 @@ module T = struct
         don't_wait_for
           (Strict_pipe.Reader.iter (Main.strongest_ledgers coda) ~f:(fun t ->
                let open Main.Inputs in
-               let p = External_transition.protocol_state (With_hash.data t) in
+               let p =
+                 External_transition.Verified.protocol_state (With_hash.data t)
+               in
                let prev_state_hash =
                  Main.Inputs.Consensus_mechanism.Protocol_state
                  .previous_state_hash p

--- a/src/app/cli/src/web_pipe.ml
+++ b/src/app/cli/src/web_pipe.ml
@@ -23,6 +23,10 @@ module type Coda_intf = sig
 
     module External_transition : sig
       type t
+
+      module Verified : sig
+        type t
+      end
     end
   end
 
@@ -34,7 +38,7 @@ module type Coda_intf = sig
 
   val strongest_ledgers :
        t
-    -> (Inputs.External_transition.t, State_hash.t) With_hash.t
+    -> (Inputs.External_transition.Verified.t, State_hash.t) With_hash.t
        Strict_pipe.Reader.t
 end
 

--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -5,9 +5,31 @@ module type S = sig
 
   module Staged_ledger_diff : sig
     type t [@@deriving bin_io, sexp]
+
+    module Verified : sig
+      type t [@@deriving sexp, bin_io]
+    end
   end
 
   type t [@@deriving sexp, bin_io, compare, eq]
+
+  module Verified : sig
+    type t [@@deriving sexp, bin_io, compare, eq]
+
+    val create :
+         protocol_state:Protocol_state.value
+      -> protocol_state_proof:Proof.t
+      -> staged_ledger_diff:Staged_ledger_diff.Verified.t
+      -> t
+
+    val protocol_state : t -> Protocol_state.value
+
+    val protocol_state_proof : t -> Proof.t
+
+    val staged_ledger_diff : t -> Staged_ledger_diff.Verified.t
+  end
+
+  val forget : Verified.t -> t
 
   val create :
        protocol_state:Protocol_state.value
@@ -26,6 +48,12 @@ end
 
 module Make (Staged_ledger_diff : sig
   type t [@@deriving bin_io, sexp]
+
+  module Verified : sig
+    type t [@@deriving bin_io, sexp]
+  end
+
+  val forget_verified : Verified.t -> t
 end)
 (Protocol_state : Protocol_state.S) :
   S
@@ -40,6 +68,31 @@ end)
     ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
     ; staged_ledger_diff: Staged_ledger_diff.t }
   [@@deriving sexp, fields, bin_io]
+
+  module Verified = struct
+    type t =
+      { protocol_state: Protocol_state.value
+      ; protocol_state_proof: Proof.Stable.V1.t
+      ; staged_ledger_diff: Staged_ledger_diff.Verified.t }
+    [@@deriving sexp, fields, bin_io]
+
+    let compare t1 t2 =
+      Protocol_state.compare t1.protocol_state t2.protocol_state
+
+    let equal t1 t2 =
+      Protocol_state.equal_value t1.protocol_state t2.protocol_state
+
+    let create ~protocol_state ~protocol_state_proof ~staged_ledger_diff =
+      {protocol_state; protocol_state_proof; staged_ledger_diff}
+  end
+
+  let forget (verified : Verified.t) =
+    let staged_ledger_diff =
+      Staged_ledger_diff.forget_verified verified.staged_ledger_diff
+    in
+    { protocol_state= verified.protocol_state
+    ; protocol_state_proof= verified.protocol_state_proof
+    ; staged_ledger_diff }
 
   (* TODO: Important for bkase to review *)
   let compare t1 t2 =

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -192,7 +192,7 @@ module type Ledger_builder_controller_intf = sig
 
   type staged_ledger_hash
 
-  type external_transition
+  type external_transition_verified
 
   type ledger
 
@@ -221,7 +221,8 @@ module type Ledger_builder_controller_intf = sig
       { parent_log: Logger.t
       ; net_deferred: net Deferred.t
       ; external_transitions:
-          (external_transition * Unix_timestamp.t) Linear_pipe.Reader.t
+          (external_transition_verified * Unix_timestamp.t)
+          Linear_pipe.Reader.t
       ; genesis_tip: tip
       ; ledger: maskable_ledger
       ; consensus_local_state: consensus_local_state
@@ -244,7 +245,7 @@ module type Ledger_builder_controller_intf = sig
     -> (staged_ledger * protocol_state) Deferred.Or_error.t
 
   val strongest_ledgers :
-    t -> (staged_ledger * external_transition) Linear_pipe.Reader.t
+    t -> (staged_ledger * external_transition_verified) Linear_pipe.Reader.t
 
   val handle_sync_ledger_queries :
        t
@@ -408,7 +409,7 @@ module type Inputs_intf = sig
      and type ledger := Ledger.t
      and type staged_ledger := Staged_ledger.t
      and type staged_ledger_hash := Staged_ledger_hash.t
-     and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type protocol_state := Consensus_mechanism.Protocol_state.value
      and type consensus_local_state := Consensus_mechanism.Local_state.t
      and type sync_query := Sync_ledger.query
@@ -428,17 +429,18 @@ module type Inputs_intf = sig
   module Transition_frontier :
     Protocols.Coda_transition_frontier.Transition_frontier_intf
     with type state_hash := Protocol_state_hash.t
-     and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type ledger_database := Ledger_db.t
      and type masked_ledger := Masked_ledger.t
      and type staged_ledger := Staged_ledger.t
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
-     and type ledger_diff := Staged_ledger_diff.t
+     and type ledger_diff_verified := Staged_ledger_diff.Verified.t
 
   module Transition_frontier_controller :
     Protocols.Coda_transition_frontier.Transition_frontier_controller_intf
     with type time_controller := Time.Controller.t
      and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type syncable_ledger_query := Sync_ledger.query
      and type syncable_ledger_answer := Sync_ledger.answer
      and type transition_frontier := Transition_frontier.t
@@ -492,7 +494,7 @@ module Make (Inputs : Inputs_intf) = struct
     ; snark_pool: Snark_pool.t
     ; transition_frontier: Transition_frontier.t
     ; strongest_ledgers:
-        (External_transition.t, Protocol_state_hash.t) With_hash.t
+        (External_transition.Verified.t, Protocol_state_hash.t) With_hash.t
         Strict_pipe.Reader.t
     ; log: Logger.t
     ; mutable seen_jobs: Work_selector.State.t
@@ -515,7 +517,7 @@ module Make (Inputs : Inputs_intf) = struct
 
   let best_protocol_state t =
     Transition_frontier.Breadcrumb.transition_with_hash (best_tip t)
-    |> With_hash.data |> External_transition.protocol_state
+    |> With_hash.data |> External_transition.Verified.protocol_state
 
   let best_ledger t = Staged_ledger.ledger (best_staged_ledger t)
 
@@ -616,22 +618,26 @@ module Make (Inputs : Inputs_intf) = struct
           Linear_pipe.create ()
         in
         let net_ivar = Ivar.create () in
+        let empty_diff_verified =
+          { Staged_ledger_diff.Verified.pre_diffs=
+              Either.First
+                { diff= {completed_works= []; user_commands= []}
+                ; coinbase_added= Staged_ledger_diff.At_most_one.Zero }
+          ; prev_hash=
+              Staged_ledger_hash.of_aux_and_ledger_hash
+                (Staged_ledger_aux_hash.of_bytes "")
+                (Ledger.merkle_root Genesis_ledger.t)
+          ; creator=
+              Account.public_key (snd (List.hd_exn Genesis_ledger.accounts)) }
+        in
+        let genesis_protocol_state =
+          With_hash.data Consensus_mechanism.genesis_protocol_state
+        in
         let first_transition =
-          External_transition.create
-            ~protocol_state:Consensus_mechanism.genesis_protocol_state.data
+          External_transition.Verified.create
+            ~protocol_state:genesis_protocol_state
             ~protocol_state_proof:Protocol_state_proof.dummy
-            ~staged_ledger_diff:
-              { Staged_ledger_diff.pre_diffs=
-                  Either.First
-                    { diff= {completed_works= []; user_commands= []}
-                    ; coinbase_added= Staged_ledger_diff.At_most_one.Zero }
-              ; prev_hash=
-                  Staged_ledger_hash.of_aux_and_ledger_hash
-                    (Staged_ledger_aux_hash.of_bytes "")
-                    (Ledger.merkle_root Genesis_ledger.t)
-              ; creator=
-                  Account.public_key
-                    (snd (List.hd_exn Genesis_ledger.accounts)) }
+            ~staged_ledger_diff:empty_diff_verified
         in
         let transition_frontier =
           Transition_frontier.create ~logger:config.log
@@ -639,7 +645,7 @@ module Make (Inputs : Inputs_intf) = struct
               (With_hash.of_data first_transition
                  ~hash_data:
                    (Fn.compose Consensus_mechanism.Protocol_state.hash
-                      External_transition.protocol_state))
+                      External_transition.Verified.protocol_state))
             ~root_transaction_snark_scan_state:
               (Staged_ledger.Scan_state.empty ())
             ~root_staged_ledger_diff:None
@@ -669,10 +675,11 @@ module Make (Inputs : Inputs_intf) = struct
                 Deferred.return
                 @@ Transition_frontier.find transition_frontier hash
               in
+              (* forget verified status of external transition in breadcrumb for broadcast *)
               Transition_frontier.path_map
                 ~f:(fun b ->
                   Transition_frontier.Breadcrumb.transition_with_hash b
-                  |> With_hash.data )
+                  |> With_hash.data |> External_transition.forget )
                 transition_frontier breadcrumb )
         in
         let valid_transitions =
@@ -701,7 +708,10 @@ module Make (Inputs : Inputs_intf) = struct
         don't_wait_for
           (Strict_pipe.Reader.iter_without_pushback
              valid_transitions_for_network ~f:(fun transition_with_hash ->
-               Net.broadcast_state net (With_hash.data transition_with_hash) )) ;
+               (* remove verified status for network broadcast *)
+               Net.broadcast_state net
+                 (External_transition.forget
+                    (With_hash.data transition_with_hash)) )) ;
         don't_wait_for
           (Linear_pipe.transfer_id (Net.states net) external_transitions_writer) ;
         let%bind snark_pool =

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -639,7 +639,7 @@ module Make (Inputs : Inputs_intf) = struct
             ~protocol_state_proof:Protocol_state_proof.dummy
             ~staged_ledger_diff:empty_diff_verified
         in
-        let transition_frontier =
+        let%bind transition_frontier =
           Transition_frontier.create ~logger:config.log
             ~root_transition:
               (With_hash.of_data first_transition

--- a/src/lib/ledger_builder_controller/catchup.ml
+++ b/src/lib/ledger_builder_controller/catchup.ml
@@ -55,7 +55,7 @@ struct
           let open Interruptible.Let_syntax in
           let scan_state = Envelope.Incoming.data scan_state_env in
           match%bind
-            Interruptible.return
+            Interruptible.uninterruptible
               (Staged_ledger.of_scan_state_and_ledger ~snarked_ledger_hash
                  ~ledger ~scan_state)
           with

--- a/src/lib/ledger_builder_controller/inputs.ml
+++ b/src/lib/ledger_builder_controller/inputs.ml
@@ -36,6 +36,10 @@ module Base = struct
     module Staged_ledger_diff : sig
       type t [@@deriving sexp, bin_io]
 
+      module Verified : sig
+        type t
+      end
+
       module With_valid_signatures_and_proofs : sig
         type t
       end
@@ -126,6 +130,16 @@ module Base = struct
       val protocol_state_proof : t -> Protocol_state_proof.t
 
       val staged_ledger_diff : t -> Staged_ledger_diff.t
+
+      module Verified : sig
+        type t [@@deriving bin_io, eq, compare, sexp]
+
+        val protocol_state : t -> Consensus_mechanism.Protocol_state.value
+
+        val protocol_state_proof : t -> Protocol_state_proof.t
+
+        val staged_ledger_diff : t -> Staged_ledger_diff.Verified.t
+      end
     end
 
     module Ledger_proof_statement : sig
@@ -147,6 +161,7 @@ module Base = struct
        and type valid_diff :=
                   Staged_ledger_diff.With_valid_signatures_and_proofs.t
        and type diff := Staged_ledger_diff.t
+       and type verified_diff := Staged_ledger_diff.Verified.t
        and type ledger_proof := Ledger_proof.t
        and type ledger := Ledger.t
        and type staged_ledger_aux_hash := Staged_ledger_aux_hash.t
@@ -161,6 +176,7 @@ module Base = struct
                   * Protocol_state_proof.t
                   * Staged_ledger.serializable
        and type external_transition := External_transition.t
+       and type external_transition_verified := External_transition.Verified.t
 
     val verify_blockchain :
          Protocol_state_proof.t

--- a/src/lib/ledger_builder_controller/ledger_builder_controller.ml
+++ b/src/lib/ledger_builder_controller/ledger_builder_controller.ml
@@ -457,9 +457,6 @@ let%test_module "test" =
               , `Ledger_proof (Some x)
               , `Staged_ledger t )
 
-          let apply_unverified (_t : t) (_x : Staged_ledger_diff.t) ~logger:_ =
-            failwith "Unimplemented"
-
           let apply_diff_unchecked (_t : t) (_x : 'a) =
             failwith "Unimplemented"
 

--- a/src/lib/ledger_builder_controller/ledger_builder_controller.ml
+++ b/src/lib/ledger_builder_controller/ledger_builder_controller.ml
@@ -446,7 +446,7 @@ let%test_module "test" =
 
           let of_scan_state_and_ledger ~snarked_ledger_hash:_ ~ledger
               ~scan_state:_ =
-            Ok (create ~ledger)
+            Deferred.Or_error.return (create ~ledger)
 
           let scan_state t = !t
 

--- a/src/lib/ledger_builder_controller/transition_logic_state_intf.ml
+++ b/src/lib/ledger_builder_controller/transition_logic_state_intf.ml
@@ -1,7 +1,7 @@
 module type S = sig
   type consensus_local_state
 
-  type external_transition
+  type external_transition_verified
 
   type tip
 
@@ -11,7 +11,7 @@ module type S = sig
 
   module Transition_tree :
     Coda_lib.Ktree_intf
-    with type elem := (external_transition, state_hash) With_hash.t
+    with type elem := (external_transition_verified, state_hash) With_hash.t
 
   type t
 
@@ -21,8 +21,10 @@ module type S = sig
 
   val ktree : t -> Transition_tree.t option
 
-  val assert_state_valid : t -> unit
+  (*  
+      TODO : remove as dead code
 
+val assert_state_valid : t -> unit *)
   module Change : sig
     type t =
       | Locked_tip of (tip, state_hash) With_hash.t

--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -2,4 +2,4 @@
   (name ledger_catchup)
   (public_name ledger_catchup)
   (preprocess (pps ppx_jane) )
-  (libraries async_kernel transition_frontier consensus core_kernel protocols pipe_lib syncable_ledger merkle_address coda_base kademlia))
+  (libraries async_kernel transition_frontier transition_handler consensus core_kernel protocols pipe_lib syncable_ledger merkle_address coda_base kademlia))

--- a/src/lib/ledger_catchup/inputs.ml
+++ b/src/lib/ledger_catchup/inputs.ml
@@ -7,16 +7,25 @@ module type S = sig
   module Transition_frontier :
     Transition_frontier_intf
     with type state_hash := State_hash.t
-     and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type ledger_database := Ledger.Db.t
      and type masked_ledger := Ledger.Mask.Attached.t
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
-     and type ledger_diff := Staged_ledger_diff.t
+     and type ledger_diff_verified := Staged_ledger_diff.Verified.t
      and type staged_ledger := Staged_ledger.t
+
+  module Transition_handler_validator :
+    Transition_handler_validator_intf
+    with type state_hash := State_hash.t
+     and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
+     and type transition_frontier := Transition_frontier.t
+     and type staged_ledger := Staged_ledger.t
+     and type time := Block_time.t0
 
   module Network :
     Network_intf
     with type peer := Kademlia.Peer.t
      and type state_hash := State_hash.t
-     and type transition := External_transition.t
+     and type external_transition := External_transition.t
 end

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -105,8 +105,7 @@ module Make (Inputs : Inputs.S) :
               Deferred.Or_error.List.map queried_transitions
                 ~f:(fun transition ->
                   Transition_handler_validator.verify_transition ~staged_ledger
-                    ~transition
-                  |> Deferred.return )
+                    ~transition )
             in
             materialize_breadcrumbs ~frontier ~logger ~peer
               queried_transitions_verified )

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -7,6 +7,8 @@ open Coda_base
 module Make (Inputs : Inputs.S) :
   Catchup_intf
   with type external_transition := Inputs.External_transition.t
+  with type external_transition_verified :=
+              Inputs.External_transition.Verified.t
    and type transition_frontier := Inputs.Transition_frontier.t
    and type transition_frontier_breadcrumb :=
               Inputs.Transition_frontier.Breadcrumb.t
@@ -20,8 +22,8 @@ module Make (Inputs : Inputs.S) :
         | Error e -> Deferred.return (Error e)
         | Ok acc -> f acc elem )
 
-  (* We would like the async scheduler to context switch between each iteration 
-  of external transitions when trying to build breadcrumb_path. Therefore, this 
+  (* We would like the async scheduler to context switch between each iteration
+  of external transitions when trying to build breadcrumb_path. Therefore, this
   function needs to return a Deferred *)
   let construct_breadcrumb_path ~logger initial_staged_ledger
       external_transitions =
@@ -30,7 +32,7 @@ module Make (Inputs : Inputs.S) :
       fold_result_seq external_transitions ~init:(initial_staged_ledger, [])
         ~f:(fun (staged_ledger, acc) external_transition ->
           let diff =
-            External_transition.staged_ledger_diff external_transition
+            External_transition.Verified.staged_ledger_diff external_transition
           in
           let%map _, _, `Staged_ledger staged_ledger =
             Deferred.create (fun ivar ->
@@ -41,7 +43,7 @@ module Make (Inputs : Inputs.S) :
             With_hash.of_data external_transition
               ~hash_data:
                 (Fn.compose Consensus.Mechanism.Protocol_state.hash
-                   External_transition.protocol_state)
+                   External_transition.Verified.protocol_state)
           in
           let new_breadcrumb =
             Transition_frontier.Breadcrumb.create transition_with_hash
@@ -54,7 +56,7 @@ module Make (Inputs : Inputs.S) :
   let materialize_breadcrumbs ~frontier ~logger ~peer external_transitions =
     let root_transition = List.hd_exn external_transitions in
     let initial_state_hash =
-      root_transition |> External_transition.protocol_state
+      root_transition |> External_transition.Verified.protocol_state
       |> External_transition.Protocol_state.previous_state_hash
     in
     match Transition_frontier.find frontier initial_state_hash with
@@ -95,8 +97,19 @@ module Make (Inputs : Inputs.S) :
             Logger.faulty_peer logger !"%s" message ;
             Deferred.return @@ Or_error.error_string message
         | Some queried_transitions ->
-            materialize_breadcrumbs ~frontier ~logger ~peer queried_transitions
-    )
+            let%bind queried_transitions_verified =
+              let staged_ledger =
+                Transition_frontier.best_tip frontier
+                |> Transition_frontier.Breadcrumb.staged_ledger
+              in
+              Deferred.Or_error.List.map queried_transitions
+                ~f:(fun transition ->
+                  Transition_handler_validator.verify_transition ~staged_ledger
+                    ~transition
+                  |> Deferred.return )
+            in
+            materialize_breadcrumbs ~frontier ~logger ~peer
+              queried_transitions_verified )
 
   let run ~logger ~network ~frontier ~catchup_job_reader
       ~catchup_breadcrumbs_writer =

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -21,12 +21,12 @@ module type Inputs_intf = sig
   module Transition_frontier :
     Protocols.Coda_transition_frontier.Transition_frontier_intf
     with type state_hash := State_hash.t
-     and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type ledger_database := Ledger_db.t
      and type staged_ledger := Staged_ledger.t
+     and type ledger_diff_verified := Staged_ledger_diff.Verified.t
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
      and type masked_ledger := Masked_ledger.t
-     and type ledger_diff := Staged_ledger_diff.t
 
   module Transaction_pool :
     Coda_lib.Transaction_pool_read_intf
@@ -246,7 +246,7 @@ module Make (Inputs : Inputs_intf) :
         let internal_transition =
           Internal_transition.create ~snark_transition
             ~prover_state:(Proposal_data.prover_state proposal_data)
-            ~staged_ledger_diff:(Staged_ledger_diff.forget diff)
+            ~staged_ledger_diff:(Staged_ledger_diff.forget_validated diff)
         in
         Some (protocol_state, internal_transition) )
 
@@ -265,11 +265,11 @@ module Make (Inputs : Inputs_intf) :
             !"Begining to propose off of crumb %{sexp: Crumb.t}"
             crumb ;
           let previous_protocol_state, previous_protocol_state_proof =
-            let transition : External_transition.t =
+            let transition : External_transition.Verified.t =
               (Crumb.transition_with_hash crumb).data
             in
-            ( External_transition.protocol_state transition
-            , External_transition.protocol_state_proof transition )
+            ( External_transition.Verified.protocol_state transition
+            , External_transition.Verified.protocol_state_proof transition )
           in
           let%bind () =
             Interruptible.lift (Deferred.return ()) (Ivar.read ivar)
@@ -317,7 +317,9 @@ module Make (Inputs : Inputs_intf) :
         let rec check_for_proposal () =
           let crumb = Transition_frontier.best_tip transition_frontier in
           let transition = (Crumb.transition_with_hash crumb).data in
-          let protocol_state = External_transition.protocol_state transition in
+          let protocol_state =
+            External_transition.Verified.protocol_state transition
+          in
           match
             Consensus_mechanism.next_proposal
               (time_to_ms (Time.now time_controller))

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1799,8 +1799,6 @@ let%test_module "test" =
           [@@deriving sexp, bin_io]
         end
 
-        type verified = Verified.t [@@deriving sexp, bin_io]
-
         let forget_verified _vf = failwith "forget_verified: not implemented"
 
         module With_valid_signatures_and_proofs = struct

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -616,7 +616,7 @@ end = struct
     ; coinbase_parts_count= List.length coinbase }
 
   (* N.B.: we don't expose apply_diff_unverified in the signature for Staged_ledger *)
-  let apply_unverified_diff t (diff : Staged_ledger_diff.t) ~logger =
+  let apply_diff_unverified t (diff : Staged_ledger_diff.t) ~logger =
     let open Result_with_rollback.Let_syntax in
     let max_throughput = Int.pow 2 Inputs.Config.transaction_capacity_log_2 in
     let spots_available, proofs_waiting =
@@ -703,7 +703,7 @@ end = struct
     , `Ledger_proof res_opt
     , `Staged_ledger {scan_state= scan_state'; ledger= new_ledger} )
 
-  let apply_verified_diff t (diff_verified : Staged_ledger_diff.Verified.t)
+  let apply_diff_verified t (diff_verified : Staged_ledger_diff.Verified.t)
       ~logger =
     (* forget the verification when applying
        that allows apply_diff_unverified to share code with apply_diff_unchecked

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -684,7 +684,6 @@ end = struct
     , `Ledger_proof res_opt
     , `Staged_ledger {scan_state= scan_state'; ledger= new_ledger} )
 
-  (* TODO: when we move to a disk-backed db, this should call "Ledger.commit_changes" at the end. *)
   let apply_verified_diff t (diff_verified : Staged_ledger_diff.Verified.t)
       ~logger =
     (* forget the verification when applying *)

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -116,8 +116,6 @@ struct
     [@@deriving sexp, bin_io]
   end
 
-  type verified = Verified.t [@@deriving sexp, bin_io]
-
   (* forget the verification of completed works in a verified diff
      unlike Staged_ledger.checked_diff_of_diff, there's no possibility of failure *)
 

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -87,6 +87,96 @@ struct
     ; creator: Compressed_public_key.t }
   [@@deriving sexp, bin_io]
 
+  module Verified = struct
+    type diff =
+      { completed_works: Transaction_snark_work.Checked.t list
+      ; user_commands: User_command.t list }
+    [@@deriving sexp, bin_io]
+
+    type diff_with_at_most_two_coinbase =
+      { diff: diff
+      ; coinbase_parts: Transaction_snark_work.Checked.t At_most_two.t }
+    [@@deriving sexp, bin_io]
+
+    type diff_with_at_most_one_coinbase =
+      { diff: diff
+      ; coinbase_added: Transaction_snark_work.Checked.t At_most_one.t }
+    [@@deriving sexp, bin_io]
+
+    type pre_diffs =
+      ( diff_with_at_most_one_coinbase
+      , diff_with_at_most_two_coinbase * diff_with_at_most_one_coinbase )
+      Either.t
+    [@@deriving sexp, bin_io]
+
+    type t =
+      { pre_diffs: pre_diffs
+      ; prev_hash: Staged_ledger_hash.t
+      ; creator: Compressed_public_key.t }
+    [@@deriving sexp, bin_io]
+  end
+
+  type verified = Verified.t [@@deriving sexp, bin_io]
+
+  (* forget the verification of completed works in a verified diff
+     unlike Staged_ledger.checked_diff_of_diff, there's no possibility of failure *)
+
+  let forget_verified (verified : Verified.t) : t =
+    let diff_of_work completed_works user_commands =
+      {completed_works; user_commands}
+    in
+    let uncheck_at_most_one
+        (at_most_one : Verified.diff_with_at_most_one_coinbase) =
+      let checked_diff = at_most_one.diff in
+      let (completed_works : Transaction_snark_work.t list) =
+        List.map checked_diff.completed_works ~f:Transaction_snark_work.forget
+      in
+      let diff = diff_of_work completed_works checked_diff.user_commands in
+      match at_most_one.coinbase_added with
+      | Zero -> {diff; coinbase_added= Zero}
+      | One maybe_work -> (
+        match maybe_work with
+        | None -> {diff; coinbase_added= One None}
+        | Some work ->
+            let completed_work = Transaction_snark_work.forget work in
+            {diff; coinbase_added= One (Some completed_work)} )
+    in
+    let uncheck_at_most_two
+        (at_most_two : Verified.diff_with_at_most_two_coinbase) =
+      let checked_diff = at_most_two.diff in
+      let completed_works =
+        List.map checked_diff.completed_works ~f:Transaction_snark_work.forget
+      in
+      let diff = diff_of_work completed_works checked_diff.user_commands in
+      match at_most_two.coinbase_parts with
+      | Zero -> {diff; coinbase_parts= Zero}
+      | One maybe_work -> (
+        match maybe_work with
+        | None -> {diff; coinbase_parts= One None}
+        | Some work ->
+            let completed_work = Transaction_snark_work.forget work in
+            {diff; coinbase_parts= One (Some completed_work)} )
+      | Two maybe_works -> (
+        match maybe_works with
+        | None -> {diff; coinbase_parts= Two None}
+        | Some (work_1, maybe_work) -> (
+            let completed_work_1 = Transaction_snark_work.forget work_1 in
+            match maybe_work with
+            | None ->
+                {diff; coinbase_parts= Two (Some (completed_work_1, None))}
+            | Some work_2 ->
+                let completed_work_2 = Transaction_snark_work.forget work_2 in
+                { diff
+                ; coinbase_parts=
+                    Two (Some (completed_work_1, Some completed_work_2)) } ) )
+    in
+    let pre_diffs =
+      Either.map verified.pre_diffs ~first:uncheck_at_most_one
+        ~second:(fun (at_most_two, at_most_one) ->
+          (uncheck_at_most_two at_most_two, uncheck_at_most_one at_most_one) )
+    in
+    {pre_diffs; prev_hash= verified.prev_hash; creator= verified.creator}
+
   module With_valid_signatures_and_proofs = struct
     type diff =
       { completed_works: Transaction_snark_work.Checked.t list
@@ -153,7 +243,7 @@ struct
     in
     {diff= forget_diff diff; coinbase_added= forget_cw}
 
-  let forget (t : With_valid_signatures_and_proofs.t) =
+  let forget_validated (t : With_valid_signatures_and_proofs.t) =
     { pre_diffs=
         Either.map t.pre_diffs ~first:forget_pre_diff_with_at_most_one
           ~second:(fun d ->

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -8,12 +8,12 @@ module type Inputs_intf = sig
   module Transition_frontier :
     Transition_frontier_intf
     with type state_hash := State_hash.t
-     and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type ledger_database := Ledger.Db.t
      and type staged_ledger := Staged_ledger.t
      and type masked_ledger := Ledger.Mask.Attached.t
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
-     and type ledger_diff := Staged_ledger_diff.t
+     and type ledger_diff_verified := Staged_ledger_diff.Verified.t
 
   module Syncable_ledger :
     Syncable_ledger.S
@@ -43,7 +43,7 @@ module Make (Inputs : Inputs_intf) :
         in
         let external_transition = With_hash.data transition_with_hash in
         let protocol_state =
-          External_transition.protocol_state external_transition
+          External_transition.Verified.protocol_state external_transition
         in
         let body = External_transition.Protocol_state.body protocol_state in
         let state_body_hash =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Async_kernel
 open Protocols.Coda_pow
 open Protocols.Coda_transition_frontier
 open Coda_base
@@ -125,6 +126,7 @@ struct
       ~root_snarked_ledger ~root_transaction_snark_scan_state
       ~root_staged_ledger_diff =
     let open Consensus.Mechanism in
+    let open Deferred.Let_syntax in
     let logger = Logger.child logger __MODULE__ in
     let root_hash = With_hash.hash root_transition in
     let root_protocol_state =
@@ -160,7 +162,7 @@ struct
              (Protocol_state.Blockchain_state.staged_ledger_hash
                 root_blockchain_state))
         (Ledger.Mask.Attached.merkle_root root_masked_ledger) ;
-    match
+    match%map
       Inputs.Staged_ledger.of_scan_state_and_ledger
         ~scan_state:root_transaction_snark_scan_state
         ~ledger:root_masked_ledger

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -18,6 +18,8 @@ module type Inputs_intf = sig
     Transition_handler_intf
     with type time_controller := Time.Controller.t
      and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
+     and type staged_ledger := Staged_ledger.t
      and type state_hash := State_hash.t
      and type transition_frontier := Transition_frontier.t
      and type time := Time.t
@@ -28,11 +30,12 @@ module type Inputs_intf = sig
     Network_intf
     with type peer := Kademlia.Peer.t
      and type state_hash := State_hash.t
-     and type transition := External_transition.t
+     and type external_transition := External_transition.t
 
   module Catchup :
     Catchup_intf
     with type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type state_hash := State_hash.t
      and type transition_frontier := Transition_frontier.t
      and type transition_frontier_breadcrumb :=
@@ -44,6 +47,8 @@ module Make (Inputs : Inputs_intf) :
   Transition_frontier_controller_intf
   with type time_controller := Inputs.Time.Controller.t
    and type external_transition := Inputs.External_transition.t
+   and type external_transition_verified :=
+              Inputs.External_transition.Verified.t
    and type syncable_ledger_query := Inputs.Syncable_ledger.query
    and type syncable_ledger_answer := Inputs.Syncable_ledger.answer
    and type transition_frontier := Inputs.Transition_frontier.t

--- a/src/lib/transition_handler/catchup_monitor.ml
+++ b/src/lib/transition_handler/catchup_monitor.ml
@@ -9,7 +9,7 @@ module Make (Inputs : Inputs.S) = struct
 
   type t =
     { catchup_job_writer:
-        ( (External_transition.t, State_hash.t) With_hash.t
+        ( (External_transition.Verified.t, State_hash.t) With_hash.t
         , drop_head buffered
         , unit )
         Writer.t
@@ -23,7 +23,7 @@ module Make (Inputs : Inputs.S) = struct
     let logger = Logger.child logger "catchup_monitor" in
     let hash = With_hash.hash transition in
     let parent_hash =
-      With_hash.data transition |> External_transition.protocol_state
+      With_hash.data transition |> External_transition.Verified.protocol_state
       |> Protocol_state.previous_state_hash
     in
     let make_timeout () =

--- a/src/lib/transition_handler/inputs.ml
+++ b/src/lib/transition_handler/inputs.ml
@@ -14,12 +14,12 @@ module type S = sig
   module Transition_frontier :
     Transition_frontier_intf
     with type state_hash := State_hash.t
-     and type external_transition := External_transition.t
+     and type external_transition_verified := External_transition.Verified.t
      and type ledger_database := Ledger.Db.t
      and type staged_ledger := Staged_ledger.t
      and type masked_ledger := Ledger.Mask.Attached.t
+     and type ledger_diff_verified := Staged_ledger_diff.Verified.t
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
-     and type ledger_diff := Staged_ledger_diff.t
 end
 
 (*

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -9,6 +9,8 @@ module Make (Inputs : Inputs.S) :
   with type state_hash := State_hash.t
    and type time_controller := Inputs.Time.Controller.t
    and type external_transition := Inputs.External_transition.t
+   and type external_transition_verified :=
+              Inputs.External_transition.Verified.t
    and type transition_frontier := Inputs.Transition_frontier.t
    and type transition_frontier_breadcrumb :=
               Inputs.Transition_frontier.Breadcrumb.t = struct
@@ -20,7 +22,8 @@ module Make (Inputs : Inputs.S) :
   let catchup_timeout_duration = Time.Span.of_ms 6000L
 
   let transition_parent_hash t =
-    External_transition.protocol_state t |> Protocol_state.previous_state_hash
+    External_transition.Verified.protocol_state t
+    |> Protocol_state.previous_state_hash
 
   let run ~logger ~time_controller ~frontier ~valid_transition_reader
       ~catchup_job_writer ~catchup_breadcrumbs_reader

--- a/src/lib/transition_handler/transition_handler.ml
+++ b/src/lib/transition_handler/transition_handler.ml
@@ -7,6 +7,9 @@ module Make (Inputs : Inputs.S) :
   with type time := Inputs.Time.t
    and type time_controller := Inputs.Time.Controller.t
    and type external_transition := Inputs.External_transition.t
+   and type external_transition_verified :=
+              Inputs.External_transition.Verified.t
+   and type staged_ledger := Inputs.Staged_ledger.t
    and type state_hash := State_hash.t
    and type transition_frontier := Inputs.Transition_frontier.t
    and type transition_frontier_breadcrumb :=

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -132,6 +132,7 @@ module Make (Inputs : Inputs.S) = struct
                           (Fn.compose Protocol_state.hash
                              External_transition.Verified.protocol_state))
                | Error _ ->
+                   (* TODO: Punish *)
                    Logger.warn logger
                      !"failed to verify transition from the network! sent by \
                        %{sexp: Host_and_port.t}"

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -530,9 +530,7 @@ module type Staged_ledger_diff_intf = sig
     [@@deriving sexp, bin_io]
   end
 
-  type verified = Verified.t [@@deriving sexp, bin_io]
-
-  val forget_verified : verified -> t
+  val forget_verified : Verified.t -> t
 
   module With_valid_signatures_and_proofs : sig
     type diff =

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -730,7 +730,7 @@ module type Staged_ledger_base_intf = sig
        snarked_ledger_hash:frozen_ledger_hash
     -> ledger:ledger
     -> scan_state:Scan_state.t
-    -> t Or_error.t
+    -> t Or_error.t Deferred.t
 
   val of_serialized_and_unserialized :
     serialized:serializable -> unserialized:ledger -> t
@@ -820,7 +820,7 @@ module type Staged_ledger_intf = sig
 
   val statement_exn : t -> [`Non_empty of ledger_proof_statement | `Empty]
 
-  val verified_diff_of_diff : t -> diff -> verified_diff Or_error.t
+  val verified_diff_of_diff : t -> diff -> verified_diff Or_error.t Deferred.t
 end
 
 module type Work_selector_intf = sig

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -750,14 +750,7 @@ module type Staged_ledger_base_intf = sig
        * [`Staged_ledger of t] )
        Or_error.t
 
-  val apply_unverified :
-       t
-    -> diff
-    -> logger:Logger.t
-    -> ( [`Hash_after_applying of staged_ledger_hash]
-       * [`Ledger_proof of ledger_proof option]
-       * [`Staged_ledger of t] )
-       Or_error.t
+  (* N.B.: apply_diff_unverified is not exposed here *)
 
   val apply_diff_unchecked :
        t

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -446,7 +446,8 @@ module type Transaction_snark_work_intf = sig
   type unchecked = t
 
   module Checked : sig
-    type t [@@deriving sexp, bin_io]
+    type t = {fee: Fee.Unsigned.t; proofs: proof list; prover: public_key}
+    [@@deriving sexp, bin_io]
 
     val create_unsafe : unchecked -> t
   end
@@ -504,6 +505,35 @@ module type Staged_ledger_diff_intf = sig
     {pre_diffs: pre_diffs; prev_hash: staged_ledger_hash; creator: public_key}
   [@@deriving sexp, bin_io]
 
+  module Verified : sig
+    type diff =
+      { completed_works: completed_work_checked list
+      ; user_commands: user_command list }
+    [@@deriving sexp, bin_io]
+
+    type diff_with_at_most_two_coinbase =
+      {diff: diff; coinbase_parts: completed_work_checked At_most_two.t}
+    [@@deriving sexp, bin_io]
+
+    type diff_with_at_most_one_coinbase =
+      {diff: diff; coinbase_added: completed_work_checked At_most_one.t}
+    [@@deriving sexp, bin_io]
+
+    type pre_diffs =
+      ( diff_with_at_most_one_coinbase
+      , diff_with_at_most_two_coinbase * diff_with_at_most_one_coinbase )
+      Either.t
+    [@@deriving sexp, bin_io]
+
+    type t =
+      {pre_diffs: pre_diffs; prev_hash: staged_ledger_hash; creator: public_key}
+    [@@deriving sexp, bin_io]
+  end
+
+  type verified = Verified.t [@@deriving sexp, bin_io]
+
+  val forget_verified : verified -> t
+
   module With_valid_signatures_and_proofs : sig
     type diff =
       { completed_works: completed_work_checked list
@@ -531,7 +561,7 @@ module type Staged_ledger_diff_intf = sig
     val user_commands : t -> user_command_with_valid_signature list
   end
 
-  val forget : With_valid_signatures_and_proofs.t -> t
+  val forget_validated : With_valid_signatures_and_proofs.t -> t
 
   val user_commands : t -> user_command list
 end
@@ -665,6 +695,8 @@ module type Staged_ledger_base_intf = sig
 
   type diff
 
+  type verified_diff
+
   type valid_diff
 
   type staged_ledger_aux_hash
@@ -713,6 +745,15 @@ module type Staged_ledger_base_intf = sig
 
   val apply :
        t
+    -> verified_diff
+    -> logger:Logger.t
+    -> ( [`Hash_after_applying of staged_ledger_hash]
+       * [`Ledger_proof of ledger_proof option]
+       * [`Staged_ledger of t] )
+       Or_error.t
+
+  val apply_unverified :
+       t
     -> diff
     -> logger:Logger.t
     -> ( [`Hash_after_applying of staged_ledger_hash]
@@ -748,7 +789,7 @@ module type Staged_ledger_intf = sig
 
   type sparse_ledger
 
-  type completed_work
+  type completed_work_checked
 
   type public_key
 
@@ -761,7 +802,7 @@ module type Staged_ledger_intf = sig
     -> self:public_key
     -> logger:Logger.t
     -> transactions_by_fee:user_command_with_valid_signature Sequence.t
-    -> get_completed_work:(statement -> completed_work option)
+    -> get_completed_work:(statement -> completed_work_checked option)
     -> valid_diff
 
   val all_work_pairs :
@@ -780,6 +821,8 @@ module type Staged_ledger_intf = sig
        list
 
   val statement_exn : t -> [`Non_empty of ledger_proof_statement | `Empty]
+
+  val verified_diff_of_diff : t -> diff -> verified_diff Or_error.t
 end
 
 module type Work_selector_intf = sig
@@ -816,6 +859,8 @@ module type Tip_intf = sig
 
   type external_transition
 
+  type external_transition_verified
+
   (* N.B.: can't derive bin_io for ledger builder containing persistent ledger *)
   type t =
     { state: protocol_state
@@ -826,8 +871,8 @@ module type Tip_intf = sig
   (* serializer for tip components other than the persistent database in the ledger builder *)
   val bin_tip : serializable Bin_prot.Type_class.t
 
-  val of_transition_and_staged_ledger :
-    external_transition -> staged_ledger -> t
+  val of_verified_transition_and_staged_ledger :
+    external_transition_verified -> staged_ledger -> t
 
   val copy : t -> t
 end
@@ -917,6 +962,8 @@ module type External_transition_intf = sig
 
   type staged_ledger_diff
 
+  type staged_ledger_diff_verified
+
   type t [@@deriving sexp, bin_io]
 
   val create :
@@ -924,6 +971,22 @@ module type External_transition_intf = sig
     -> protocol_state_proof:protocol_state_proof
     -> staged_ledger_diff:staged_ledger_diff
     -> t
+
+  module Verified : sig
+    type t [@@deriving sexp, bin_io]
+
+    val create :
+         protocol_state:protocol_state
+      -> protocol_state_proof:protocol_state_proof
+      -> staged_ledger_diff:staged_ledger_diff_verified
+      -> t
+
+    val protocol_state : t -> protocol_state
+
+    val protocol_state_proof : t -> protocol_state_proof
+  end
+
+  val forget : Verified.t -> t
 
   val protocol_state : t -> protocol_state
 
@@ -1278,7 +1341,7 @@ Merge Snark:
      and type user_command_with_valid_signature :=
                 User_command.With_valid_signature.t
      and type statement := Transaction_snark_work.Statement.t
-     and type completed_work := Transaction_snark_work.Checked.t
+     and type completed_work_checked := Transaction_snark_work.Checked.t
      and type sparse_ledger := Sparse_ledger.t
      and type ledger_proof_statement := Ledger_proof_statement.t
      and type ledger_proof_statement_set := Ledger_proof_statement.Set.t
@@ -1319,6 +1382,7 @@ Merge Snark:
     External_transition_intf
     with type protocol_state := Consensus_mechanism.Protocol_state.value
      and type staged_ledger_diff := Staged_ledger_diff.t
+     and type staged_ledger_diff_verified := Staged_ledger_diff.Verified.t
      and type protocol_state_proof := Protocol_state_proof.t
 
   module Tip :

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -57,7 +57,7 @@ module type Transition_frontier_base_intf = sig
     -> root_snarked_ledger:ledger_database
     -> root_transaction_snark_scan_state:transaction_snark_scan_state
     -> root_staged_ledger_diff:ledger_diff_verified option
-    -> t
+    -> t Deferred.t
 
   val find_exn : t -> state_hash -> Breadcrumb.t
 end
@@ -159,7 +159,7 @@ module type Transition_handler_validator_intf = sig
   val verify_transition :
        staged_ledger:staged_ledger
     -> transition:external_transition
-    -> external_transition_verified Or_error.t
+    -> external_transition_verified Or_error.t Deferred.t
 end
 
 module type Transition_handler_processor_intf = sig

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -9,18 +9,21 @@ module type Network_intf = sig
 
   type state_hash
 
-  type transition
+  type external_transition
 
   val random_peers : t -> int -> peer list
 
   val catchup_transition :
-    t -> peer -> state_hash -> transition list option Or_error.t Deferred.t
+       t
+    -> peer
+    -> state_hash
+    -> external_transition list option Or_error.t Deferred.t
 end
 
 module type Transition_frontier_base_intf = sig
   type state_hash
 
-  type external_transition
+  type external_transition_verified
 
   type transaction_snark_scan_state
 
@@ -28,30 +31,32 @@ module type Transition_frontier_base_intf = sig
 
   type staged_ledger
 
-  type ledger_diff
-
   module Breadcrumb : sig
     type t [@@deriving sexp]
 
     val create :
-      (external_transition, state_hash) With_hash.t -> staged_ledger -> t
+         (external_transition_verified, state_hash) With_hash.t
+      -> staged_ledger
+      -> t
 
     val transition_with_hash :
-      t -> (external_transition, state_hash) With_hash.t
+      t -> (external_transition_verified, state_hash) With_hash.t
 
     val staged_ledger : t -> staged_ledger
   end
 
   type ledger_database
 
+  type ledger_diff_verified
+
   type t
 
   val create :
        logger:Logger.t
-    -> root_transition:(external_transition, state_hash) With_hash.t
+    -> root_transition:(external_transition_verified, state_hash) With_hash.t
     -> root_snarked_ledger:ledger_database
     -> root_transaction_snark_scan_state:transaction_snark_scan_state
-    -> root_staged_ledger_diff:ledger_diff option
+    -> root_staged_ledger_diff:ledger_diff_verified option
     -> t
 
   val find_exn : t -> state_hash -> Breadcrumb.t
@@ -92,13 +97,15 @@ module type Transition_frontier_intf = sig
   val attach_breadcrumb_exn : t -> Breadcrumb.t -> unit
 
   val add_transition_exn :
-    t -> (external_transition, state_hash) With_hash.t -> Breadcrumb.t
+    t -> (external_transition_verified, state_hash) With_hash.t -> Breadcrumb.t
 end
 
 module type Catchup_intf = sig
   type state_hash
 
   type external_transition
+
+  type external_transition_verified
 
   type transition_frontier
 
@@ -110,7 +117,9 @@ module type Catchup_intf = sig
        logger:Logger.t
     -> network:network
     -> frontier:transition_frontier
-    -> catchup_job_reader:(external_transition, state_hash) With_hash.t
+    -> catchup_job_reader:( external_transition_verified
+                          , state_hash )
+                          With_hash.t
                           Reader.t
     -> catchup_breadcrumbs_writer:( transition_frontier_breadcrumb list
                                   , crash buffered
@@ -126,7 +135,11 @@ module type Transition_handler_validator_intf = sig
 
   type external_transition
 
+  type external_transition_verified
+
   type transition_frontier
+
+  type staged_ledger
 
   val run :
        logger:Logger.t
@@ -135,11 +148,18 @@ module type Transition_handler_validator_intf = sig
                                             Envelope.Incoming.t ]
                          * [`Time_received of time] )
                          Reader.t
-    -> valid_transition_writer:( (external_transition, state_hash) With_hash.t
+    -> valid_transition_writer:( ( external_transition_verified
+                                 , state_hash )
+                                 With_hash.t
                                , drop_head buffered
                                , unit )
                                Writer.t
     -> unit
+
+  val verify_transition :
+       staged_ledger:staged_ledger
+    -> transition:external_transition
+    -> external_transition_verified Or_error.t
 end
 
 module type Transition_handler_processor_intf = sig
@@ -149,6 +169,8 @@ module type Transition_handler_processor_intf = sig
 
   type external_transition
 
+  type external_transition_verified
+
   type transition_frontier
 
   type transition_frontier_breadcrumb
@@ -157,14 +179,18 @@ module type Transition_handler_processor_intf = sig
        logger:Logger.t
     -> time_controller:time_controller
     -> frontier:transition_frontier
-    -> valid_transition_reader:(external_transition, state_hash) With_hash.t
+    -> valid_transition_reader:( external_transition_verified
+                               , state_hash )
+                               With_hash.t
                                Reader.t
-    -> catchup_job_writer:( (external_transition, state_hash) With_hash.t
+    -> catchup_job_writer:( ( external_transition_verified
+                            , state_hash )
+                            With_hash.t
                           , drop_head buffered
                           , unit )
                           Writer.t
     -> catchup_breadcrumbs_reader:transition_frontier_breadcrumb list Reader.t
-    -> processed_transition_writer:( ( external_transition
+    -> processed_transition_writer:( ( external_transition_verified
                                      , state_hash )
                                      With_hash.t
                                    , drop_head buffered
@@ -182,7 +208,11 @@ module type Transition_handler_intf = sig
 
   type external_transition
 
+  type external_transition_verified
+
   type transition_frontier
+
+  type staged_ledger
 
   type transition_frontier_breadcrumb
 
@@ -191,12 +221,15 @@ module type Transition_handler_intf = sig
     with type time := time
      and type state_hash := state_hash
      and type external_transition := external_transition
+     and type external_transition_verified := external_transition_verified
      and type transition_frontier := transition_frontier
+     and type staged_ledger := staged_ledger
 
   module Processor :
     Transition_handler_processor_intf
     with type time_controller := time_controller
      and type external_transition := external_transition
+     and type external_transition_verified := external_transition_verified
      and type state_hash := state_hash
      and type transition_frontier := transition_frontier
      and type transition_frontier_breadcrumb := transition_frontier_breadcrumb
@@ -221,6 +254,8 @@ module type Transition_frontier_controller_intf = sig
 
   type external_transition
 
+  type external_transition_verified
+
   type syncable_ledger_query
 
   type syncable_ledger_answer
@@ -242,5 +277,5 @@ module type Transition_frontier_controller_intf = sig
                                             Envelope.Incoming.t ]
                          * [`Time_received of time] )
                          Reader.t
-    -> (external_transition, state_hash) With_hash.t Reader.t
+    -> (external_transition_verified, state_hash) With_hash.t Reader.t
 end


### PR DESCRIPTION
> Explain your changes here.

Transitions are verified in the Validator, by calling `verified_diff_of_diff`. To accomdate that change, there's a new submodule `Verified` in the functor to create `External_transitions`, which contains a verified staged ledger diff. Similarly, `Staged_ledger_diff` contains a `Verified` submodule.

There was a function `forget` in `Staged_ledger_diff`, that forgot about the "validated signatures and proofs" of a diff, now renamed to `forget_validated`. There's a new function `forget_verified`, which forgets about the "verified"-ness of a diff.

Transitions sent on the network are unverified. See the comment "remove verified status" in `coda_lib.ml`.

Many of the changes are simply pushing through the verified status through the code. For example, breadcrumbs contain verified transitions.

> Explain how you tested your changes here.

Ran unit tests.

Checklist:

- [ ] Tests were added for the new behavior: no
- [X] All tests pass (CI will check this if you didn't)
- [X] Does this close issues? List them:

Closes #1259 
