### PR TITLE
Fix coda shared state test in tfc-staging

### DIFF
--- a/src/app/cli/src/coda_worker_testnet.ml
+++ b/src/app/cli/src/coda_worker_testnet.ml
@@ -103,7 +103,7 @@ let start_prefix_check log workers events proposal_interval testnet =
   in
   let last_time = ref (Time.now ()) in
   don't_wait_for
-    (let epsilon = 0.5 in
+    (let epsilon = 1.0 in
      let rec go () =
        let diff = Time.diff (Time.now ()) !last_time in
        let diff = Time.Span.to_sec diff in

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -18,15 +18,6 @@ module Make (Inputs : Inputs.S) = struct
       | `Reject, _ -> `Reject
       | `Valid, `Valid -> `Valid
     in
-    let ( || ) a b =
-      match (a, b) with
-      | _, `Duplicate -> `Duplicate
-      | `Duplicate, _ -> `Duplicate
-      | `Valid, _ -> `Valid
-      | _, `Valid -> `Valid
-      | `Reject, `Reject -> `Reject
-    in
-    let of_bool = function true -> `Valid | false -> `Reject in
     let t = Envelope.Incoming.data t_env in
     let time_received =
       Time.to_span_since_epoch time_received
@@ -37,7 +28,7 @@ module Make (Inputs : Inputs.S) = struct
         Logger.info logger "transition rejected: %s" error_msg ;
         `Reject
       in
-      of_bool condition || log ()
+      if condition then `Valid else log ()
     in
     let consensus_state =
       Fn.compose Protocol_state.consensus_state


### PR DESCRIPTION
I loosened the epsilon in coda_worker_testnet and also fixed some log statements that were printing unconditionally.