### PR TITLE
transition_frontier: don't raise Already_exists in attach_node_to

### DIFF
--- a/src/app/cli/src/coda_receipt_chain_test.ml
+++ b/src/app/cli/src/coda_receipt_chain_test.ml
@@ -47,28 +47,16 @@ let main () =
     Coda_process.send_payment_exn worker sender_sk receiver_pk send_amount fee
       User_command_memo.dummy
   in
+  let receipt_chain_hash = Or_error.ok_exn receipt_chain_hash in
   let%bind restarted_worker = restart_node ~config worker in
   let%map proof =
     Coda_process.prove_receipt_exn restarted_worker receipt_chain_hash
       receipt_chain_hash
   in
-  let%map result =
-    let open Deferred.Option.Let_syntax in
-    (* TODO: we should test sending multiple payments simultaneously. See #1143*)
-    match%bind
-      Coda_worker_testnet.Api.send_payment_with_receipt testnet 0 sender_sk
-        receiver_pk send_amount fee
-    with
-    | Error err -> assert false
-    | Ok receipt_chain_hash ->
-        let%bind () = restart_node testnet 0 |> lift in
-        let%map proof =
-          Coda_worker_testnet.Api.prove_receipt testnet 0 receipt_chain_hash
-            receipt_chain_hash
-        in
-        Receipt.Chain_hash.equal
-          (Payment_proof.initial_receipt proof)
-          receipt_chain_hash
+  let result =
+    Receipt.Chain_hash.equal
+      (Payment_proof.initial_receipt proof)
+      receipt_chain_hash
   in
   assert result
 

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -265,7 +265,7 @@ struct
     then
       Logger.warn t.logger
         !"attach_node_to with breadcrumb for state %{sexp:State_hash.t} \
-         already present; catchup monitor bug?"
+          already present; catchup monitor bug?"
         hash
     else
       Hashtbl.set t.table
@@ -350,7 +350,7 @@ struct
           Inputs.Staged_ledger.apply ~logger:t.logger staged_ledger
             (Inputs.External_transition.Verified.staged_ledger_diff transition)
           |> Or_error.ok_exn
-
+      
       with
       | ( `Hash_after_applying staged_ledger_hash
         , `Ledger_proof proof_opt
@@ -455,5 +455,5 @@ let%test_module "Transition_frontier tests" =
       interface_works ()
     done
      *)
-
+  
   end )

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -262,12 +262,17 @@ struct
     if
       Hashtbl.add t.table ~key:(Breadcrumb.hash node.breadcrumb) ~data:node
       <> `Ok
-    then Error.raise (Error.of_exn (Already_exists hash)) ;
-    Hashtbl.set t.table
-      ~key:(Breadcrumb.hash parent_node.breadcrumb)
-      ~data:
-        { parent_node with
-          successor_hashes= hash :: parent_node.successor_hashes }
+    then
+      Logger.warn t.logger
+        !"attach_node_to with breadcrumb for state %{sexp:State_hash.t} \
+         already present; catchup monitor bug?"
+        hash
+    else
+      Hashtbl.set t.table
+        ~key:(Breadcrumb.hash parent_node.breadcrumb)
+        ~data:
+          { parent_node with
+            successor_hashes= hash :: parent_node.successor_hashes }
 
   let attach_breadcrumb_exn t breadcrumb =
     let hash = Breadcrumb.hash breadcrumb in
@@ -295,7 +300,7 @@ struct
   (* Adding a transition to the transition frontier is broken into the following steps:
    *   1) create a new breadcrumb for a transition
           a) apply the staged_ledger_diff on to the parent breadcrumb of the transition
-          b) validate the snarked ledger hash from the transition 
+          b) validate the snarked ledger hash from the transition
    *   2) attach the breadcrumb to the transition frontier
    *   3) move the root if the path to the new node is longer than the max length
    *     a) calculate the distance from the new node to the parent
@@ -345,7 +350,7 @@ struct
           Inputs.Staged_ledger.apply ~logger:t.logger staged_ledger
             (Inputs.External_transition.Verified.staged_ledger_diff transition)
           |> Or_error.ok_exn
-      
+
       with
       | ( `Hash_after_applying staged_ledger_hash
         , `Ledger_proof proof_opt
@@ -450,5 +455,5 @@ let%test_module "Transition_frontier tests" =
       interface_works ()
     done
      *)
-  
+
   end )


### PR DESCRIPTION
(also fixes the type error in coda_receipt_chain_test that I let sneak in)