### PR TITLE
Instrument two way rpcs

### DIFF
--- a/scripts/ocamlformat
+++ b/scripts/ocamlformat
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Created at http://ellenandpaulsnewstartup.com - we're hiring!
-
-script=$(basename $0)
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/run-in-docker "$script" ${@} <&0

--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -191,20 +191,35 @@ let get_nonce_cmd =
 let status =
   let open Deferred.Let_syntax in
   let open Daemon_rpcs in
+  let open Command.Param in
+  let flag =
+    let open Command.Param in
+    return (fun a b -> (a, b))
+    <*> Cli_lib.Flag.json <*> Cli_lib.Flag.performance
+  in
   Command.async ~summary:"Get running daemon status"
-    (Cli_lib.Background_daemon.init Cli_lib.Flag.json ~f:(fun port json ->
+    (Cli_lib.Background_daemon.init flag ~f:(fun port (json, performance) ->
          dispatch_pretty_message ~json
            (module Daemon_rpcs.Types.Status)
-           Get_status.rpc () port ))
+           Get_status.rpc
+           (if performance then `Performance else `None)
+           port ))
 
 let status_clear_hist =
   let open Deferred.Let_syntax in
   let open Daemon_rpcs in
+  let flag =
+    let open Command.Param in
+    return (fun a b -> (a, b))
+    <*> Cli_lib.Flag.json <*> Cli_lib.Flag.performance
+  in
   Command.async ~summary:"Clear histograms reported in status"
-    (Cli_lib.Background_daemon.init Cli_lib.Flag.json ~f:(fun port json ->
+    (Cli_lib.Background_daemon.init flag ~f:(fun port (json, performance) ->
          dispatch_pretty_message ~json
            (module Daemon_rpcs.Types.Status)
-           Clear_hist_status.rpc () port ))
+           Clear_hist_status.rpc
+           (if performance then `Performance else `None)
+           port ))
 
 let get_nonce_exn public_key port =
   match%bind get_nonce public_key port with

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1195,7 +1195,7 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
 
   let start_time = Time_ns.now ()
 
-  let get_status t =
+  let get_status ~flag t =
     let open Participating_state.Let_syntax in
     let%bind ledger = best_ledger t in
     let ledger_merkle_root =
@@ -1216,17 +1216,34 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
       |> Time_ns.Span.to_sec |> Int.of_float
     in
     let r = Perf_histograms.report in
-    let rpc_timings =
-      let open Daemon_rpcs.Types.Status.Rpc_timings in
-      { get_staged_ledger_aux=
-          { Rpc_pair.dispatch= r ~name:"rpc_dispatch_get_staged_ledger_aux"
-          ; impl= r ~name:"rpc_impl_get_staged_ledger_aux" }
-      ; answer_sync_ledger_query=
-          { Rpc_pair.dispatch= r ~name:"rpc_dispatch_answer_sync_ledger_query"
-          ; impl= r ~name:"rpc_impl_answer_sync_ledger_query" }
-      ; transition_catchup=
-          { Rpc_pair.dispatch= r ~name:"rpc_dispatch_transition_catchup"
-          ; impl= r ~name:"rpc_impl_transition_catchup" } }
+    let histograms =
+      match flag with
+      | `Performance ->
+          let rpc_timings =
+            let open Daemon_rpcs.Types.Status.Rpc_timings in
+            { get_staged_ledger_aux=
+                { Rpc_pair.dispatch=
+                    r ~name:"rpc_dispatch_get_staged_ledger_aux"
+                ; impl= r ~name:"rpc_impl_get_staged_ledger_aux" }
+            ; answer_sync_ledger_query=
+                { Rpc_pair.dispatch=
+                    r ~name:"rpc_dispatch_answer_sync_ledger_query"
+                ; impl= r ~name:"rpc_impl_answer_sync_ledger_query" }
+            ; get_ancestry=
+                { Rpc_pair.dispatch= r ~name:"rpc_dispatch_get_ancestry"
+                ; impl= r ~name:"rpc_impl_get_ancestry" }
+            ; transition_catchup=
+                { Rpc_pair.dispatch= r ~name:"rpc_dispatch_transition_catchup"
+                ; impl= r ~name:"rpc_impl_transition_catchup" } }
+          in
+          Some
+            { Daemon_rpcs.Types.Status.Histograms.rpc_timings
+            ; external_transition_latency=
+                r ~name:"external_transition_latency"
+            ; snark_worker_transition_time=
+                r ~name:"snark_worker_transition_time"
+            ; snark_worker_merge_time= r ~name:"snark_worker_merge_time" }
+      | `None -> None
     in
     let%map staged_ledger = best_staged_ledger t in
     { Daemon_rpcs.Types.Status.num_accounts
@@ -1237,18 +1254,15 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
         staged_ledger |> Staged_ledger.hash |> Staged_ledger_hash.sexp_of_t
         |> Sexp.to_string
     ; state_hash
-    ; external_transition_latency= r ~name:"external_transition_latency"
-    ; snark_worker_transition_time= r ~name:"snark_worker_transition_time"
-    ; snark_worker_merge_time= r ~name:"snark_worker_merge_time"
     ; commit_id= Config_in.commit_id
     ; conf_dir= Config_in.conf_dir
     ; peers= List.map (peers t) ~f:(fun (p, _) -> Host_and_port.to_string p)
     ; user_commands_sent= !txn_count
     ; run_snark_worker= run_snark_worker t
     ; proposal_interval= Int64.to_int_exn Consensus.Mechanism.block_interval_ms
-    ; rpc_timings
     ; propose_pubkey=
-        Option.map ~f:(fun kp -> kp.public_key) (propose_keypair t) }
+        Option.map ~f:(fun kp -> kp.public_key) (propose_keypair t)
+    ; histograms }
 
   let get_lite_chain :
       (t -> Public_key.Compressed.t list -> Lite_base.Lite_chain.t) option =
@@ -1296,7 +1310,7 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
         let proof = Lite_compat.proof proof in
         {Lite_base.Lite_chain.proof; ledger; protocol_state} )
 
-  let clear_hist_status t = Perf_histograms.wipe () ; get_status t
+  let clear_hist_status ~flag t = Perf_histograms.wipe () ; get_status ~flag t
 
   (* TODO: handle participation_status more appropriately than doing participate_exn *)
   let setup_local_server ?(client_whitelist = []) ?rest_server_port ~coda ~log
@@ -1345,10 +1359,11 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
             return (get_public_keys coda |> Participating_state.active_exn) )
       ; Rpc.Rpc.implement Daemon_rpcs.Get_nonce.rpc (fun () pk ->
             return (get_nonce coda pk |> Participating_state.active_exn) )
-      ; Rpc.Rpc.implement Daemon_rpcs.Get_status.rpc (fun () () ->
-            return (get_status coda |> Participating_state.active_exn) )
-      ; Rpc.Rpc.implement Daemon_rpcs.Clear_hist_status.rpc (fun () () ->
-            return (clear_hist_status coda |> Participating_state.active_exn)
+      ; Rpc.Rpc.implement Daemon_rpcs.Get_status.rpc (fun () flag ->
+            return (get_status ~flag coda |> Participating_state.active_exn) )
+      ; Rpc.Rpc.implement Daemon_rpcs.Clear_hist_status.rpc (fun () flag ->
+            return
+              (clear_hist_status ~flag coda |> Participating_state.active_exn)
         )
       ; Rpc.Rpc.implement Daemon_rpcs.Get_ledger.rpc (fun () lh ->
             get_ledger coda lh )
@@ -1393,12 +1408,15 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
                   let route_not_found () =
                     Server.respond_string ~status:`Not_found "Route not found"
                   in
+                  let status flag =
+                    Server.respond_string
+                      ( get_status ~flag coda |> Participating_state.active_exn
+                      |> Daemon_rpcs.Types.Status.to_yojson
+                      |> Yojson.Safe.pretty_to_string )
+                  in
                   match Uri.path uri with
-                  | "/status" ->
-                      Server.respond_string
-                        ( get_status coda |> Participating_state.active_exn
-                        |> Daemon_rpcs.Types.Status.to_yojson
-                        |> Yojson.Safe.pretty_to_string )
+                  | "/status" -> status `None
+                  | "/status/performance" -> status `Performance
                   | _ -> route_not_found () )) )
         |> ignore ) ;
     let where_to_listen =

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -4,6 +4,13 @@ let json =
   Command.Param.(
     flag "json" no_arg ~doc:"Use json output (default: plaintext)")
 
+let performance =
+  Command.Param.(
+    flag "performance" no_arg
+      ~doc:
+        "Include performance histograms in status output (default: don't \
+         include)")
+
 let privkey_write_path =
   let open Command.Param in
   flag "privkey-path"

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -47,7 +47,13 @@ struct
     end
 
     include T.T
-    include Versioned_rpc.Both_convert.Plain.Make (T)
+    module M = Versioned_rpc.Both_convert.Plain.Make (T)
+    include M
+
+    include Perf_histograms.Rpc.Plain.Extend (struct
+      include M
+      include T
+    end)
 
     module V1 = struct
       module T = struct
@@ -88,7 +94,56 @@ struct
     end
 
     include T.T
-    include Versioned_rpc.Both_convert.Plain.Make (T)
+    module M = Versioned_rpc.Both_convert.Plain.Make (T)
+    include M
+
+    include Perf_histograms.Rpc.Plain.Extend (struct
+      include M
+      include T
+    end)
+
+    module V1 = struct
+      module T = struct
+        include T.T
+
+        let version = 1
+
+        let query_of_caller_model = Fn.id
+
+        let callee_model_of_query = Fn.id
+
+        let response_of_callee_model = Fn.id
+
+        let caller_model_of_response = Fn.id
+      end
+
+      include T
+      include Register (T)
+    end
+  end
+
+  module Transition_catchup = struct
+    module T = struct
+      let name = "transition_catchup"
+
+      module T = struct
+        type query = State_hash.t [@@deriving bin_io]
+
+        type response = External_transition.t list option [@@deriving bin_io]
+      end
+
+      module Caller = T
+      module Callee = T
+    end
+
+    include T.T
+    module M = Versioned_rpc.Both_convert.Plain.Make (T)
+    include M
+
+    include Perf_histograms.Rpc.Plain.Extend (struct
+      include M
+      include T
+    end)
 
     module V1 = struct
       module T = struct

--- a/src/lib/perf_histograms/intf.ml
+++ b/src/lib/perf_histograms/intf.ml
@@ -1,0 +1,48 @@
+open Async
+
+type ('q, 'r) dispatch =
+  Versioned_rpc.Connection_with_menu.t -> 'q -> 'r Deferred.Or_error.t
+
+type ('q, 'r, 'state) impl = 'state -> version:int -> 'q -> 'r Deferred.t
+
+module Rpc = struct
+  module type S = sig
+    module Caller : sig
+      type query
+
+      type response
+    end
+
+    module Callee : sig
+      type query
+
+      type response
+    end
+
+    include
+      Versioned_rpc.Both_convert.Plain.S
+      with type callee_query := Callee.query
+       and type callee_response := Callee.response
+       and type caller_query := Caller.query
+       and type caller_response := Caller.response
+  end
+end
+
+module Patched = struct
+  module type S = sig
+    type callee_query
+
+    type callee_response
+
+    type caller_query
+
+    type caller_response
+
+    val dispatch_multi : (caller_query, caller_response) dispatch
+
+    val implement_multi :
+         ?log_not_previously_seen_version:(name:string -> int -> unit)
+      -> (callee_query, callee_response, 'state) impl
+      -> 'state Async.Rpc.Implementation.t list
+  end
+end

--- a/src/lib/perf_histograms/jbuild
+++ b/src/lib/perf_histograms/jbuild
@@ -5,9 +5,9 @@
   (public_name perf_histograms)
   (flags (:standard -short-paths -warn-error -39))
   (library_flags (-linkall))
-  (modules (perf_histograms histogram))
+  (modules (perf_histograms0 perf_histograms histogram rpc intf))
   (inline_tests)
   (libraries
-   ( core_kernel yojson ppx_deriving_yojson.runtime ))
+   ( core async core_kernel yojson ppx_deriving_yojson.runtime ))
   (preprocess (pps (ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx -conditional)))
   (synopsis "Performance monitoring with histograms")))

--- a/src/lib/perf_histograms/perf_histograms.ml
+++ b/src/lib/perf_histograms/perf_histograms.ml
@@ -1,19 +1,3 @@
-open Core_kernel
 module Report = Histogram.Exp_time_spans.Pretty
-
-(* For now, we'll just support Exp_time_spans histogram *)
-let t : Histogram.Exp_time_spans.t String.Table.t = String.Table.create ()
-
-let add_span ~name s =
-  let hist =
-    String.Table.find_or_add t name ~default:Histogram.Exp_time_spans.create
-  in
-  Histogram.Exp_time_spans.add hist s
-
-let report ~name =
-  String.Table.find_and_call t name
-    ~if_found:(fun tbl -> Some (Histogram.Exp_time_spans.report tbl))
-    ~if_not_found:(fun _ -> None)
-
-let wipe () =
-  String.Table.iter t ~f:(fun tbl -> Histogram.Exp_time_spans.clear tbl)
+module Rpc = Rpc
+include Perf_histograms0

--- a/src/lib/perf_histograms/perf_histograms.mli
+++ b/src/lib/perf_histograms/perf_histograms.mli
@@ -1,5 +1,16 @@
 open Core_kernel
 
+module Rpc : sig
+  module Plain : sig
+    module Extend (Rpc : Intf.Rpc.S) :
+      Intf.Patched.S
+      with type callee_query := Rpc.Callee.query
+       and type callee_response := Rpc.Callee.response
+       and type caller_query := Rpc.Caller.query
+       and type caller_response := Rpc.Caller.response
+  end
+end
+
 module Report : sig
   type t =
     { values: int list

--- a/src/lib/perf_histograms/perf_histograms0.ml
+++ b/src/lib/perf_histograms/perf_histograms0.ml
@@ -1,0 +1,18 @@
+open Core_kernel
+
+(* For now, we'll just support Exp_time_spans histogram *)
+let t : Histogram.Exp_time_spans.t String.Table.t = String.Table.create ()
+
+let add_span ~name s =
+  let hist =
+    String.Table.find_or_add t name ~default:Histogram.Exp_time_spans.create
+  in
+  Histogram.Exp_time_spans.add hist s
+
+let report ~name =
+  String.Table.find_and_call t name
+    ~if_found:(fun tbl -> Some (Histogram.Exp_time_spans.report tbl))
+    ~if_not_found:(fun _ -> None)
+
+let wipe () =
+  String.Table.iter t ~f:(fun tbl -> Histogram.Exp_time_spans.clear tbl)

--- a/src/lib/perf_histograms/rpc.ml
+++ b/src/lib/perf_histograms/rpc.ml
@@ -1,0 +1,41 @@
+open Core
+open Async
+
+let decorate_dispatch ~name (dispatch : ('q, 'r) Intf.dispatch) :
+    ('q, 'r) Intf.dispatch =
+ fun conn q ->
+  let open Deferred.Or_error.Let_syntax in
+  let start = Time.now () in
+  let%map r = dispatch conn q in
+  Perf_histograms0.add_span
+    ~name:(sprintf "rpc_dispatch_%s" name)
+    (Time.diff (Time.now ()) start) ;
+  r
+
+let deocorate_impl ~name (impl : ('q, 'r, 'state) Intf.impl) :
+    ('q, 'r, 'state) Intf.impl =
+ fun state ~version q ->
+  let open Deferred.Let_syntax in
+  let start = Time.now () in
+  let%map r = impl state ~version q in
+  Perf_histograms0.add_span
+    ~name:(sprintf "rpc_impl_%s" name)
+    (Time.diff (Time.now ()) start) ;
+  r
+
+module Plain = struct
+  module Extend (Rpc : Intf.Rpc.S) :
+    Intf.Patched.S
+    with type callee_query := Rpc.Callee.query
+     and type callee_response := Rpc.Callee.response
+     and type caller_query := Rpc.Caller.query
+     and type caller_response := Rpc.Caller.response = struct
+    include Rpc
+
+    let dispatch_multi = dispatch_multi |> decorate_dispatch ~name
+
+    let implement_multi ?log_not_previously_seen_version f =
+      implement_multi ?log_not_previously_seen_version
+        (f |> deocorate_impl ~name)
+  end
+end


### PR DESCRIPTION
All two-way RPCs (that we currently have) now automatically record two performance histograms, one on the dispatch side and one on the implementation side. These are all reported in the `coda client status`