### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ build: git_hooks
 	cd src ; $(WRAPSRC) env CODA_COMMIT_SHA1=$(GITLONGHASH) dune build --profile=$(DUNE_PROFILE)
 	$(info Build complete)
 
-dev: docker container build
+dev: codabuilder containerstart build
 
 ########################################
 ## Lint

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ endif
 ifeq ($(USEDOCKER),TRUE)
  $(info INFO Using Docker Named $(DOCKERNAME))
  WRAP = docker exec -it $(DOCKERNAME)
- WRAPSRC = docker exec --workdir /home/opam/app/src -it $(DOCKERNAME)
+ WRAPSRC = docker exec --workdir /home/opam/app/src -t $(DOCKERNAME)
 else
  $(info INFO Not using Docker)
  WRAP =


### PR DESCRIPTION
This PR fixes a couple of Makefile problems I've hit:
* updates `make dev` to use the new names for `docker` and `container` (`codabuilder` and `containerstart` respectively)
* removes the `i` flag from `WRAPSRC` so that docker doesn't fail when there is no input TTY (which was making the git commit hook fail for me)