### PR TITLE
to_list masks accounts in parent

### DIFF
--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -1,11 +1,13 @@
 open Core
 
 module type Key = sig
-  type t [@@deriving sexp, bin_io, eq]
+  type t [@@deriving sexp, bin_io]
 
   val empty : t
 
   include Hashable.S_binable with type t := t
+
+  include Comparable.S with type t := t
 end
 
 module type Balance = sig

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -161,4 +161,5 @@ module Key = struct
 
   include T
   include Hashable.Make_binable (T)
+  include Comparable.Make (T)
 end

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -355,7 +355,16 @@ struct
     let to_list t =
       let mask_accounts = Location.Table.data t.account_tbl in
       let parent_accounts = Base.to_list (get_parent t) in
-      mask_accounts @ parent_accounts
+      (* if an account is in mask and parent, favor the mask version *)
+      let in_mask parent_account =
+        (* N.B.: List.find is slow, but so is converting to, say, a Set representation *)
+        let parent_key = Account.public_key parent_account in
+        Option.is_none
+          (List.find mask_accounts ~f:(fun mask_account ->
+               Key.equal (Account.public_key mask_account) parent_key ))
+      in
+      let masked_parent_accounts = List.filter parent_accounts ~f:in_mask in
+      mask_accounts @ masked_parent_accounts
 
     let foldi t ~init ~f =
       let parent_result = Base.foldi (get_parent t) ~init ~f in


### PR DESCRIPTION
> Explain your changes here.

In masks, `to_list` was appending accounts from the mask and parent. Instead, accounts in the mask with the same key as an account in the parent should mask the parent version of the account.

> Explain how you tested your changes here.

Added a test where the parent accounts have a non-zero balance. After adding accounts with the same keys to the mask, but with a zero balances, `to_list` has the same number of accounts, all with a zero balance.

Note: there still needs to be similar changes made for the mask folds, and there should be a testing facility to show all accounts at all levels.

Checklist:

- [ ] Tests were added for the new behavior
- [X] All tests pass (CI will check this if you didn't)
- [X] Does this close issues? List them:

Closes #1307