### PR TITLE
SIMPLE: use a common log file for stdout and stderr

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -110,8 +110,8 @@ let daemon log =
            Core.printf "Starting background coda daemon. (Log Dir: %s)\n%!"
              conf_dir ;
            Daemon.daemonize
-             ~redirect_stdout:(`File_append (conf_dir ^/ "coda.stdout"))
-             ~redirect_stderr:(`File_append (conf_dir ^/ "coda.stderr"))
+             ~redirect_stdout:(`File_append (conf_dir ^/ "coda.log"))
+             ~redirect_stderr:(`File_append (conf_dir ^/ "coda.log"))
              () ;
            Deferred.return conf_dir )
          else Sys.home_directory () >>| compute_conf_dir


### PR DESCRIPTION
Some stderr logs have no context. (being called directly from Async, bypassing our Logger lib)
This makes debugging some errors difficult.

This change will merge stderr and stdout in to one common/share log file by default. (coda.log)

