### PR TITLE
foldi in mask does not include masked accounts in parent

### DIFF
--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -10,6 +10,7 @@ module Make (Ledger : sig
      and type hash := Ledger_hash.t
      and type account := Account.t
      and type key := Public_key.Compressed.t
+     and type key_set := Public_key.Compressed.Set.t
 
   val create : unit -> t
 end) =
@@ -17,6 +18,8 @@ struct
   include Ledger
 
   type account = Account.t
+
+  type key_set = Public_key.Compressed.Set.t
 
   let create_new_account_exn t pk account =
     let action, _ = get_or_create_account_exn t pk account in

--- a/src/lib/merkle_ledger/any_ledger.ml
+++ b/src/lib/merkle_ledger/any_ledger.ml
@@ -1,4 +1,4 @@
-(** Any_ledger let's you use any arbitrary ledger whenever some ledger is
+(** Any_ledger lets you use any arbitrary ledger whenever some ledger is
  * required. This uses dynamic dispatch and is equivalent to the notion of
  * consuming a value conforming to an interface in Java.
  *
@@ -29,6 +29,7 @@ struct
     with module Addr = Location.Addr
     with module Location = Location
     with type key := Key.t
+     and type key_set := Key.Set.t
      and type hash := Hash.t
      and type root_hash := Hash.t
      and type account := Account.t
@@ -92,6 +93,12 @@ struct
     let location_of_key (T ((module Base), t)) = Base.location_of_key t
 
     let fold_until (T ((module Base), t)) = Base.fold_until t
+
+    (* ignored_keys must be Base.Keys.Set.t, but that isn't necessarily the same as Keys.Set.t for the
+       Keys passed to this functor; as long as we use the same Keys for all ledgers, this should work
+     *)
+    let foldi_with_ignored_keys (T ((module Base), t)) =
+      Base.foldi_with_ignored_keys t
 
     let foldi (T ((module Base), t)) = Base.foldi t
 

--- a/src/lib/merkle_ledger/base_ledger_intf.ml
+++ b/src/lib/merkle_ledger/base_ledger_intf.ml
@@ -9,6 +9,8 @@ module type S = sig
 
   type key
 
+  type key_set
+
   type index = int
 
   (* no deriving, purposely; signatures that include this one may add deriving *)
@@ -32,6 +34,15 @@ module type S = sig
      and type t := t
 
   val to_list : t -> account list
+
+  val foldi_with_ignored_keys :
+       t
+    -> key_set
+    -> init:'accum
+    -> f:(Addr.t -> 'accum -> account -> 'accum)
+    -> 'accum
+
+  (* the set of keys are ledger elements to skip during the fold, because they're in a mask *)
 
   val foldi :
     t -> init:'accum -> f:(Addr.t -> 'accum -> account -> 'accum) -> 'accum

--- a/src/lib/merkle_ledger/jbuild
+++ b/src/lib/merkle_ledger/jbuild
@@ -3,7 +3,7 @@
 (library
  ((name merkle_ledger)
   (public_name merkle_ledger)
-  (flags (:standard -short-paths -warn-error -6-33-27-9-58))
+  (flags (:standard -short-paths -warn-error -6-33-34-27-9-58))
   (library_flags (-linkall))
   (libraries (core bitstring integers extlib signature_lib immutable_array dyn_array merkle_address direction))
   (preprocess (pps (ppx_jane ppx_deriving.eq ppx_deriving.show)))

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -9,6 +9,7 @@ let%test_module "test functor on in memory databases" =
     module type DB =
       Merkle_ledger.Database_intf.S
       with type key := Key.t
+       and type key_set := Key.Set.t
        and type account := Account.t
        and type root_hash := Hash.t
        and type hash := Hash.t

--- a/src/lib/merkle_ledger_tests/test_ledger.ml
+++ b/src/lib/merkle_ledger_tests/test_ledger.ml
@@ -4,16 +4,18 @@ module Ledger = Merkle_ledger.Ledger
 
 let%test_module "test functor on in memory databases" =
   ( module struct
-    module Key = Test_stubs.Key
+    module Key_with_gen = Test_stubs.Key
     module Hash = Test_stubs.Hash
     module Account = Test_stubs.Account
     module Receipt = Test_stubs.Receipt
     module Balance = Test_stubs.Balance
 
     module Make (Depth : Intf.Depth) = struct
-      include Ledger.Make (Key) (Account) (Hash) (Depth)
+      include Ledger.Make (Key_with_gen) (Account) (Hash) (Depth)
 
-      type key = Key.t
+      type key = Key_with_gen.t
+
+      type key_set = Key_with_gen.Set.t
 
       type account = Account.t
 
@@ -32,7 +34,7 @@ let%test_module "test functor on in memory databases" =
         (ledger, keys)
 
       let load_ledger num_accounts balance : t * key list =
-        let keys = Key.gen_keys num_accounts in
+        let keys = Key_with_gen.gen_keys num_accounts in
         load_ledger_with_keys keys balance
     end
 
@@ -78,7 +80,8 @@ let%test_module "test functor on in memory databases" =
       let b = 100 in
       let ledger, _ = L16.load_ledger 10 (Balance.of_int b) in
       let key =
-        Quickcheck.random_value ~seed:(`Deterministic "key_nonexist") Key.gen
+        Quickcheck.random_value ~seed:(`Deterministic "key_nonexist")
+          Key_with_gen.gen
       in
       None = L16.location_of_key ledger key
 
@@ -86,7 +89,8 @@ let%test_module "test functor on in memory databases" =
       let b = 100 in
       let ledger, _keys = L16.load_ledger 10 (Balance.of_int b) in
       let key =
-        Quickcheck.random_value ~seed:(`Deterministic "idx_nonexist") Key.gen
+        Quickcheck.random_value ~seed:(`Deterministic "idx_nonexist")
+          Key_with_gen.gen
       in
       None = get (module L16) ledger key
 
@@ -112,7 +116,7 @@ let%test_module "test functor on in memory databases" =
       let new_b = Balance.of_int 50 in
       let public_key =
         Quickcheck.random_value ~seed:(`Deterministic "modify_account_by_idx")
-          Key.gen
+          Key_with_gen.gen
       in
       L16.set_at_index_exn ledger idx (Account.create public_key new_b) ;
       assert (
@@ -280,7 +284,7 @@ let%test_module "test functor on in memory databases" =
 
          therefore, we produce the key list separately, take a prefix, and pass that to load_ledger_with_keys
        *)
-      let all_keys = Key.gen_keys 10 in
+      let all_keys = Key_with_gen.gen_keys 10 in
       let l1_keys = List.take all_keys 8 in
       let l1, _ = L16.load_ledger_with_keys l1_keys Balance.one in
       let l2_keys = all_keys in
@@ -291,7 +295,7 @@ let%test_module "test functor on in memory databases" =
 
     let%test_unit "remove last account is as if it were never there" =
       (* see remark in previous test about load_ledger *)
-      let all_keys = Key.gen_keys 10 in
+      let all_keys = Key_with_gen.gen_keys 10 in
       let l1_keys = List.take all_keys 9 in
       let l1, _ = L16.load_ledger_with_keys l1_keys Balance.one in
       let l2_keys = all_keys in
@@ -375,7 +379,7 @@ let%test_module "test functor on in memory databases" =
 
     let%test_unit "set_all_accounts_rooted_at_exn can work out of order" =
       (* see remark for test "remove last two accounts is as if they were never there" above *)
-      let all_keys = Key.gen_keys 8 in
+      let all_keys = Key_with_gen.gen_keys 8 in
       let l1_keys = all_keys in
       let l1, _ = L16.load_ledger_with_keys l1_keys Balance.one in
       let l2_keys = List.take all_keys 2 in

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -135,9 +135,9 @@ end
 module Key = struct
   module T = struct
     type t = Account.key [@@deriving sexp, bin_io, eq, compare, hash]
-
-    let gen = Account.key_gen
   end
+
+  let gen = Account.key_gen
 
   let empty = Account.empty.public_key
 
@@ -151,7 +151,7 @@ module Key = struct
     let num_to_gen = num_keys + (num_keys / 5) in
     let more_than_enough_keys =
       Quickcheck.random_value
-        (Quickcheck.Generator.list_with_length num_to_gen T.gen)
+        (Quickcheck.Generator.list_with_length num_to_gen gen)
     in
     let unique_keys =
       List.dedup_and_sort ~compare:T.compare more_than_enough_keys

--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -13,13 +13,15 @@ module Make
              and type account := Account.t
              and type root_hash := Hash.t
              and type hash := Hash.t
-             and type key := Key.t)
+             and type key := Key.t
+             and type key_set := Key.Set.t)
     (Mask : Masking_merkle_tree_intf.S
             with module Location = Location
              and type account := Account.t
              and type location := Location.t
              and type hash := Hash.t
              and type key := Key.t
+             and type key_set := Key.Set.t
              and type parent := Base.t) =
 struct
   include Base

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -15,6 +15,8 @@ module type S = sig
 
   type key
 
+  type key_set
+
   module Location : Merkle_ledger.Location_intf.S
 
   module Addr : Merkle_address.S
@@ -30,6 +32,7 @@ module type S = sig
        and type root_hash := hash
        and type hash := hash
        and type key := key
+       and type key_set := key_set
 
     val get_hash : t -> Addr.t -> hash option
     (** get hash from mask, if present, else from its parent *)


### PR DESCRIPTION
> Explain your changes here.

For masks, `foldi` was folding over mask accounts and all accounts in mask parents. With this PR, `foldi` folds over mask accounts and only those parent accounts that don't have corresponding accounts in the mask.

To accomplish that change, the base ledger interface adds `foldi_with_ignored_keys`, which takes a set of keys that should be ignored when folding. The mask passes all its keys to its parent.

So `foldi` now calls this new function, and passes an empty set of keys to ignore.

> Explain how you tested your changes here.

There's a new test that creates accounts in the parent, and accounts in the mask, with the same keys, so all parent accounts are masked. The parent accounts all have non-zero balances, while the mask accounts all have a zero balance. Folding addition over the parent accounts gives a non-zero sum, while folding over the mask gives a zero sum.

Checklist:

- [X] Tests were added for the new behavior
- [X] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? No. but this issue was noted in the comments for #1307.
