### PR TITLE
Add 'to_constant' function to snarky

### DIFF
--- a/src/lib/snarky/src/snark0.ml
+++ b/src/lib/snarky/src/snark0.ml
@@ -1483,6 +1483,10 @@ module Make_basic (Backend : Backend_intf.S) = struct
     module Checked = struct
       include Cvar1
 
+      let to_constant : var -> Field0.t option = function
+        | Constant x -> Some x
+        | _ -> None
+
       let equal = Checked.equal
 
       let mul x y = Checked.mul ~label:"Field.Checked.mul" x y

--- a/src/lib/snarky/src/snark_intf.ml
+++ b/src/lib/snarky/src/snark_intf.ml
@@ -282,6 +282,8 @@ module type Basic = sig
 
       val constant : field -> t
 
+      val to_constant : t -> field option
+
       val linear_combination : (field * t) list -> t
 
       val sum : t list -> t

--- a/src/lib/snarky_field_extensions/field_extensions.ml
+++ b/src/lib/snarky_field_extensions/field_extensions.ml
@@ -1,3 +1,5 @@
+open Core_kernel
+
 module Make (F : Intf.Basic) = struct
   open F.Impl
   open Let_syntax
@@ -77,6 +79,17 @@ module Make_applicative (F : Intf.S) (A : Intf.Applicative) = struct
 
   let constant = A.map ~f:F.constant
 
+  let to_constant =
+    let exception None_exn in
+    fun t ->
+      try
+        Some
+          (A.map t ~f:(fun x ->
+               match F.to_constant x with
+               | Some x -> x
+               | None -> raise None_exn ))
+      with None_exn -> None
+
   let scale t x = A.map t ~f:(fun a -> F.scale a x)
 
   let scale' t x = A.map t ~f:(fun a -> F.scale x a)
@@ -131,6 +144,8 @@ struct
     let typ = Field.typ
 
     let constant = Field.Checked.constant
+
+    let to_constant = Field.Checked.to_constant
 
     let scale = Field.Checked.scale
 

--- a/src/lib/snarky_field_extensions/intf.ml
+++ b/src/lib/snarky_field_extensions/intf.ml
@@ -37,6 +37,8 @@ module type Basic = sig
 
   val constant : Unchecked.t -> t
 
+  val to_constant : t -> Unchecked.t option
+
   val scale : t -> Field.t -> t
 
   val mul_field : t -> Field.Checked.t -> (t, _) Checked.t


### PR DESCRIPTION
This PR adds functions for checking whether a 'checked' value is a constant. This is convenient for implementing optimizations in library functions and sound from the point of view of the semantics.