### PR TITLE
Remove use config.mlh from snarky

### DIFF
--- a/src/lib/snarky/src/jbuild
+++ b/src/lib/snarky/src/jbuild
@@ -12,5 +12,4 @@
       (:standard "\\" -pedantic)
       (-I re2_c/libre2)
       ))
-  (preprocessor_deps ("../../../config.mlh"))
   (preprocess (pps (ppx_jane ppx_deriving.enum ppx_deriving.eq bisect_ppx -conditional)))))

--- a/src/lib/snarky/src/libsnark.ml
+++ b/src/lib/snarky/src/libsnark.ml
@@ -1,20 +1,6 @@
-[%%import
-"../../../config.mlh"]
-
 open Core
 open Ctypes
 open Foreign
-
-[%%if
-call_logger]
-
-let foreign name t =
-  let f = foreign name t in
-  fun x ->
-    Coda_debug.Call_logger.record_call name ;
-    f x
-
-[%%endif]
 
 let with_prefix prefix s = sprintf "%s_%s" prefix s
 


### PR DESCRIPTION
This PR removes reference to config.mlh from snarky. We can add it back in if we need to profile again but it was blocking merging changes into the snarky repo.