### PR TITLE
Suppress errors for 'unused rec' in Logger deriving statements

### DIFF
--- a/src/lib/logger/jbuild
+++ b/src/lib/logger/jbuild
@@ -3,7 +3,7 @@
 (library
  ((name logger)
   (public_name logger)
-  (flags (:standard -short-paths -warn-error -58))
+  (flags (:standard -short-paths -warn-error -58 -warn-error -39))
   (library_flags (-linkall))
   (inline_tests)
   (libraries (core async yojson ppx_deriving_yojson.runtime))


### PR DESCRIPTION
My local docker build has been erroring out with `Warning 39: unused rec flag` in `Logger`. These come from the `deriving` statements, so there's no obvious way to fix the warning.

This PR turns off warn-error for warning 39 so that I can run a build to completion.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:
