### PR TITLE
Lift snarky types out of the functor

### DIFF
--- a/src/lib/coda_base/snark_transition.ml
+++ b/src/lib/coda_base/snark_transition.ml
@@ -164,7 +164,7 @@ module Make (Inputs : Inputs_intf) :
       ; supply_increase
       ; ledger_proof= None }
     in
-    {store; read; check; alloc}
+    {Snarky.Types.Typ.store; read; check; alloc}
 
   let genesis =
     { blockchain_state= Blockchain_state.genesis

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -4,44 +4,50 @@ open Snark_bits
 module Tick_backend = Crypto_params.Tick_backend
 module Tock_backend = Crypto_params.Tock_backend
 
-module Extend (Impl : Snarky.Snark_intf.S) = struct
-  include Impl
+module Make_snarkable (Impl : Snarky.Snark_intf.S) = struct
+  open Impl
 
-  module Snarkable = struct
-    module type S = sig
-      type var
+  module type S = sig
+    type var
 
-      type value
+    type value
 
-      val typ : (var, value) Typ.t
-    end
+    val typ : (var, value) Typ.t
+  end
 
-    module Bits = struct
-      module type Lossy =
-        Bits_intf.Snarkable.Lossy
-        with type ('a, 'b) typ := ('a, 'b) Typ.t
-         and type ('a, 'b) checked := ('a, 'b) Checked.t
-         and type boolean_var := Boolean.var
+  module Bits = struct
+    module type Lossy =
+      Bits_intf.Snarkable.Lossy
+      with type ('a, 'b) typ := ('a, 'b) Typ.t
+       and type ('a, 'b) checked := ('a, 'b) Checked.t
+       and type boolean_var := Boolean.var
 
-      module type Faithful =
-        Bits_intf.Snarkable.Faithful
-        with type ('a, 'b) typ := ('a, 'b) Typ.t
-         and type ('a, 'b) checked := ('a, 'b) Checked.t
-         and type boolean_var := Boolean.var
+    module type Faithful =
+      Bits_intf.Snarkable.Faithful
+      with type ('a, 'b) typ := ('a, 'b) Typ.t
+       and type ('a, 'b) checked := ('a, 'b) Checked.t
+       and type boolean_var := Boolean.var
 
-      module type Small =
-        Bits_intf.Snarkable.Small
-        with type ('a, 'b) typ := ('a, 'b) Typ.t
-         and type ('a, 'b) checked := ('a, 'b) Checked.t
-         and type boolean_var := Boolean.var
-         and type comparison_result := Field.Checked.comparison_result
-         and type field_var := Field.Checked.t
-    end
+    module type Small =
+      Bits_intf.Snarkable.Small
+      with type ('a, 'b) typ := ('a, 'b) Typ.t
+       and type ('a, 'b) checked := ('a, 'b) Checked.t
+       and type boolean_var := Boolean.var
+       and type comparison_result := Field.Checked.comparison_result
+       and type field_var := Field.Checked.t
   end
 end
 
-module Tock0 = Extend (Crypto_params.Tock0)
-module Tick0 = Extend (Crypto_params.Tick0)
+module Tock0 = struct
+  include Crypto_params.Tock0
+  module Snarkable = Make_snarkable (Crypto_params.Tock0)
+end
+
+module Tick0 = struct
+  include Crypto_params.Tick0
+  module Snarkable = Make_snarkable (Crypto_params.Tick0)
+end
+
 module Wrap_input = Crypto_params.Wrap_input
 
 module Make_inner_curve_scalar

--- a/src/lib/snarky/src/as_prover.mli
+++ b/src/lib/snarky/src/as_prover.mli
@@ -2,6 +2,8 @@ open Core_kernel
 
 include Monad.S3 with type ('a, 'e, 's) t = 'e -> 's -> 's * 'a
 
+val run : ('a, 'e, 's) t -> 'e -> 's -> 's * 'a
+
 module type S = sig
   type env
 

--- a/src/lib/snarky/src/boolean.ml
+++ b/src/lib/snarky/src/boolean.ml
@@ -1,0 +1,5 @@
+type 'v t = 'v
+
+module Unsafe = struct
+  let create x = x
+end

--- a/src/lib/snarky/src/boolean.mli
+++ b/src/lib/snarky/src/boolean.mli
@@ -1,0 +1,5 @@
+type 'v t = private 'v
+
+module Unsafe : sig
+  val create : 'v -> 'v t
+end

--- a/src/lib/snarky/src/constraint.ml
+++ b/src/lib/snarky/src/constraint.ml
@@ -1,0 +1,13 @@
+open Base
+
+type 'var basic =
+  | Boolean of 'var
+  | Equal of 'var * 'var
+  | Square of 'var * 'var
+  | R1CS of 'var * 'var * 'var
+[@@deriving sexp]
+
+type 'v basic_with_annotation = {basic: 'v basic; annotation: string option}
+[@@deriving sexp]
+
+type 'v t = 'v basic_with_annotation list [@@deriving sexp]

--- a/src/lib/snarky/src/cvar.ml
+++ b/src/lib/snarky/src/cvar.ml
@@ -1,5 +1,14 @@
 open Core_kernel
 
+type ('f, 'v) t =
+  | Constant of 'f
+  | Var of 'v
+  | Add of ('f, 'v) t * ('f, 'v) t
+  | Scale of 'f * ('f, 'v) t
+[@@deriving sexp]
+
+type ('f, 'v) cvar = ('f, 'v) t [@@deriving sexp]
+
 module Make
     (Field : Field_intf.Extended) (Var : sig
         include Comparable.S
@@ -7,12 +16,7 @@ module Make
         include Sexpable.S with type t := t
     end) =
 struct
-  type t =
-    | Constant of Field.t
-    | Var of Var.t
-    | Add of t * t
-    | Scale of Field.t * t
-  [@@deriving sexp]
+  type t = (Field.t, Var.t) cvar [@@deriving sexp]
 
   let length _ = failwith "TODO"
 

--- a/src/lib/snarky/src/free_monad.ml
+++ b/src/lib/snarky/src/free_monad.ml
@@ -1,12 +1,26 @@
 open Base
 
-module type Functor_intf = sig
-  type 'a t
+module Functor = struct
+  module type S = sig
+    type 'a t
 
-  val map : 'a t -> f:('a -> 'b) -> 'b t
+    val map : 'a t -> f:('a -> 'b) -> 'b t
+  end
+
+  module type S2 = sig
+    type ('a, 'e) t
+
+    val map : ('a, 'e) t -> f:('a -> 'b) -> ('b, 'e) t
+  end
+
+  module type S3 = sig
+    type ('a, 'x, 'y) t
+
+    val map : ('a, 'x, 'y) t -> f:('a -> 'b) -> ('b, 'x, 'y) t
+  end
 end
 
-module Make (F : Functor_intf) : sig
+module Make (F : Functor.S) : sig
   type 'a t = Pure of 'a | Free of 'a t F.t
 
   include Monad.S with type 'a t := 'a t
@@ -29,4 +43,54 @@ end = struct
 
   include T
   include Monad.Make (T)
+end
+
+module Make2 (F : Functor.S2) : sig
+  type ('a, 'x) t = Pure of 'a | Free of (('a, 'x) t, 'x) F.t
+
+  include Monad.S2 with type ('a, 'x) t := ('a, 'x) t
+end = struct
+  module T = struct
+    type ('a, 'x) t = Pure of 'a | Free of (('a, 'x) t, 'x) F.t
+
+    let rec map t ~f =
+      match t with
+      | Pure x -> Pure (f x)
+      | Free tf -> Free (F.map tf ~f:(map ~f))
+
+    let map = `Custom map
+
+    let return x = Pure x
+
+    let rec bind t ~f =
+      match t with Pure x -> f x | Free tf -> Free (F.map tf ~f:(bind ~f))
+  end
+
+  include T
+  include Monad.Make2 (T)
+end
+
+module Make3 (F : Functor.S3) : sig
+  type ('a, 'x, 'y) t = Pure of 'a | Free of (('a, 'x, 'y) t, 'x, 'y) F.t
+
+  include Monad.S3 with type ('a, 'x, 'y) t := ('a, 'x, 'y) t
+end = struct
+  module T = struct
+    type ('a, 'x, 'y) t = Pure of 'a | Free of (('a, 'x, 'y) t, 'x, 'y) F.t
+
+    let rec map t ~f =
+      match t with
+      | Pure x -> Pure (f x)
+      | Free tf -> Free (F.map tf ~f:(map ~f))
+
+    let map = `Custom map
+
+    let return x = Pure x
+
+    let rec bind t ~f =
+      match t with Pure x -> f x | Free tf -> Free (F.map tf ~f:(bind ~f))
+  end
+
+  include T
+  include Monad.Make3 (T)
 end

--- a/src/lib/snarky/src/handle.ml
+++ b/src/lib/snarky/src/handle.ml
@@ -1,0 +1,1 @@
+type ('var, 'value) t = {var: 'var; value: 'value option}

--- a/src/lib/snarky/src/provider.ml
+++ b/src/lib/snarky/src/provider.ml
@@ -1,0 +1,16 @@
+type ('a, 'e, 's) t =
+  | Request of ('a Request.t, 'e, 's) As_prover.t
+  | Compute of ('a, 'e, 's) As_prover.t
+  | Both of ('a Request.t, 'e, 's) As_prover.t * ('a, 'e, 's) As_prover.t
+
+let run t tbl s (handler : Request.Handler.t) =
+  match t with
+  | Request rc ->
+      let s', r = As_prover.run rc tbl s in
+      (s', Request.Handler.run handler r)
+  | Compute c -> As_prover.run c tbl s
+  | Both (rc, c) -> (
+      let s', r = As_prover.run rc tbl s in
+      match Request.Handler.run handler r with
+      | exception _ -> As_prover.run c tbl s
+      | x -> (s', x) )

--- a/src/lib/snarky/src/restrict_monad.ml
+++ b/src/lib/snarky/src/restrict_monad.ml
@@ -1,0 +1,57 @@
+open Base
+
+module Make2
+    (M : Monad.S2) (T : sig
+        type t
+    end) : Monad.S with type 'a t = ('a, T.t) M.t = struct
+  type 'a t = ('a, T.t) M.t
+
+  let map = M.map
+
+  let bind = M.bind
+
+  let return = M.return
+
+  let all = M.all
+
+  let all_ignore = M.all_unit
+
+  let all_unit = M.all_unit
+
+  let ignore_m = M.ignore_m
+
+  let join = M.join
+
+  module Let_syntax = M.Let_syntax
+  module Monad_infix = M.Monad_infix
+  include Monad_infix
+end
+
+module Make3
+    (M : Monad.S3) (T : sig
+        type t1
+
+        type t2
+    end) : Monad.S with type 'a t = ('a, T.t1, T.t2) M.t = struct
+  type 'a t = ('a, T.t1, T.t2) M.t
+
+  let map = M.map
+
+  let bind = M.bind
+
+  let return = M.return
+
+  let all = M.all
+
+  let all_ignore = M.all_unit
+
+  let all_unit = M.all_unit
+
+  let ignore_m = M.ignore_m
+
+  let join = M.join
+
+  module Let_syntax = M.Let_syntax
+  module Monad_infix = M.Monad_infix
+  include Monad_infix
+end

--- a/src/lib/snarky/src/snark_intf.ml
+++ b/src/lib/snarky/src/snark_intf.ml
@@ -1,5 +1,7 @@
 module Bignum_bigint = Bigint
 open Core_kernel
+module Constraint0 = Constraint
+module Boolean0 = Boolean
 
 module type Basic = sig
   module Proving_key : sig
@@ -61,7 +63,7 @@ module type Basic = sig
   end
 
   module rec Constraint : sig
-    type t
+    type t = Field.Checked.t Constraint0.t
 
     type 'k with_constraint_args = ?label:string -> 'k
 
@@ -182,7 +184,7 @@ module type Basic = sig
   end
   
   and Boolean : sig
-    type var = private Field.Checked.t
+    type var = Field.Checked.t Boolean0.t
 
     type value = bool
 

--- a/src/lib/snarky/src/snark_intf.ml
+++ b/src/lib/snarky/src/snark_intf.ml
@@ -285,7 +285,7 @@ module type Basic = sig
     val project : bool list -> t
 
     module Checked : sig
-      type t
+      type t = private (field, Var.t) Cvar.t
 
       val length : t -> int
       (** For debug purposes *)

--- a/src/lib/snarky/src/snark_intf.ml
+++ b/src/lib/snarky/src/snark_intf.ml
@@ -88,28 +88,34 @@ module type Basic = sig
   
   and Typ : sig
     module Store : sig
-      include Monad.S
+      include
+        Monad.S
+        with type 'a t = ('a, Field.t, Field.Checked.t) Typ_monads.Store.t
 
       val store : field -> Field.Checked.t t
     end
 
     module Alloc : sig
-      include Monad.S
+      include Monad.S with type 'a t = ('a, Field.Checked.t) Typ_monads.Alloc.t
 
       val alloc : Field.Checked.t t
     end
 
     module Read : sig
-      include Monad.S
+      include
+        Monad.S
+        with type 'a t = ('a, Field.t, Field.Checked.t) Typ_monads.Read.t
 
       val read : Field.Checked.t -> field t
     end
 
     type ('var, 'value) t =
-      { store: 'value -> 'var Store.t
-      ; read: 'var -> 'value Read.t
-      ; alloc: 'var Alloc.t
-      ; check: 'var -> (unit, unit) Checked.t }
+      ( 'var
+      , 'value
+      , Field.t
+      , Field.Checked.t
+      , R1CS_constraint_system.t )
+      Types.Typ.t
 
     val store : ('var, 'value) t -> 'value -> 'var Store.t
 
@@ -244,7 +250,15 @@ module type Basic = sig
   end
   
   and Checked : sig
-    include Monad.S2
+    include
+      Monad.S2
+      with type ('a, 's) t =
+                  ( 'a
+                  , 's
+                  , Field.t
+                  , Field.Checked.t
+                  , R1CS_constraint_system.t )
+                  Types.Checked.t
 
     module List :
       Monad_sequence.S

--- a/src/lib/snarky/src/typ_monads.ml
+++ b/src/lib/snarky/src/typ_monads.ml
@@ -1,0 +1,44 @@
+module Store = struct
+  module T = struct
+    type ('k, 'field, 'var) t = Store of 'field * ('var -> 'k)
+
+    let map t ~f = match t with Store (x, k) -> Store (x, fun v -> f (k v))
+  end
+
+  include Free_monad.Make3 (T)
+
+  let store x = Free (T.Store (x, fun v -> Pure v))
+
+  let rec run t f =
+    match t with Pure x -> x | Free (T.Store (x, k)) -> run (k (f x)) f
+end
+
+module Read = struct
+  module T = struct
+    type ('k, 'field, 'cvar) t = Read of 'cvar * ('field -> 'k)
+
+    let map t ~f = match t with Read (v, k) -> Read (v, fun x -> f (k x))
+  end
+
+  include Free_monad.Make3 (T)
+
+  let read v = Free (T.Read (v, return))
+
+  let rec run t f =
+    match t with Pure x -> x | Free (T.Read (x, k)) -> run (k (f x)) f
+end
+
+module Alloc = struct
+  module T = struct
+    type ('k, 'var) t = Alloc of ('var -> 'k)
+
+    let map t ~f = match t with Alloc k -> Alloc (fun v -> f (k v))
+  end
+
+  include Free_monad.Make2 (T)
+
+  let alloc = Free (T.Alloc (fun v -> Pure v))
+
+  let rec run t f =
+    match t with Pure x -> x | Free (T.Alloc k) -> run (k (f ())) f
+end

--- a/src/lib/snarky/src/types.ml
+++ b/src/lib/snarky/src/types.ml
@@ -1,0 +1,53 @@
+module rec Typ : sig
+  open Typ_monads
+
+  type ('var, 'value, 'field, 'field_var, 'sys) t =
+    { store: 'value -> ('var, 'field, 'field_var) Store.t
+    ; read: 'var -> ('value, 'field, 'field_var) Read.t
+    ; alloc: ('var, 'field_var) Alloc.t
+    ; check: 'var -> (unit, unit, 'field, 'field_var, 'sys) Checked.t }
+end =
+  Typ
+
+and Checked : sig
+  (* TODO-someday: Consider having an "Assembly" type with only a store constructor for straight up Var.t's
+    that this gets compiled into. *)
+
+  type ('a, 's, 'f, 'v, 'sys) t =
+    | Pure : 'a -> ('a, 's, 'f, 'v, 'sys) t
+    | Add_constraint :
+        'v Constraint.t * ('a, 's, 'f, 'v, 'sys) t
+        -> ('a, 's, 'f, 'v, 'sys) t
+    | With_constraint_system :
+        ('sys -> unit) * ('a, 's, 'f, 'v, 'sys) t
+        -> ('a, 's, 'f, 'v, 'sys) t
+    | As_prover :
+        (unit, 'v -> 'f, 's) As_prover.t * ('a, 's, 'f, 'v, 'sys) t
+        -> ('a, 's, 'f, 'v, 'sys) t
+    | With_label :
+        string * ('a, 's, 'f, 'v, 'sys) t * ('a -> ('b, 's, 'f, 'v, 'sys) t)
+        -> ('b, 's, 'f, 'v, 'sys) t
+    | With_state :
+        ('s1, 'v -> 'f, 's) As_prover.t
+        * ('s1 -> (unit, 'v -> 'f, 's) As_prover.t)
+        * ('b, 's1, 'f, 'v, 'sys) t
+        * ('b -> ('a, 's, 'f, 'v, 'sys) t)
+        -> ('a, 's, 'f, 'v, 'sys) t
+    | With_handler :
+        Request.Handler.single
+        * ('a, 's, 'f, 'v, 'sys) t
+        * ('a -> ('b, 's, 'f, 'v, 'sys) t)
+        -> ('b, 's, 'f, 'v, 'sys) t
+    | Clear_handler :
+        ('a, 's, 'f, 'v, 'sys) t * ('a -> ('b, 's, 'f, 'v, 'sys) t)
+        -> ('b, 's, 'f, 'v, 'sys) t
+    | Exists :
+        ('var, 'value, 'f, 'v, 'sys) Typ.t
+        * ('value, 'v -> 'f, 's) Provider.t
+        * (('var, 'value) Handle.t -> ('a, 's, 'f, 'v, 'sys) t)
+        -> ('a, 's, 'f, 'v, 'sys) t
+    | Next_auxiliary :
+        (int -> ('a, 's, 'f, 'v, 'sys) t)
+        -> ('a, 's, 'f, 'v, 'sys) t
+end =
+  Checked


### PR DESCRIPTION
This PR lifts the main snarky types out of the snarky functor so that typs and checked functions can be reused across multiple proof systems with the same field. This is necessary for a snarkitecture change I'm making where we use Groth16 in some places and the BG snark in others.