### PR TITLE
Groth 16 verifier in snarky

### DIFF
--- a/src/lib/snarky_verifier/dune
+++ b/src/lib/snarky_verifier/dune
@@ -1,0 +1,9 @@
+(library
+  (name snarky_verifier)
+  (public_name snarky_verifier)
+  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (libraries
+    sgn
+    snarky
+    snarkette
+    core_kernel ))

--- a/src/lib/snarky_verifier/groth.ml
+++ b/src/lib/snarky_verifier/groth.ml
@@ -1,0 +1,65 @@
+open Core
+
+(* This module implements a snarky function for the gammaless Groth16 verifier. *)
+module Make (Inputs : Inputs.S) = struct
+  open Inputs
+  open Impl
+
+  module Verification_key = struct
+    type ('g1, 'g2, 'fqk) t_ =
+      {query_base: 'g1; query: 'g1 list; delta: 'g2; alpha_beta_inv: 'fqk}
+
+    type ('a, 'b, 'c) vk = ('a, 'b, 'c) t_
+
+    module Precomputation = struct
+      type t = {delta: G2_precomputation.t}
+
+      let create (vk : (_, _, _) vk) = G2_precomputation.create vk.delta
+
+      let create_constant (vk : (_, _, _) vk) =
+        G2_precomputation.create_constant vk.delta
+    end
+  end
+
+  module Proof = struct
+    type ('g1, 'g2) t_ = {a: 'g1; b: 'g2; c: 'g1}
+
+    let to_hlist {a; b; c} = Snarky.H_list.[a; b; c]
+
+    let of_hlist :
+        (unit, 'a -> 'b -> 'a -> unit) Snarky.H_list.t -> ('a, 'b) t_ =
+      function
+      | [a; b; c] -> {a; b; c}
+
+    let typ =
+      Typ.of_hlistable
+        Data_spec.[G1.typ; G2.typ; G1.typ]
+        ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+        ~value_of_hlist:of_hlist
+  end
+
+  let verify (vk : (_, _, _) Verification_key.t_)
+      (vk_precomp : Verification_key.Precomputation.t) inputs {Proof.a; b; c} =
+    let open Let_syntax in
+    let%bind acc =
+      let%bind (module Shifted) = G1.Shifted.create () in
+      let%bind init = Shifted.(add zero vk.query_base) in
+      Checked.List.fold (List.zip_exn vk.query inputs) ~init
+        ~f:(fun acc (g, input) ->
+          let%bind term = G1.scale g input in
+          Shifted.add acc term )
+      >>= Shifted.unshift_nonzero
+    in
+    let%bind test =
+      let%bind b = G2_precomputation.create b in
+      group_miller_loop
+        (* This is where we use [one : G2.t] rather than gamma. *)
+        [ ( Pos
+          , G1_precomputation.create acc
+          , G2_precomputation.create_constant G2.Unchecked.one )
+        ; (Pos, G1_precomputation.create c, vk_precomp.delta)
+        ; (Neg, G1_precomputation.create a, b) ]
+      >>= final_exponentiation
+    in
+    Fqk.equal test vk.alpha_beta_inv
+end

--- a/src/lib/snarky_verifier/inputs.ml
+++ b/src/lib/snarky_verifier/inputs.ml
@@ -1,0 +1,76 @@
+module type S = sig
+  module Impl : Snarky.Snark_intf.S
+
+  open Impl
+
+  module G1 : sig
+    type t
+
+    module Unchecked : sig
+      type t
+    end
+
+    val typ : (t, Unchecked.t) Typ.t
+
+    (* This should check if the input is constant and do [scale_known] if so *)
+    val scale : t -> Boolean.var list -> (t, _) Checked.t
+
+    module Shifted : sig
+      module type S =
+        Snarky.Curves.Shifted_intf
+        with type ('a, 'b) checked := ('a, 'b) Checked.t
+         and type curve_var := t
+         and type boolean_var := Boolean.var
+
+      type 'a m = (module S with type t = 'a)
+
+      val create : unit -> ((module S), _) Checked.t
+    end
+  end
+
+  module G2 : sig
+    type t
+
+    module Unchecked : sig
+      type t
+
+      val one : t
+    end
+
+    val typ : (t, Unchecked.t) Typ.t
+  end
+
+  module G1_precomputation : sig
+    type t
+
+    val create : G1.t -> t
+  end
+
+  module G2_precomputation : sig
+    type t
+
+    val create : G2.t -> (t, _) Checked.t
+
+    val create_constant : G2.Unchecked.t -> t
+  end
+
+  module Fqk : sig
+    type t
+
+    module Unchecked : sig
+      type t
+    end
+
+    val typ : (t, Unchecked.t) Typ.t
+
+    val ( * ) : t -> t -> (t, _) Checked.t
+
+    val equal : t -> t -> (Boolean.var, _) Checked.t
+  end
+
+  val group_miller_loop :
+       (Sgn.t * G1_precomputation.t * G2_precomputation.t) list
+    -> (Fqk.t, _) Checked.t
+
+  val final_exponentiation : Fqk.t -> (Fqk.t, _) Checked.t
+end

--- a/src/snarky_verifier.opam
+++ b/src/snarky_verifier.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
This PR implements the groth16 verifier in snarky. It will be used as part of the new snarkitecture. The verifier is described at the bottom of page 14 here: https://eprint.iacr.org/2016/260.pdf

Note that we use a version without gamma, as gamma is not actually necessary.