### PR TITLE
Rename catchup monitor to scheduler

### DIFF
--- a/docs/res/transition_frontier_controller.dot
+++ b/docs/res/transition_frontier_controller.dot
@@ -8,11 +8,11 @@ digraph G {
   "Transition_handler.Validator" -> "Transition_handler.Processor" [label="valid transitions (overflow: drop old)",color=blue];
   "Transition_handler.Processor" -> "transition has parent";
   "transition has parent" -> Frontier [label="yes",color=red];
-  "transition has parent" -> "Catchup.Monitor" [label="no"];
-  "Transition_handler.Processor" -> "Catchup.Monitor" [label="notify"];
+  "transition has parent" -> "Catchup.Scheduler" [label="no"];
+  "Transition_handler.Processor" -> "Catchup.Scheduler" [label="notify"];
 
   "after timeout" [shape=diamond];
-  "Catchup.Monitor" -> "after timeout";
+  "Catchup.Scheduler" -> "after timeout";
   "after timeout" -> "Catchup.Worker" [label="catchup job (overflow: drop old)",color=blue];
   "Catchup.Worker" -> "Transition_handler.Processor" [label="bulk breadcrumbs (overflow: blocking)",color=blue];
 

--- a/docs/res/transition_frontier_controller.dot.png
+++ b/docs/res/transition_frontier_controller.dot.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9f3e6d6270820303c619ef112f6140056271ee83ad857acd78d04d0fbdd8202e
-size 109713
+oid sha256:779e8ef544ac5eb80d50d158f51d42004e8584a96946bad771c0c4e991571bf3
+size 82352

--- a/rfcs/0008-transition-frontier-controller.md
+++ b/rfcs/0008-transition-frontier-controller.md
@@ -147,14 +147,14 @@ table and not applying an ledger-builder-diffs.
 
 The add process runs in two phases:
 
-1. Perform a `lookup` on the `Transition_frontier` for the previous `State_hash.t` of this transition. If it is absent, send to [catchup monitor](#catchup-monitor). If present, continue.
+1. Perform a `lookup` on the `Transition_frontier` for the previous `State_hash.t` of this transition. If it is absent, send to [catchup scheduler](#catchup-scheduler). If present, continue.
 2. Derive a mask from the parent retrieved in (1) and apply the `Staged_ledger_diff.t` of the breadcrumb to that new mask. See [Transition Frontier](#transition-frontier) for more.
 3. Construct the new `Breadcrumb.t` from the new mask and transition, and attempt a true mutate-add to the underlying [Transition Frontier](#transition-frontier) data.
 
-<a href="catchup-monitor"></a>
-#### Catchup Monitor
+<a href="catchup-scheduler"></a>
+#### Catchup Scheduler
 
-The catchup monitor is responsible for waiting a bit before initiating a long
+The catchup scheduler is responsible for waiting a bit before initiating a long
 catchup job. The idea here is to mitigate out-of-order messages since it is much
 quicker to avoid such catchups if possible. This will be a module that waits on
 a small timeout before yielding to the ledger catchup component. And can be
@@ -181,11 +181,11 @@ sync ledger queries if we have ledger builders at every position.
 <a href="ledger-catchup"></a>
 ### Ledger Catchup
 
-Input: `External_transition.t` (from catchup monitor)
+Input: `External_transition.t` (from catchup scheduler)
 Output: `Breadcrumb.t list` (to processor)
 
 Ledger catchup runs a single catchup worker job at a time. Whenever catchup
-monitor descides it's time for a new catchup job to start, it will send
+scheduler decides it's time for a new catchup job to start, it will send
 something on the pipe.
 
 #### Catchup worker
@@ -351,4 +351,3 @@ this function unless they are late joiners.
 The implementation of this feature before the first merge will omit the mutable
 transition frontier implementation (if we can pass integration tests by wrapping
 the existing ktree)
-

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -338,7 +338,7 @@ struct
     then
       Logger.warn t.logger
         !"attach_node_to with breadcrumb for state %{sexp:State_hash.t} \
-          already present; catchup monitor bug?"
+          already present; catchup scheduler bug?"
         hash
     else
       Hashtbl.set t.table

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -1,12 +1,12 @@
 (**
- * [Catchup_monitor] defines a process which schedules catchup jobs and
+ * [Catchup_scheduler] defines a process which schedules catchup jobs and
  * monitors them for invalidation. This allows the transition frontier
  * controller to handle out of order transitions without spinning up
- * and tearing down catchup jobs constantly. The [Catchup_monitor] must
+ * and tearing down catchup jobs constantly. The [Catchup_scheduler] must
  * receive notifications whenever a new transition is added to the
  * transition frontier so that it can determine if any pending catchup
  * jobs can be invalidated. When catchup jobs are invalidated, the
- * catchup monitor extracts all of the invalidated catchup jobs and
+ * catchup scheduler extracts all of the invalidated catchup jobs and
  * spins up a process to materialize breadcrumbs from those transitions,
  * which will write the breadcrumbs back into the processor as if
  * catchup had successfully completed.
@@ -42,7 +42,7 @@ module Make (Inputs : Inputs.S) = struct
 
   let create ~logger ~frontier ~time_controller ~catchup_job_writer
       ~catchup_breadcrumbs_writer =
-    let logger = Logger.child logger "catchup_monitor" in
+    let logger = Logger.child logger "catchup_scheduler" in
     let timeouts = State_hash.Table.create () in
     let breadcrumb_builder_supervisor =
       Capped_supervisor.create ~job_capacity:5 (fun transition_branches ->


### PR DESCRIPTION
> Explain your changes here.

Rename `catchup monitor` to `catchup scheduler`, which may be a better name.

Checklist:

- [ ] Tests were added for the new behavior: no
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? no
