### PR TITLE
Create-diff refactoring PART 1: change the type of ledger builder diff

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -83,6 +83,7 @@ module type Init_intf = sig
      and type user_command := User_command.t
      and type user_command_with_valid_signature :=
                 User_command.With_valid_signature.t
+     and type fee_transfer_single := Fee_transfer.single
 
   module Make_work_selector : Work_selector_F
 
@@ -332,6 +333,7 @@ module User_command = struct
   end
 end
 
+module Fee_transfer = Coda_base.Fee_transfer
 module Ledger_proof_statement = Transaction_snark.Statement
 module Completed_work =
   Ledger_builder.Make_completed_work (Public_key.Compressed) (Ledger_proof)
@@ -345,6 +347,7 @@ module Ledger_builder_diff = Ledger_builder.Make_diff (struct
   module Compressed_public_key = Public_key.Compressed
   module User_command = User_command
   module Completed_work = Completed_work
+  module Fee_transfer = Fee_transfer
 end)
 
 let make_init ~should_propose (module Config : Config_intf) :
@@ -423,8 +426,8 @@ struct
           false
   end
 
-  module Fee_transfer = Coda_base.Fee_transfer
   module Coinbase = Coda_base.Coinbase
+  module Fee_transfer = Fee_transfer
 
   module Transaction = struct
     module T = struct

--- a/src/lib/ledger_builder/inputs.ml
+++ b/src/lib/ledger_builder/inputs.ml
@@ -99,6 +99,7 @@ module type S = sig
                 User_command.With_valid_signature.t
      and type public_key := Compressed_public_key.t
      and type ledger_builder_hash := Ledger_builder_hash.t
+     and type fee_transfer_single := Fee_transfer.single
 
   module Config : sig
     val transaction_capacity_log_2 : int

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -96,6 +96,7 @@ let main () =
           open Signature_lib
           open Coda_base
           module Compressed_public_key = Public_key.Compressed
+          module Fee_transfer = Fee_transfer
 
           module User_command = struct
             include (

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -153,6 +153,7 @@ let gen_keys () =
     module Ledger_builder_diff = Ledger_builder.Make_diff (struct
       open Coda_base
       module Compressed_public_key = Public_key.Compressed
+      module Fee_transfer = Fee_transfer
 
       module User_command = struct
         include (


### PR DESCRIPTION
This is the first of all the PRs related to the refactoring of the `create_diff` function in `Ledger_builder`. None of these PRs will compile because they don't have all the changes. They will be merged to a different branch and then to master. It is split this way to make it relatively easy to review.

>Changes

Coinbase in the diff now just has the fee transfer (instead of `Completed_work.t`) for the work required to include it in the diff. This is then subtracted from the fee transfers for the work required to add user commands.