### PR TITLE
Rename Snarky.Request.Reraise to Delegate

### DIFF
--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -71,9 +71,9 @@ type _ Request.t +=
 
 let reraise_merkle_requests (With {request; respond}) =
   match request with
-  | Merkle_tree.Get_path addr -> respond (Reraise (Get_path addr))
-  | Merkle_tree.Set (addr, account) -> respond (Reraise (Set (addr, account)))
-  | Merkle_tree.Get_element addr -> respond (Reraise (Get_element addr))
+  | Merkle_tree.Get_path addr -> respond (Delegate (Get_path addr))
+  | Merkle_tree.Set (addr, account) -> respond (Delegate (Set (addr, account)))
+  | Merkle_tree.Get_element addr -> respond (Delegate (Get_element addr))
   | _ -> unhandled
 
 let get t addr = Merkle_tree.get_req ~depth (var_to_hash_packed t) addr

--- a/src/lib/snarky/src/request.ml
+++ b/src/lib/snarky/src/request.ml
@@ -11,7 +11,7 @@ type response += Unhandled
 let unhandled = Unhandled
 
 module Response = struct
-  type 'a t = Provide of 'a | Reraise of 'a req | Unhandled
+  type 'a t = Provide of 'a | Delegate of 'a req | Unhandled
 end
 
 type request =
@@ -31,7 +31,7 @@ module Handler = struct
       | {handle} :: hs -> (
         match handle req with
         | Provide x -> x
-        | Reraise req' -> go req' hs
+        | Delegate req' -> go req' hs
         | Unhandled -> go req hs )
     in
     go req0 stack0

--- a/src/lib/snarky/src/request.mli
+++ b/src/lib/snarky/src/request.mli
@@ -9,7 +9,7 @@ type response
 val unhandled : response
 
 module Response : sig
-  type nonrec 'a t = Provide of 'a | Reraise of 'a t | Unhandled
+  type nonrec 'a t = Provide of 'a | Delegate of 'a t | Unhandled
 end
 
 type request =


### PR DESCRIPTION
This PR changes the name to be closer to its actual function. This should be a no-op.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them: