### PR TITLE
Move Field.var to Field.Var.t

### DIFF
--- a/src/lib/blockchain_snark/blockchain_state.ml
+++ b/src/lib/blockchain_snark/blockchain_state.ml
@@ -107,7 +107,7 @@ module Make (Consensus_mechanism : Consensus.Mechanism.S) :
   module Checked = struct
     let%snarkydef is_base_hash h =
       Field.Checked.equal
-        (Field.Checked.constant
+        (Field.Var.constant
            (Consensus_mechanism.genesis_protocol_state.hash :> Field.t))
         (State_hash.var_to_hash_packed h)
 

--- a/src/lib/coda_base/block_time.ml
+++ b/src/lib/coda_base/block_time.ml
@@ -111,7 +111,7 @@ module Timeout = struct
   let cancel () {cancel; _} value = cancel value
 end
 
-let field_var_to_unpacked (x : Tick.Field.Checked.t) =
+let field_var_to_unpacked (x : Tick.Field.Var.t) =
   Tick.Field.Checked.unpack ~length:64 x
 
 let epoch = of_time Time.epoch

--- a/src/lib/coda_base/block_time.mli
+++ b/src/lib/coda_base/block_time.mli
@@ -30,7 +30,7 @@ include
   Tick.Snarkable.Bits.Faithful
   with type Unpacked.value = t
    and type Packed.value = t
-   and type Packed.var = private Tick.Field.Checked.t
+   and type Packed.var = private Tick.Field.Var.t
 
 module Span : sig
   type t [@@deriving sexp]
@@ -90,7 +90,7 @@ val ( <= ) : t -> t -> bool
 val ( >= ) : t -> t -> bool
 
 val field_var_to_unpacked :
-  Tick.Field.Checked.t -> (Unpacked.var, _) Tick.Checked.t
+  Tick.Field.Var.t -> (Unpacked.var, _) Tick.Checked.t
 
 val diff_checked :
   Unpacked.var -> Unpacked.var -> (Span.Unpacked.var, _) Tick.Checked.t

--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -113,7 +113,7 @@ struct
 
   let var_of_t t =
     let n = Bigint.of_field t in
-    { digest= Field.Checked.constant t
+    { digest= Field.Var.constant t
     ; bits=
         Some
           (Bitstring.Lsb_first.of_list

--- a/src/lib/coda_base/receipt.ml
+++ b/src/lib/coda_base/receipt.ml
@@ -28,7 +28,7 @@ module Chain_hash = struct
 
   module Checked = struct
     let constant (t : t) =
-      var_of_hash_packed (Field.Checked.constant (t :> Field.t))
+      var_of_hash_packed (Field.Var.constant (t :> Field.t))
 
     type t = var
 

--- a/src/lib/coda_base/target.ml
+++ b/src/lib/coda_base/target.ml
@@ -20,7 +20,7 @@ let max_bigint =
 
 let max = Bigint.to_field max_bigint
 
-let constant = Tick.Field.Checked.constant
+let constant = Tick.Field.Var.constant
 
 let of_field x =
   assert (Bigint.compare (Bigint.of_field x) max_bigint <= 0) ;
@@ -61,5 +61,5 @@ module Bits =
 open Tick
 open Let_syntax
 
-let var_to_unpacked (x : Field.Checked.t) =
+let var_to_unpacked (x : Field.Var.t) =
   Field.Checked.unpack ~length:bit_length x

--- a/src/lib/coda_base/target.mli
+++ b/src/lib/coda_base/target.mli
@@ -23,9 +23,9 @@ include
   Snarkable.Bits.Faithful
   with type Unpacked.value = t
    and type Packed.value = t
-   and type Packed.var = private Field.Checked.t
+   and type Packed.var = private Field.Var.t
 
-val var_to_unpacked : Field.Checked.t -> (Unpacked.var, _) Tick.Checked.t
+val var_to_unpacked : Field.Var.t -> (Unpacked.var, _) Tick.Checked.t
 
 val constant : Packed.value -> Packed.var
 

--- a/src/lib/coda_base/transition_system.ml
+++ b/src/lib/coda_base/transition_system.ml
@@ -52,7 +52,7 @@ end
 module Make (Digest : sig
   module Tick :
     Tick.Snarkable.Bits.Lossy
-    with type Packed.var = Tick.Field.Checked.t
+    with type Packed.var = Tick.Field.Var.t
      and type Packed.value = Tick.Pedersen.Digest.t
 end)
 (System : S) =

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1055,12 +1055,12 @@ module Make (Inputs : Inputs_intf) : Intf.S = struct
         and length =
           let%bind base =
             Field.Checked.if_ epoch_increased
-              ~then_:Field.(Checked.constant zero)
+              ~then_:Field.(Var.constant zero)
               ~else_:
                 ( Length.pack_var previous_state.curr_epoch_data.length
                   :> Field.var )
           in
-          Length.var_of_field Field.(Checked.(add (constant one) base))
+          Length.var_of_field Field.(Var.(add (constant one) base))
         and ledger =
           Epoch_ledger.if_ epoch_increased
             ~then_:

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1058,7 +1058,7 @@ module Make (Inputs : Inputs_intf) : Intf.S = struct
               ~then_:Field.(Var.constant zero)
               ~else_:
                 ( Length.pack_var previous_state.curr_epoch_data.length
-                  :> Field.var )
+                  :> Field.Var.t )
           in
           Length.var_of_field Field.(Var.(add (constant one) base))
         and ledger =

--- a/src/lib/consensus/proof_of_work.ml.ignore
+++ b/src/lib/consensus/proof_of_work.ml.ignore
@@ -17,7 +17,7 @@ module Pow_hash = struct
     let open Let_syntax in
     let%map {less; _} =
       Field.Checked.compare ~bit_length:length_in_bits (var_to_hash_packed pow)
-        (target :> Field.Checked.t)
+        (target :> Field.Var.t)
     in
     less
 end
@@ -45,7 +45,7 @@ module Strength = struct
     assert (Tick.Field.compare x max <= 0) ;
     x
 
-  let field_var_to_unpacked (x: Tick.Field.Checked.t) =
+  let field_var_to_unpacked (x: Tick.Field.Var.t) =
     Tick.Field.Checked.unpack ~length:bit_length x
 
   include Bits.Snarkable.Small (Tick)

--- a/src/lib/consensus/proof_of_work.ml.ignore
+++ b/src/lib/consensus/proof_of_work.ml.ignore
@@ -119,13 +119,13 @@ module Strength = struct
           (Tick.Field.Checked.constant (Tick.Field.of_int b))
       in
       let m =
-        Tick.Field.Checked.(sub (constant (Tick.Field.of_int (b + 1))) k)
+        Tick.Field.Var.(sub (constant (Tick.Field.of_int (b + 1))) k)
       in
       let%bind z_unpacked = Tick.Field.Checked.unpack z ~length:b in
       Tick.Util.assert_num_bits_upper_bound z_unpacked m
     in
     let%bind zy = Tick.Field.Checked.mul z y in
-    let numerator = Tick.Field.Checked.constant (two_to_the b) in
+    let numerator = Tick.Field.Var.constant (two_to_the b) in
     let%map () = Tick.Field.Checked.Assert.lte ~bit_length:(b + 1) zy numerator
     and () =
       Tick.Field.Checked.Assert.lt ~bit_length:(b + 1) numerator
@@ -141,7 +141,7 @@ module Strength = struct
               map (read Target.Packed.typ y) ~f:of_target_unchecked)
       else
         floor_divide ~numerator:(`Two_to_the bit_length)
-          (y :> Tick.Field.var)
+          (y :> Tick.Field.Var.t)
           (Target.Unpacked.var_to_bits y_unpacked) )
 
   let ( < ) x y = compare x y < 0

--- a/src/lib/crypto_params/crypto_params_init/crypto_params_init.ml
+++ b/src/lib/crypto_params/crypto_params_init/crypto_params_init.ml
@@ -54,7 +54,7 @@ module Wrap_input = struct
 
     module Checked : sig
       val tick_field_to_scalars :
-           Tick0.Field.var
+           Tick0.Field.Var.t
         -> (Tick0.Boolean.var Bitstring.Lsb_first.t list, _) Tick0.Checked.t
 
       val to_scalar : var -> (Boolean.var Bitstring.Lsb_first.t, _) Checked.t
@@ -64,7 +64,7 @@ module Wrap_input = struct
   module Tock_field_larger : S = struct
     open Tock0
 
-    type var = Field.var
+    type var = Field.Var.t
 
     type t = Field.t
 
@@ -90,7 +90,7 @@ module Wrap_input = struct
   module Tock_field_smaller : S = struct
     open Tock0
 
-    type var = {low_bits: Field.var; high_bit: Boolean.var}
+    type var = {low_bits: Field.Var.t; high_bit: Boolean.var}
 
     type t = Tick0.Field.t
 

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -195,9 +195,9 @@ end) : sig
 
   val var_of_bits : Boolean.var Bitstring.Lsb_first.t -> var
 
-  val unpack_var : Field.Checked.t -> (var, _) Tick.Checked.t
+  val unpack_var : Field.Var.t -> (var, _) Tick.Checked.t
 
-  val pack_var : var -> Field.Checked.t
+  val pack_var : var -> Field.Var.t
 end = struct
   let max_int = Unsigned.max_int
 
@@ -401,7 +401,7 @@ end = struct
         Bitstring.pad_to_triple_list ~default:Boolean.false_ (to_bits t)
 
       let to_field_var ({magnitude; sgn} : var) =
-        Tick.Field.Checked.mul (pack_var magnitude) (sgn :> Field.Checked.t)
+        Tick.Field.Checked.mul (pack_var magnitude) (sgn :> Field.Var.t)
 
       let add (x : var) (y : var) =
         let%bind xv = to_field_var x and yv = to_field_var y in
@@ -413,9 +413,7 @@ end = struct
             (Option.value_exn (add x y)).sgn)
         in
         let%bind res =
-          Tick.Field.Checked.mul
-            (sgn :> Field.Checked.t)
-            (Field.Checked.add xv yv)
+          Tick.Field.Checked.mul (sgn :> Field.Var.t) (Field.Var.add xv yv)
         in
         let%map magnitude = unpack_var res in
         {magnitude; sgn}
@@ -426,7 +424,7 @@ end = struct
         (* (x + b(y - x), y + b(x - y)) *)
         let open Field.Checked.Infix in
         let%map b_y_minus_x =
-          Tick.Field.Checked.mul (b :> Field.Checked.t) (y - x)
+          Tick.Field.Checked.mul (b :> Field.Var.t) (y - x)
         in
         (x + b_y_minus_x, y - b_y_minus_x)
 
@@ -462,10 +460,10 @@ end = struct
 
     (* Unpacking protects against underflow *)
     let sub (x : Unpacked.var) (y : Unpacked.var) =
-      unpack_var (Field.Checked.sub (pack_var x) (pack_var y))
+      unpack_var (Field.Var.sub (pack_var x) (pack_var y))
 
     let sub_flagged x y =
-      let z = Field.Checked.sub (pack_var x) (pack_var y) in
+      let z = Field.Var.sub (pack_var x) (pack_var y) in
       let%map bits, `Success no_underflow =
         Field.Checked.unpack_flagged z ~length:length_in_bits
       in
@@ -492,10 +490,10 @@ end = struct
 
     (* Unpacking protects against overflow *)
     let add (x : Unpacked.var) (y : Unpacked.var) =
-      unpack_var (Field.Checked.add (pack_var x) (pack_var y))
+      unpack_var (Field.Var.add (pack_var x) (pack_var y))
 
     let add_flagged x y =
-      let z = Field.Checked.add (pack_var x) (pack_var y) in
+      let z = Field.Var.add (pack_var x) (pack_var y) in
       let%map bits, `Success no_overflow =
         Field.Checked.unpack_flagged z ~length:length_in_bits
       in
@@ -507,7 +505,7 @@ end = struct
 
     let add_signed (t : var) (d : Signed.var) =
       let%bind d = Signed.Checked.to_field_var d in
-      Field.Checked.add (pack_var t) d |> unpack_var
+      Field.Var.add (pack_var t) d |> unpack_var
 
     let%test_module "currency_test" =
       ( module struct
@@ -626,7 +624,7 @@ module Amount = struct
     let to_fee (t : var) : Fee.var = t
 
     let add_fee (t : var) (fee : Fee.var) =
-      Field.Checked.add (pack_var t) (Fee.pack_var fee) |> unpack_var
+      Field.Var.add (pack_var t) (Fee.pack_var fee) |> unpack_var
   end
 end
 

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -130,7 +130,7 @@ module type Signed_intf = sig
 
     val ( + ) : var -> var -> (var, _) Checked.t
 
-    val to_field_var : var -> (Field.var, _) Checked.t
+    val to_field_var : var -> (Field.Var.t, _) Checked.t
 
     val cswap :
          Boolean.var

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -155,7 +155,7 @@ module type Signed_intf = sig
 
     val ( + ) : var -> var -> (var, _) Checked.t
 
-    val to_field_var : var -> (Field.var, _) Checked.t
+    val to_field_var : var -> (Field.Var.t, _) Checked.t
 
     val cswap :
          Boolean.var

--- a/src/lib/keys_lib/keys.ml
+++ b/src/lib/keys_lib/keys.ml
@@ -24,7 +24,7 @@ module type S = sig
 
     val input :
          unit
-      -> ('a, 'b, Tick.Field.var -> 'a, Tick.Field.t -> 'b) Tick.Data_spec.t
+      -> ('a, 'b, Tick.Field.Var.t -> 'a, Tick.Field.t -> 'b) Tick.Data_spec.t
 
     module Verification_key : sig
       val to_bool_list : Tock.Verification_key.t -> bool list
@@ -35,7 +35,7 @@ module type S = sig
     val instance_hash :
       Consensus_mechanism.Protocol_state.value -> Tick.Field.t
 
-    val main : Tick.Field.var -> (unit, Prover_state.t) Tick.Checked.t
+    val main : Tick.Field.Var.t -> (unit, Prover_state.t) Tick.Checked.t
   end
 
   module Wrap : sig

--- a/src/lib/keys_lib/keys.mli
+++ b/src/lib/keys_lib/keys.mli
@@ -22,7 +22,7 @@ module type S = sig
 
     val input :
          unit
-      -> ('a, 'b, Tick.Field.var -> 'a, Tick.Field.t -> 'b) Tick.Data_spec.t
+      -> ('a, 'b, Tick.Field.Var.t -> 'a, Tick.Field.t -> 'b) Tick.Data_spec.t
 
     module Verification_key : sig
       val to_bool_list : Tock.Verification_key.t -> bool list
@@ -33,7 +33,7 @@ module type S = sig
     val instance_hash :
       Consensus_mechanism.Protocol_state.value -> Tick.Field.t
 
-    val main : Tick.Field.var -> (unit, Prover_state.t) Tick.Checked.t
+    val main : Tick.Field.Var.t -> (unit, Prover_state.t) Tick.Checked.t
   end
 
   module Wrap : sig

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -12,7 +12,7 @@ end
 include Stable.V1
 include Comparable.Make_binable (Stable.V1)
 
-type var = Tick.Field.var * Tick.Field.var
+type var = Tick.Field.Var.t * Tick.Field.Var.t
 
 let var_of_t (x, y) = (Tick.Field.Var.constant x, Tick.Field.Var.constant y)
 
@@ -78,7 +78,7 @@ module Compressed = struct
 
   let length_in_triples = bit_length_to_triple_length (1 + Field.size_in_bits)
 
-  type var = (Field.var, Boolean.var) t_
+  type var = (Field.Var.t, Boolean.var) t_
 
   let to_hlist {x; is_odd} = Snarky.H_list.[x; is_odd]
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -14,8 +14,7 @@ include Comparable.Make_binable (Stable.V1)
 
 type var = Tick.Field.var * Tick.Field.var
 
-let var_of_t (x, y) =
-  (Tick.Field.Checked.constant x, Tick.Field.Checked.constant y)
+let var_of_t (x, y) = (Tick.Field.Var.constant x, Tick.Field.Var.constant y)
 
 let typ : (var, t) Tick.Typ.t = Tick.Typ.(field * field)
 
@@ -93,7 +92,7 @@ module Compressed = struct
       ~value_of_hlist:of_hlist
 
   let var_of_t ({x; is_odd} : t) : var =
-    {x= Field.Checked.constant x; is_odd= Boolean.var_of_value is_odd}
+    {x= Field.Var.constant x; is_odd= Boolean.var_of_value is_odd}
 
   let assert_equal (t1 : var) (t2 : var) =
     let open Let_syntax in

--- a/src/lib/sgn/sgn.ml
+++ b/src/lib/sgn/sgn.ml
@@ -15,11 +15,11 @@ let of_field_exn x =
   else if Field.equal x neg_one then Neg
   else failwith "Sgn.of_field: Expected positive or negative 1"
 
-type var = Field.Checked.t
+type var = Field.Var.t
 
 let typ : (var, t) Typ.t =
   let open Typ in
-  { check= (fun x -> assert_r1cs x x (Field.Checked.constant Field.one))
+  { check= (fun x -> assert_r1cs x x (Field.Var.constant Field.one))
   ; store= (fun t -> Store.store (to_field t))
   ; read= (fun x -> Read.(read x >>| of_field_exn))
   ; alloc= Alloc.alloc }
@@ -36,24 +36,24 @@ module Checked = struct
   let is_pos (v : var) =
     Boolean.Unsafe.of_cvar
       (let open Field.Checked in
-      Infix.(one_half * (v + constant Field.one)))
+      Infix.(one_half * (v + Field.Var.constant Field.one)))
 
   let is_neg (v : var) =
     Boolean.Unsafe.of_cvar
       (let open Field.Checked in
-      Infix.(neg_one_half * (v - constant Field.one)))
+      Infix.(neg_one_half * (v - Field.Var.constant Field.one)))
 
   let pos_if_true (b : Boolean.var) =
     let open Field.Checked in
-    Infix.((two * (b :> Field.Checked.t)) - constant Field.one)
+    Infix.((two * (b :> Field.Var.t)) - Field.Var.constant Field.one)
 
   let neg_if_true (b : Boolean.var) =
     let open Field.Checked in
-    Infix.((neg_two * (b :> Field.Checked.t)) + constant Field.one)
+    Infix.((neg_two * (b :> Field.Var.t)) + Field.Var.constant Field.one)
 
-  let negate t = Field.Checked.scale t neg_one
+  let negate t = Field.Var.scale t neg_one
 
-  let constant = Fn.compose Field.Checked.constant to_field
+  let constant = Fn.compose Field.Var.constant to_field
 
   let neg = constant Neg
 

--- a/src/lib/sgn/sgn.mli
+++ b/src/lib/sgn/sgn.mli
@@ -8,7 +8,7 @@ val to_field : t -> Field.t
 
 val gen : t Quickcheck.Generator.t
 
-type var = private Field.Checked.t
+type var = private Field.Var.t
 
 val typ : (var, t) Typ.t
 

--- a/src/lib/signature_lib/checked.ml
+++ b/src/lib/signature_lib/checked.ml
@@ -141,7 +141,7 @@ module Schnorr
 
         type t [@@deriving eq]
 
-        type var = Field.Checked.t * Field.Checked.t
+        type var = Field.Var.t * Field.Var.t
 
         module Checked :
           Curves.Weierstrass_checked_intf

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -16,7 +16,7 @@ end
 
 include Comparable.S_binable with type t := t
 
-type var = Field.var * Field.var
+type var = Field.Var.t * Field.Var.t
 
 val typ : (var, t) Typ.t
 
@@ -45,7 +45,7 @@ module Compressed : sig
 
   val length_in_triples : int
 
-  type var = (Field.var, Boolean.var) t_
+  type var = (Field.Var.t, Boolean.var) t_
 
   val typ : (var, t) Typ.t
 

--- a/src/lib/snark_bits/bits.ml
+++ b/src/lib/snark_bits/bits.ml
@@ -158,8 +158,8 @@ module Snarkable = struct
     with type ('a, 'b) typ := ('a, 'b) Impl.Typ.t
      and type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
      and type boolean_var := Impl.Boolean.var
-     and type field_var := Impl.Field.Checked.t
-     and type Packed.var = Impl.Field.Checked.t
+     and type field_var := Impl.Field.Var.t
+     and type Packed.var = Impl.Field.Var.t
      and type Packed.value = V.t
      and type Unpacked.var = Impl.Boolean.var list
      and type Unpacked.value = V.t
@@ -178,7 +178,7 @@ module Snarkable = struct
       go V.empty 0
 
     module Packed = struct
-      type var = Field.Checked.t
+      type var = Field.Var.t
 
       type value = V.t
 
@@ -249,13 +249,13 @@ module Snarkable = struct
     let%snarkydef increment_if_var bs (b : Boolean.var) =
       let open Impl in
       let v = Field.Checked.pack bs in
-      let v' = Field.Checked.add v (b :> Field.Checked.t) in
+      let v' = Field.Var.add v (b :> Field.Var.t) in
       Field.Checked.unpack v' ~length:V.length
 
     let%snarkydef increment_var bs =
       let open Impl in
       let v = Field.Checked.pack bs in
-      let v' = Field.Checked.add v (Field.Checked.constant Field.one) in
+      let v' = Field.Var.add v (Field.Var.constant Field.one) in
       Field.Checked.unpack v' ~length:V.length
 
     let%snarkydef equal_var (n : Unpacked.var) (n' : Unpacked.var) =
@@ -289,7 +289,7 @@ module Snarkable = struct
     include M
 
     module Packed = struct
-      type var = Field.Checked.t
+      type var = Field.Var.t
 
       type value = Field.t
 
@@ -334,7 +334,7 @@ module Snarkable = struct
     with type ('a, 'b) typ := ('a, 'b) Impl.Typ.t
      and type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
      and type boolean_var := Impl.Boolean.var
-     and type Packed.var = Impl.Field.Checked.t
+     and type Packed.var = Impl.Field.Var.t
      and type Packed.value = Impl.Field.t
      and type Unpacked.var = Impl.Boolean.var list
      and type Unpacked.value = Impl.Field.t =
@@ -352,7 +352,7 @@ module Snarkable = struct
     with type ('a, 'b) typ := ('a, 'b) Impl.Typ.t
      and type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
      and type boolean_var := Impl.Boolean.var
-     and type Packed.var = Impl.Field.Checked.t
+     and type Packed.var = Impl.Field.Var.t
      and type Packed.value = Impl.Field.t
      and type Unpacked.var = Impl.Boolean.var list
      and type Unpacked.value = Impl.Field.t = struct

--- a/src/lib/snark_params/pedersen.ml
+++ b/src/lib/snark_params/pedersen.ml
@@ -19,7 +19,7 @@ module type S = sig
 
     module Snarkable (Impl : Snark_intf.S) :
       Impl.Snarkable.Bits.Lossy
-      with type Packed.var = Impl.Field.Checked.t
+      with type Packed.var = Impl.Field.Var.t
        and type Packed.value = Impl.Field.t
        and type Unpacked.value = Impl.Field.t
   end

--- a/src/lib/snark_params/pedersen.mli
+++ b/src/lib/snark_params/pedersen.mli
@@ -19,7 +19,7 @@ module type S = sig
 
     module Snarkable (Impl : Snark_intf.S) :
       Impl.Snarkable.Bits.Lossy
-      with type Packed.var = Impl.Field.Checked.t
+      with type Packed.var = Impl.Field.Var.t
        and type Packed.value = Impl.Field.t
        and type Unpacked.value = Impl.Field.t
   end

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -34,7 +34,7 @@ module Make_snarkable (Impl : Snarky.Snark_intf.S) = struct
        and type ('a, 'b) checked := ('a, 'b) Checked.t
        and type boolean_var := Boolean.var
        and type comparison_result := Field.Checked.comparison_result
-       and type field_var := Field.Checked.t
+       and type field_var := Field.Var.t
   end
 end
 
@@ -112,7 +112,7 @@ module Make_inner_curve_aux
 struct
   open Impl
 
-  type var = Field.Checked.t * Field.Checked.t
+  type var = Field.Var.t * Field.Var.t
 
   module Scalar = Make_inner_curve_scalar (Impl) (Other_impl)
 

--- a/src/lib/snarky/examples/election/knapsack_hash.ml
+++ b/src/lib/snarky/examples/election/knapsack_hash.ml
@@ -4,7 +4,7 @@ module M = Snarky.Knapsack.Make (Impl)
 
 let dimension = 1
 
-type var = Field.Checked.t list
+type var = Field.Var.t list
 
 type t = Field.t list
 

--- a/src/lib/snarky/examples/tutorial/tutorial.ml
+++ b/src/lib/snarky/examples/tutorial/tutorial.ml
@@ -44,24 +44,23 @@ let () =
 (* Try seeing what operations there are in the [Field] module by using
    your editor's auto-completion feature
 *)
-(* Inside Checked.t's we work with "Field.var"s. These are sort of like
+(* Inside Checked.t's we work with "Field.Var.t"s. These are sort of like
    Field.t's but we can make assertions about them.
 
    Field.Checked provides "Checked" versions of the usual field operations.
 *)
-(* [assert_equal : Field.var -> Field.var -> (unit, _) Checked.t] lets us
+(* [assert_equal : Field.Var.t -> Field.Var.t -> (unit, _) Checked.t] lets us
    make an assertion that two field elements are equal.
 
    Here we assert that [x] is a square root of 9.
 *)
-let assert_is_square_root_of_9 (x : Field.var) : (unit, _) Checked.t =
+let assert_is_square_root_of_9 (x : Field.Var.t) : (unit, _) Checked.t =
   let%bind x_squared = Field.Checked.mul x x in
-  Field.Checked.Assert.equal x_squared
-    (Field.Checked.constant (Field.of_int 9))
+  Field.Checked.Assert.equal x_squared (Field.Var.constant (Field.of_int 9))
 
 (* Exercise 1:
    Write a function
-   [assert_is_cube_root_of_1 : Field.var -> (unit, _) Checked.t]
+   [assert_is_cube_root_of_1 : Field.Var.t -> (unit, _) Checked.t]
    that asserts its argument is a cube root of 1.
 
    Aside:
@@ -82,7 +81,7 @@ let assert_is_square_root_of_9 (x : Field.var) : (unit, _) Checked.t =
 (* In this field, it happens to be the case that -3 is a square. *)
 let () = assert (Field.is_square (Field.of_int (-3)))
 
-let assert_is_cube_root_of_1 (x : Field.var) = failwith "Exercise 1"
+let assert_is_cube_root_of_1 (x : Field.Var.t) = failwith "Exercise 1"
 
 let cube_root_of_1 =
   let open Field in
@@ -96,7 +95,7 @@ let exercise1 () =
      list type constructors. We also need to make input a function over unit due
      to value restriction reasons.
 
-     Here our function `assert_is_curbe_root_of_1` takes a single Field.var as
+     Here our function `assert_is_curbe_root_of_1` takes a single Field.Var.t as
      input. The type of that var is `Field.typ`.
    *)
   let input () = Data_spec.[Field.typ] in
@@ -215,7 +214,7 @@ module Exercise3 = struct
    * monad, and the Field.Checked version with the Checked monad
    *)
   module Mat_checked = struct
-    type t = Field.var array array
+    type t = Field.Var.t array array
 
     (* Exercise 3: fill me out *)
     let mul : t -> t -> (t, _) Checked.t =
@@ -231,7 +230,7 @@ module Exercise3 = struct
      matrix (the square of [1; 2]; [4; 5] )
   *)
   let assert_exists_sqrt sqrt_x =
-    let f x = Field.Checked.constant (Field.of_int x) in
+    let f x = Field.Var.constant (Field.of_int x) in
     assert_exists_mat_sqrt [|[|f 9; f 12|]; [|f 24; f 33|]|] sqrt_x
 
   (* Now the data_spec is more interesting:

--- a/src/lib/snarky/src/curves.ml
+++ b/src/lib/snarky/src/curves.ml
@@ -571,7 +571,7 @@ module Make_weierstrass_checked
   Weierstrass_checked_intf
   with module Impl := Impl
    and type t := Curve.t
-   and type var := Impl.Field.var * Impl.Field.var = struct
+   and type var := Impl.Field.Var.t * Impl.Field.Var.t = struct
   open Impl
 
   type var = Field.Var.t * Field.Var.t

--- a/src/lib/snarky/src/enumerable.ml
+++ b/src/lib/snarky/src/enumerable.ml
@@ -24,7 +24,7 @@ struct
     assert (n < Field.size_in_bits) ;
     n
 
-  type var = Field.Checked.t
+  type var = Field.Var.t
 
   let to_field t = Field.of_int (to_enum t)
 
@@ -37,7 +37,7 @@ struct
       if M.max = 1 then fun x -> assert_ (Constraint.boolean x)
       else fun x ->
         Field.Checked.Assert.lte ~bit_length x
-          (Field.Checked.constant (Field.of_int M.max))
+          (Field.Var.constant (Field.of_int M.max))
     in
     {(Typ.transport Field.typ ~there:to_field ~back:of_field) with check}
 
@@ -48,7 +48,7 @@ struct
 
   let if_ b ~(then_ : var) ~(else_ : var) = Field.Checked.if_ b ~then_ ~else_
 
-  let var t : var = Field.Checked.constant (to_field t)
+  let var t : var = Field.Var.constant (to_field t)
 
   let ( = ) = Field.Checked.equal
 end

--- a/src/lib/snarky/src/enumerable.mli
+++ b/src/lib/snarky/src/enumerable.mli
@@ -6,5 +6,5 @@ module Make
   with type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
    and type ('a, 'b) typ := ('a, 'b) Impl.Typ.t
    and type bool_var := Impl.Boolean.var
-   and type var = Impl.Field.var
+   and type var = Impl.Field.Var.t
    and type t := M.t

--- a/src/lib/snarky/src/gadget.ml
+++ b/src/lib/snarky/src/gadget.ml
@@ -19,8 +19,8 @@ module Make
 
         val create :
              Libsnark.Protoboard.t
-          -> (Impl.Field.Checked.t -> Libsnark.Protoboard.Variable.t)
-          -> (Libsnark.Protoboard.Variable.t -> Impl.Field.Checked.t)
+          -> (Impl.Field.Var.t -> Libsnark.Protoboard.Variable.t)
+          -> (Libsnark.Protoboard.Variable.t -> Impl.Field.Var.t)
           -> input
           -> t
 
@@ -39,7 +39,7 @@ struct
     let num_input_vars = ref 0 in
     let var_pairs = ref [] in
     let conv cvar =
-      let c, terms = Field.Checked.to_constant_and_terms cvar in
+      let c, terms = Field.Var.to_constant_and_terms cvar in
       let lc =
         match c with
         | None -> Linear_combination.create ()

--- a/src/lib/snarky/src/gm_verifier_gadget.ml
+++ b/src/lib/snarky/src/gm_verifier_gadget.ml
@@ -19,7 +19,7 @@ module Make
 
       type t [@@deriving sexp]
 
-      type var = Field.var * Field.var
+      type var = Field.Var.t * Field.Var.t
 
       val typ : (var, t) Typ.t
 
@@ -271,7 +271,7 @@ struct
 
     type t = (Inner_curve.t, Field.t) t_ [@@deriving sexp]
 
-    type var = (Inner_curve.var, Field.var) t_
+    type var = (Inner_curve.var, Field.Var.t) t_
 
     let of_hlist
         (H_list.([query_base; query; other_data]) :
@@ -438,7 +438,7 @@ struct
 
     type input =
       { pvk: Preprocessed_verification_key.t
-      ; accumulated_input: Field.var * Field.var
+      ; accumulated_input: Field.Var.t * Field.Var.t
       ; proof: Proof.t }
 
     type witness = unit

--- a/src/lib/snarky/src/knapsack.ml
+++ b/src/lib/snarky/src/knapsack.ml
@@ -35,14 +35,14 @@ module Make (Impl : Snark_intf.S) = struct
 
   module Checked = struct
     let hash_to_field ({dimension; max_input_length; coefficients} : t)
-        (vs : Boolean.var list) : (Field.Checked.t list, _) Checked.t =
-      let vs = (vs :> Field.Checked.t list) in
+        (vs : Boolean.var list) : (Field.Var.t list, _) Checked.t =
+      let vs = (vs :> Field.Var.t list) in
       let input_len = List.length vs in
       if input_len > max_input_length then
         failwithf "Input size %d exceeded max %d" input_len max_input_length () ;
       List.map coefficients ~f:(fun cs ->
-          Field.Checked.linear_combination
-            (map2_lax cs vs ~f:(fun c v -> (c, v))) )
+          Field.Var.linear_combination (map2_lax cs vs ~f:(fun c v -> (c, v)))
+      )
       |> Checked.return
 
     let hash_to_bits (t : t) (vs : Boolean.var list) :
@@ -90,12 +90,12 @@ module Make (Impl : Snark_intf.S) = struct
         let open Field.Checked.Infix in
         assert_all
           (List.map3_exn
-             (xs :> Field.Checked.t list)
-             (ys :> Field.Checked.t list)
-             (res :> Field.Checked.t list)
+             (xs :> Field.Var.t list)
+             (ys :> Field.Var.t list)
+             (res :> Field.Var.t list)
              ~f:(fun x y r ->
                Constraint.r1cs ~label:"Knapsack.Hash.if_"
-                 (b :> Field.Checked.t)
+                 (b :> Field.Var.t)
                  (y - x) (r - x) ))
       in
       res

--- a/src/lib/snarky/src/knapsack.mli
+++ b/src/lib/snarky/src/knapsack.mli
@@ -29,7 +29,7 @@ module Make (M : Snark_intf.S) : sig
 
   module Checked : sig
     val hash_to_field :
-      t -> Boolean.var list -> (Field.Checked.t list, _) Checked.t
+      t -> Boolean.var list -> (Field.Var.t list, _) Checked.t
 
     val hash_to_bits : t -> Boolean.var list -> (Boolean.var list, _) Checked.t
   end

--- a/src/lib/snarky/src/number.ml
+++ b/src/lib/snarky/src/number.ml
@@ -17,7 +17,7 @@ module Make (Impl : Snark_intf.Basic) = struct
   type t =
     { upper_bound: Bignum_bigint.t
     ; lower_bound: Bignum_bigint.t
-    ; var: Field.Checked.t
+    ; var: Field.Var.t
     ; bits: Boolean.var list option }
 
   let two_to_the n =
@@ -76,7 +76,7 @@ module Make (Impl : Snark_intf.Basic) = struct
          let%bind fits = Field.Checked.equal t.var g in
          let%map r =
            Field.Checked.if_ fits ~then_:g
-             ~else_:(Field.Checked.constant Field.(sub (two_to_the n) one))
+             ~else_:(Field.Var.constant Field.(sub (two_to_the n) one))
          in
          { upper_bound= Bignum_bigint.(k - one)
          ; lower_bound= t.lower_bound
@@ -140,7 +140,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     let n = Bigint.to_bignum_bigint tick_n in
     { upper_bound= n
     ; lower_bound= n
-    ; var= Field.Checked.constant x
+    ; var= Field.Var.constant x
     ; bits=
         Some
           (List.init (bigint_num_bits n) ~f:(fun i ->
@@ -166,7 +166,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     if upper_bound < Field.size then
       { upper_bound
       ; lower_bound= x.lower_bound + y.lower_bound
-      ; var= Field.Checked.add x.var y.var
+      ; var= Field.Var.add x.var y.var
       ; bits= None }
     else
       failwithf "Number.+: Potential overflow: (%s + %s > Field.size)"
@@ -178,7 +178,7 @@ module Make (Impl : Snark_intf.Basic) = struct
     if x.lower_bound >= y.upper_bound then
       { upper_bound= x.upper_bound - y.lower_bound
       ; lower_bound= x.lower_bound - y.upper_bound
-      ; var= Field.Checked.sub x.var y.var
+      ; var= Field.Var.sub x.var y.var
       ; bits= None }
     else
       failwithf "Number.-: Potential underflow (%s < %s)"

--- a/src/lib/snarky/src/number.mli
+++ b/src/lib/snarky/src/number.mli
@@ -2,5 +2,5 @@ module Make (Impl : Snark_intf.Basic) :
   Number_intf.S
   with type ('a, 'b) checked := ('a, 'b) Impl.Checked.t
    and type field := Impl.Field.t
-   and type field_var := Impl.Field.Checked.t
+   and type field_var := Impl.Field.Var.t
    and type bool_var := Impl.Boolean.var

--- a/src/lib/snarky/src/pedersen.ml
+++ b/src/lib/snarky/src/pedersen.ml
@@ -7,7 +7,7 @@ let local_function ~negate quad (b0, b1, b2) =
 
 module Make
     (Impl : Snark_intf.S) (Weierstrass_curve : sig
-        type var = Impl.Field.Checked.t * Impl.Field.Checked.t
+        type var = Impl.Field.Var.t * Impl.Field.Var.t
 
         type t [@@deriving eq]
 
@@ -44,7 +44,7 @@ module Make
   open Impl
 
   module Digest : sig
-    type var = Field.Checked.t
+    type var = Field.Var.t
 
     module Unpacked : sig
       type var = private Boolean.var list
@@ -53,7 +53,7 @@ module Make
 
       val typ : (var, t) Typ.t
 
-      val project : var -> Field.Checked.t
+      val project : var -> Field.Var.t
 
       val constant : t -> var
     end
@@ -117,10 +117,10 @@ end = struct
     let%bind s_and = Boolean.(s0 && s1) in
     let open Field.Checked.Infix in
     let lookup_one (a1, a2, a3, a4) =
-      Field.Checked.constant a1
-      + (Field.Infix.(a2 - a1) * (s0 :> Field.Checked.t))
-      + (Field.Infix.(a3 - a1) * (s1 :> Field.Checked.t))
-      + (Field.Infix.(a4 + a1 - a2 - a3) * (s_and :> Field.Checked.t))
+      Field.Var.constant a1
+      + (Field.Infix.(a2 - a1) * (s0 :> Field.Var.t))
+      + (Field.Infix.(a3 - a1) * (s1 :> Field.Var.t))
+      + (Field.Infix.(a4 + a1 - a2 - a3) * (s_and :> Field.Var.t))
     in
     let x_q, y_q = coords q in
     let x = lookup_one x_q in
@@ -128,8 +128,7 @@ end = struct
       let sign =
         (* sign = 1 if s2 = 0
           sign = -1 if s2 = 1 *)
-        Field.Checked.constant Field.one
-        - (Field.of_int 2 * (s2 :> Field.Checked.t))
+        Field.Var.constant Field.one - (Field.of_int 2 * (s2 :> Field.Var.t))
       in
       Field.Checked.mul sign (lookup_one y_q)
     in
@@ -150,7 +149,7 @@ end = struct
       let constant = List.map ~f:Boolean.var_of_value
     end
 
-    type var = Field.Checked.t
+    type var = Field.Var.t
 
     type t = Field.t
 

--- a/src/lib/snarky/src/sha256.ml
+++ b/src/lib/snarky/src/sha256.ml
@@ -330,14 +330,14 @@ end = struct
 
         type t =
           { gadget: Compression_gadget.t
-          ; output_unconstrained: Impl.Field.var list }
+          ; output_unconstrained: Impl.Field.Var.t list }
 
         let create pb conv conv_back {prev_state; block} =
           let conv_bits (bits : Boolean.var list) =
             let arr = Protoboard.Variable_array.create () in
             List.iter bits ~f:(fun b ->
                 Protoboard.Variable_array.emplace_back arr
-                  (conv (b :> Impl.Field.var)) ) ;
+                  (conv (b :> Impl.Field.Var.t)) ) ;
             arr
           in
           let prev_state = conv_bits prev_state in

--- a/src/lib/snarky/src/snark0.ml
+++ b/src/lib/snarky/src/snark0.ml
@@ -1382,14 +1382,20 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
     type var = Cvar.t
 
+    type var' = Var.t
+
     let typ = Typ.field
 
-    module Checked = struct
+    module Var = struct
       include Cvar1
 
       let to_constant : var -> Field0.t option = function
         | Constant x -> Some x
         | _ -> None
+    end
+
+    module Checked = struct
+      include Cvar1
 
       let equal = Checked.equal
 
@@ -1415,7 +1421,7 @@ module Make_basic (Backend : Backend_intf.S) = struct
           (let alpha_packed =
              Cvar.Infix.(Cvar.constant (two_to_the bit_length) + b - a)
            in
-           let%bind alpha = unpack alpha_packed ~length:(bit_length + 1) in
+           let%bind alpha = Var.unpack alpha_packed ~length:(bit_length + 1) in
            let prefix, less_or_equal =
              match Core_kernel.List.split_n alpha bit_length with
              | p, [l] -> (p, l)
@@ -1446,8 +1452,9 @@ module Make_basic (Backend : Backend_intf.S) = struct
 
         let equal x y = Checked.assert_equal ~label:"Checked.Assert.equal" x y
 
-        let not_equal (x : t) (y : t) =
-          Checked.with_label "Checked.Assert.not_equal" (non_zero (sub x y))
+        let not_equal (x : Var.t) (y : Var.t) =
+          Checked.with_label "Checked.Assert.not_equal"
+            (non_zero (Var.sub x y))
       end
 
       let lt_bitstring_value =

--- a/src/lib/snarky/src/snark_intf.ml
+++ b/src/lib/snarky/src/snark_intf.ml
@@ -566,6 +566,6 @@ module type S = sig
     with type ('a, 'b) checked := ('a, 'b) Checked.t
      and type ('a, 'b) typ := ('a, 'b) Typ.t
      and type bool_var := Boolean.var
-     and type var = Field.var
+     and type var = Field.Var.t
      and type t := M.t
 end

--- a/src/lib/snarky_curves/snarky_curves.ml
+++ b/src/lib/snarky_curves/snarky_curves.ml
@@ -307,11 +307,11 @@ module Make_weierstrass_checked
   let if_value (cond : Boolean.var) ~then_ ~else_ =
     let x1, y1 = Curve.to_affine_coordinates then_ in
     let x2, y2 = Curve.to_affine_coordinates else_ in
-    let cond = (cond :> Field.Checked.t) in
+    let cond = (cond :> Field.Var.t) in
     let choose a1 a2 =
       let open Field.Checked in
       F.map2_ a1 a2 ~f:(fun a1 a2 ->
-          Infix.((a1 * cond) + (a2 * (constant Field.one - cond))) )
+          Infix.((a1 * cond) + (a2 * (Field.Var.constant Field.one - cond))) )
     in
     (choose x1 x2, choose y1 y2)
 
@@ -343,12 +343,12 @@ module Make_weierstrass_checked
     let%map b0_and_b1 = Boolean.( && ) b0 b1 in
     let lookup_one (a1, a2, a3, a4) =
       let open F.Unchecked in
-      let ( * ) x b = F.map_ x ~f:(fun x -> Field.Checked.scale b x) in
+      let ( * ) x b = F.map_ x ~f:(fun x -> Field.Var.scale b x) in
       let ( +^ ) = F.( + ) in
       F.constant a1
-      +^ ((a2 - a1) * (b0 :> Field.Checked.t))
-      +^ ((a3 - a1) * (b1 :> Field.Checked.t))
-      +^ ((a4 + a1 - a2 - a3) * (b0_and_b1 :> Field.Checked.t))
+      +^ ((a2 - a1) * (b0 :> Field.Var.t))
+      +^ ((a3 - a1) * (b1 :> Field.Var.t))
+      +^ ((a4 + a1 - a2 - a3) * (b0_and_b1 :> Field.Var.t))
     in
     let x1, y1 = Curve.to_affine_coordinates t1
     and x2, y2 = Curve.to_affine_coordinates t2
@@ -361,9 +361,7 @@ module Make_weierstrass_checked
     let lookup_one (a1, a2) =
       let open F in
       constant a1
-      + map_
-          Unchecked.(a2 - a1)
-          ~f:(Field.Checked.scale (b :> Field.Checked.t))
+      + map_ Unchecked.(a2 - a1) ~f:(Field.Var.scale (b :> Field.Var.t))
     in
     let x1, y1 = Curve.to_affine_coordinates t1
     and x2, y2 = Curve.to_affine_coordinates t2 in

--- a/src/lib/snarky_field_extensions/field_extensions.ml
+++ b/src/lib/snarky_field_extensions/field_extensions.ml
@@ -195,7 +195,7 @@ struct
         type t = Field.t t_
       end
 
-      type t = Field.Checked.t t_
+      type t = Field.Var.t t_
 
       let map_ = map_
     end
@@ -219,17 +219,17 @@ struct
       include Field.Infix
     end
 
-    type t = Field.Checked.t
+    type t = Field.Var.t
 
     let if_ = Field.Checked.if_
 
     let typ = Field.typ
 
-    let constant = Field.Checked.constant
+    let constant = Field.Var.constant
 
-    let to_constant = Field.Checked.to_constant
+    let to_constant = Field.Var.to_constant
 
-    let scale = Field.Checked.scale
+    let scale = Field.Var.scale
 
     let mul_field = Field.Checked.mul
 
@@ -239,7 +239,7 @@ struct
 
     let ( - ) = Field.Checked.Infix.( - )
 
-    let negate t = Field.Checked.scale t Unchecked.(negate one)
+    let negate t = Field.Var.scale t Unchecked.(negate one)
 
     let assert_square = `Custom (fun a c -> assert_square a c)
 
@@ -666,13 +666,13 @@ module Cyclotomic_square = struct
       and bsq0, bsq1 = F2.square b
       and csq0, csq1 = F2.square c in
       let fpos x y =
-        Field.(Checked.(add (scale x (of_int 3)) (scale y (of_int 2))))
+        Field.(Var.(add (scale x (of_int 3)) (scale y (of_int 2))))
       in
       let fneg x y =
-        Field.(Checked.(sub (scale x (of_int 3)) (scale y (of_int 2))))
+        Field.(Var.(sub (scale x (of_int 3)) (scale y (of_int 2))))
       in
       ( (fneg asq0 a0, fneg bsq0 c0, fneg csq0 b1)
-      , ( fpos (Field.Checked.scale csq1 Params.cubic_non_residue) b0
+      , ( fpos (Field.Var.scale csq1 Params.cubic_non_residue) b0
         , fpos asq1 a1
         , fpos bsq1 c1 ) )
   end

--- a/src/lib/snarky_field_extensions/intf.ml
+++ b/src/lib/snarky_field_extensions/intf.ml
@@ -26,7 +26,7 @@ module type Basic = sig
       type t = Field.t t_
     end
 
-    type t = Field.Checked.t t_
+    type t = Field.Var.t t_
   end
 
   module A : Traversable_applicative with module Impl := Impl
@@ -51,7 +51,7 @@ module type Basic = sig
 
   val scale : t -> Field.t -> t
 
-  val mul_field : t -> Field.Checked.t -> (t, _) Checked.t
+  val mul_field : t -> Field.Var.t -> (t, _) Checked.t
 
   val assert_r1cs : t -> t -> t -> (unit, _) Checked.t
 

--- a/src/lib/snarky_pairing/g1_precomputation.ml
+++ b/src/lib/snarky_pairing/g1_precomputation.ml
@@ -5,9 +5,9 @@ module type S = sig
 
   open Impl
 
-  type t = {p: Field.Checked.t * Field.Checked.t; py_twist_squared: Fqe.t}
+  type t = {p: Field.Var.t * Field.Var.t; py_twist_squared: Fqe.t}
 
-  val create : Field.Checked.t * Field.Checked.t -> t
+  val create : Field.Var.t * Field.Var.t -> t
 end
 
 module Make
@@ -21,7 +21,7 @@ struct
   module Fqe = Fqe
   open Impl
 
-  type g1 = Field.Checked.t * Field.Checked.t
+  type g1 = Field.Var.t * Field.Var.t
 
   type t = {p: g1; py_twist_squared: Fqe.t}
 
@@ -29,6 +29,6 @@ struct
     let _, y = p in
     let twist_squared = Fqe.Unchecked.square Params.twist in
     { p
-    ; py_twist_squared=
-        Fqe.map_ twist_squared ~f:(fun c -> Field.Checked.scale y c) }
+    ; py_twist_squared= Fqe.map_ twist_squared ~f:(fun c -> Field.Var.scale y c)
+    }
 end

--- a/src/lib/snarky_pairing/g2_precomputation.ml
+++ b/src/lib/snarky_pairing/g2_precomputation.ml
@@ -39,7 +39,7 @@ struct
   type loop_state = {rx: Fqe.t; ry: Fqe.t}
 
   let length (a, b, c) =
-    let l = Field.Checked.length in
+    let l = Field.Var.length in
     max (l a) (max (l b) (l c))
 
   (* I verified using sage that if the input [s] satisfies ry^2 = rx^3 + a rx + b, then

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -918,7 +918,7 @@ let check_transaction_union sok_message source target transaction handler =
   let main =
     handle
       (Checked.map
-         (Base.main (Field.Checked.constant top_hash))
+         (Base.main (Field.Var.constant top_hash))
          ~f:As_prover.return)
       handler
   in

--- a/src/lib/vrf_lib/standalone.ml
+++ b/src/lib/vrf_lib/standalone.ml
@@ -407,7 +407,7 @@ let%test_module "vrf-test" =
     module Curve = struct
       open Impl
 
-      type var = Field.Checked.t * Field.Checked.t
+      type var = Field.Var.t * Field.Var.t
 
       include Snarky.Libsnark.Mnt6.Group
 


### PR DESCRIPTION
This PR renames `Field.var` to `Field.Var.t` and moves the unchecked functions on `Field.Var.t` into `Field.Var`.

Functions moved are: `length`, `var_indices`, `to_constant_and_terms`, `constant`, `to_constant`, `linear_combination`, `sum`, `add`, `sub` and `scale`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them: