### PR TITLE
make the genesis ledgers ephemeral

### DIFF
--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -59,7 +59,8 @@ module Db :
     (Storage_locations)
 
 module Null =
-  Null_ledger.Make (Public_key.Compressed) (Account) (Hash) (Location_at_depth) (Depth)
+  Null_ledger.Make (Public_key.Compressed) (Account) (Hash) (Location_at_depth)
+    (Depth)
 
 module Any_ledger :
   Merkle_ledger.Any_ledger.S

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -58,6 +58,9 @@ module Db :
     (Kvdb)
     (Storage_locations)
 
+module Null =
+  Null_ledger.Make (Public_key.Compressed) (Account) (Hash) (Location_at_depth) (Depth)
+
 module Any_ledger :
   Merkle_ledger.Any_ledger.S
   with module Location = Location_at_depth
@@ -124,6 +127,12 @@ let of_database db =
    shadow create in order to create an attached mask
 *)
 let create ?directory_name () = of_database (Db.create ?directory_name ())
+
+let create_ephemeral () =
+  let maskable = Null.create () in
+  let casted = Any_ledger.cast (module Null) maskable in
+  let mask = Mask.create () in
+  Maskable.register_mask casted mask
 
 let with_ledger ~f =
   let ledger = create () in

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -73,6 +73,8 @@ val with_ledger : f:(t -> 'a) -> 'a
 
 val create : ?directory_name:string -> unit -> t
 
+val create_ephemeral : unit -> t
+
 val of_database : Db.t -> t
 
 val copy : t -> t

--- a/src/lib/genesis_ledger/functor.ml
+++ b/src/lib/genesis_ledger/functor.ml
@@ -15,7 +15,7 @@ module Make_from_base (Base : Base_intf) : Intf.S = struct
   include Base
 
   let t =
-    let ledger = Ledger.create () in
+    let ledger = Ledger.create_ephemeral () in
     List.iter accounts ~f:(fun (_, account) ->
         let open Account in
         Ledger.create_new_account_exn ledger account.public_key account ) ;

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -1,0 +1,135 @@
+open Core_kernel
+
+module Make
+    (Key : Intf.Key)
+    (Account : Intf.Account with type key := Key.t)
+    (Hash : Intf.Hash with type account := Account.t)
+    (Location : Location_intf.S) (Depth : sig
+        val depth : int
+    end) :
+    sig
+    include Base_ledger_intf.S
+    with module Addr = Location.Addr
+    with module Location = Location
+    with type key := Key.t
+     and type key_set := Key.Set.t
+     and type hash := Hash.t
+     and type root_hash := Hash.t
+     and type account := Account.t
+
+    val create : unit -> t
+  end
+   = struct
+    type t = Core.Uuid.t [@@deriving sexp_of]
+
+    let t_of_sexp _ = failwith "t_of_sexp unimplemented"
+
+    type index = int
+
+    module Location = Location
+    module Path = Merkle_path.Make (Hash)
+
+    type path = Path.t
+
+    module Addr = Location.Addr
+
+    let create () = Core.Uuid.create ()
+
+    let remove_accounts_exn _t = failwith "null ledgers cannot be mutated"
+
+    let empty_hash_at_heights depth =
+      let empty_hash_at_heights =
+        Array.create ~len:(depth + 1) Hash.empty_account
+      in
+      let rec go i =
+        if i <= depth then (
+          let h = empty_hash_at_heights.(i - 1) in
+          empty_hash_at_heights.(i) <- Hash.merge ~height:(i - 1) h h ;
+          go (i + 1) )
+      in
+      go 1 ; empty_hash_at_heights
+
+    let memoized_empty_hash_at_height = empty_hash_at_heights Depth.depth
+
+    let empty_hash_at_height d = memoized_empty_hash_at_height.(d)
+
+    let merkle_path t location =
+      let location =
+        if Location.is_account location then
+          Location.Hash (Location.to_path_exn location)
+        else location
+      in
+      assert (Location.is_hash location) ;
+      let rec loop k =
+        let h = Location.height k in
+        if h >= Depth.depth then []
+        else
+        let sibling_dir = Location.last_direction (Location.to_path_exn k) in
+        let hash = empty_hash_at_height h in
+        Direction.map sibling_dir ~left:(`Left hash) ~right:(`Right hash)
+        :: loop (Location.parent k)
+      in
+      loop location
+
+    let merkle_root _t = empty_hash_at_height Depth.depth
+
+    let merkle_path_at_addr_exn t addr =
+      merkle_path t (Location.Hash addr)
+
+    let merkle_path_at_index_exn t index =
+      merkle_path_at_addr_exn t (Addr.of_int_exn index)
+
+    let index_of_key_exn _t = failwith "null ledgers are empty"
+
+    let set_at_index_exn _t = failwith "null ledgers cannot be mutated"
+
+    let get_at_index_exn _t = failwith "null ledgers are empty"
+
+    let set_batch _t = failwith "null ledgers cannot be mutated"
+
+    let set _t = failwith "null ledgers cannot be mutated"
+
+    let get _t _loc = None
+
+    let get_uuid t = t
+
+    let last_filled _t = None
+
+    let close _t = ()
+
+    let get_or_create_account_exn _t =
+      failwith "null ledgers cannot be mutated"
+
+    let get_or_create_account _t =
+      failwith "null ledgers cannot be mutated"
+
+    let location_of_key _t _ = None
+
+    let fold_until _t ~init ~f:_ ~finish = finish init
+
+    let foldi_with_ignored_keys _t _ ~init ~f:_ = init
+
+    let foldi _t ~init ~f:_ = init
+
+    let to_list _t = []
+
+    let make_space_for _t _tot = ()
+
+    let get_all_accounts_rooted_at_exn _t addr =
+      List.init (1 lsl (Addr.height addr)) ~f:(Fn.const Account.empty)
+
+    let set_all_accounts_rooted_at_exn _t =
+      failwith "null ledgers cannot be mutated"
+
+    let set_inner_hash_at_addr_exn _t =
+      failwith "null ledgers cannot be mutated"
+
+    let get_inner_hash_at_addr_exn _t =
+      failwith "null ledgers are empty"
+
+    let num_accounts _t = failwith "intentionally unimplemented"
+
+    (* This better be the same depth inside Base or you're going to have a bad
+     * time *)
+    let depth = Depth.depth
+  end

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -6,9 +6,9 @@ module Make
     (Hash : Intf.Hash with type account := Account.t)
     (Location : Location_intf.S) (Depth : sig
         val depth : int
-    end) :
-    sig
-    include Base_ledger_intf.S
+    end) : sig
+  include
+    Base_ledger_intf.S
     with module Addr = Location.Addr
     with module Location = Location
     with type key := Key.t
@@ -17,119 +17,113 @@ module Make
      and type root_hash := Hash.t
      and type account := Account.t
 
-    val create : unit -> t
-  end
-   = struct
-    type t = Core.Uuid.t [@@deriving sexp_of]
+  val create : unit -> t
+end = struct
+  type t = Core.Uuid.t [@@deriving sexp_of]
 
-    let t_of_sexp _ = failwith "t_of_sexp unimplemented"
+  let t_of_sexp _ = failwith "t_of_sexp unimplemented"
 
-    type index = int
+  type index = int
 
-    module Location = Location
-    module Path = Merkle_path.Make (Hash)
+  module Location = Location
+  module Path = Merkle_path.Make (Hash)
 
-    type path = Path.t
+  type path = Path.t
 
-    module Addr = Location.Addr
+  module Addr = Location.Addr
 
-    let create () = Core.Uuid.create ()
+  let create () = Core.Uuid.create ()
 
-    let remove_accounts_exn _t = failwith "null ledgers cannot be mutated"
+  let remove_accounts_exn _t = failwith "null ledgers cannot be mutated"
 
-    let empty_hash_at_heights depth =
-      let empty_hash_at_heights =
-        Array.create ~len:(depth + 1) Hash.empty_account
-      in
-      let rec go i =
-        if i <= depth then (
-          let h = empty_hash_at_heights.(i - 1) in
-          empty_hash_at_heights.(i) <- Hash.merge ~height:(i - 1) h h ;
-          go (i + 1) )
-      in
-      go 1 ; empty_hash_at_heights
+  let empty_hash_at_heights depth =
+    let empty_hash_at_heights =
+      Array.create ~len:(depth + 1) Hash.empty_account
+    in
+    let rec go i =
+      if i <= depth then (
+        let h = empty_hash_at_heights.(i - 1) in
+        empty_hash_at_heights.(i) <- Hash.merge ~height:(i - 1) h h ;
+        go (i + 1) )
+    in
+    go 1 ; empty_hash_at_heights
 
-    let memoized_empty_hash_at_height = empty_hash_at_heights Depth.depth
+  let memoized_empty_hash_at_height = empty_hash_at_heights Depth.depth
 
-    let empty_hash_at_height d = memoized_empty_hash_at_height.(d)
+  let empty_hash_at_height d = memoized_empty_hash_at_height.(d)
 
-    let merkle_path t location =
-      let location =
-        if Location.is_account location then
-          Location.Hash (Location.to_path_exn location)
-        else location
-      in
-      assert (Location.is_hash location) ;
-      let rec loop k =
-        let h = Location.height k in
-        if h >= Depth.depth then []
-        else
+  let merkle_path t location =
+    let location =
+      if Location.is_account location then
+        Location.Hash (Location.to_path_exn location)
+      else location
+    in
+    assert (Location.is_hash location) ;
+    let rec loop k =
+      let h = Location.height k in
+      if h >= Depth.depth then []
+      else
         let sibling_dir = Location.last_direction (Location.to_path_exn k) in
         let hash = empty_hash_at_height h in
         Direction.map sibling_dir ~left:(`Left hash) ~right:(`Right hash)
         :: loop (Location.parent k)
-      in
-      loop location
+    in
+    loop location
 
-    let merkle_root _t = empty_hash_at_height Depth.depth
+  let merkle_root _t = empty_hash_at_height Depth.depth
 
-    let merkle_path_at_addr_exn t addr =
-      merkle_path t (Location.Hash addr)
+  let merkle_path_at_addr_exn t addr = merkle_path t (Location.Hash addr)
 
-    let merkle_path_at_index_exn t index =
-      merkle_path_at_addr_exn t (Addr.of_int_exn index)
+  let merkle_path_at_index_exn t index =
+    merkle_path_at_addr_exn t (Addr.of_int_exn index)
 
-    let index_of_key_exn _t = failwith "null ledgers are empty"
+  let index_of_key_exn _t = failwith "null ledgers are empty"
 
-    let set_at_index_exn _t = failwith "null ledgers cannot be mutated"
+  let set_at_index_exn _t = failwith "null ledgers cannot be mutated"
 
-    let get_at_index_exn _t = failwith "null ledgers are empty"
+  let get_at_index_exn _t = failwith "null ledgers are empty"
 
-    let set_batch _t = failwith "null ledgers cannot be mutated"
+  let set_batch _t = failwith "null ledgers cannot be mutated"
 
-    let set _t = failwith "null ledgers cannot be mutated"
+  let set _t = failwith "null ledgers cannot be mutated"
 
-    let get _t _loc = None
+  let get _t _loc = None
 
-    let get_uuid t = t
+  let get_uuid t = t
 
-    let last_filled _t = None
+  let last_filled _t = None
 
-    let close _t = ()
+  let close _t = ()
 
-    let get_or_create_account_exn _t =
-      failwith "null ledgers cannot be mutated"
+  let get_or_create_account_exn _t = failwith "null ledgers cannot be mutated"
 
-    let get_or_create_account _t =
-      failwith "null ledgers cannot be mutated"
+  let get_or_create_account _t = failwith "null ledgers cannot be mutated"
 
-    let location_of_key _t _ = None
+  let location_of_key _t _ = None
 
-    let fold_until _t ~init ~f:_ ~finish = finish init
+  let fold_until _t ~init ~f:_ ~finish = finish init
 
-    let foldi_with_ignored_keys _t _ ~init ~f:_ = init
+  let foldi_with_ignored_keys _t _ ~init ~f:_ = init
 
-    let foldi _t ~init ~f:_ = init
+  let foldi _t ~init ~f:_ = init
 
-    let to_list _t = []
+  let to_list _t = []
 
-    let make_space_for _t _tot = ()
+  let make_space_for _t _tot = ()
 
-    let get_all_accounts_rooted_at_exn _t addr =
-      List.init (1 lsl (Addr.height addr)) ~f:(Fn.const Account.empty)
+  let get_all_accounts_rooted_at_exn _t addr =
+    List.init (1 lsl Addr.height addr) ~f:(Fn.const Account.empty)
 
-    let set_all_accounts_rooted_at_exn _t =
-      failwith "null ledgers cannot be mutated"
+  let set_all_accounts_rooted_at_exn _t =
+    failwith "null ledgers cannot be mutated"
 
-    let set_inner_hash_at_addr_exn _t =
-      failwith "null ledgers cannot be mutated"
+  let set_inner_hash_at_addr_exn _t = failwith "null ledgers cannot be mutated"
 
-    let get_inner_hash_at_addr_exn _t =
-      failwith "null ledgers are empty"
+  let get_inner_hash_at_addr_exn _t = failwith "null ledgers are empty"
 
-    let num_accounts _t = failwith "intentionally unimplemented"
+  let num_accounts _t = failwith "intentionally unimplemented"
 
-    (* This better be the same depth inside Base or you're going to have a bad
+  (* This better be the same depth inside Base or you're going to have a bad
      * time *)
-    let depth = Depth.depth
-  end
+  let depth = Depth.depth
+end

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -34,7 +34,7 @@ end = struct
 
   let create () = Core.Uuid.create ()
 
-  let remove_accounts_exn _t = failwith "null ledgers cannot be mutated"
+  let remove_accounts_exn _t = failwith "remove_accounts_exn: null ledgers cannot be mutated"
 
   let empty_hash_at_heights depth =
     let empty_hash_at_heights =
@@ -77,15 +77,15 @@ end = struct
   let merkle_path_at_index_exn t index =
     merkle_path_at_addr_exn t (Addr.of_int_exn index)
 
-  let index_of_key_exn _t = failwith "null ledgers are empty"
+  let index_of_key_exn _t = failwith "index_of_key_exn: null ledgers are empty"
 
-  let set_at_index_exn _t = failwith "null ledgers cannot be mutated"
+  let set_at_index_exn _t = failwith "set_at_index_exn: null ledgers cannot be mutated"
 
-  let get_at_index_exn _t = failwith "null ledgers are empty"
+  let get_at_index_exn _t = failwith "get_at_index_exn: null ledgers are empty"
 
-  let set_batch _t = failwith "null ledgers cannot be mutated"
+  let set_batch _t = failwith "set_batch: null ledgers cannot be mutated"
 
-  let set _t = failwith "null ledgers cannot be mutated"
+  let set _t = failwith "set: null ledgers cannot be mutated"
 
   let get _t _loc = None
 
@@ -95,9 +95,9 @@ end = struct
 
   let close _t = ()
 
-  let get_or_create_account_exn _t = failwith "null ledgers cannot be mutated"
+  let get_or_create_account_exn _t = failwith "get_or_create_accoutn_exn: null ledgers cannot be mutated"
 
-  let get_or_create_account _t = failwith "null ledgers cannot be mutated"
+  let get_or_create_account _t = failwith "get_or_create_account: null ledgers cannot be mutated"
 
   let location_of_key _t _ = None
 
@@ -115,9 +115,9 @@ end = struct
     List.init (1 lsl Addr.height addr) ~f:(Fn.const Account.empty)
 
   let set_all_accounts_rooted_at_exn _t =
-    failwith "null ledgers cannot be mutated"
+    failwith "set_all_accounts_rooted_at_exn: null ledgers cannot be mutated"
 
-  let set_inner_hash_at_addr_exn _t = failwith "null ledgers cannot be mutated"
+  let set_inner_hash_at_addr_exn _t = failwith "set_inner_hash_at_addr_exn: null ledgers cannot be mutated"
 
   let get_inner_hash_at_addr_exn _t = failwith "null ledgers are empty"
 

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -98,7 +98,7 @@ end = struct
   let close _t = ()
 
   let get_or_create_account_exn _t =
-    failwith "get_or_create_accoutn_exn: null ledgers cannot be mutated"
+    failwith "get_or_create_account_exn: null ledgers cannot be mutated"
 
   let get_or_create_account _t =
     failwith "get_or_create_account: null ledgers cannot be mutated"

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -119,9 +119,9 @@ end = struct
 
   let set_inner_hash_at_addr_exn _t = failwith "set_inner_hash_at_addr_exn: null ledgers cannot be mutated"
 
-  let get_inner_hash_at_addr_exn _t = failwith "null ledgers are empty"
+  let get_inner_hash_at_addr_exn _t addr = empty_hash_at_height (Addr.height addr)
 
-  let num_accounts _t = failwith "intentionally unimplemented"
+  let num_accounts _t = 0
 
   (* This better be the same depth inside Base or you're going to have a bad
      * time *)

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -53,7 +53,7 @@ end = struct
 
   let empty_hash_at_height d = memoized_empty_hash_at_height.(d)
 
-  let merkle_path t location =
+  let merkle_path _t location =
     let location =
       if Location.is_account location then
         Location.Hash (Location.to_path_exn location)

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -34,7 +34,8 @@ end = struct
 
   let create () = Core.Uuid.create ()
 
-  let remove_accounts_exn _t = failwith "remove_accounts_exn: null ledgers cannot be mutated"
+  let remove_accounts_exn _t =
+    failwith "remove_accounts_exn: null ledgers cannot be mutated"
 
   let empty_hash_at_heights depth =
     let empty_hash_at_heights =
@@ -79,7 +80,8 @@ end = struct
 
   let index_of_key_exn _t = failwith "index_of_key_exn: null ledgers are empty"
 
-  let set_at_index_exn _t = failwith "set_at_index_exn: null ledgers cannot be mutated"
+  let set_at_index_exn _t =
+    failwith "set_at_index_exn: null ledgers cannot be mutated"
 
   let get_at_index_exn _t = failwith "get_at_index_exn: null ledgers are empty"
 
@@ -95,9 +97,11 @@ end = struct
 
   let close _t = ()
 
-  let get_or_create_account_exn _t = failwith "get_or_create_accoutn_exn: null ledgers cannot be mutated"
+  let get_or_create_account_exn _t =
+    failwith "get_or_create_accoutn_exn: null ledgers cannot be mutated"
 
-  let get_or_create_account _t = failwith "get_or_create_account: null ledgers cannot be mutated"
+  let get_or_create_account _t =
+    failwith "get_or_create_account: null ledgers cannot be mutated"
 
   let location_of_key _t _ = None
 
@@ -117,9 +121,11 @@ end = struct
   let set_all_accounts_rooted_at_exn _t =
     failwith "set_all_accounts_rooted_at_exn: null ledgers cannot be mutated"
 
-  let set_inner_hash_at_addr_exn _t = failwith "set_inner_hash_at_addr_exn: null ledgers cannot be mutated"
+  let set_inner_hash_at_addr_exn _t =
+    failwith "set_inner_hash_at_addr_exn: null ledgers cannot be mutated"
 
-  let get_inner_hash_at_addr_exn _t addr = empty_hash_at_height (Addr.height addr)
+  let get_inner_hash_at_addr_exn _t addr =
+    empty_hash_at_height (Addr.height addr)
 
   let num_accounts _t = 0
 

--- a/src/lib/merkle_ledger/null_ledger.ml
+++ b/src/lib/merkle_ledger/null_ledger.ml
@@ -123,7 +123,5 @@ end = struct
 
   let num_accounts _t = 0
 
-  (* This better be the same depth inside Base or you're going to have a bad
-     * time *)
   let depth = Depth.depth
 end


### PR DESCRIPTION
Implemented as a mask on top of a 'null ledger', which is
the ledger you can't add accounts to. This prevents writing
ledger dbs outside of the conf dir. There's no reason these
shouldn't be in memory anyway.

I edited https://github.com/CodaProtocol/coda/issues/872 to include testing what this fixes.

Tested by running `coda daemon` and seeing that it wasn't writing UUID directories to cwd.