### PR TITLE
MacOS supported fork of rpc_parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     tracetool:
         docker:
-            - image: codaprotocol/coda:toolchain-rust-a5cc8a0501bef5075fe614d2246153d42a67e49f
+            - image: codaprotocol/coda:toolchain-rust-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -13,7 +13,7 @@ jobs:
     build:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -40,7 +40,7 @@ jobs:
     build_withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -67,7 +67,7 @@ jobs:
     build_public:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -85,7 +85,7 @@ jobs:
     test-unit-test:
        resource_class: large
        docker:
-       - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+       - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
        steps:
            - checkout
            - run:
@@ -95,7 +95,7 @@ jobs:
     test-withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -109,7 +109,7 @@ jobs:
     test-all_sig_integration_tests:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+      - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
       steps:
           - checkout
           - run:
@@ -150,7 +150,7 @@ jobs:
     test-all_stake_integration_tests:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+      - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
       steps:
           - checkout
           - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -3,7 +3,7 @@ version: 2
 jobs:
     tracetool:
         docker:
-            - image: codaprotocol/coda:toolchain-rust-a5cc8a0501bef5075fe614d2246153d42a67e49f
+            - image: codaprotocol/coda:toolchain-rust-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -13,7 +13,7 @@ jobs:
     build:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -40,7 +40,7 @@ jobs:
     build_withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -67,7 +67,7 @@ jobs:
     build_public:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -85,7 +85,7 @@ jobs:
     test-unit-test:
        resource_class: large
        docker:
-       - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+       - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
        steps:
            - checkout
            - run:
@@ -95,7 +95,7 @@ jobs:
     test-withsnark:
         resource_class: large
         docker:
-        - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+        - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
         steps:
             - checkout
             - run:
@@ -109,7 +109,7 @@ jobs:
     test-{{test.name}}:
       resource_class: large
       docker:
-      - image: codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+      - image: codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
       steps:
           - checkout
           - run:

--- a/README-dev.md
+++ b/README-dev.md
@@ -40,7 +40,7 @@ Now you'll have a `src/_build/codaclient.deb` ready to install on Ubuntu or Debi
 
 * Pull down developer container image  (~2GB download, go stretch your legs)
 
-`docker pull codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f`
+`docker pull codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91`
 
 * Create local builder image
 

--- a/README-dev.md
+++ b/README-dev.md
@@ -131,6 +131,7 @@ with `dune`, so you need to add them manually:
 * `opam pin add src/external/ocaml-sodium`
 * `opam pin add src/external/ocaml-rocksdb`
 * `opam pin add src/external/ocaml-dune`
+* `opam pin add src/external/rpc_parallel`
 
 There are a variety of C libraries we expect to be available in the system.
 These are also listed in the dockerfiles. Unlike most of the C libraries,

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM codaprotocol/coda:toolchain-a5cc8a0501bef5075fe614d2246153d42a67e49f
+FROM codaprotocol/coda:toolchain-5b183eb006ea0bf720c8f14965c31f7890909e91
 
 ENV OPAM_DIR             "/home/opam/.opam/4.07"
 ENV PATH                 "${OPAM_DIR}/bin:$PATH"

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -53,6 +53,10 @@ RUN opam switch import opam.export ; rm opam.export
 ADD /src/external/ocaml-sodium /ocaml-sodium
 RUN cd /ocaml-sodium && yes | opam pin add .
 
+# Source copy of rpc_parallel (modified for macOS support)
+ADD /src/external/rpc_parallel /rpc_parallel
+RUN cd /rpc_parallel && yes | opam pin add .
+
 # Install local copy of ocaml-rocksdb (exposes opaque types)
 RUN cd /ocaml-rocksdb && yes | opam pin add .
 

--- a/dockerfiles/Dockerfile-toolchain-haskell
+++ b/dockerfiles/Dockerfile-toolchain-haskell
@@ -5,6 +5,10 @@ FROM nixos/nix:latest
 # Add OS tools
 RUN apk add patchelf dpkg tar
 
+# Update nixkgs
+RUN nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+RUN nix-channel --update
+
 # Source tree nix-built haskell kademlia
 ADD /src/app/kademlia-haskell /src
 

--- a/src/external/rpc_parallel/.gitignore
+++ b/src/external/rpc_parallel/.gitignore
@@ -1,0 +1,4 @@
+_build
+*.install
+*.merlin
+

--- a/src/external/rpc_parallel/CHANGES.md
+++ b/src/external/rpc_parallel/CHANGES.md
@@ -1,0 +1,204 @@
+## v0.10
+
+- Changed the API to make the shutdown behavior of workers more explicit
+
+## v0.9
+
+## 113.43.00
+
+- Take away `@@deriving bin_io` for managed workers.
+
+- Introduce a `spawn_in_foreground` function that returns a `Process.t` along with the worker.
+
+  Also use this opportunity to clean up the handling of file descriptors in the `spawn` case as well.
+
+- Add a couple features to Rpc\_parallel to make debugging connection issues
+  easier.
+
+  * Add `Worker.Connection.close_reason`
+  * Add `Worker.Connection.sexp_of_t`
+
+
+- Add some extra security around making Rpc calls to workers.
+
+  Because we do not expose the port of a worker, unless you do really
+  hacky things, you are going to go through Rpc\_parallel when running
+  Rpcs.  When Rpc\_parallel connects to a worker, it initializes a
+  connection state (that includes the worker state). This
+  initialization would raise if the worker did not have a server
+  listening on the port that the client was talking to. Add some
+  security by enforcing unification of worker\_ids instead of ports
+  (which will be reused by the OS).
+
+- Make an Rpc_parallel test case deterministic
+
+## 113.33.00
+
+- Adding the mandatory arguments `redirect_stderr` and `redirect_stdout` to `Map_reduce` so it is easier to debug your workers.
+  Also removed `spawn_exn` in favor of only exposing `spawn_config_exn`. If you want to spawn a single worker, make a config of one worker.
+
+- Cleans up the implementation-side interface for aborting `Pipe_rpc`s.
+
+  Summary
+
+  The `aborted` `Deferred.t` that got passed to `Pipe_rpc` implementations is
+  gone. The situations where it would have been determined now close the reading
+  end of the user-supplied pipe instead.
+
+  Details
+
+  Previously, when an RPC dispatcher decided to abort a query, the RPC
+  implementation would get its `aborted` `Deferred.t` filled in, but would remain
+  free to write some final elements to the pipe.
+
+  This is a little bit more flexible than the new interface, but it's also
+  problematic in that the implementer could easily just not pay attention to
+  `aborted`. (They're not obligated to pay attention to when the pipe is closed,
+  either, but at least they can't keep writing to it.) We don't think the extra
+  flexibility was used at all.
+
+  In the future, we may also simplify the client side to remove the `abort`
+  function on the dispatch side (at least when not using `dispatch_iter`). For the
+  time being it remains, but closing the received pipe is the preferred way of
+  aborting the query.
+
+  There are a couple of known ways this might have changed behavior from before.
+  Both of these appear not to cause problems in the jane repo.
+
+  - In the past, an implementation could write to a pipe as long as the client
+    didn't disconnect, even if it closed its pipe. Now writes will raise after
+    a client closes its pipe (or calls `abort`), since the implementor's pipe will
+    also be closed in this case. Doing this was already unsafe, though, since the
+    pipe *was* closed if the RPC connection was closed.
+
+  - `aborted` was only determined if a client aborted the query or the connection
+    was closed. The new alternative, `Pipe.closed` called on the returned pipe,
+    will also be determined if the implementation closes the pipe itself. This is
+    unlikely to cause serious issues but could potentially cause some confusing
+    logging.
+
+- Deal with an fd leak in Managed worker connections
+
+- This feature completely restructured `rpc_parallel` to make it more
+  transparent in what it does and doesn't do. I offloaded all the
+  connection management and cleanup responsibilities to the user.
+
+  What `Rpc_parallel` used to do for you:
+  ------------------------------------
+   - Internally there was a special (behind the scenes) Rpc connection
+     maintained between the worker and its master upon spawn. Upon this
+     connection closing, the worker would shut itself down and the
+     master would be notified of a connection lost.
+   - We would keep a connection table for you. `run` was called on the
+     worker type (i.e. a host and port) because it's implementation
+     would get a connection (using an existing one or doing a
+     `Rpc.Connection.client`).
+
+  What it now does:
+  -----------------
+   - No special Rpc connection is maintained, so all cleanup is the job
+     of the user
+   - No internal connection table. `run` is called on a connection type,
+     so you have to manage connections yourself
+   - Exposes connection states (unique to each connection) along with
+     worker states (shared between connections)
+   - There is an explicit `Managed` module that does connection
+     management for you
+   - There is an explicit `Heartbeater` type that can be used in spawned
+     workers to connect to their master and handle cleanup
+
+- There was a race condition where `spawn` would return a `Worker.t` even though the worker had not daemonized yet.
+  This manifested itself in a spurious test case failure.
+
+  This also allowed for running the worker initialization code before we daemonize.
+
+- Reuse the master rpc settings when the worker connects using the `Heartbeater` module
+
+- Make all global state and rpc servers lazy.
+
+  Namely:
+  1) Toplevel hashtables are initialized with size 1 to reduce overhead due to linking with `Rpc_parallel`
+  2) The master rpc server is only started upon the first call to spawn
+
+
+- Fixed a `Rpc_parallel` bug that caused a Master to Worker call to never return.
+
+- Add new functions `spawn_and_connect` and `spawn_and_connection_exn` which return back the worker and a connection to the worker.
+
+  Also, move all the example code off of the managed module
+
+- Some refactoring:
+
+  1) Take `serve` out of the `Connection` module. It shouldn't be in there because it does nothing with the `Connection.t` type
+  2) Remove some unnecessary functions defined on `Connection.t`'s. E.g. no longer expose `close_reason` because all the exception handling will be done with the registered exn handlers.
+  3) Move `Rpc_settings` module
+  4) Separate `global_state` into `as_worker` and `as_master`
+  5) Some cleanup with how we are managing worker ids
+  6) create a record type for `Init_connection_state_rpc.query`
+
+## 113.24.00
+
+- Switched to PPX.
+
+- Expose the `connection_timeout` argument in rpc\_parallel. This argument
+  exists in `Rpc_parallel_core.Parallel`, but it is not exposed in
+  `Rpc_parallel.Parallel`.
+
+- Allow custom handling of missed async\_rpc heartbeats.
+
+- Give a better error message when redirecting output on a remote box to a file
+  path that does not exist.
+
+- remove unncessary chmod 700 call on the remote executable
+
+- Give a clear error message for the common mistake of not making the
+  `Parallel.Make_worker()` functor application top-level
+
+- Make errors/exceptions in `Rpc_parallel` more observable
+
+  - Make stderr and stdout redirection mandatory in order to encourage logging stderr
+  - Clean up the use of monitors across `Rpc_parallel`
+  - Fix bug with exceptions that are sent directly to `Monitor.main`
+    (e.g. `Async_log` does this)
+
+- Add the ability to explicitly initialize as a master and use some subcommand for the
+  worker. This would allow writing programs with complex command structures that don't have
+  to invoke a bunch of `Rpc_parallel` logic and start RPC servers for every command.
+
+
+- Add the ability to get log messages from a worker sent back to the master.
+  In fact, any worker can register for the log messages of any other workers.
+
+## 113.00.00
+
+- Fixed a file-descriptor leak
+
+    There was a file descriptor leak when killing workers.  Their stdin,
+    stdout, and stderr remain open. We now close them after the worker process
+    exits.
+
+## 112.24.00
+
+- Added `Parallel.State.get` function, to check whether `Rpc_parallel` has been
+  initialized correctly.
+- Added `Map_reduce` module, which is an easy-to-use parallel map/reduce library.
+
+  It can be used to map/fold over a list while utilizing multiple cores on multiple machines.
+
+  Also added support for workers to keep their own inner state.
+
+- Fixed bug in which  zombie process was created per spawned worker.
+
+  Also fixed shutdown on remote workers
+
+- Made it possible for workers to spawn other workers, i.e.  act as masters.
+
+- Made the connection timeout configurable and bumped the default to 10s.
+
+## 112.17.00
+
+- Follow changes in Async RPC
+
+## 112.01.00
+
+Initial import.

--- a/src/external/rpc_parallel/LICENSE.txt
+++ b/src/external/rpc_parallel/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/external/rpc_parallel/Makefile
+++ b/src/external/rpc_parallel/Makefile
@@ -1,0 +1,18 @@
+INSTALL_ARGS := $(if $(PREFIX),--prefix $(PREFIX),)
+
+# Default rule
+default:
+	jbuilder build @install
+
+install:
+	jbuilder install $(INSTALL_ARGS)
+
+uninstall:
+	jbuilder uninstall $(INSTALL_ARGS)
+
+reinstall: uninstall reinstall
+
+clean:
+	rm -rf _build
+
+.PHONY: default install uninstall reinstall clean

--- a/src/external/rpc_parallel/README.org
+++ b/src/external/rpc_parallel/README.org
@@ -1,0 +1,56 @@
+# Mental Model
+
+- =Worker.t= identifies a worker rpc server
+- =spawn= (=serve=) starts a worker Rpc server in another process (the same
+  process)
+- =client= connects to a worker Rpc server
+- =run= dispatches on a connection to a worker Rpc server
+
+# Top-level
+
+It is highly recommended for =Rpc\_parallel.start\_app= and =Rpc\_parallel.Make=
+calls to be top-level. But the real requirements are:
+
+1) The master's state is initialized before any calls to =spawn=. This will be
+   achieved either by =Rpc\_parallel.start\_app= or
+   =Rpc\_parallel.Expert.start\_master\_server\_exn=.
+
+2) Spawned workers (runs of your executable with a certain environment variable
+   set) must start running as a worker. This will be achieved either by
+   =Rpc\_parallel.start\_app= or =Rpc\_parallel.Expert.worker\_command=.
+
+3) Spawned workers must be able to find their function implementations when they
+   start running as a worker. These implementations are gathered on the
+   application of the =Rpc\_parallel.Make= functor.
+
+4) The worker implementations must be defined completely and in the same order,
+   regardless of master and worker code paths. This is necessary for the masters
+   and workers to agree on certain generated ids.
+
+# Monitoring your workers
+
+Uncaught exceptions in workers will always result in the worker shutting down.
+The master can be notified of these exceptions in multiple ways:
+
+- If the exception occured in a function implementation =f= before =f= is
+  determined, the exception will be returned back to the caller. E.g. the caller
+  of =spawn= or =run= will get an =Error.t= describing the exception.
+
+- If the exception occured after =f= is determined, =on\_failure exn= will be
+  called (in =Monitor.current ()= at the time of =spawn=) in the spawning
+  process.
+
+- If =redirect\_stderr= specifies a file, the worker will also write its
+  exception to that file before shutting down.
+
+# Optional Rpc Settings
+
+The master's Rpc server will be started with the =max\_message\_size=,
+=heartbeat\_config=, and =handshake\_timeout= settings passed in to
+=start\_app=/=init\_master\_exn=.
+
+Each worker's Rpc server will be started with the settings passed in upon
+=spawn= or =serve= of that worker.
+
+All =client= calls will use the corresponding Rpc settings for the given
+worker/master that it is connecting to.

--- a/src/external/rpc_parallel/example/add_numbers.ml
+++ b/src/external/rpc_parallel/example/add_numbers.ml
@@ -1,0 +1,63 @@
+open Core
+open Async
+
+module Add_numbers_map_function = Rpc_parallel.Map_reduce.Make_map_function(struct
+    module Input = struct
+      type t = int * int [@@deriving bin_io]
+    end
+    module Output = struct
+      type t = int * int [@@deriving bin_io]
+    end
+
+    let rec spin ntimes =
+      match ntimes with
+      | 0 -> ()
+      | _ -> spin (ntimes - 1)
+
+    let map (index, max) =
+      spin 100000000; (* Waste some CPU time *)
+      return (index, (List.fold ~init:0 ~f:(+) (List.init max ~f:Fn.id)))
+  end)
+
+let command =
+  Command.async_spec ~summary:"Add numbers in parallel"
+    Command.Spec.(
+      empty
+      +> flag "max" (required int) ~doc:" Number to add up to"
+      +> flag "ntimes" (optional_with_default 1000 int)
+           ~doc:" Number of times to repeat the operation"
+      +> flag "nworkers" (optional_with_default 4 int) ~doc:" Number of workers"
+      +> flag "ordered" (optional_with_default true bool) ~doc:" Ordered or unordered"
+    )
+    (fun max ntimes nworkers ordered () ->
+       let list = (Pipe.of_list (List.init ntimes ~f:(fun i -> (i, max)))) in
+       let config =
+         Rpc_parallel.Map_reduce.Config.create ~local:nworkers
+           ~redirect_stderr:`Dev_null ~redirect_stdout:`Dev_null ()
+       in
+       if ordered then
+         (Rpc_parallel.Map_reduce.map
+            config
+            list
+            ~m:(module Add_numbers_map_function)
+            ~param:()
+          >>= fun output_reader ->
+          Pipe.iter output_reader ~f:(fun (index, sum) ->
+            printf "%i: %i\n" index sum;
+            Deferred.unit
+          ))
+       else
+         (Rpc_parallel.Map_reduce.map_unordered
+            config
+            list
+            ~m:(module Add_numbers_map_function)
+            ~param:()
+          >>= fun output_reader ->
+          Pipe.iter output_reader ~f:(fun ((index, sum), mf_index) ->
+            assert (index = mf_index);
+            printf "%i:%i: %i\n" mf_index index sum;
+            Deferred.unit
+          ))
+    )
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/alternative_init.ml
+++ b/src/external/rpc_parallel/example/alternative_init.ml
@@ -1,0 +1,70 @@
+open Core
+open Async
+
+module Worker = struct
+  module T = struct
+    type 'worker functions = unit
+
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      let functions = ()
+
+      let init_worker_state () = Deferred.unit
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make(T)
+end
+
+let worker_command =
+  let open Command.Let_syntax in
+  Command.Staged.async
+    ~summary:"for internal use"
+    [%map_open
+      let () = return ()
+      in
+      fun () ->
+        let worker_env = Rpc_parallel.Expert.worker_init_before_async_exn () in
+        stage (fun `Scheduler_started ->
+          Rpc_parallel.Expert.start_worker_server_exn worker_env;
+          Deferred.never ())
+    ]
+
+let main_command =
+  let open Command.Let_syntax in
+  Command.async
+    ~summary:"start the master and spawn a worker"
+    [%map_open
+      let () = return ()
+      in
+      fun () ->
+        Rpc_parallel.Expert.start_master_server_exn ~worker_command_args:["worker"] ();
+        Worker.spawn_exn ~on_failure:Error.raise
+          ~shutdown_on:Disconnect
+          ~connection_state_init_arg:()
+          ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null ()
+        >>| fun (_connection : Worker.Connection.t) ->
+        printf "Success.\n"
+    ]
+
+let command =
+  Command.group
+    ~summary:"Using Rpc_parallel.Expert"
+    [ "worker", worker_command
+    ; "main", main_command
+    ]
+
+let () = Command.run command

--- a/src/external/rpc_parallel/example/async_log.ml
+++ b/src/external/rpc_parallel/example/async_log.ml
@@ -1,0 +1,74 @@
+open Core
+open Async
+
+module Worker = struct
+  module T = struct
+    type 'worker functions =
+      { write_to_log_global : ('worker, unit, unit) Rpc_parallel.Function.t }
+
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions (C : Rpc_parallel.Creator) = struct
+      let write_to_log_global =
+        C.create_rpc ~bin_input:Unit.bin_t ~bin_output:Unit.bin_t
+          ~f:(fun ~worker_state:_ ~conn_state:_ () ->
+            Log.Global.info "worker log message";
+            Log.Global.flushed ())
+          ()
+      ;;
+
+      let functions = { write_to_log_global }
+
+      let init_worker_state () = Deferred.unit
+      ;;
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make(T)
+end
+
+let expect_log_entry readers =
+  Deferred.List.iter readers ~f:(fun reader ->
+    match%map Pipe.read reader with
+    | `Eof -> failwith "Unexpected EOF"
+    | `Ok entry ->
+      printf !"%{sexp:Log.Message.Stable.V2.t}\n" entry)
+;;
+
+let main () =
+  let%bind worker =
+    Worker.spawn_exn ~on_failure:Error.raise
+      ~shutdown_on:Heartbeater_timeout
+      ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null ()
+  in
+  let%bind conn = Worker.Connection.client_exn worker () in
+  let get_log_reader () =
+    Worker.Connection.run_exn conn ~f:Rpc_parallel.Function.async_log ~arg:()
+  in
+  let worker_write_to_log_global () =
+    Worker.Connection.run_exn conn ~f:Worker.functions.write_to_log_global ~arg:()
+  in
+  let%bind log_reader1 = get_log_reader () in
+  let%bind log_reader2 = get_log_reader () in
+  let%bind () = worker_write_to_log_global () in
+  let%bind () = expect_log_entry [log_reader1; log_reader2] in
+  Pipe.close_read log_reader1;
+  let%bind () = worker_write_to_log_global () in
+  expect_log_entry [log_reader2]
+;;
+
+let command =
+  Command.async ~summary:"Using the built in log redirection function"
+    (Command.Param.return main)
+;;
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/jbuild
+++ b/src/external/rpc_parallel/example/jbuild
@@ -1,0 +1,19 @@
+(executables (
+  (names (
+    add_numbers
+    alternative_init
+    async_log
+    number_stats
+    reverse_pipe
+    rpc_direct_pipe
+    serve
+    side_arg
+    simple
+    spawn_in_foreground
+    stream_workers
+    worker_binprot
+    workers_as_masters))
+  (libraries (async core jane rpc_parallel sexp_app sexplib))
+  (preprocess (pps (ppx_jane ppxlib.runner)))))
+
+(jbuild_version 1)

--- a/src/external/rpc_parallel/example/number_stats.ml
+++ b/src/external/rpc_parallel/example/number_stats.ml
@@ -1,0 +1,88 @@
+open Jane
+open Async
+
+module Generate_random_map_function =
+  Rpc_parallel.Map_reduce.Make_map_function_with_init(struct
+    type state_type = unit
+    module Param = struct
+      type t = unit [@@deriving bin_io]
+    end
+    module Input = struct
+      type t = unit [@@deriving bin_io]
+    end
+    module Output = struct
+      type t = float array [@@deriving bin_io]
+    end
+
+    let init () =
+      Random.self_init ();
+      Deferred.unit
+    let map () () =
+      return (Array.init 50000 ~f:(fun _ ->
+        Float.(atan (atan (atan (atan (atan (atan (Random.float 100.)))))))))
+  end)
+
+module Compute_stats_map_reduce_function =
+  Rpc_parallel.Map_reduce.Make_map_reduce_function(struct
+    module Accum = struct
+      type t = immutable Rstats.t [@@deriving bin_io]
+    end
+    module Input = struct
+      type t = float array [@@deriving bin_io]
+    end
+
+    let map input =
+      return (Array.fold input ~init:(Rstats.empty ())
+                ~f:(fun acc x -> Rstats.update acc x))
+
+    let combine acc1 acc2 =
+      return (Rstats.merge acc1 acc2)
+  end)
+
+let command =
+  Command.async_spec ~summary:"Compute summary statistics in parallel"
+    Command.Spec.(
+      empty
+      +> flag "nblocks" (optional_with_default 10000 int)
+           ~doc:" Blocks to generate (total number of random numbers is 50000 * blocks)"
+      +> flag "nworkers" (optional_with_default 4 int) ~doc:" Number of workers"
+      +> flag "remote-host" (optional string) ~doc:" Remote host name"
+      +> flag "remote-path" (optional string) ~doc:" Path to this exe on the remote host"
+      +> flag "ordered" (optional_with_default true bool)
+           ~doc:" Commutative or noncommutative fold (should not affect the result)"
+    )
+    (fun nblocks nworkers remote_host remote_path ordered () ->
+       let config = match remote_host with
+         | Some remote_host ->
+           (match remote_path with
+            | Some remote_path ->
+              Rpc_parallel.Map_reduce.Config.create
+                ~remote:[ (Rpc_parallel.Remote_executable.existing_on_host
+                             ~executable_path:remote_path remote_host, nworkers) ]
+                ~redirect_stderr:`Dev_null ~redirect_stdout:`Dev_null ()
+            | _ -> failwith "No remote path specified")
+         | _ -> Rpc_parallel.Map_reduce.Config.create ~local:nworkers
+                  ~redirect_stderr:`Dev_null ~redirect_stdout:`Dev_null ()
+       in
+       Rpc_parallel.Map_reduce.map_unordered config
+         (Pipe.of_list (List.init nblocks ~f:(Fn.const ())))
+         ~m:(module Generate_random_map_function)
+         ~param:()
+       >>= fun blocks ->
+       (if ordered then Rpc_parallel.Map_reduce.map_reduce
+        else Rpc_parallel.Map_reduce.map_reduce_commutative)
+         config
+         (Pipe.map blocks ~f:(fun (block, _index) -> block))
+         ~m:(module Compute_stats_map_reduce_function)
+         ~param:()
+       >>= function
+       | Some stats ->
+         printf "Samples: %i\n" (Rstats.samples stats);
+         printf "Mean: %f\n" (Rstats.mean stats);
+         printf "Variance: %f\n" (Rstats.var stats);
+         Deferred.unit
+       | None ->
+         Deferred.unit
+    )
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/reverse_pipe.ml
+++ b/src/external/rpc_parallel/example/reverse_pipe.ml
@@ -1,0 +1,92 @@
+open Core
+open Async
+
+module Shard = struct
+  module T = struct
+    type 'worker functions =
+      ('worker, int * int Pipe.Reader.t, string list) Rpc_parallel.Function.t
+
+    module Worker_state = struct
+      type t        = int
+      type init_arg = int
+      [@@deriving bin_io]
+    end
+
+    module Connection_state = struct
+      type t        = unit
+      type init_arg = unit
+      [@@deriving bin_io]
+    end
+
+    module Functions
+        (Creator : Rpc_parallel.Creator
+         with type worker_state = Worker_state.t
+          and type connection_state = Connection_state.t) = struct
+
+      let functions =
+        Creator.create_reverse_pipe
+          ~bin_query:Int.bin_t
+          ~bin_update:Int.bin_t
+          ~bin_response:(List.bin_t String.bin_t)
+          ~f:(fun ~worker_state:id ~conn_state:() prefix numbers ->
+            Pipe.fold_without_pushback numbers ~init:[] ~f:(fun acc number ->
+              sprintf "worker %d got %d:%d" id prefix number :: acc))
+          ()
+      ;;
+
+      let init_worker_state = return
+      ;;
+
+      let init_connection_state ~connection:_ ~worker_state:_ () = Deferred.unit
+      ;;
+    end
+  end
+  include T
+  include Rpc_parallel.Make (T)
+end
+
+let main () =
+  let shards = 10 in
+  let%bind connections =
+    Array.init shards ~f:(fun id ->
+      Shard.spawn_exn
+        ~shutdown_on:Disconnect
+        ~redirect_stdout:`Dev_null
+        ~redirect_stderr:`Dev_null
+        ~on_failure:Error.raise
+        ~connection_state_init_arg:()
+        id)
+    |> Deferred.Array.all
+  in
+  let readers =
+    let readers, writers =
+      Array.init shards ~f:(fun (_ : int) -> Pipe.create ()) |> Array.unzip
+    in
+    let write_everything =
+      let%map () =
+        Sequence.init 1_000 ~f:Fn.id
+        |> Sequence.delayed_fold
+             ~init:()
+             ~f:(fun () i ~k -> Pipe.write writers.(i % shards) i >>= k)
+             ~finish:return
+      in
+      Array.iter writers ~f:Pipe.close
+    in
+    don't_wait_for write_everything;
+    readers
+  in
+  let%bind () =
+    Array.mapi connections ~f:(fun i connection ->
+      Shard.Connection.run_exn connection ~f:Shard.functions ~arg:(i, readers.(i)))
+    |> Deferred.Array.all
+    >>| printf !"%{sexp: string list array}\n"
+  in
+  Array.map connections ~f:Shard.Connection.close
+  |> Deferred.Array.all_unit
+;;
+
+let () =
+  Rpc_parallel.start_app
+    (Command.async ~summary:"Demonstrate using Rpc_parallel with reverse pipes"
+       (Command.Param.return main))
+;;

--- a/src/external/rpc_parallel/example/rpc_direct_pipe.ml
+++ b/src/external/rpc_parallel/example/rpc_direct_pipe.ml
@@ -1,0 +1,85 @@
+open Core
+open Async
+
+module Sum_worker = struct
+  module T = struct
+    type 'worker functions =
+      { sum : ('worker, int, string) Rpc_parallel.Function.Direct_pipe.t }
+
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+
+      let sum_impl ~worker_state:() ~conn_state:() arg writer =
+        let _sum =
+          List.fold
+            ~init:0
+            ~f:(fun acc x ->
+              let acc = acc + x in
+              let output = sprintf "Sum_worker.sum: %i\n" acc in
+              let _ = Rpc.Pipe_rpc.Direct_stream_writer.write writer output in
+              acc)
+            (List.init arg ~f:Fn.id)
+        in
+        Rpc.Pipe_rpc.Direct_stream_writer.close writer;
+        Deferred.unit
+
+      let sum =
+        C.create_direct_pipe ~f:sum_impl ~bin_input:Int.bin_t ~bin_output:String.bin_t ()
+
+      let functions = { sum }
+
+      let init_worker_state () = return ()
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make(T)
+end
+
+let main max log_dir () =
+  let redirect_stdout, redirect_stderr =
+    match log_dir with
+    | None -> (`Dev_null, `Dev_null)
+    | Some _ -> (`File_append "sum.out", `File_append "sum.err")
+  in
+  Sum_worker.spawn
+    ~on_failure:Error.raise
+    ?cd:log_dir
+    ~shutdown_on:Disconnect
+    ~redirect_stdout
+    ~redirect_stderr
+    ~connection_state_init_arg:()
+    ()
+  >>=? fun conn ->
+  let on_write = function
+    | Rpc.Pipe_rpc.Pipe_message.Closed _ -> Rpc.Pipe_rpc.Pipe_response.Continue
+    | Update s ->
+      Core.print_string s;
+      Rpc.Pipe_rpc.Pipe_response.Continue
+  in
+  Sum_worker.Connection.run conn ~f:Sum_worker.functions.sum ~arg:(max, on_write)
+  >>|? fun _ -> ()
+
+let command =
+  Command.async_spec_or_error ~summary:"Simple use of Async Rpc_parallel V2"
+    Command.Spec.(
+      empty
+      +> flag "max" (required int) ~doc:""
+      +> flag "log-dir" (optional string)
+           ~doc:" Folder to write worker logs to"
+    )
+    main
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/serve.ml
+++ b/src/external/rpc_parallel/example/serve.ml
@@ -1,0 +1,70 @@
+open Core
+open Async
+
+module Worker = struct
+  module T = struct
+    type 'worker functions = { inc : ('worker, unit, int) Rpc_parallel.Function.t }
+
+    module Worker_state = struct
+      type init_arg = int [@@deriving bin_io]
+      type t = int ref
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      let inc = C.create_rpc
+                  ~f:(fun ~worker_state ~conn_state:() () ->
+                    incr worker_state; return !worker_state)
+                  ~bin_input:Unit.bin_t ~bin_output:Int.bin_t ()
+
+      let functions = {inc}
+
+      let init_worker_state arg = return (ref arg)
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make(T)
+end
+
+let main () =
+  Deferred.List.iter ~how:`Parallel (List.init 10 ~f:Fn.id) ~f:(fun i ->
+    Worker.serve i
+    >>= fun worker ->
+    Worker.Connection.client_exn worker ()
+    >>= fun connection1 ->
+    Worker.Connection.client_exn worker ()
+    >>= fun connection2 ->
+    Worker.Connection.run_exn connection1 ~f:Worker.functions.inc ~arg:()
+    >>= fun i_plus_one ->
+    Worker.Connection.run_exn connection2 ~f:Worker.functions.inc ~arg:()
+    >>= fun i_plus_two ->
+    assert (i + 1 = i_plus_one);
+    assert (i + 2 = i_plus_two);
+    Worker.Connection.run_exn connection1 ~f:Rpc_parallel.Function.close_server ~arg:()
+    >>= fun () ->
+    (* Ensure we can't connect to this server anymore *)
+    Worker.Connection.client worker ()
+    >>= function
+    | Ok _ -> failwith "Should not have been able to connect"
+    | Error _ ->
+      (* Ensure existing connections still work *)
+      Worker.Connection.run_exn connection1 ~f:Worker.functions.inc ~arg:()
+      >>| fun i_plus_three ->
+      assert (i + 3 = i_plus_three))
+  >>| fun () ->
+  printf "Success.\n"
+
+let command =
+  Command.async_spec ~summary:"Use of the in process [serve] functionality"
+    Command.Spec.empty
+    main
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/side_arg.ml
+++ b/src/external/rpc_parallel/example/side_arg.ml
@@ -1,0 +1,48 @@
+open Core
+open Async
+
+module Side_arg_map_function = Rpc_parallel.Map_reduce.Make_map_function_with_init(struct
+    type state_type = string
+    module Param = struct
+      type t = string [@@deriving bin_io]
+    end
+    module Input = struct
+      type t = unit [@@deriving bin_io]
+    end
+    module Output = struct
+      type t = string [@@deriving bin_io]
+    end
+
+    let init param =
+      Random.self_init ();
+      return (sprintf "[%i] %s" (Random.bits ()) param)
+    let map state () =
+      return state
+  end)
+
+let command =
+  Command.async_spec ~summary:"Pass a side arg"
+    Command.Spec.(
+      empty
+      +> flag "ntimes" (optional_with_default 100 int) ~doc:" Number of things to map"
+      +> flag "nworkers" (optional_with_default 4 int) ~doc:" Number of workers"
+    )
+    (fun ntimes nworkers () ->
+       let list = (Pipe.of_list (List.init ntimes ~f:(fun _i -> ()))) in
+       let config =
+         Rpc_parallel.Map_reduce.Config.create ~local:nworkers ()
+           ~redirect_stderr:`Dev_null ~redirect_stdout:`Dev_null
+       in
+       Rpc_parallel.Map_reduce.map_unordered
+         config
+         list
+         ~m:(module Side_arg_map_function)
+         ~param:"Message from the master"
+       >>= fun output_reader ->
+       Pipe.iter output_reader ~f:(fun (message, index) ->
+         printf "%i: %s\n" index message;
+         Deferred.unit
+       )
+    )
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/simple.ml
+++ b/src/external/rpc_parallel/example/simple.ml
@@ -1,0 +1,84 @@
+open Core
+open Async
+
+(* A bare bones use case of the [Rpc_parallel] library. This demonstrates how to
+   define a simple worker type that implements some functions. The master then spawns a
+   worker of this type and calls a function to run on this worker *)
+
+module Sum_worker = struct
+  module T = struct
+    (* A [Sum_worker.worker] implements a single function [sum : int -> int]. Because this
+       function is parameterized on a ['worker], it can only be run on workers of the
+       [Sum_worker.worker] type. *)
+    type 'worker functions = {sum:('worker, int, int) Rpc_parallel.Function.t}
+
+    (* No initialization upon spawn *)
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      (* Define the implementation for the [sum] function *)
+      let sum_impl ~worker_state:() ~conn_state:() arg =
+        let sum = List.fold ~init:0 ~f:(+) (List.init arg ~f:Fn.id) in
+        Log.Global.info "Sum_worker.sum: %i\n" sum;
+        return sum
+
+      (* Create a [Rpc_parallel.Function.t] from the above implementation *)
+      let sum = C.create_rpc ~f:sum_impl ~bin_input:Int.bin_t ~bin_output:Int.bin_t ()
+
+      (* This type must match the ['worker functions] type defined above *)
+      let functions = {sum}
+
+      let init_worker_state () = Deferred.unit
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make(T)
+end
+
+let main max log_dir () =
+  let redirect_stdout, redirect_stderr =
+    match log_dir with
+    | None -> (`Dev_null, `Dev_null)
+    | Some _ -> (`File_append "sum.out", `File_append "sum.err")
+  in
+  (* This is the main function called in the master. Spawn a local worker and run
+     the [sum] function on this worker *)
+  Sum_worker.spawn
+    ~on_failure:Error.raise
+    ?cd:log_dir
+    ~shutdown_on:Disconnect
+    ~redirect_stdout
+    ~redirect_stderr
+    ~connection_state_init_arg:()
+    ()
+  >>=? fun conn ->
+  Sum_worker.Connection.run conn ~f:Sum_worker.functions.sum ~arg:max
+  >>=? fun res ->
+  Core.Printf.printf "sum_worker: %d\n%!" res;
+  Deferred.Or_error.ok_unit
+
+let command =
+  (* Make sure to always use [Command.async] *)
+  Command.async_spec_or_error ~summary:"Simple use of Async Rpc_parallel V2"
+    Command.Spec.(
+      empty
+      +> flag "max" (required int) ~doc:""
+      +> flag "log-dir" (optional string)
+           ~doc:" Folder to write worker logs to"
+    )
+    main
+
+(* This call to [Rpc_parallel.start_app] must be top level *)
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/spawn_in_foreground.ml
+++ b/src/external/rpc_parallel/example/spawn_in_foreground.ml
@@ -1,0 +1,67 @@
+open Core
+open Async
+
+module Worker = struct
+  module T = struct
+    type 'worker functions = {print:('worker, string, unit) Rpc_parallel.Function.t}
+
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      let print_impl ~worker_state:() ~conn_state:() string =
+        printf "%s\n" string;
+        return ()
+
+      let print = C.create_rpc ~f:print_impl ~bin_input:String.bin_t ~bin_output:Unit.bin_t ()
+
+      let functions = {print}
+
+      let init_worker_state () = Deferred.unit
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make(T)
+end
+
+let main () =
+  Worker.spawn_in_foreground ~shutdown_on:Disconnect ~connection_state_init_arg:()
+    ~on_failure:Error.raise ()
+  >>=? fun (conn, process) ->
+  Worker.Connection.run conn ~f:Worker.functions.print ~arg:"HELLO"
+  >>=? fun () ->
+  Worker.Connection.run conn ~f:Worker.functions.print ~arg:"HELLO2"
+  >>=? fun () ->
+  Worker.Connection.close conn
+  >>= fun () ->
+  Process.wait process
+  >>= fun (_ : Unix.Exit_or_signal.t) ->
+  let worker_stderr = Reader.lines (Process.stderr process) in
+  let worker_stdout = Reader.lines (Process.stdout process) in
+  Pipe.iter worker_stderr ~f:(fun line ->
+    let line' = sprintf "[WORKER STDERR]: %s\n" line in
+    Writer.write (Lazy.force Writer.stdout) line' |> return)
+  >>= fun () ->
+  Pipe.iter worker_stdout ~f:(fun line ->
+    let line' = sprintf "[WORKER STDOUT]: %s\n" line in
+    Writer.write (Lazy.force Writer.stdout) line' |> return)
+  >>= fun () ->
+  Deferred.Or_error.ok_unit
+
+let command =
+  Command.async_spec_or_error ~summary:"Example of spawn_in_foreground"
+    Command.Spec.empty
+    main
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/stream_workers.ml
+++ b/src/external/rpc_parallel/example/stream_workers.ml
@@ -1,0 +1,182 @@
+open Core
+open Async
+
+(* This example involves a [Stream_worker.t] that generates a stream of elements.
+   Each element of the stream is sent to a random [Worker.t] that has registered itself
+   with that stream. Each [Worker.t] processes the elements (in this example by sending it
+   back to the main process for printing) *)
+
+module Stream_worker = struct
+  module T = struct
+    type 'worker functions =
+      { subscribe : ('worker, unit, int Pipe.Reader.t) Rpc_parallel.Function.t
+      ; start : ('worker, unit, unit) Rpc_parallel.Function.t }
+
+    module Worker_state = struct
+      type init_arg = int [@@deriving bin_io]
+      type t =
+        { num_elts : int
+        ; mutable workers : int Pipe.Writer.t list }
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions (C : Rpc_parallel.Creator
+                      with type connection_state := unit
+                       and type worker_state := Worker_state.t) = struct
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+
+      let init_worker_state num_elts =
+        return
+          { Worker_state.num_elts
+          ; workers = []
+          }
+
+      let subscribe_impl ~worker_state ~conn_state:() () =
+        let r, w = Pipe.create () in
+        (Pipe.closed w
+         >>> fun () ->
+         worker_state.Worker_state.workers <-
+           List.filter worker_state.Worker_state.workers ~f:(fun worker ->
+             not (Pipe.equal worker w)));
+        worker_state.Worker_state.workers <- w :: worker_state.Worker_state.workers;
+        return r
+
+      let start_impl ~worker_state ~conn_state:() () =
+        let next_elt = ref 0 in
+        let get_element () =
+          let elt = !next_elt in
+          incr next_elt;
+          elt
+        in
+        don't_wait_for
+          (Deferred.repeat_until_finished worker_state.Worker_state.num_elts (fun count ->
+             Clock.after (sec 0.05) >>= fun () ->
+             if count = 0 then
+               return (`Finished ())
+             else
+               let elt = get_element () in
+               let to_worker =
+                 List.nth_exn worker_state.workers
+                   (Random.int (List.length worker_state.workers))
+               in
+               Pipe.write to_worker elt
+               >>| fun () -> `Repeat (count -1))
+           >>| fun () ->
+           List.iter worker_state.workers
+             ~f:(fun writer -> Pipe.close writer));
+        return ()
+
+      let subscribe =
+        C.create_pipe ~f:subscribe_impl
+          ~bin_input:Unit.bin_t ~bin_output:Int.bin_t ()
+
+      let start =
+        C.create_rpc ~f:start_impl
+          ~bin_input:Unit.bin_t ~bin_output:Unit.bin_t ()
+
+      let functions = { start; subscribe }
+    end
+  end
+  include Rpc_parallel.Make (T)
+end
+
+module Worker = struct
+  module T = struct
+    type 'worker functions =
+      { process_elts : ('worker, Stream_worker.t, int Pipe.Reader.t) Rpc_parallel.Function.t }
+
+    module Worker_state = struct
+      type t = unit
+      type init_arg = unit [@@deriving bin_io]
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+
+      let process_elts_impl ~worker_state:() ~conn_state:() stream_worker =
+        let check_r, check_w = Pipe.create () in
+        Stream_worker.Connection.client_exn stream_worker ()
+        >>= fun conn ->
+        Stream_worker.Connection.run_exn conn ~f:Stream_worker.functions.subscribe ~arg:()
+        >>= fun reader ->
+        (Pipe.iter reader ~f:(fun i -> Pipe.write check_w i)
+         >>> fun () ->
+         Pipe.close check_w);
+        return check_r
+
+      let process_elts =
+        C.create_pipe ~f:process_elts_impl
+          ~bin_input:Stream_worker.bin_t ~bin_output:Int.bin_t ()
+
+      let functions = { process_elts }
+
+      let init_worker_state () = Deferred.unit
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+
+  end
+  include Rpc_parallel.Make (T)
+end
+
+let handle_error worker err =
+  failwiths (sprintf "error in %s" worker) err Error.sexp_of_t
+
+let command =
+  Command.async_spec_or_error ~summary:"foo"
+    Command.Spec.(
+      empty
+      +> flag "-num-workers" (optional_with_default 4 int)
+           ~doc:" number of workers"
+      +> flag "-num-elts" (optional_with_default 50 int)
+           ~doc:" number of elements to process"
+    )
+    (fun num_workers num_elements () ->
+       (* Spawn a stream worker *)
+       Stream_worker.spawn
+         ~shutdown_on:Heartbeater_timeout
+         ~redirect_stdout:`Dev_null
+         ~redirect_stderr:`Dev_null
+         num_elements
+         ~on_failure:(handle_error "stream worker")
+       >>=? fun stream_worker ->
+       (* Spawn workers and tell them about the stream worker  *)
+       Deferred.Or_error.List.init num_workers ~f:(fun i ->
+         Worker.spawn
+           ~shutdown_on:Disconnect
+           ~connection_state_init_arg:()
+           ~redirect_stdout:`Dev_null
+           ~redirect_stderr:`Dev_null
+           ()
+           ~on_failure:(handle_error (sprintf "worker %d" i))
+         >>=? fun worker_conn ->
+         Worker.Connection.run worker_conn
+           ~f:Worker.functions.process_elts ~arg:stream_worker)
+       >>=? fun workers ->
+       (* Start the stream *)
+       Stream_worker.Connection.client stream_worker ()
+       >>=? fun stream_conn ->
+       Stream_worker.Connection.run stream_conn ~f:Stream_worker.functions.start ~arg:()
+       >>=? fun () ->
+       (* Collect the results *)
+       let elements = List.init num_elements ~f:(fun _i -> Ivar.create ()) in
+       don't_wait_for (Deferred.List.iter ~how:`Parallel workers ~f:(fun worker ->
+         Pipe.iter worker ~f:(fun num -> Ivar.fill (List.nth_exn elements num) () |> return)));
+       Deferred.all_unit (List.map elements ~f:Ivar.read)
+       >>| fun () ->
+       printf "Ok.\n";
+       Or_error.return ())
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/worker_binprot.ml
+++ b/src/external/rpc_parallel/example/worker_binprot.ml
@@ -1,0 +1,131 @@
+open Core
+open Async
+
+
+(* This demonstrates how to take advantage of the feature in the [Rpc_parallel]
+   library that a [Worker.t] type is defined [with bin_io]. *)
+
+module Worker = struct
+  module T = struct
+    (* A [Worker.t] implements two functions: [ping : unit -> int] and
+       [dispatch : Worker.t -> int] *)
+    type 'worker functions =
+      { ping:('worker, unit, int) Rpc_parallel.Function.t }
+
+    (* Internal state for each [Worker.t]. Every [Worker.t] has a counter that gets
+       incremented anytime it gets pinged *)
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = int ref
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      (* When a worker gets a [ping ()] call, increment its counter and return the current
+         value *)
+      let ping_impl ~worker_state:counter ~conn_state:() () =
+        incr counter; return (!counter)
+
+      let ping = C.create_rpc ~f:ping_impl ~bin_input:Unit.bin_t ~bin_output:Int.bin_t ()
+
+      let functions = {ping}
+
+      let init_worker_state () = return (ref 0)
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make (T)
+end
+
+module Dispatcher = struct
+  module T = struct
+    type 'worker functions =
+      { dispatch: ('worker, Worker.t, int) Rpc_parallel.Function.t }
+
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      (* When a worker gets a [dispatch worker] call, call [ping] on the supplied worker
+         and return the same result. *)
+      let dispatch_impl ~worker_state:_ ~conn_state:() worker =
+        Worker.Connection.with_client worker () ~f:(fun conn ->
+          Worker.Connection.run_exn conn ~f:Worker.functions.ping ~arg:())
+        >>| Or_error.ok_exn
+
+      let dispatch =
+        C.create_rpc ~f:dispatch_impl ~bin_input:Worker.bin_t ~bin_output:Int.bin_t ()
+
+      let functions = {dispatch}
+
+      let init_worker_state () = Deferred.unit
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+
+    end
+
+  end
+  include Rpc_parallel.Make (T)
+end
+
+let command =
+  Command.async_spec_or_error ~summary:
+    "Example of a worker taking in another worker as an argument to one of its functions"
+    Command.Spec.(
+      empty
+    )
+    (fun () ->
+       Worker.spawn
+         ~shutdown_on:Heartbeater_timeout
+         ~redirect_stdout:`Dev_null
+         ~redirect_stderr:`Dev_null
+         ~on_failure:Error.raise
+         ()
+       >>=? fun worker ->
+       Worker.Connection.client worker ()
+       >>=? fun worker_conn ->
+       Dispatcher.spawn
+         ~shutdown_on:Disconnect
+         ~redirect_stdout:`Dev_null
+         ~redirect_stderr:`Dev_null
+         ~on_failure:Error.raise
+         ~connection_state_init_arg:()
+         ()
+       >>=? fun dispatcher_conn ->
+       let repeat job n =
+         Deferred.List.iter (List.range 0 n) ~f:(fun _i -> job ())
+       in
+       Deferred.all_unit [
+         repeat (fun () ->
+           Dispatcher.Connection.run_exn dispatcher_conn ~f:Dispatcher.functions.dispatch
+             ~arg:worker
+           >>= fun count ->
+           Core.Printf.printf "worker pinged from dispatcher: %d\n%!" count;
+           return ()) 10;
+         repeat (fun () ->
+           Worker.Connection.run_exn worker_conn ~f:Worker.functions.ping
+             ~arg:()
+           >>= fun count ->
+           Core.Printf.printf "worker pinged from master: %d\n%!" count;
+           return ()) 10
+       ] >>= fun () -> Deferred.Or_error.ok_unit)
+
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/example/workers_as_masters.ml
+++ b/src/external/rpc_parallel/example/workers_as_masters.ml
@@ -1,0 +1,140 @@
+open Core
+open Async
+
+(* An example demonstrating how workers can themselves act as masters and spawn more
+   workers. We have two layers of workers, where the first layer spawns the workers of the
+   second layer. *)
+
+module Secondary_worker = struct
+  module T = struct
+    type 'worker functions =
+      { ping:('worker, unit, string) Rpc_parallel.Function.t
+      }
+
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      let ping_impl ~worker_state:() ~conn_state:() () = return "pong"
+
+      let ping =
+        C.create_rpc ~f:ping_impl ~bin_input:Unit.bin_t ~bin_output:String.bin_t ()
+
+      let functions = {ping}
+
+      let init_worker_state () = Deferred.unit
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make (T)
+end
+
+module Primary_worker = struct
+  module T = struct
+    type ping_result = string list [@@deriving bin_io]
+    type 'worker functions =
+      { run:('worker, int, unit) Rpc_parallel.Function.t
+      ; ping:('worker, unit, ping_result) Rpc_parallel.Function.t
+      }
+
+    let workers = Bag.create ()
+    let next_worker_name () = sprintf "Secondary worker #%i" (Bag.length workers)
+
+    module Worker_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Connection_state = struct
+      type init_arg = unit [@@deriving bin_io]
+      type t = unit
+    end
+
+    module Functions
+        (C : Rpc_parallel.Creator
+         with type worker_state := Worker_state.t
+          and type connection_state := Connection_state.t) = struct
+      let run_impl ~worker_state:() ~conn_state:() num_workers =
+        Deferred.List.init ~how:`Parallel num_workers ~f:(fun _i ->
+          Secondary_worker.spawn_exn
+            ~shutdown_on:Heartbeater_timeout
+            ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null
+            ~on_failure:Error.raise ()
+          >>| fun secondary_worker ->
+          ignore(Bag.add workers (next_worker_name (), secondary_worker));
+        )
+        >>| ignore
+
+      let run = C.create_rpc ~f:run_impl ~bin_input:Int.bin_t ~bin_output:Unit.bin_t ()
+
+      let ping_impl ~worker_state:() ~conn_state:() () =
+        Deferred.List.map ~how:`Parallel (Bag.to_list workers) ~f:(fun (name, worker) ->
+          Secondary_worker.Connection.client worker ()
+          >>= function
+          | Error e -> failwiths "failed connecting to worker" e [%sexp_of: Error.t]
+          | Ok conn ->
+            Secondary_worker.Connection.run conn ~arg:() ~f:Secondary_worker.functions.ping
+            >>| function
+            | Error e ->
+              sprintf "%s: failed (%s)" name (Error.to_string_hum e)
+            | Ok s -> sprintf "%s: %s" name s
+        )
+
+      let ping =
+        C.create_rpc ~f:ping_impl ~bin_input:Unit.bin_t ~bin_output:bin_ping_result ()
+
+      let functions = {run; ping}
+
+      let init_worker_state () =
+        Bag.clear workers;
+        Deferred.unit
+
+      let init_connection_state ~connection:_ ~worker_state:_ = return
+    end
+  end
+  include Rpc_parallel.Make(T)
+end
+
+let command =
+  (* Make sure to always use [Command.async] *)
+  Command.async_spec_or_error ~summary:"Simple use of Async Rpc_parallel V2"
+    Command.Spec.(
+      empty
+      +> flag "primary" (required int)
+           ~doc:" Number of primary workers to spawn"
+      +> flag "secondary" (required int)
+           ~doc:" Number of secondary workers each primary worker should spawn"
+    )
+    (fun primary secondary () ->
+       Deferred.Or_error.List.init ~how:`Parallel primary ~f:(fun worker_id ->
+         Primary_worker.spawn
+           ~shutdown_on:Disconnect
+           ~redirect_stdout:`Dev_null ~redirect_stderr:`Dev_null
+           ~on_failure:Error.raise
+           ~connection_state_init_arg:()
+           ()
+         >>=? fun conn ->
+         Primary_worker.Connection.run conn
+           ~f:Primary_worker.functions.run ~arg:secondary
+         >>=? fun () ->
+         Primary_worker.Connection.run conn
+           ~f:Primary_worker.functions.ping ~arg:()
+         >>|? fun ping_results ->
+         List.map ping_results ~f:(fun s -> sprintf "Primary worker #%i: %s" worker_id s))
+       >>|? fun l ->
+       List.iter (List.join l) ~f:(printf "%s\n%!")
+    )
+
+(* This call to [Rpc_parallel.start_app] must be top level *)
+let () = Rpc_parallel.start_app command

--- a/src/external/rpc_parallel/rpc_parallel.opam
+++ b/src/external/rpc_parallel/rpc_parallel.opam
@@ -1,0 +1,29 @@
+opam-version: "1.2"
+version: "v0.11.0"
+maintainer: "opensource@janestreet.com"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/rpc_parallel"
+bug-reports: "https://github.com/janestreet/rpc_parallel/issues"
+dev-repo: "git+https://github.com/janestreet/rpc_parallel.git"
+license: "Apache-2.0"
+build: [
+  ["jbuilder" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "async"                   {>= "v0.11" & < "v0.12"}
+  "core"                    {>= "v0.11" & < "v0.12"}
+  "ppx_jane"                {>= "v0.11" & < "v0.12"}
+  "sexplib"                 {>= "v0.11" & < "v0.12"}
+  "jbuilder"                {build & >= "1.0+beta18.1"}
+  "ocaml-migrate-parsetree" {>= "1.0"}
+  "ppxlib"                  {>= "0.1.0"}
+]
+available: [ ocaml-version >= "4.04.1" ]
+descr: "
+Type-safe parallel library built on top of Async_rpc
+
+Rpc_parallel offers an API to define various workers and protocols,
+spawn workers as separate processes, and communicate with them using
+Async Rpc.
+
+"

--- a/src/external/rpc_parallel/src/executable_location.ml
+++ b/src/external/rpc_parallel/src/executable_location.ml
@@ -1,0 +1,5 @@
+open! Core
+
+type t =
+  | Local
+  | Remote : _ Remote_executable.t -> t

--- a/src/external/rpc_parallel/src/executable_location.mli
+++ b/src/external/rpc_parallel/src/executable_location.mli
@@ -1,0 +1,5 @@
+open! Core
+
+type t =
+  | Local
+  | Remote : _ Remote_executable.t -> t

--- a/src/external/rpc_parallel/src/fd_redirection.ml
+++ b/src/external/rpc_parallel/src/fd_redirection.ml
@@ -1,0 +1,7 @@
+open Core
+
+type t =
+  [ `Dev_null
+  | `File_append of string
+  | `File_truncate of string
+  ] [@@deriving sexp]

--- a/src/external/rpc_parallel/src/fd_redirection.mli
+++ b/src/external/rpc_parallel/src/fd_redirection.mli
@@ -1,0 +1,5 @@
+type t =
+  [ `Dev_null
+  | `File_append of string
+  | `File_truncate of string
+  ] [@@deriving sexp]

--- a/src/external/rpc_parallel/src/jbuild
+++ b/src/external/rpc_parallel/src/jbuild
@@ -1,0 +1,8 @@
+(library (
+  (name        rpc_parallel)
+  (public_name rpc_parallel)
+  (flags (:standard -safe-string))
+  (libraries (core async ctypes sexplib))
+  (preprocess (pps (ppx_jane ppxlib.runner)))))
+
+(jbuild_version 1)

--- a/src/external/rpc_parallel/src/map_reduce.ml
+++ b/src/external/rpc_parallel/src/map_reduce.ml
@@ -1,0 +1,516 @@
+open Core
+open Async
+
+module Half_open_interval = struct
+  module T = struct
+    type t = int * int [@@deriving sexp]
+    let create_exn l u =
+      if l >= u then failwiths "Lower bound must be less than upper bound"
+                       (l, u) [%sexp_of: int * int];
+      (l, u)
+    let lbound t = fst t
+    let ubound t = snd t
+    let intersects t1 t2 = (lbound t1 < ubound t2) && (lbound t2 < ubound t1)
+    let compare t1 t2 =
+      if t1 = t2 then
+        0
+      else
+        (if intersects t1 t2 then
+           failwiths "Cannot compare unequal intersecting intervals"
+             (t1, t2) [%sexp_of: t * t];
+         Int.compare (lbound t1) (lbound t2))
+  end
+  include T
+  include Comparable.Make(T)
+end
+
+let append_index reader =
+  let index = ref 0 in
+  Pipe.map reader ~f:(fun item ->
+    let item_index = !index in
+    index := !index + 1;
+    (item, item_index))
+
+type packed_remote = Packed_remote : 'remote Remote_executable.t -> packed_remote
+
+module Config = struct
+  type t =
+    { local           : int
+    ; remote          : (packed_remote * int) list
+    ; cd              : string option
+    ; redirect_stderr : [ `Dev_null | `File_append of string ]
+    ; redirect_stdout : [ `Dev_null | `File_append of string ]
+    }
+
+  let default_cores () =
+    (ok_exn Linux_ext.cores) ()
+
+  let create ?(local = 0) ?(remote = []) ?cd
+        ~redirect_stderr ~redirect_stdout () =
+    let (local, remote) =
+      if local = 0 && (List.is_empty remote) then
+        (default_cores (), remote)
+      else
+        (local, remote)
+    in
+    { local; remote = List.map remote ~f:(fun (remote, n) -> (Packed_remote remote, n));
+      cd; redirect_stderr; redirect_stdout }
+end
+
+(* Wrappers for generic worker *)
+module type Worker = sig
+  type t
+  type param_type
+  type run_input_type
+  type run_output_type
+
+  val spawn_config_exn : Config.t -> param_type -> t list Deferred.t
+  val run_exn : t -> run_input_type -> run_output_type Deferred.t
+  val shutdown_exn : t -> unit Deferred.t
+end
+
+module type Rpc_parallel_worker_spec = sig
+  type state_type
+  module Param : Binable
+  module Run_input : Binable
+  module Run_output : Binable
+
+  val init : Param.t -> state_type Deferred.t
+  val execute : state_type -> Run_input.t -> Run_output.t Deferred.t
+end
+
+module Make_rpc_parallel_worker(S : Rpc_parallel_worker_spec) = struct
+  module Parallel_worker = struct
+    module T = struct
+      type 'worker functions =
+        { execute  : ('worker, S.Run_input.t, S.Run_output.t) Parallel.Function.t }
+
+      module Worker_state = struct
+        type init_arg = S.Param.t [@@deriving bin_io]
+        type t   = S.state_type
+      end
+
+      module Connection_state = struct
+        type init_arg = unit [@@deriving bin_io]
+        type t =  unit
+      end
+
+      module Functions(C : Parallel.Creator
+                       with type worker_state := Worker_state.t
+                        and type connection_state := Connection_state.t) = struct
+        let execute =
+          C.create_rpc
+            ~f:(fun ~worker_state ~conn_state:() -> S.execute worker_state)
+            ~bin_input:S.Run_input.bin_t ~bin_output:S.Run_output.bin_t ()
+
+        let functions = { execute }
+
+        let init_worker_state = S.init
+
+        let init_connection_state ~connection:_ ~worker_state:_ () = return ()
+      end
+    end
+
+    include Parallel.Make (T)
+  end
+
+  type t = Parallel_worker.Connection.t
+  type param_type = S.Param.t
+  type run_input_type = S.Run_input.t
+  type run_output_type = S.Run_output.t
+
+  let spawn_exn where param ?cd ~redirect_stderr ~redirect_stdout =
+    Parallel_worker.spawn_exn ~where ?cd ~shutdown_on:Disconnect
+      ~redirect_stderr ~redirect_stdout param ~on_failure:Error.raise
+      ~connection_state_init_arg:()
+
+  let spawn_config_exn
+        { Config.local; remote; cd; redirect_stderr; redirect_stdout }
+        param =
+    if local < 0 then
+      failwiths "config.local must be nonnegative" local Int.sexp_of_t;
+    (match List.find remote ~f:(fun (_remote, n) -> n < 0) with
+     | Some remote ->
+       failwiths "remote number of workers must be nonnegative" (snd remote) Int.sexp_of_t
+     | None -> ());
+    if local = 0 &&
+       not (List.exists remote ~f:(fun (_remote, n) -> n > 0)) then
+      failwiths "total number of workers must be positive"
+        (local, List.map remote ~f:snd) [%sexp_of: int * int list];
+    let spawn_n where n =
+      Deferred.List.init n ~f:(fun _i ->
+        spawn_exn where param ?cd
+          ~redirect_stderr:(redirect_stderr :> Fd_redirection.t)
+          ~redirect_stdout:(redirect_stdout :> Fd_redirection.t))
+    in
+    Deferred.both
+      (spawn_n Local local)
+      (Deferred.List.concat_map ~how:`Parallel remote
+         ~f:(fun (Packed_remote remote, n) -> spawn_n (Remote remote) n))
+    >>| fun (local_workers, remote_workers) ->
+    local_workers @ remote_workers
+
+  let run_exn t input =
+    Parallel_worker.Connection.run_exn t
+      ~f:Parallel_worker.functions.execute ~arg:input
+
+  let shutdown_exn conn = Parallel_worker.Connection.close conn
+end
+
+(* Map *)
+
+module type Map_function = sig
+  module Param : Binable
+  module Input : Binable
+  module Output : Binable
+
+  module Worker : Worker
+    with type param_type = Param.t
+    with type run_input_type = Input.t
+    with type run_output_type = Output.t
+end
+
+module type Map_function_with_init_spec = sig
+  type state_type
+  module Param : Binable
+  module Input : Binable
+  module Output : Binable
+
+  val init : Param.t -> state_type Deferred.t
+  val map : state_type -> Input.t -> Output.t Deferred.t
+end
+
+module Make_map_function_with_init(S : Map_function_with_init_spec) = struct
+  module Param = S.Param
+  module Input = S.Input
+  module Output = S.Output
+
+  module Worker = Make_rpc_parallel_worker(struct
+      type state_type = S.state_type
+      module Param = Param
+      module Run_input = Input
+      module Run_output = Output
+
+      let init = S.init
+      let execute = S.map
+    end)
+end
+
+module type Map_function_spec = sig
+  module Input : Binable
+  module Output : Binable
+
+  val map : Input.t -> Output.t Deferred.t
+end
+
+module Make_map_function(S : Map_function_spec) =
+  Make_map_function_with_init(struct
+    type state_type = unit
+    module Param = struct
+      type t = unit [@@deriving bin_io]
+    end
+    module Input = S.Input
+    module Output = S.Output
+
+    let init = return
+    let map () = S.map
+  end)
+
+(* Map-combine *)
+
+module type Map_reduce_function = sig
+  module Param : Binable
+  module Accum : Binable
+  module Input : Binable
+
+  module Worker : Worker
+    with type param_type = Param.t
+    with type run_input_type =
+           [ `Map of Input.t
+           | `Combine of Accum.t * Accum.t
+           | `Map_right_combine of Accum.t * Input.t (* combine accum (map input) *)
+           ]
+    with type run_output_type = Accum.t
+end
+
+module type Map_reduce_function_with_init_spec = sig
+  type state_type
+  module Param : Binable
+  module Accum : Binable
+  module Input : Binable
+
+  val init : Param.t -> state_type Deferred.t
+  val map : state_type -> Input.t -> Accum.t Deferred.t
+  val combine : state_type -> Accum.t -> Accum.t -> Accum.t Deferred.t
+end
+
+module Make_map_reduce_function_with_init(S : Map_reduce_function_with_init_spec) =
+struct
+  module Param = S.Param
+  module Accum = S.Accum
+  module Input = S.Input
+
+  module Worker = Make_rpc_parallel_worker(struct
+      type state_type = S.state_type
+      module Param = Param
+      module Run_input = struct
+        type t =
+          [ `Map of Input.t
+          | `Combine of Accum.t * Accum.t
+          | `Map_right_combine of Accum.t * Input.t
+          ]
+        [@@deriving bin_io]
+      end
+      module Run_output = Accum
+
+      let init = S.init
+      let execute state = function
+        | `Map input -> S.map state input
+        | `Combine (accum1, accum2) -> S.combine state accum1 accum2
+        | `Map_right_combine (accum1, input) ->
+          S.map state input >>= fun accum2 -> S.combine state accum1 accum2
+    end)
+end
+
+module type Map_reduce_function_spec = sig
+  module Accum : Binable
+  module Input : Binable
+
+  val map : Input.t -> Accum.t Deferred.t
+  val combine : Accum.t -> Accum.t -> Accum.t Deferred.t
+end
+
+module Make_map_reduce_function(S : Map_reduce_function_spec) =
+  Make_map_reduce_function_with_init(struct
+    type state_type = unit
+    module Param = struct
+      type t = unit [@@deriving bin_io]
+    end
+    module Accum = S.Accum
+    module Input = S.Input
+
+    let init = return
+    let map () = S.map
+    let combine () = S.combine
+  end)
+
+let map_unordered (type param) (type a) (type b)
+      config input_reader ~m  ~(param : param) =
+  let module Map_function = (val m : Map_function
+                             with type Param.t = param
+                              and type Input.t = a
+                              and type Output.t = b)
+  in
+  Map_function.Worker.spawn_config_exn config param
+  >>= fun workers ->
+  let input_with_index_reader = append_index input_reader in
+  let (output_reader, output_writer) = Pipe.create () in
+  let consumer =
+    Pipe.add_consumer
+      input_with_index_reader
+      ~downstream_flushed:(fun () -> Pipe.downstream_flushed output_writer)
+  in
+  let rec map_loop worker =
+    Pipe.read ~consumer input_with_index_reader
+    >>= function
+    | `Eof -> Map_function.Worker.shutdown_exn worker
+    | `Ok (input, index) ->
+      Map_function.Worker.run_exn worker input
+      >>= fun output ->
+      Pipe.write output_writer (output, index)
+      >>= fun () ->
+      map_loop worker
+  in
+  don't_wait_for (
+    Deferred.all_unit (List.map workers ~f:map_loop)
+    >>| fun () ->
+    Pipe.close output_writer
+  );
+  return output_reader
+
+let map config input_reader ~m ~param =
+  map_unordered config input_reader ~m ~param
+  >>= fun mapped_reader ->
+  let (new_reader, new_writer) = Pipe.create () in
+  let expecting_index = ref 0 in
+  let out_of_order_output =
+    Heap.create ~cmp:(fun (_, index1) (_, index2) -> Int.compare index1 index2) ()
+  in
+  (* Pops in-order output until we reach a gap. *)
+  let rec write_out_of_order_output () =
+    match Heap.top out_of_order_output with
+    | Some (output, index) when index = !expecting_index ->
+      expecting_index := !expecting_index + 1;
+      Heap.remove_top out_of_order_output;
+      Pipe.write new_writer output
+      >>= fun () ->
+      write_out_of_order_output ()
+    | _ -> Deferred.unit
+  in
+  don't_wait_for (
+    Pipe.iter mapped_reader ~f:(fun ((output, index) as output_and_index) ->
+      if index = !expecting_index then
+        (expecting_index := !expecting_index + 1;
+         Pipe.write new_writer output
+         >>= fun () ->
+         write_out_of_order_output ())
+      else if index > !expecting_index then
+        (Heap.add out_of_order_output output_and_index;
+         Deferred.unit)
+      else assert false
+    )
+    >>| fun () ->
+    Pipe.close new_writer
+  );
+  return new_reader
+
+let find_map (type param) (type a) (type b)
+      config input_reader ~m ~(param : param) =
+  let module Map_function = (val m : Map_function
+                             with type Param.t = param
+                              and type Input.t = a
+                              and type Output.t = b option)
+  in
+  Map_function.Worker.spawn_config_exn config param
+  >>= fun workers ->
+  let found_value = ref None in
+  let rec find_loop worker =
+    Pipe.read input_reader
+    >>= function
+    | `Eof -> Map_function.Worker.shutdown_exn worker
+    | `Ok input ->
+      (* Check result and exit early if we've found something. *)
+      match !found_value with
+      | Some _ -> Map_function.Worker.shutdown_exn worker
+      | None ->
+        Map_function.Worker.run_exn worker input
+        >>= function
+        | Some value ->
+          found_value := Some value;
+          Map_function.Worker.shutdown_exn worker
+        | None ->
+          find_loop worker
+  in
+  Deferred.all_unit (List.map workers ~f:find_loop)
+  >>| fun () ->
+  !found_value
+
+let map_reduce_commutative (type param) (type a) (type accum)
+      config input_reader ~m ~(param : param) =
+  let module Map_reduce_function = (val m : Map_reduce_function
+                                    with type Param.t = param
+                                     and type Input.t = a
+                                     and type Accum.t = accum)
+  in
+  Map_reduce_function.Worker.spawn_config_exn config param
+  >>= fun workers ->
+  let rec map_and_combine_loop worker acc =
+    Pipe.read input_reader
+    >>= function
+    | `Eof -> return acc
+    | `Ok input ->
+      (match acc with
+       | Some acc ->
+         Map_reduce_function.Worker.run_exn worker (`Map_right_combine (acc, input))
+       | None ->
+         Map_reduce_function.Worker.run_exn worker (`Map input))
+      >>= fun acc ->
+      map_and_combine_loop worker (Some acc)
+  in
+  let combined_acc = ref None in
+  let rec combine_loop worker acc =
+    match !combined_acc with
+    | Some other_acc ->
+      combined_acc := None;
+      Map_reduce_function.Worker.run_exn worker (`Combine (other_acc, acc))
+      >>= combine_loop worker
+    | None ->
+      combined_acc := Some acc;
+      Map_reduce_function.Worker.shutdown_exn worker
+  in
+  Deferred.all_unit (List.map workers ~f:(fun worker ->
+    map_and_combine_loop worker None
+    >>= function
+    | Some acc -> combine_loop worker acc
+    | None -> Map_reduce_function.Worker.shutdown_exn worker))
+  >>| fun () ->
+  !combined_acc
+
+let map_reduce (type param) (type a) (type accum)
+      config input_reader ~m ~(param : param) =
+  let module Map_reduce_function = (val m : Map_reduce_function
+                                    with type Param.t = param
+                                     and type Input.t = a
+                                     and type Accum.t = accum)
+  in
+  Map_reduce_function.Worker.spawn_config_exn config param
+  >>= fun workers ->
+  let input_with_index_reader = append_index input_reader in
+  let module H = Half_open_interval in
+  let acc_map = ref H.Map.empty in
+  let rec combine_loop worker key acc
+            (dir : [ `Left | `Left_nothing_right | `Right | `Right_nothing_left ]) =
+    match dir with
+    | `Left | `Left_nothing_right as dir' ->
+      (match H.Map.closest_key !acc_map `Less_than key with
+       | Some (left_key, left_acc) when H.ubound left_key = H.lbound key ->
+         (* combine acc_{left_lbound, left_ubound} acc_{this_lbound, this_ubound}
+            -> acc_{left_lbound, this_ubound} *)
+         (* We need to remove both nodes from the tree to indicate that we are working on
+            combining them. *)
+         acc_map := H.Map.remove (H.Map.remove !acc_map key) left_key;
+         Map_reduce_function.Worker.run_exn worker (`Combine (left_acc, acc))
+         >>= fun new_acc ->
+         let new_key = H.create_exn (H.lbound left_key) (H.ubound key) in
+         acc_map := H.Map.set !acc_map ~key:new_key ~data:new_acc;
+         (* Continue searching in the same direction. (See above comment.) *)
+         combine_loop worker new_key new_acc `Left
+       | _ ->
+         match dir' with
+         | `Left -> combine_loop worker key acc `Right_nothing_left
+         | `Left_nothing_right -> Deferred.unit)
+    | `Right | `Right_nothing_left as dir' ->
+      (match H.Map.closest_key !acc_map `Greater_than key with
+       | Some (right_key, right_acc) when H.lbound right_key = H.ubound key ->
+         (* combine acc_{this_lbound, this_ubound} acc_{right_lbound, right_ubound}
+            -> acc_{this_lbound, right_ubound} *)
+         acc_map := H.Map.remove (H.Map.remove !acc_map key) right_key;
+         Map_reduce_function.Worker.run_exn worker (`Combine (acc, right_acc))
+         >>= fun new_acc ->
+         let new_key = H.create_exn (H.lbound key) (H.ubound right_key) in
+         acc_map := H.Map.set !acc_map ~key:new_key ~data:new_acc;
+         combine_loop worker new_key new_acc `Right
+       | _ ->
+         match dir' with
+         | `Right -> combine_loop worker key acc `Left_nothing_right
+         | `Right_nothing_left -> Deferred.unit)
+  in
+  let rec map_and_combine_loop worker =
+    Pipe.read input_with_index_reader
+    >>= function
+    | `Eof -> Map_reduce_function.Worker.shutdown_exn worker
+    | `Ok (input, index) ->
+      let key = H.create_exn index (index + 1) in
+      (match H.Map.closest_key !acc_map `Less_than key with
+       | Some (left_key, left_acc) when H.ubound left_key = H.lbound key ->
+         (* combine acc_{left_lbound, left_ubound} (map a_index)
+            -> acc_{left_lbound, index + 1} *)
+         acc_map := H.Map.remove !acc_map left_key;
+         Map_reduce_function.Worker.run_exn worker (`Map_right_combine (left_acc, input))
+         >>= fun acc ->
+         let key = H.create_exn (H.lbound left_key) (H.ubound key) in
+         acc_map := H.Map.set !acc_map ~key ~data:acc;
+         combine_loop worker key acc `Left
+       | _ ->
+         (* map a_index -> acc_{index, index + 1} *)
+         Map_reduce_function.Worker.run_exn worker (`Map input)
+         >>= fun acc ->
+         acc_map := H.Map.set !acc_map ~key ~data:acc;
+         combine_loop worker key acc `Left)
+      >>= fun () ->
+      map_and_combine_loop worker
+  in
+  Deferred.all_unit (List.map workers ~f:map_and_combine_loop)
+  >>| fun () ->
+  assert (Map.length !acc_map <= 1);
+  Option.map (Map.min_elt !acc_map) ~f:snd

--- a/src/external/rpc_parallel/src/map_reduce.mli
+++ b/src/external/rpc_parallel/src/map_reduce.mli
@@ -1,0 +1,203 @@
+(** A parallel map/reduce library. See examples/add_numbers.ml and
+    examples/number_stats.ml for examples. *)
+
+open! Core
+open! Async
+
+module Config : sig
+  type t
+
+  (** Default is to create the same number of local workers as the cores in local
+      machine. All spawned workers will their redirect stdout and stderr to the same
+      file. *)
+  val create
+    :  ?local : int
+    -> ?remote : (_ Remote_executable.t * int) list
+    -> ?cd : string  (** default / *)
+    -> redirect_stderr : [ `Dev_null | `File_append of string ]
+    -> redirect_stdout : [ `Dev_null | `File_append of string ]
+    -> unit
+    -> t
+end
+
+module type Worker = sig
+  type t
+  type param_type
+  type run_input_type
+  type run_output_type
+
+  val spawn_config_exn : Config.t -> param_type -> t list Deferred.t
+  val run_exn : t -> run_input_type -> run_output_type Deferred.t
+  val shutdown_exn : t -> unit Deferred.t
+end
+
+(** {4 Map functions} *)
+
+(** [Map_function] modules must be created using the [Make_map_function] or
+    [Make_map_function_with_init] functors. The init variety allows you to specify an
+    [init] function that takes a "param" argument. The non-init variety is equivalent to
+    the init variety with [init] equal to [return] and a [unit] "param"
+    argument. Similarly, [Map_reduce_function] modules must be created using the
+    [Make_map_combine_function] or [Make_map_combine_function_with_init] functors. *)
+
+module type Map_function = sig
+  module Param : Binable
+  module Input : Binable
+  module Output : Binable
+
+  module Worker : Worker
+    with type param_type = Param.t
+     and type run_input_type = Input.t
+     and type run_output_type = Output.t
+end
+
+module type Map_function_with_init_spec = sig
+  type state_type
+  module Param : Binable
+  module Input : Binable
+  module Output : Binable
+
+  val init : Param.t -> state_type Deferred.t
+  val map : state_type -> Input.t -> Output.t Deferred.t
+end
+
+module Make_map_function_with_init(S : Map_function_with_init_spec) : Map_function
+  with type Param.t = S.Param.t
+   and type Input.t = S.Input.t
+   and type Output.t = S.Output.t
+
+module type Map_function_spec = sig
+  module Input : Binable
+  module Output : Binable
+
+  val map : Input.t -> Output.t Deferred.t
+end
+
+module Make_map_function(S : Map_function_spec) : Map_function
+  with type Param.t = unit
+   and type Input.t = S.Input.t
+   and type Output.t = S.Output.t
+
+(** The [map_unordered] operation takes ['a Pipe.Reader.t] along with a [Map_function] and
+    sends the ['a] values to workers for mapping. Each pair in the resulting [('b * int)
+    Pipe.Reader.t] contains the mapped value and the index of the value in the input
+    pipe. *)
+val map_unordered
+  :  Config.t
+  -> 'a Pipe.Reader.t
+  -> m : (module Map_function
+           with type Param.t = 'param
+            and type Input.t = 'a
+            and type Output.t = 'b)
+  -> param : 'param
+  -> ('b * int) Pipe.Reader.t Deferred.t
+
+(** The [map] operation is similar to [map_unordered], but the result is a ['b
+    Pipe.Reader.t] where the mapped values are guaranteed to be in the same order as the
+    input values. *)
+val map
+  :  Config.t
+  -> 'a Pipe.Reader.t
+  -> m : (module Map_function
+           with type Param.t = 'param
+            and type Input.t = 'a
+            and type Output.t = 'b)
+  -> param : 'param
+  -> 'b Pipe.Reader.t Deferred.t
+
+(** The [find_map] operation takes ['a Pipe.Reader.t] along with a [Map_function] that
+    returns ['b option] values. As soon as [map] returns [Some value], all workers are
+    stopped and [Some value] is returned. If [map] never returns [Some value] then [None]
+    is returned. If more than one worker returns [Some value], one value is chosen
+    arbitrarily and returned. *)
+val find_map
+  :  Config.t
+  -> 'a Pipe.Reader.t
+  -> m : (module Map_function
+           with type Param.t = 'param
+            and type Input.t = 'a
+            and type Output.t = 'b option)
+  -> param : 'param
+  -> 'b option Deferred.t
+
+
+(** {4 Map-reduce} functions *)
+
+module type Map_reduce_function = sig
+  module Param : Binable
+  module Accum : Binable
+  module Input : Binable
+
+  module Worker : Worker
+    with type param_type = Param.t
+     and type run_input_type =
+           [ `Map of Input.t
+           | `Combine of Accum.t * Accum.t
+           | `Map_right_combine of Accum.t * Input.t (* combine accum (map input) *)
+           ]
+     and type run_output_type = Accum.t
+end
+
+module type Map_reduce_function_with_init_spec = sig
+  type state_type
+  module Param : Binable
+  module Accum : Binable
+  module Input : Binable
+
+  val init : Param.t -> state_type Deferred.t
+  val map : state_type -> Input.t -> Accum.t Deferred.t
+  val combine : state_type -> Accum.t -> Accum.t -> Accum.t Deferred.t
+end
+
+module Make_map_reduce_function_with_init(S : Map_reduce_function_with_init_spec)
+  : Map_reduce_function
+    with type Param.t = S.Param.t
+     and type Accum.t = S.Accum.t
+     and type Input.t = S.Input.t
+
+module type Map_reduce_function_spec = sig
+  module Accum : Binable
+  module Input : Binable
+
+  val map : Input.t -> Accum.t Deferred.t
+  val combine : Accum.t -> Accum.t -> Accum.t Deferred.t
+end
+
+module Make_map_reduce_function(S : Map_reduce_function_spec) : Map_reduce_function
+  with type Param.t = unit
+   and type Accum.t = S.Accum.t
+   and type Input.t = S.Input.t
+
+(** The [map_reduce_commutative] operation takes ['a Pipe.Reader.t] along with a
+    [Map_reduce_function] and applies the [map] function to ['a] values (in an unspecified
+    order), resulting in ['accum] values. The [combine] function is then called to combine
+    the ['accum] values (in an unspecified order) into a single ['accum]
+    value. Commutative map-reduce assumes that [combine] is associative and
+    commutative. *)
+val map_reduce_commutative
+  :  Config.t
+  -> 'a Pipe.Reader.t
+  -> m : (module Map_reduce_function
+           with type Param.t = 'param
+            and type Accum.t = 'accum
+            and type Input.t = 'a)
+  -> param : 'param
+  -> 'accum option Deferred.t
+
+(** The [map_reduce] operation makes strong guarantees about the order in which the values
+    are processed by [combine]. For a list a_0, a_1, a_2, ..., a_n of ['a] values, the
+    noncommutative map-reduce operation applies the [map] function to produce
+    [acc_{i,i+1}] from each [a_i]. The [combine] function is used to compute [combine
+    acc_{i,j} acc_{j,k}] for i<j<k, producing [acc_{i,k}]. The [map] and [combine]
+    functions are called repeatedly until the entire list is reduced to a single
+    [acc_{0,n+1}] value. Noncommutative map-reduce assumes that [combine] is
+    associative. *)
+val map_reduce
+  :  Config.t
+  -> 'a Pipe.Reader.t
+  -> m : (module Map_reduce_function
+           with type Param.t = 'param
+            and type Accum.t = 'accum
+            and type Input.t = 'a)
+  -> param : 'param
+  -> 'accum option Deferred.t

--- a/src/external/rpc_parallel/src/parallel.ml
+++ b/src/external/rpc_parallel/src/parallel.ml
@@ -1,0 +1,1427 @@
+open Core
+open Async
+open Parallel_intf
+module Worker_type_id = Utils.Worker_type_id
+module Worker_id = Utils.Worker_id
+
+(* All processes start a "master" rpc server. This is a server that has two
+   implementations:
+
+   (1) Register - Spawned workers say hello to the spawner
+   (2) Handle_exn - Spawned workers send exceptions to the spawner
+
+   Processes can also start "worker" rpc servers (in process using [serve] or out of
+   process using [spawn]). A "worker" rpc server has all the user defined implementations
+   as well as:
+
+   (1) Init_worker_state - Spawner sends the worker init argument
+   (2) Init_connection_state - Connector sends the connection state init argument
+   (3) Shutdown, Close_server, Async_log, etc.
+
+   The handshake protocol for spawning a worker:
+
+   (Master) - SSH and start running executable
+   (Worker) - Start server, send [Register_rpc] with its host and port
+   (Master) - Connect to worker, send [Init_worker_state_rpc]
+   (Worker) - Do initialization (ensure we have daemonized first)
+   (Master) - Finally, return a [Worker.t] to the caller
+*)
+
+module Rpc_settings = struct
+  type t =
+    { max_message_size: int option
+    ; handshake_timeout: Time.Span.t option
+    ; heartbeat_config: Rpc.Connection.Heartbeat_config.t option }
+  [@@deriving sexp, bin_io]
+
+  let create ~max_message_size ~handshake_timeout ~heartbeat_config =
+    {max_message_size; handshake_timeout; heartbeat_config}
+end
+
+module Worker_implementations = struct
+  type t =
+    | T :
+        ('state, 'connection_state) Utils.Internal_connection_state.t
+        Rpc.Implementation.t
+        list
+        -> t
+end
+
+(* Applications of the [Make()] functor have the side effect of populating an
+   [implementations] list which subsequently adds an entry for that worker type id to the
+   [worker_implementations]. *)
+let worker_implementations = Worker_type_id.Table.create ~size:1 ()
+
+(* All global state that is needed for a process to act as a master *)
+type master_state =
+  { (* The [Host_and_port.t] corresponding to one's own master Rpc server. *)
+    my_server:
+      Host_and_port.t Deferred.t lazy_t
+      (* The rpc settings used universally for all rpc connections *)
+  ; app_rpc_settings:
+      Rpc_settings.t
+      (* Used to facilitate timeout of connecting to a spawned worker *)
+  ; pending:
+      Host_and_port.t Ivar.t Worker_id.Table.t
+      (* Arguments used when spawning a new worker. *)
+  ; worker_command_args:
+      [`Decorate_with_name | `User_supplied of string list]
+      (* Callbacks for spawned worker exceptions along with the monitor that was current
+     when [spawn] was called *)
+  ; on_failures: ((Error.t -> unit) * Monitor.t) Worker_id.Table.t }
+
+(* All global state that is not specific to worker types is collected here *)
+type worker_state =
+  { (* Currently running worker servers in this process *)
+    my_worker_servers:
+      (Socket.Address.Inet.t, int) Tcp.Server.t Worker_id.Table.t
+      (* To facilitate process creation cleanup.*)
+  ; initialized:
+      [`Init_started of [`Initialized] Or_error.t Deferred.t] Set_once.t }
+
+type global_state = {as_master: master_state; as_worker: worker_state}
+
+(* Each running instance has the capability to work as a master. This state includes
+   information needed to spawn new workers (my_server, my_rpc_settings, pending,
+   worker_command_args), information to handle existing spawned workerd (on_failures), and
+   information to handle worker servers that are running in process. *)
+let global_state : global_state Set_once.t = Set_once.create ()
+
+let get_state_exn () =
+  match Set_once.get global_state with
+  | None -> failwith "State should have been set already"
+  | Some state -> state
+
+let get_master_state_exn () = (get_state_exn ()).as_master
+
+let get_worker_state_exn () = (get_state_exn ()).as_worker
+
+(* Functions that are implemented by all workers *)
+module Shutdown_rpc = struct
+  let rpc =
+    Rpc.One_way.create ~name:"shutdown_rpc" ~version:0 ~bin_msg:Unit.bin_t
+end
+
+module Close_server_rpc = struct
+  let rpc =
+    Rpc.One_way.create ~name:"close_server_rpc" ~version:0 ~bin_msg:Unit.bin_t
+end
+
+module Async_log_rpc = struct
+  let rpc =
+    Rpc.Pipe_rpc.create ~name:"async_log_rpc" ~version:0 ~bin_query:Unit.bin_t
+      ~bin_response:Log.Message.Stable.V2.bin_t ~bin_error:Error.bin_t ()
+end
+
+module Function = struct
+  module Rpc_id = Unique_id.Int ()
+
+  let maybe_generate_name ~prefix ~name =
+    match name with
+    | None -> sprintf "%s_%s" prefix (Rpc_id.to_string (Rpc_id.create ()))
+    | Some n -> n
+
+  module Function_piped = struct
+    type ('worker, 'query, 'response) t =
+      ('query, 'response, Error.t) Rpc.Pipe_rpc.t
+
+    let make_impl ~monitor ~f protocol =
+      Rpc.Pipe_rpc.implement protocol
+        (fun ((_conn : Rpc.Connection.t), internal_conn_state) arg ->
+          let {Utils.Internal_connection_state.conn_state; worker_state; _} =
+            Set_once.get_exn internal_conn_state [%here]
+          in
+          Utils.try_within ~monitor (fun () -> f ~worker_state ~conn_state arg)
+      )
+
+    let make_direct_impl ~monitor ~f protocol =
+      Rpc.Pipe_rpc.implement_direct protocol
+        (fun ((_conn : Rpc.Connection.t), internal_conn_state) arg writer ->
+          let {Utils.Internal_connection_state.conn_state; worker_state; _} =
+            Set_once.get_exn internal_conn_state [%here]
+          in
+          Utils.try_within ~monitor (fun () ->
+              f ~worker_state ~conn_state arg writer ) )
+
+    let make_proto ~name ~bin_input ~bin_output =
+      let name = maybe_generate_name ~prefix:"rpc_parallel_piped" ~name in
+      Rpc.Pipe_rpc.create ~name ~version:0 ~bin_query:bin_input
+        ~bin_response:bin_output ~bin_error:Error.bin_t ()
+  end
+
+  module Function_plain = struct
+    type ('worker, 'query, 'response) t = ('query, 'response) Rpc.Rpc.t
+
+    let make_impl ~monitor ~f protocol =
+      Rpc.Rpc.implement protocol
+        (fun ((_conn : Rpc.Connection.t), internal_conn_state) arg ->
+          let {Utils.Internal_connection_state.conn_state; worker_state; _} =
+            Set_once.get_exn internal_conn_state [%here]
+          in
+          (* We want to raise any exceptions from [f arg] to the current monitor (handled
+               by Rpc) so the caller can see it. Additional exceptions will be handled by the
+               specified monitor *)
+          Utils.try_within_exn ~monitor (fun () ->
+              f ~worker_state ~conn_state arg ) )
+
+    let make_proto ~name ~bin_input ~bin_output =
+      let name = maybe_generate_name ~prefix:"rpc_parallel_plain" ~name in
+      Rpc.Rpc.create ~name ~version:0 ~bin_query:bin_input
+        ~bin_response:bin_output
+  end
+
+  module Function_reverse_piped = struct
+    module Id = Unique_id.Int ()
+
+    type ('worker, 'query, 'update, 'response) t =
+      { worker_rpc: ('query * Id.t, 'response) Rpc.Rpc.t
+      ; master_rpc: (Id.t, 'update, Error.t) Rpc.Pipe_rpc.t
+      ; master_in_progress: 'update Pipe.Reader.t Id.Table.t }
+
+    let make_worker_impl ~monitor ~f t =
+      Rpc.Rpc.implement t.worker_rpc
+        (fun (conn, internal_conn_state) (arg, id) ->
+          let {Utils.Internal_connection_state.conn_state; worker_state; _} =
+            Set_once.get_exn internal_conn_state [%here]
+          in
+          Utils.try_within_exn ~monitor (fun () ->
+              Rpc.Pipe_rpc.dispatch t.master_rpc conn id
+              >>= function
+              | Ok (Ok (updates, (_ : Rpc.Pipe_rpc.Metadata.t))) ->
+                  f ~worker_state ~conn_state arg updates
+              | Ok (Error error) | Error error -> Error.raise error ) )
+
+    let make_master_impl t =
+      Rpc.Pipe_rpc.implement t.master_rpc (fun () id ->
+          match Hashtbl.find_and_remove t.master_in_progress id with
+          | None ->
+              Deferred.Or_error.error_s
+                [%message
+                  "Bug in Rpc_parallel: reverse pipe master implementation \
+                   not found"
+                    (id : Id.t)
+                    (Rpc.Pipe_rpc.name t.master_rpc : string)]
+          | Some pipe_reader -> Deferred.Or_error.return pipe_reader )
+
+    let make_proto ~name ~bin_query ~bin_update ~bin_response =
+      let name =
+        maybe_generate_name ~prefix:"rpc_parallel_reverse_piped" ~name
+      in
+      let worker_rpc =
+        let module With_id = struct
+          type 'a t = 'a * Id.t [@@deriving bin_io]
+        end in
+        Rpc.Rpc.create ~name ~version:0 ~bin_query:(With_id.bin_t bin_query)
+          ~bin_response
+      in
+      let master_rpc =
+        Rpc.Pipe_rpc.create ~name ~version:0 ~bin_query:Id.bin_t
+          ~bin_response:bin_update ~bin_error:Error.bin_t ()
+      in
+      let master_in_progress = Id.Table.create () in
+      {worker_rpc; master_rpc; master_in_progress}
+  end
+
+  module Function_one_way = struct
+    type ('worker, 'query) t = 'query Rpc.One_way.t
+
+    let make_impl ~monitor ~f protocol =
+      Rpc.One_way.implement protocol
+        (fun ((_conn : Rpc.Connection.t), internal_conn_state) arg ->
+          let {Utils.Internal_connection_state.conn_state; worker_state; _} =
+            Set_once.get_exn internal_conn_state [%here]
+          in
+          don't_wait_for
+            (* Even though [f] returns [unit], we want to use [try_within_exn] so if it
+                 starts any background jobs we won't miss the exceptions *)
+            (Utils.try_within_exn ~monitor (fun () ->
+                 f ~worker_state ~conn_state arg |> return )) )
+
+    let make_proto ~name ~bin_input =
+      let name =
+        match name with
+        | None ->
+            sprintf "rpc_parallel_one_way_%s"
+              (Rpc_id.to_string (Rpc_id.create ()))
+        | Some n -> n
+      in
+      Rpc.One_way.create ~name ~version:0 ~bin_msg:bin_input
+  end
+
+  type ('worker, 'query, 'response) t_internal =
+    | Plain of ('worker, 'query, 'response) Function_plain.t
+    | Piped :
+        ('worker, 'query, 'response) Function_piped.t
+        * ('r, 'response Pipe.Reader.t) Type_equal.t
+        -> ('worker, 'query, 'r) t_internal
+    | Directly_piped :
+        ('worker, 'query, 'response) Function_piped.t
+        -> ( 'worker
+           , 'query
+             * (   'response Rpc.Pipe_rpc.Pipe_message.t
+                -> Rpc.Pipe_rpc.Pipe_response.t)
+           , Rpc.Pipe_rpc.Id.t )
+           t_internal
+    | One_way :
+        ('worker, 'query) Function_one_way.t
+        -> ('worker, 'query, unit) t_internal
+    | Reverse_piped :
+        ('worker, 'query, 'update, 'response) Function_reverse_piped.t
+        * ('q, 'query * 'update Pipe.Reader.t) Type_equal.t
+        -> ('worker, 'q, 'response) t_internal
+
+  type ('worker, 'query, 'response) t =
+    | T :
+        ('query -> 'query_internal)
+        * ('worker, 'query_internal, 'response_internal) t_internal
+        * ('response_internal -> 'response)
+        -> ('worker, 'query, 'response) t
+
+  module Direct_pipe = struct
+    type nonrec ('worker, 'query, 'response) t =
+      ( 'worker
+      , 'query
+        * (   'response Rpc.Pipe_rpc.Pipe_message.t
+           -> Rpc.Pipe_rpc.Pipe_response.t)
+      , Rpc.Pipe_rpc.Id.t )
+      t
+  end
+
+  let map (T (q, i, r)) ~f = T (q, i, Fn.compose f r)
+
+  let contra_map (T (q, i, r)) ~f = T (Fn.compose q f, i, r)
+
+  let create_rpc ~monitor ~name ~f ~bin_input ~bin_output =
+    let proto = Function_plain.make_proto ~name ~bin_input ~bin_output in
+    let impl = Function_plain.make_impl ~monitor ~f proto in
+    (T (Fn.id, Plain proto, Fn.id), impl)
+
+  let create_pipe ~monitor ~name ~f ~bin_input ~bin_output =
+    let proto = Function_piped.make_proto ~name ~bin_input ~bin_output in
+    let impl = Function_piped.make_impl ~monitor ~f proto in
+    (T (Fn.id, Piped (proto, Type_equal.T), Fn.id), impl)
+
+  let create_direct_pipe ~monitor ~name ~f ~bin_input ~bin_output =
+    let proto = Function_piped.make_proto ~name ~bin_input ~bin_output in
+    let impl = Function_piped.make_direct_impl ~monitor ~f proto in
+    (T (Fn.id, Directly_piped proto, Fn.id), impl)
+
+  let create_one_way ~monitor ~name ~f ~bin_input =
+    let proto = Function_one_way.make_proto ~name ~bin_input in
+    let impl = Function_one_way.make_impl ~monitor ~f proto in
+    (T (Fn.id, One_way proto, Fn.id), impl)
+
+  let create_reverse_pipe ~monitor ~name ~f ~bin_query ~bin_update
+      ~bin_response =
+    let proto =
+      Function_reverse_piped.make_proto ~name ~bin_query ~bin_update
+        ~bin_response
+    in
+    let worker_impl =
+      Function_reverse_piped.make_worker_impl ~monitor ~f proto
+    in
+    let master_impl = Function_reverse_piped.make_master_impl proto in
+    ( T (Fn.id, Reverse_piped (proto, Type_equal.T), Fn.id)
+    , `Worker worker_impl
+    , `Master master_impl )
+
+  let of_async_rpc ~monitor ~f proto =
+    let impl = Function_plain.make_impl ~monitor ~f proto in
+    (T (Fn.id, Plain proto, Fn.id), impl)
+
+  let of_async_pipe_rpc ~monitor ~f proto =
+    let impl = Function_piped.make_impl ~monitor ~f proto in
+    (T (Fn.id, Piped (proto, Type_equal.T), Fn.id), impl)
+
+  let of_async_direct_pipe_rpc ~monitor ~f proto =
+    let impl = Function_piped.make_direct_impl ~monitor ~f proto in
+    (T (Fn.id, Directly_piped proto, Fn.id), impl)
+
+  let of_async_one_way_rpc ~monitor ~f proto =
+    let impl = Function_one_way.make_impl ~monitor ~f proto in
+    (T (Fn.id, One_way proto, Fn.id), impl)
+
+  let run_internal (type query response)
+      (t_internal : (_, query, response) t_internal) connection ~(arg : query)
+      : response Or_error.t Deferred.t =
+    match t_internal with
+    | Plain proto -> Rpc.Rpc.dispatch proto connection arg
+    | Piped (proto, Type_equal.T) ->
+        Rpc.Pipe_rpc.dispatch proto connection arg
+        >>| fun result ->
+        Or_error.join result |> Or_error.map ~f:(fun (reader, _) -> reader)
+    | One_way proto -> Rpc.One_way.dispatch proto connection arg |> return
+    | Reverse_piped
+        ({worker_rpc; master_rpc= _; master_in_progress}, Type_equal.T) ->
+        let query, updates = arg in
+        let key = Function_reverse_piped.Id.create () in
+        Hashtbl.add_exn master_in_progress ~key ~data:updates ;
+        Rpc.Rpc.dispatch worker_rpc connection (query, key)
+        >>| fun result ->
+        Hashtbl.remove master_in_progress key ;
+        result
+    | Directly_piped proto ->
+        let arg, f = arg in
+        Rpc.Pipe_rpc.dispatch_iter proto connection arg ~f >>| Or_error.join
+
+  let run (T (query_f, t_internal, response_f)) connection ~arg =
+    run_internal t_internal connection ~arg:(query_f arg)
+    >>| Or_error.map ~f:response_f
+
+  let async_log = T (Fn.id, Piped (Async_log_rpc.rpc, Type_equal.T), Fn.id)
+
+  let close_server = T (Fn.id, One_way Close_server_rpc.rpc, Fn.id)
+end
+
+module Daemonize_args = struct
+  type args =
+    { umask: int option
+    ; redirect_stderr: Fd_redirection.t
+    ; redirect_stdout: Fd_redirection.t }
+  [@@deriving sexp]
+
+  type t = [`Don't_daemonize | `Daemonize of args] [@@deriving sexp]
+end
+
+module Heartbeater_master : sig
+  type t [@@deriving bin_io]
+
+  val create :
+    host_and_port:Host_and_port.t -> rpc_settings:Rpc_settings.t -> t
+
+  val connect_and_shutdown_on_disconnect_exn : t -> [`Connected] Deferred.t
+end = struct
+  type t = {host_and_port: Host_and_port.t; rpc_settings: Rpc_settings.t}
+  [@@deriving bin_io]
+
+  let create ~host_and_port ~rpc_settings = {host_and_port; rpc_settings}
+
+  let connect_and_wait_for_disconnect_exn {host_and_port; rpc_settings} =
+    let {Rpc_settings.handshake_timeout; heartbeat_config; _} = rpc_settings in
+    Rpc.Connection.client
+      (Tcp.Where_to_connect.of_host_and_port host_and_port)
+      ?handshake_timeout ?heartbeat_config
+    >>| function
+    | Error e -> raise e
+    | Ok conn ->
+        `Connected
+          (Rpc.Connection.close_finished conn >>| fun () -> `Disconnected)
+
+  let connect_and_shutdown_on_disconnect_exn heartbeater =
+    connect_and_wait_for_disconnect_exn heartbeater
+    >>= fun (`Connected wait_for_disconnect) ->
+    ( wait_for_disconnect
+    >>> fun `Disconnected ->
+    Log.Global.error
+      "Rpc_parallel: Heartbeater with master lost connection... Shutting down." ;
+    Shutdown.shutdown 254 ) ;
+    return `Connected
+end
+
+module type Worker =
+  Worker with type ('w, 'q, 'r) _function := ('w, 'q, 'r) Function.t
+
+module type Functions = Functions
+
+module type Creator =
+  Creator
+  with type ('w, 'q, 'r) _function := ('w, 'q, 'r) Function.t
+   and type ('w, 'q, 'r) _direct := ('w, 'q, 'r) Function.Direct_pipe.t
+
+module type Worker_spec =
+  Worker_spec
+  with type ('w, 'q, 'r) _function := ('w, 'q, 'r) Function.t
+   and type ('w, 'q, 'r) _direct := ('w, 'q, 'r) Function.Direct_pipe.t
+
+let start_server ~max_message_size ~handshake_timeout ~heartbeat_config
+    ~where_to_listen ~implementations ~initial_connection_state =
+  let implementations =
+    Rpc.Implementations.create_exn ~implementations
+      ~on_unknown_rpc:`Close_connection
+  in
+  Rpc.Connection.serve ~implementations ~initial_connection_state
+    ?max_message_size ?handshake_timeout ?heartbeat_config ~where_to_listen ()
+
+module Worker_config = struct
+  type t =
+    { worker_type: Worker_type_id.t
+    ; worker_id: Worker_id.t
+    ; name: string option
+    ; master: Host_and_port.t
+    ; app_rpc_settings: Rpc_settings.t
+    ; cd: string
+    ; daemonize_args: Daemonize_args.t
+    ; connection_timeout: Time.Span.t
+    ; worker_command_args: [`Decorate_with_name | `User_supplied of string list]
+    }
+  [@@deriving fields, sexp]
+end
+
+module Worker_env = struct
+  type t = {config: Worker_config.t; maybe_release_daemon: unit -> unit}
+  [@@deriving fields]
+end
+
+(* Rpcs implemented by master *)
+module Register_rpc = struct
+  type t = Worker_id.t * Host_and_port.t [@@deriving bin_io]
+
+  type response = [`Shutdown | `Registered] [@@deriving bin_io]
+
+  let rpc =
+    Rpc.Rpc.create ~name:"register_worker_rpc" ~version:0 ~bin_query:bin_t
+      ~bin_response
+
+  let implementation =
+    Rpc.Rpc.implement rpc (fun () (id, worker_hp) ->
+        let global_state = get_master_state_exn () in
+        match Hashtbl.find global_state.pending id with
+        | None ->
+            (* We already returned a failure to the [spawn_worker] caller *)
+            return `Shutdown
+        | Some ivar ->
+            Ivar.fill ivar worker_hp ;
+            return `Registered )
+end
+
+module Handle_exn_rpc = struct
+  type t = {id: Worker_id.t; name: string option; error: Error.t}
+  [@@deriving bin_io]
+
+  let rpc =
+    Rpc.Rpc.create ~name:"handle_worker_exn_rpc" ~version:0 ~bin_query:bin_t
+      ~bin_response:Unit.bin_t
+
+  let implementation =
+    Rpc.Rpc.implement rpc (fun () {id; name; error} ->
+        let global_state = get_master_state_exn () in
+        let on_failure, monitor =
+          Hashtbl.find_exn global_state.on_failures id
+        in
+        let name = Option.value ~default:(Worker_id.to_string id) name in
+        let error = Error.tag error ~tag:name in
+        (* We can't just run [on_failure error] because this will be caught by the Rpc
+           monitor for this implementation. *)
+        Scheduler.within ~monitor (fun () -> on_failure error) ;
+        return () )
+end
+
+(* In order to spawn other workers, you must have an rpc server implementing
+   [Register_rpc] and [Handle_exn_rpc] *)
+let master_implementations =
+  [Register_rpc.implementation; Handle_exn_rpc.implementation]
+
+(* Setup some global state necessary to act as a master (i.e. spawn workers). This
+   includes starting an Rpc server with [master_implementations] *)
+let init_master_state ~rpc_max_message_size ~rpc_handshake_timeout
+    ~rpc_heartbeat_config ~worker_command_args =
+  match Set_once.get global_state with
+  | Some _state -> failwith "Master state must not be set up twice"
+  | None ->
+      let app_rpc_settings =
+        Rpc_settings.create ~max_message_size:rpc_max_message_size
+          ~handshake_timeout:rpc_handshake_timeout
+          ~heartbeat_config:rpc_heartbeat_config
+      in
+      (* Use [size:1] so there is minimal top-level overhead linking with Rpc_parallel *)
+      let pending = Worker_id.Table.create ~size:1 () in
+      let on_failures = Worker_id.Table.create ~size:1 () in
+      let my_worker_servers = Worker_id.Table.create ~size:1 () in
+      (* Lazily start our master rpc server *)
+      let my_server =
+        lazy
+          ( start_server ~max_message_size:rpc_max_message_size
+              ~handshake_timeout:rpc_handshake_timeout
+              ~heartbeat_config:rpc_heartbeat_config
+              ~where_to_listen:Tcp.Where_to_listen.of_port_chosen_by_os
+              ~implementations:master_implementations
+              ~initial_connection_state:(fun _ _ -> () )
+          >>| fun server ->
+          Host_and_port.create ~host:(Unix.gethostname ())
+            ~port:(Tcp.Server.listening_on server) )
+      in
+      let as_master =
+        {my_server; app_rpc_settings; pending; worker_command_args; on_failures}
+      in
+      let as_worker = {my_worker_servers; initialized= Set_once.create ()} in
+      Set_once.set_exn global_state [%here] {as_master; as_worker}
+
+module Make (S : Worker_spec) = struct
+  module Id = Utils.Worker_id
+
+  type t =
+    { host_and_port: Host_and_port.t
+    ; rpc_settings: Rpc_settings.t
+    ; id: Worker_id.t
+    ; name: string option }
+  [@@deriving bin_io, sexp_of]
+
+  type worker = t
+
+  (* Internally we use [Worker_id.t] for all worker ids, but we want to expose an [Id]
+     module that is specific to each worker. *)
+  let id t = t.id
+
+  type worker_state =
+    { (* A unique identifier for each application of the [Make] functor.
+         Because we are running the same executable and this is supposed to run at the
+         top level, the master and the workers agree on these ids *)
+      type_:
+        Worker_type_id.t
+        (* Persistent states associated with instances of this worker server *)
+    ; states:
+        S.Worker_state.t Worker_id.Table.t
+        (* To facilitate cleanup in the [Shutdown_on.Disconnect] case *)
+    ; mutable client_has_connected:
+        bool (* Build up a list of all implementations for this worker type *)
+    ; mutable implementations:
+        ( S.Worker_state.t
+        , S.Connection_state.t )
+        Utils.Internal_connection_state.t
+        Rpc.Implementation.t
+        list
+    ; mutable master_implementations: unit Rpc.Implementation.t list }
+
+  let worker_state =
+    { type_= Worker_type_id.create ()
+    ; states= Worker_id.Table.create ~size:1 ()
+    ; client_has_connected= false
+    ; implementations= []
+    ; master_implementations= [] }
+
+  (* Schedule all worker implementations in [Monitor.main] so no exceptions are lost.
+     Async log automatically throws its exceptions to [Monitor.main] so we can't make
+     our own local monitor. We detach [Monitor.main] and send exceptions back to the
+     master. *)
+  let monitor = Monitor.main
+
+  (* Rpcs implemented by this worker type. The implementations for some must be below
+     because User_functions is defined below (by supplying a [Creator] module) *)
+  module Init_worker_state_rpc = struct
+    type query =
+      { (* The heartbeater of the process that called [spawn] *)
+        master: Heartbeater_master.t option (* The process that got spawned *)
+      ; worker: Worker_id.t
+      ; arg: S.Worker_state.init_arg
+      ; initial_client_connection_timeout: Time.Span.t option }
+    [@@deriving bin_io]
+
+    let rpc =
+      Rpc.Rpc.create
+        ~name:
+          (sprintf "worker_init_rpc_%s"
+             (Worker_type_id.to_string worker_state.type_))
+        ~version:0 ~bin_query ~bin_response:Unit.bin_t
+  end
+
+  module Init_connection_state_rpc = struct
+    type query =
+      { worker_id: Worker_id.t
+      ; worker_shutdown_on_disconnect: bool
+      ; arg: S.Connection_state.init_arg }
+    [@@deriving bin_io]
+
+    let rpc =
+      Rpc.Rpc.create
+        ~name:
+          (sprintf "set_connection_state_rpc_%s"
+             (Worker_type_id.to_string worker_state.type_))
+        ~version:0 ~bin_query ~bin_response:Unit.bin_t
+  end
+
+  let run_executable where ~env ~worker_command_args ~input =
+    Utils.create_worker_env ~extra:env
+    |> return
+    >>=? fun env ->
+    match where with
+    | Executable_location.Local ->
+        Utils.our_binary ()
+        >>=? fun our_binary ->
+        Process.create ~prog:our_binary ~args:worker_command_args
+          ~env:(`Extend env) ()
+        >>|? fun p ->
+        Writer.write_sexp (Process.stdin p) input ;
+        p
+    | Executable_location.Remote exec ->
+        Remote_executable.run exec ~env ~args:worker_command_args
+        >>|? fun p ->
+        Writer.write_sexp (Process.stdin p) input ;
+        p
+
+  module Function_creator = struct
+    type nonrec worker = worker
+
+    type connection_state = S.Connection_state.t
+
+    type worker_state = S.Worker_state.t
+
+    let with_add_impl f =
+      let func, impl = f () in
+      worker_state.implementations <- impl :: worker_state.implementations ;
+      func
+
+    let create_rpc ?name ~f ~bin_input ~bin_output () =
+      with_add_impl (fun () ->
+          Function.create_rpc ~monitor ~name ~f ~bin_input ~bin_output )
+
+    let create_pipe ?name ~f ~bin_input ~bin_output () =
+      with_add_impl (fun () ->
+          Function.create_pipe ~monitor ~name ~f ~bin_input ~bin_output )
+
+    let create_direct_pipe ?name ~f ~bin_input ~bin_output () =
+      with_add_impl (fun () ->
+          Function.create_direct_pipe ~monitor ~name ~f ~bin_input ~bin_output
+      )
+
+    let create_one_way ?name ~f ~bin_input () =
+      with_add_impl (fun () ->
+          Function.create_one_way ~monitor ~name ~f ~bin_input )
+
+    let create_reverse_pipe ?name ~f ~bin_query ~bin_update ~bin_response () =
+      let func, `Worker worker_impl, `Master master_impl =
+        Function.create_reverse_pipe ~monitor ~name ~f ~bin_query ~bin_update
+          ~bin_response
+      in
+      worker_state.implementations
+      <- worker_impl :: worker_state.implementations ;
+      worker_state.master_implementations
+      <- master_impl :: worker_state.master_implementations ;
+      func
+
+    let of_async_rpc ~f proto =
+      with_add_impl (fun () -> Function.of_async_rpc ~monitor ~f proto)
+
+    let of_async_pipe_rpc ~f proto =
+      with_add_impl (fun () -> Function.of_async_pipe_rpc ~monitor ~f proto)
+
+    let of_async_direct_pipe_rpc ~f proto =
+      with_add_impl (fun () ->
+          Function.of_async_direct_pipe_rpc ~monitor ~f proto )
+
+    let of_async_one_way_rpc ~f proto =
+      with_add_impl (fun () -> Function.of_async_one_way_rpc ~monitor ~f proto)
+  end
+
+  module User_functions = S.Functions (Function_creator)
+
+  let functions = User_functions.functions
+
+  let master_implementations : _ Rpc.Connection.Client_implementations.t =
+    { connection_state= const ()
+    ; implementations=
+        Rpc.Implementations.create_exn
+          ~implementations:worker_state.master_implementations
+          ~on_unknown_rpc:`Close_connection }
+
+  let serve ?max_message_size ?handshake_timeout ?heartbeat_config
+      worker_state_init_arg =
+    match Hashtbl.find worker_implementations worker_state.type_ with
+    | None ->
+        failwith
+          "Worker could not find RPC implementations. Make sure the \
+           Parallel.Make () functor is applied in the worker. It is suggested \
+           to make this toplevel."
+    | Some (Worker_implementations.T worker_implementations) ->
+        start_server ~implementations:worker_implementations
+          ~initial_connection_state:(fun _address connection ->
+            (connection, Set_once.create ()) )
+          ~max_message_size ~handshake_timeout ~heartbeat_config
+          ~where_to_listen:Tcp.Where_to_listen.of_port_chosen_by_os
+        >>= fun server ->
+        let id = Worker_id.create () in
+        let host = Unix.gethostname () in
+        let port = Tcp.Server.listening_on server in
+        let global_state = get_worker_state_exn () in
+        Hashtbl.add_exn global_state.my_worker_servers ~key:id ~data:server ;
+        User_functions.init_worker_state worker_state_init_arg
+        >>| fun state ->
+        Hashtbl.add_exn worker_state.states ~key:id ~data:state ;
+        let rpc_settings =
+          Rpc_settings.create ~max_message_size ~handshake_timeout
+            ~heartbeat_config
+        in
+        { host_and_port= Host_and_port.create ~host ~port
+        ; rpc_settings
+        ; id
+        ; name= None }
+
+  module Connection = struct
+    type t = {connection: Rpc.Connection.t; worker_id: Id.t}
+    [@@deriving fields, sexp_of]
+
+    let close t = Rpc.Connection.close t.connection
+
+    let close_finished t = Rpc.Connection.close_finished t.connection
+
+    let close_reason t = Rpc.Connection.close_reason t.connection
+
+    let is_closed t = Rpc.Connection.is_closed t.connection
+
+    let client_aux ~worker_shutdown_on_disconnect
+        {host_and_port; rpc_settings; id= worker_id; _} init_arg =
+      let {Rpc_settings.max_message_size; handshake_timeout; heartbeat_config}
+          =
+        rpc_settings
+      in
+      Rpc.Connection.client ?max_message_size ?handshake_timeout
+        ?heartbeat_config ~implementations:master_implementations
+        (Tcp.Where_to_connect.of_host_and_port host_and_port)
+      >>= function
+      | Error exn -> return (Error (Error.of_exn exn))
+      | Ok connection -> (
+          Rpc.Rpc.dispatch Init_connection_state_rpc.rpc connection
+            {worker_id; worker_shutdown_on_disconnect; arg= init_arg}
+          >>= function
+          | Error e -> Rpc.Connection.close connection >>| fun () -> Error e
+          | Ok () -> Deferred.Or_error.return {connection; worker_id} )
+
+    let client = client_aux ~worker_shutdown_on_disconnect:false
+
+    let client_with_worker_shutdown_on_disconnect =
+      client_aux ~worker_shutdown_on_disconnect:true
+
+    let client_exn worker init_arg = client worker init_arg >>| Or_error.ok_exn
+
+    let with_client worker init_arg ~f =
+      client worker init_arg
+      >>=? fun conn ->
+      Monitor.try_with (fun () -> f conn)
+      >>= fun result ->
+      close conn
+      >>| fun () -> Result.map_error result ~f:(fun exn -> Error.of_exn exn)
+
+    let run t ~f ~arg = Function.run f t.connection ~arg
+
+    let run_exn t ~f ~arg = run t ~f ~arg >>| Or_error.ok_exn
+  end
+
+  module Shutdown_on (M : T1) = struct
+    type _ t =
+      | Heartbeater_timeout : worker M.t Deferred.t t
+      | Disconnect
+          : (   connection_state_init_arg:S.Connection_state.init_arg
+             -> Connection.t M.t Deferred.t)
+            t
+      | Called_shutdown_function : worker M.t Deferred.t t
+
+    let args : type a.
+           a t
+        -> [`Client_will_immediately_connect of bool]
+           * [`Setup_master_heartbeater of bool] = function
+      | Heartbeater_timeout ->
+          ( `Client_will_immediately_connect false
+          , `Setup_master_heartbeater true )
+      | Disconnect ->
+          (* No heartbeater needed because we call
+           [Connection.client_with_worker_shutdown_on_disconnect] and the worker shuts
+           itself down if it times out waiting for a connection from the master. *)
+          ( `Client_will_immediately_connect true
+          , `Setup_master_heartbeater false )
+      | Called_shutdown_function ->
+          ( `Client_will_immediately_connect false
+          , `Setup_master_heartbeater false )
+  end
+
+  type 'a with_spawn_args =
+       ?where:Executable_location.t
+    -> ?name:string
+    -> ?env:(string * string) list
+    -> ?connection_timeout:Time.Span.t
+    -> ?cd:string
+    -> on_failure:(Error.t -> unit)
+    -> 'a
+
+  (* This timeout serves three purposes.
+
+     [spawn] returns an error if:
+     (1) the master hasn't gotten a register rpc from the spawned worker within
+     [connection_timeout] of sending the register rpc.
+     (2) a worker hasn't gotten its [init_arg] from the master within [connection_timeout]
+     of sending the register rpc
+
+     Additionally, if [~shutdown_on:Disconnect] was used:
+     (3) a worker will shut itself down if it doesn't get a connection from the master
+     after spawn succeeded. *)
+  let connection_timeout_default = sec 10.
+
+  let spawn_process ~where ~env ~cd ~name ~connection_timeout ~daemonize_args =
+    let where = Option.value where ~default:Executable_location.Local in
+    let env = Option.value env ~default:[] in
+    let cd = Option.value cd ~default:"/" in
+    let connection_timeout =
+      Option.value connection_timeout ~default:connection_timeout_default
+    in
+    ( match Set_once.get global_state with
+    | None ->
+        Deferred.Or_error.error_string
+          "You must initialize this process to run as a master before calling \
+           [spawn]. Either use a top-level [start_app] call or use the \
+           [Expert] module."
+    | Some global_state -> Deferred.Or_error.return global_state.as_master )
+    >>=? fun global_state ->
+    (* generate a unique identifier for this worker *)
+    let id = Worker_id.create () in
+    Lazy.force global_state.my_server
+    >>= fun master_server ->
+    let input =
+      { Worker_config.worker_type= worker_state.type_
+      ; worker_id= id
+      ; name
+      ; master= master_server
+      ; app_rpc_settings= global_state.app_rpc_settings
+      ; cd
+      ; daemonize_args
+      ; connection_timeout
+      ; worker_command_args= global_state.worker_command_args }
+      |> Worker_config.sexp_of_t
+    in
+    let pending_ivar = Ivar.create () in
+    let worker_command_args =
+      match global_state.worker_command_args with
+      | `Decorate_with_name ->
+          ["RPC_PARALLEL_WORKER"]
+          @ Option.value_map name ~default:[] ~f:(fun name -> [name])
+      | `User_supplied args -> args
+    in
+    Hashtbl.add_exn global_state.pending ~key:id ~data:pending_ivar ;
+    run_executable where ~env ~worker_command_args ~input
+    >>| function
+    | Error _ as err ->
+        Hashtbl.remove global_state.pending id ;
+        err
+    | Ok process -> Ok (id, process)
+
+  let with_client worker ~f =
+    let {host_and_port; rpc_settings; _} = worker in
+    let {Rpc_settings.max_message_size; handshake_timeout; heartbeat_config} =
+      rpc_settings
+    in
+    Rpc.Connection.with_client ?max_message_size ?handshake_timeout
+      ?heartbeat_config ~implementations:master_implementations
+      (Tcp.Where_to_connect.of_host_and_port host_and_port)
+      f
+
+  let shutdown worker =
+    with_client worker ~f:(fun conn ->
+        Rpc.One_way.dispatch Shutdown_rpc.rpc conn () |> return )
+    >>| Or_error.of_exn_result >>| Or_error.join
+
+  let with_shutdown_on_error worker ~f =
+    f ()
+    >>= function
+    | Ok _ as ret -> return ret
+    | Error _ as ret ->
+        shutdown worker >>= fun (_ : unit Or_error.t) -> return ret
+
+  let wait_for_connection_and_initialize ~name ~connection_timeout ~on_failure
+      ~id ~client_will_immediately_connect ~setup_master_heartbeater init_arg =
+    let connection_timeout =
+      Option.value connection_timeout ~default:connection_timeout_default
+    in
+    let global_state = get_master_state_exn () in
+    let pending_ivar = Hashtbl.find_exn global_state.pending id in
+    (* Ensure that we got a register from the worker *)
+    Clock.with_timeout connection_timeout (Ivar.read pending_ivar)
+    >>= function
+    | `Timeout ->
+        Hashtbl.remove global_state.pending id ;
+        Deferred.Or_error.error_string
+          "Timed out getting connection from process"
+    | `Result host_and_port ->
+        Hashtbl.remove global_state.pending id ;
+        let worker =
+          {host_and_port; rpc_settings= global_state.app_rpc_settings; id; name}
+        in
+        Lazy.force global_state.my_server
+        >>= fun master_server ->
+        Hashtbl.add_exn global_state.on_failures ~key:worker.id
+          ~data:(on_failure, Monitor.current ()) ;
+        with_shutdown_on_error worker ~f:(fun () ->
+            with_client worker ~f:(fun conn ->
+                let heartbeater =
+                  Option.some_if setup_master_heartbeater
+                    (Heartbeater_master.create ~host_and_port:master_server
+                       ~rpc_settings:global_state.app_rpc_settings)
+                in
+                Rpc.Rpc.dispatch Init_worker_state_rpc.rpc conn
+                  { master= heartbeater
+                  ; worker= id
+                  ; arg= init_arg
+                  ; initial_client_connection_timeout=
+                      Option.some_if client_will_immediately_connect
+                        connection_timeout } )
+            >>| function
+            | Error exn ->
+                Hashtbl.remove global_state.on_failures worker.id ;
+                Error (Error.of_exn exn)
+            | Ok (Error e) ->
+                Hashtbl.remove global_state.on_failures worker.id ;
+                Error e
+            | Ok (Ok ()) -> Ok worker )
+
+  module Spawn_in_foreground_result = struct
+    type 'a t = ('a * Process.t) Or_error.t
+  end
+
+  module Spawn_in_foreground_shutdown_on =
+    Shutdown_on (Spawn_in_foreground_result)
+
+  let spawn_in_foreground (type a) ?where ?name ?env ?connection_timeout ?cd
+      ~on_failure ~(shutdown_on : a Spawn_in_foreground_shutdown_on.t)
+      worker_state_init_arg : a =
+    let open Spawn_in_foreground_shutdown_on in
+    let daemonize_args = `Don't_daemonize in
+    let ( `Client_will_immediately_connect client_will_immediately_connect
+        , `Setup_master_heartbeater setup_master_heartbeater ) =
+      args shutdown_on
+    in
+    let spawn_worker ~client_will_immediately_connect ~setup_master_heartbeater
+        =
+      spawn_process ~where ~env ~cd ~name ~connection_timeout ~daemonize_args
+      >>= function
+      | Error e -> return (Error e)
+      | Ok (id, process) ->
+          wait_for_connection_and_initialize ~name ~connection_timeout
+            ~on_failure ~id ~client_will_immediately_connect
+            ~setup_master_heartbeater worker_state_init_arg
+          >>| Or_error.map ~f:(fun worker -> (worker, process))
+    in
+    match shutdown_on with
+    | Heartbeater_timeout ->
+        spawn_worker ~client_will_immediately_connect ~setup_master_heartbeater
+    | Disconnect ->
+        fun ~connection_state_init_arg ->
+          spawn_worker ~client_will_immediately_connect
+            ~setup_master_heartbeater
+          >>=? fun (worker, process) ->
+          (* If [Connection_state.init] raises, [client_internal] will close the Rpc
+           connection, causing the worker to shutdown. *)
+          Connection.client_with_worker_shutdown_on_disconnect worker
+            connection_state_init_arg
+          >>|? fun conn -> (conn, process)
+    | Called_shutdown_function ->
+        spawn_worker ~client_will_immediately_connect ~setup_master_heartbeater
+
+  module Spawn_in_foreground_exn_result = struct
+    type 'a t = 'a * Process.t
+  end
+
+  module Spawn_in_foreground_exn_shutdown_on =
+    Shutdown_on (Spawn_in_foreground_exn_result)
+
+  let spawn_in_foreground_exn (type a) ?where ?name ?env ?connection_timeout
+      ?cd ~on_failure ~(shutdown_on : a Spawn_in_foreground_exn_shutdown_on.t)
+      init_arg : a =
+    let open Spawn_in_foreground_exn_shutdown_on in
+    match shutdown_on with
+    | Disconnect ->
+        fun ~connection_state_init_arg ->
+          spawn_in_foreground ?where ?name ?env ?connection_timeout ?cd
+            ~on_failure ~shutdown_on:Disconnect init_arg
+            ~connection_state_init_arg
+          >>| ok_exn
+    | Heartbeater_timeout ->
+        spawn_in_foreground ?where ?name ?env ?connection_timeout ?cd
+          ~on_failure ~shutdown_on:Heartbeater_timeout init_arg
+        >>| ok_exn
+    | Called_shutdown_function ->
+        spawn_in_foreground ?where ?name ?env ?connection_timeout ?cd
+          ~on_failure ~shutdown_on:Called_shutdown_function init_arg
+        >>| ok_exn
+
+  let wait_for_daemonization_and_collect_stderr name process =
+    Writer.close (Process.stdin process)
+    >>= fun () ->
+    Process.wait process
+    >>= fun exit_or_signal ->
+    Reader.close (Process.stdout process)
+    >>= fun () ->
+    let worker_stderr = Reader.lines (Process.stderr process) in
+    Pipe.iter worker_stderr ~f:(fun line ->
+        let line' = sprintf "[WORKER %s STDERR]: %s\n" name line in
+        Writer.write (Lazy.force Writer.stderr) line' |> return )
+    >>| fun () ->
+    match exit_or_signal with
+    | Ok () -> Ok ()
+    | Error _ ->
+        let error_string =
+          sprintf "Worker process %s"
+            (Unix.Exit_or_signal.to_string_hum exit_or_signal)
+        in
+        Error (Error.of_string error_string)
+
+  module Spawn_shutdown_on = Shutdown_on (Or_error)
+
+  let spawn (type a) ?where ?name ?env ?connection_timeout ?cd ~on_failure
+      ?umask ~(shutdown_on : a Spawn_shutdown_on.t) ~redirect_stdout
+      ~redirect_stderr worker_state_init_arg : a =
+    let daemonize_args =
+      `Daemonize {Daemonize_args.umask; redirect_stderr; redirect_stdout}
+    in
+    let ( `Client_will_immediately_connect client_will_immediately_connect
+        , `Setup_master_heartbeater setup_master_heartbeater ) =
+      Spawn_shutdown_on.args shutdown_on
+    in
+    let spawn_worker ~client_will_immediately_connect ~setup_master_heartbeater
+        =
+      spawn_process ~where ~env ~cd ~name ~connection_timeout ~daemonize_args
+      >>= function
+      | Error e -> return (Error e)
+      | Ok (id, process) -> (
+          let id_or_name =
+            Option.value ~default:(Worker_id.to_string id) name
+          in
+          wait_for_daemonization_and_collect_stderr id_or_name process
+          >>= function
+          | Error e -> return (Error e)
+          | Ok () ->
+              wait_for_connection_and_initialize ~name ~connection_timeout
+                ~on_failure ~id ~client_will_immediately_connect
+                ~setup_master_heartbeater worker_state_init_arg )
+    in
+    let open Spawn_shutdown_on in
+    match shutdown_on with
+    | Heartbeater_timeout ->
+        spawn_worker ~client_will_immediately_connect ~setup_master_heartbeater
+    | Disconnect ->
+        fun ~connection_state_init_arg ->
+          spawn_worker ~client_will_immediately_connect
+            ~setup_master_heartbeater
+          >>=? fun worker ->
+          (* If [Connection_state.init] raises, [client_internal] will close the Rpc
+           connection, causing the worker to shutdown. *)
+          Connection.client_with_worker_shutdown_on_disconnect worker
+            connection_state_init_arg
+    | Called_shutdown_function ->
+        spawn_worker ~client_will_immediately_connect ~setup_master_heartbeater
+
+  module Spawn_exn_shutdown_on = Shutdown_on (Monad.Ident)
+
+  let spawn_exn (type a) ?where ?name ?env ?connection_timeout ?cd ~on_failure
+      ?umask ~(shutdown_on : a Spawn_exn_shutdown_on.t) ~redirect_stdout
+      ~redirect_stderr init_arg : a =
+    let open Spawn_exn_shutdown_on in
+    match shutdown_on with
+    | Disconnect ->
+        fun ~connection_state_init_arg ->
+          spawn ?where ?name ?env ?connection_timeout ?cd ~on_failure ?umask
+            ~shutdown_on:Disconnect ~redirect_stdout ~redirect_stderr init_arg
+            ~connection_state_init_arg
+          >>| ok_exn
+    | Heartbeater_timeout ->
+        spawn ?where ?name ?env ?connection_timeout ?cd ~on_failure ?umask
+          ~shutdown_on:Heartbeater_timeout ~redirect_stdout ~redirect_stderr
+          init_arg
+        >>| ok_exn
+    | Called_shutdown_function ->
+        spawn ?where ?name ?env ?connection_timeout ?cd ~on_failure ?umask
+          ~shutdown_on:Called_shutdown_function ~redirect_stdout
+          ~redirect_stderr init_arg
+        >>| ok_exn
+
+  module Deprecated = struct
+    let spawn_and_connect ?where ?name ?env ?connection_timeout ?cd ~on_failure
+        ?umask ~redirect_stdout ~redirect_stderr ~connection_state_init_arg
+        worker_state_init_arg =
+      spawn ?where ?name ?env ?connection_timeout ?cd ?umask ~redirect_stdout
+        ~redirect_stderr ~on_failure ~shutdown_on:Heartbeater_timeout
+        worker_state_init_arg
+      >>=? fun worker ->
+      with_shutdown_on_error worker ~f:(fun () ->
+          Connection.client worker connection_state_init_arg )
+      >>| Or_error.map ~f:(fun conn -> (worker, conn))
+
+    let spawn_and_connect_exn ?where ?name ?env ?connection_timeout ?cd
+        ~on_failure ?umask ~redirect_stdout ~redirect_stderr
+        ~connection_state_init_arg worker_state_init_arg =
+      spawn_and_connect ?where ?name ?env ?connection_timeout ?cd ~on_failure
+        ?umask ~redirect_stdout ~redirect_stderr ~connection_state_init_arg
+        worker_state_init_arg
+      >>| ok_exn
+  end
+
+  let init_worker_state_impl =
+    Rpc.Rpc.implement Init_worker_state_rpc.rpc
+      (fun _conn_state
+      { Init_worker_state_rpc.master
+      ; worker
+      ; arg
+      ; initial_client_connection_timeout }
+      ->
+        let init_finished =
+          Utils.try_within ~monitor (fun () ->
+              let%bind () =
+                match master with
+                | None -> Deferred.unit
+                | Some master ->
+                    let%map `Connected =
+                      Heartbeater_master.connect_and_shutdown_on_disconnect_exn
+                        master
+                    in
+                    ()
+              in
+              User_functions.init_worker_state arg )
+        in
+        Set_once.set_exn (get_worker_state_exn ()).initialized [%here]
+          (`Init_started (init_finished >>|? const `Initialized)) ;
+        init_finished
+        >>| function
+        | Error e -> Error.raise e
+        | Ok state ->
+            ( match initial_client_connection_timeout with
+            | None -> ()
+            | Some timeout ->
+                Clock.after timeout
+                >>> fun () ->
+                if not worker_state.client_has_connected then (
+                  Log.Global.error
+                    "Rpc_parallel: worker timed out waiting for client \
+                     connection... Shutting down" ;
+                  Shutdown.shutdown 254 ) ) ;
+            Hashtbl.add_exn worker_state.states ~key:worker ~data:state )
+
+  let init_connection_state_impl =
+    Rpc.Rpc.implement Init_connection_state_rpc.rpc
+      (fun (connection, internal_conn_state)
+      {worker_id; worker_shutdown_on_disconnect; arg= init_arg}
+      ->
+        worker_state.client_has_connected <- true ;
+        let worker_state = Hashtbl.find_exn worker_state.states worker_id in
+        if worker_shutdown_on_disconnect then (
+          Rpc.Connection.close_finished connection
+          >>> fun () ->
+          Log.Global.info
+            "Rpc_parallel: initial client connection closed... Shutting down." ;
+          Shutdown.shutdown 0 ) ;
+        Utils.try_within_exn ~monitor (fun () ->
+            User_functions.init_connection_state ~connection ~worker_state
+              init_arg )
+        >>| fun conn_state ->
+        Set_once.set_exn internal_conn_state [%here]
+          {Utils.Internal_connection_state.worker_id; conn_state; worker_state}
+    )
+
+  let shutdown_impl =
+    Rpc.One_way.implement Shutdown_rpc.rpc (fun _conn_state () ->
+        Log.Global.info "Rpc_parallel: Got shutdown rpc... Shutting down." ;
+        Shutdown.shutdown 0 )
+
+  let close_server_impl =
+    Rpc.One_way.implement Close_server_rpc.rpc (fun (_conn, conn_state) () ->
+        let {Utils.Internal_connection_state.worker_id; _} =
+          Set_once.get_exn conn_state [%here]
+        in
+        let global_state = get_worker_state_exn () in
+        match Hashtbl.find global_state.my_worker_servers worker_id with
+        | None -> ()
+        | Some tcp_server ->
+            Tcp.Server.close tcp_server
+            >>> fun () ->
+            Hashtbl.remove global_state.my_worker_servers worker_id ;
+            Hashtbl.remove worker_state.states worker_id )
+
+  let async_log_impl =
+    Rpc.Pipe_rpc.implement Async_log_rpc.rpc (fun _conn_state () ->
+        let r, w = Pipe.create () in
+        let new_output =
+          Log.Output.create
+            ~flush:(fun () -> Deferred.ignore (Pipe.downstream_flushed w))
+            (fun msgs ->
+              if not (Pipe.is_closed w) then
+                Queue.iter msgs ~f:(fun msg ->
+                    Pipe.write_without_pushback w msg ) ;
+              return () )
+        in
+        Log.Global.set_output (new_output :: Log.Global.get_output ()) ;
+        (* Remove this new output upon the pipe closing. *)
+        upon (Pipe.closed w) (fun () ->
+            let new_outputs =
+              List.filter (Log.Global.get_output ()) ~f:(fun output ->
+                  not (phys_equal output new_output) )
+            in
+            Log.Global.set_output new_outputs ) ;
+        return (Ok r) )
+
+  let () =
+    worker_state.implementations
+    <- [ init_worker_state_impl
+       ; init_connection_state_impl
+       ; shutdown_impl
+       ; close_server_impl
+       ; async_log_impl ]
+       @ worker_state.implementations ;
+    Hashtbl.add_exn worker_implementations ~key:worker_state.type_
+      ~data:(Worker_implementations.T worker_state.implementations)
+end
+
+(* Start an Rpc server based on the implementations defined in the [Make] functor
+   for this worker type. Return a [Host_and_port.t] describing the server *)
+let worker_main ~worker_env =
+  let {Worker_env.config; maybe_release_daemon} = worker_env in
+  let {Rpc_settings.max_message_size; handshake_timeout; heartbeat_config} =
+    Worker_config.app_rpc_settings config
+  in
+  let id = Worker_config.worker_id config in
+  let register my_host_and_port =
+    Rpc.Connection.with_client ?max_message_size ?handshake_timeout
+      ?heartbeat_config (Tcp.Where_to_connect.of_host_and_port config.master)
+      (fun conn -> Rpc.Rpc.dispatch Register_rpc.rpc conn (id, my_host_and_port)
+    )
+    >>| function
+    | Error exn -> failwiths "Worker failed to register" exn [%sexp_of: Exn.t]
+    | Ok (Error e) ->
+        failwiths "Worker failed to register" e [%sexp_of: Error.t]
+    | Ok (Ok `Shutdown) -> failwith "Got [`Shutdown] on register"
+    | Ok (Ok `Registered) -> ()
+  in
+  (* We want the following two things to occur:
+
+     (1) Catch exceptions in workers and report them back to the master
+     (2) Write the exceptions to stderr *)
+  let setup_exception_handling () =
+    Scheduler.within (fun () ->
+        Monitor.detach_and_get_next_error Monitor.main
+        >>> fun exn ->
+        (* We must be careful that this code here doesn't raise *)
+        Rpc.Connection.with_client ?max_message_size ?handshake_timeout
+          ?heartbeat_config
+          (Tcp.Where_to_connect.of_host_and_port config.master) (fun conn ->
+            Rpc.Rpc.dispatch Handle_exn_rpc.rpc conn
+              {id; name= config.name; error= Error.of_exn exn} )
+        >>> fun _ ->
+        Log.Global.error !"Rpc_parallel: %{Exn} ... Shutting down." exn ;
+        Shutdown.shutdown 254 )
+  in
+  (* Ensure we do not leak processes. Make sure we have initialized successfully, meaning
+     we have heartbeats with the master established if the user wants them. *)
+  let setup_cleanup_on_timeout () =
+    Clock.after config.connection_timeout
+    >>> fun () ->
+    match Set_once.get (get_worker_state_exn ()).initialized with
+    | None ->
+        Log.Global.error
+          "Rpc_parallel: Timeout getting Init_worker_state rpc from master... \
+           Shutting down." ;
+        Shutdown.shutdown 254
+    | Some (`Init_started initialize_result) -> (
+        initialize_result
+        >>> function Ok `Initialized -> () | Error e -> Error.raise e )
+  in
+  match Hashtbl.find worker_implementations config.worker_type with
+  | None ->
+      failwith
+        "Worker could not find RPC implementations. Make sure the \
+         Parallel.Make () functor is applied in the worker. It is suggested \
+         to make this toplevel."
+  | Some (Worker_implementations.T worker_implementations) ->
+      start_server ~implementations:worker_implementations
+        ~initial_connection_state:(fun _address connection ->
+          (connection, Set_once.create ()) )
+        ~max_message_size ~handshake_timeout ~heartbeat_config
+        ~where_to_listen:Tcp.Where_to_listen.of_port_chosen_by_os
+      >>> fun server ->
+      let host = Unix.gethostname () in
+      let port = Tcp.Server.listening_on server in
+      let global_state = get_worker_state_exn () in
+      Hashtbl.add_exn global_state.my_worker_servers ~key:id ~data:server ;
+      register (Host_and_port.create ~host ~port)
+      >>> fun () ->
+      setup_exception_handling () ;
+      setup_cleanup_on_timeout () ;
+      (* Daemonize as late as possible but still before running any user code. This lets
+       us read any setup errors from stderr *)
+      maybe_release_daemon ()
+
+module Expert = struct
+  module Worker_env = Worker_env
+
+  let worker_init_before_async_exn () =
+    match Utils.whoami () with
+    | `Master ->
+        failwith
+          "[worker_init_before_async_exn] should not be called in a process \
+           that was not spawned."
+    | `Worker ->
+        if Scheduler.is_running () then
+          failwith
+            "[worker_init_before_async_exn] must be called before the async \
+             scheduler has been started." ;
+        Utils.clear_env () ;
+        let config =
+          try Sexp.input_sexp In_channel.stdin |> Worker_config.t_of_sexp
+          with _ ->
+            failwith
+              "Unable to read worker config from stdin. Make sure nothing is \
+               read from stdin before [worker_init_before_async_exn] is \
+               called."
+        in
+        let maybe_release_daemon =
+          match config.daemonize_args with
+          | `Don't_daemonize -> Core.Unix.chdir config.cd ; Fn.id
+          | `Daemonize {Daemonize_args.umask; redirect_stderr; redirect_stdout}
+            ->
+              (* The worker is started via SSH. We want to go to the background so we can close
+             the SSH connection, but not until we've connected back to the master via
+             Rpc. This allows us to report any initialization errors to the master via the SSH
+             connection. *)
+              let redirect_stdout =
+                Utils.to_daemon_fd_redirection redirect_stdout
+              in
+              let redirect_stderr =
+                Utils.to_daemon_fd_redirection redirect_stderr
+              in
+              Staged.unstage
+                (Daemon.daemonize_wait ~cd:config.cd ~redirect_stdout
+                   ~redirect_stderr ?umask ())
+        in
+        {Worker_env.config; maybe_release_daemon}
+
+  let start_worker_server_exn worker_env =
+    let {Rpc_settings.max_message_size; handshake_timeout; heartbeat_config} =
+      Worker_env.config worker_env |> Worker_config.app_rpc_settings
+    in
+    let worker_command_args =
+      Worker_env.config worker_env |> Worker_config.worker_command_args
+    in
+    init_master_state ~rpc_max_message_size:max_message_size
+      ~rpc_handshake_timeout:handshake_timeout
+      ~rpc_heartbeat_config:heartbeat_config ~worker_command_args ;
+    worker_main ~worker_env
+
+  let start_master_server_exn ?rpc_max_message_size ?rpc_handshake_timeout
+      ?rpc_heartbeat_config ~worker_command_args () =
+    match Utils.whoami () with
+    | `Worker -> failwith "Do not call [init_master_exn] in a spawned worker"
+    | `Master ->
+        init_master_state ~rpc_max_message_size ~rpc_handshake_timeout
+          ~rpc_heartbeat_config
+          ~worker_command_args:(`User_supplied worker_command_args)
+
+  let worker_command =
+    let open Command.Let_syntax in
+    Command.async ~summary:"internal use only"
+      [%map_open
+        let () = return () in
+        let worker_env = worker_init_before_async_exn () in
+        fun () ->
+          start_worker_server_exn worker_env ;
+          Deferred.never ()]
+end
+
+module State = struct
+  type t = [`started]
+
+  let get () = Option.map (Set_once.get global_state) ~f:(fun _ -> `started)
+end
+
+let start_app ?rpc_max_message_size ?rpc_handshake_timeout
+    ?rpc_heartbeat_config command =
+  match Utils.whoami () with
+  | `Worker ->
+      let worker_env = Expert.worker_init_before_async_exn () in
+      Expert.start_worker_server_exn worker_env ;
+      never_returns (Scheduler.go ())
+  | `Master ->
+      init_master_state ~rpc_max_message_size ~rpc_handshake_timeout
+        ~rpc_heartbeat_config ~worker_command_args:`Decorate_with_name ;
+      Command.run command

--- a/src/external/rpc_parallel/src/parallel.mli
+++ b/src/external/rpc_parallel/src/parallel.mli
@@ -1,0 +1,1 @@
+include Parallel_intf.Parallel

--- a/src/external/rpc_parallel/src/parallel_intf.ml
+++ b/src/external/rpc_parallel/src/parallel_intf.ml
@@ -1,0 +1,555 @@
+open! Core
+open! Async
+
+(** See README for more details *)
+
+(** A [('worker, 'query, 'response) Function.t] is a type-safe function ['query ->
+    'response Deferred.t] that can only be run on a ['worker]. Under the hood it
+    represents an Async Rpc protocol that we know a ['worker] will implement. *)
+module type Function = sig
+  type ('worker, 'query, 'response) t
+
+  module Direct_pipe : sig
+    type nonrec ('worker, 'query, 'response) t =
+      ( 'worker
+      , 'query * ('response Rpc.Pipe_rpc.Pipe_message.t -> Rpc.Pipe_rpc.Pipe_response.t)
+      , Rpc.Pipe_rpc.Id.t
+      ) t
+  end
+
+  val map
+    :  ('worker, 'query, 'a) t
+    -> f:('a -> 'b)
+    -> ('worker, 'query, 'b) t
+
+  val contra_map
+    :  ('worker, 'a, 'response) t
+    -> f:('b -> 'a)
+    -> ('worker, 'b, 'response) t
+
+  (** Common functions that are implemented by all workers *)
+
+  (** This implementation will add another [Log.Output] for [Log.Global] that transfers
+      log messages to the returned pipe. You can subscribe to a worker's log more than
+      once and from different processes, as each call simply adds a new [Log.Output].
+      Closing the pipe will remove the corresponding [Log.Output].
+
+      NOTE: You will never get any log messages before this implementation has run (there
+      is no queuing of log messages). As a consequence, you will never get any log
+      messages written in a worker's init functions. *)
+  val async_log : (_, unit, Log.Message.Stable.V2.t Pipe.Reader.t) t
+
+  (** A given process can have multiple worker servers running (of the same or different
+      worker types). This implementation closes the server on which it is run. All
+      existing open connections will remain open, but no further connections to this
+      worker server will be accepted.
+
+      NOTE: calling [close_server] on a worker process that is only running one worker
+      server will leave a stranded worker process if no other cleanup has been setup
+      (e.g. setting up [on_client_disconnect] or [Connection.close_finished] handlers) *)
+  val close_server : (_, unit, unit) t
+end
+
+module type Worker = sig
+  type ('worker, 'query, 'response) _function
+
+  (** A [Worker.t] type is defined [with bin_io] so it is possible to create functions
+      that take a worker as an argument. *)
+  type t [@@deriving bin_io, sexp_of]
+
+  (** A type alias to make the [Connection] signature more readable *)
+  type worker = t
+
+  type 'a functions
+
+  (** Accessor for the functions implemented by this worker type *)
+  val functions : t functions
+
+  type worker_state_init_arg
+  type connection_state_init_arg
+
+  module Id : Identifiable
+  val id : t -> Id.t
+
+  (** [serve arg] will start an Rpc server in process implementing all the functions
+      of the given worker. *)
+  val serve
+    :  ?max_message_size  : int
+    -> ?handshake_timeout : Time.Span.t
+    -> ?heartbeat_config  : Rpc.Connection.Heartbeat_config.t
+    -> worker_state_init_arg
+    -> worker Deferred.t
+
+  module Connection : sig
+    type t [@@deriving sexp_of]
+
+    (** The [id] of the connected worker *)
+    val worker_id : t -> Id.t
+
+    (** Run functions implemented by this worker *)
+    val run
+      :  t
+      -> f : (worker, 'query, 'response) _function
+      -> arg : 'query
+      -> 'response Or_error.t Deferred.t
+
+    val run_exn
+      :  t
+      -> f : (worker, 'query, 'response) _function
+      -> arg : 'query
+      -> 'response Deferred.t
+
+    (** Connect to a given worker, returning a type wrapped [Rpc.Connection.t] that can be
+        used to run functions. *)
+    val client : worker -> connection_state_init_arg -> t Or_error.t Deferred.t
+    val client_exn : worker -> connection_state_init_arg -> t Deferred.t
+
+    (** [with_client worker init_arg f] connects to the [worker]'s server, initializes the
+        connection state with [init_arg]  and runs [f] until an exception is thrown or
+        until the returned Deferred is determined.
+
+        NOTE: You should be careful when using this with [Pipe_rpc].
+        See [Rpc.Connection.with_close] for more information. *)
+    val with_client
+      :  worker
+      -> connection_state_init_arg
+      -> f: (t -> 'a Deferred.t)
+      -> 'a Or_error.t Deferred.t
+
+    val close : t -> unit Deferred.t
+    val close_finished : t -> unit Deferred.t
+    val close_reason : t -> on_close: [`started | `finished] -> Info.t Deferred.t
+    val is_closed : t -> bool
+  end
+
+  module Shutdown_on (M : T1) : sig
+    type _ t =
+      | Heartbeater_timeout : worker M.t Deferred.t t
+      (** A "heartbeater" connection is established between the worker and its master. The
+          worker shuts itself down when [Rpc.Connection.close_finished] on this connection,
+          which is likely when the master process exits. *)
+      | Disconnect :
+          (connection_state_init_arg:connection_state_init_arg ->
+           Connection.t M.t Deferred.t) t
+      (** An initial connection to the worker is established. The worker shuts itself down
+          when [Rpc.Connection.close_finished] on this connection. *)
+      | Called_shutdown_function : worker M.t Deferred.t t
+      (** WARNING! Worker's spawned with this variant do not shutdown when the master
+          process exits. The worker only shuts itself down on an explicit shutdown
+          request. *)
+  end
+
+  (** The various [spawn] functions create a new worker process that implements the
+      functions specified in the [Worker_spec].
+
+      [name] will be attached to certain error messages and is useful for debugging.
+
+      [env] extends the environment of the spawned worker process.
+
+      [connection_timeout] is used for various internal timeouts. This may need be to
+      increased if the init arg is really large (serialization and deserialization
+      takes more than [connection_timeout]).
+
+      [cd] changes the current working directory of a spawned worker process.
+
+      [shutdown_on] specifies when a worker should shut itself down.
+
+      [on_failure exn] will be called in the spawning process upon the worker process
+      raising a background exception. All exceptions raised before functions return will be
+      returned to the caller. [on_failure] will be called in [Monitor.current ()] at the
+      time of this spawn call. The worker initiates shutdown upon sending the exception
+      to the master process.
+
+      [worker_state_init_arg] (below) will be passed to [init_worker_state] of the given
+      [Worker_spec] module. This initializes a persistent worker state for all connections
+      to this worker. *)
+  type 'a with_spawn_args
+    =  ?where : Executable_location.t  (** default Local *)
+    -> ?name : string
+    -> ?env : (string * string) list
+    -> ?connection_timeout:Time.Span.t  (** default 10 sec *)
+    -> ?cd : string  (** default / *)
+    -> on_failure : (Error.t -> unit)
+    -> 'a
+
+  (** The spawned worker process daemonizes. Any initialization errors that wrote to
+      stderr (Rpc_parallel internal initialization, not user initialization code) will be
+      captured and rewritten to the spawning process's stderr with the prefix
+      "[WORKER %NAME% STDERR]".
+
+      [redirect_stdout] and [redirect_stderr] specify stdout and stderr of the worker
+      process. *)
+  val spawn
+    : (?umask : int  (** defaults to use existing umask *)
+       -> shutdown_on : 'a Shutdown_on(Or_error).t
+       -> redirect_stdout : Fd_redirection.t
+       -> redirect_stderr : Fd_redirection.t
+       -> worker_state_init_arg
+       -> 'a) with_spawn_args
+
+  val spawn_exn
+    : (?umask : int  (** defaults to use existing umask *)
+       -> shutdown_on : 'a Shutdown_on(Monad.Ident).t
+       -> redirect_stdout : Fd_redirection.t
+       -> redirect_stderr : Fd_redirection.t
+       -> worker_state_init_arg
+       -> 'a) with_spawn_args
+
+  module Spawn_in_foreground_result : sig
+    type 'a t = ('a * Process.t) Or_error.t
+  end
+
+  (** Similar to [spawn] but the worker process does not daemonize. If the process was
+      spawned on a remote host, the ssh [Process.t] is returned. *)
+  val spawn_in_foreground
+    :  (shutdown_on : 'a Shutdown_on(Spawn_in_foreground_result).t
+        -> worker_state_init_arg
+        -> 'a) with_spawn_args
+
+  module Spawn_in_foreground_exn_result : sig
+    type 'a t = 'a * Process.t
+  end
+
+  val spawn_in_foreground_exn
+    :  (shutdown_on : 'a Shutdown_on(Spawn_in_foreground_exn_result).t
+        -> worker_state_init_arg
+        -> 'a) with_spawn_args
+
+  (** [shutdown] attempts to connect to a worker. Upon success, [Shutdown.shutdown 0] is
+      run in the worker. If you want strong guarantees that a worker did shutdown, consider
+      using [spawn_in_foreground] and inspecting the [Process.t]. *)
+  val shutdown : t -> unit Or_error.t Deferred.t
+
+  module Deprecated : sig
+    (** This is nearly identical to calling [spawn ~shutdown_on:Heartbeater_timeout] and
+        then [Connection.client]. The only difference is that this function handles
+        shutting down the worker when [Connection.client] returns an error.
+
+        Uses of [spawn_and_connect] that disregard [t] can likely be replaced with [spawn
+        ~shutdown_on:Disconnect]. If [t] is used for reconnecting, then you can use [spawn]
+        followed by [Connection.client]. *)
+    val spawn_and_connect
+      : (?umask : int
+         -> redirect_stdout : Fd_redirection.t
+         -> redirect_stderr : Fd_redirection.t
+         -> connection_state_init_arg : connection_state_init_arg
+         -> worker_state_init_arg
+         -> (t * Connection.t) Or_error.t Deferred.t) with_spawn_args
+
+    val spawn_and_connect_exn
+      : (?umask : int
+         -> redirect_stdout : Fd_redirection.t
+         -> redirect_stderr : Fd_redirection.t
+         -> connection_state_init_arg : connection_state_init_arg
+         -> worker_state_init_arg
+         -> (t * Connection.t) Deferred.t) with_spawn_args
+  end
+end
+
+module type Functions = sig
+  type worker
+
+  type worker_state_init_arg
+  type worker_state
+
+  type connection_state_init_arg
+  type connection_state
+
+  type 'worker functions
+  val functions : worker functions
+
+  (** [init_worker_state] is called with the [init_arg] passed to [spawn] or [serve] *)
+  val init_worker_state
+    :  worker_state_init_arg
+    -> worker_state Deferred.t
+
+  (** [init_connection_state] is called with the [init_arg] passed to [Connection.client]
+
+      [connection] should only be used to register [close_finished] callbacks, not to
+      dispatch.  *)
+  val init_connection_state
+    :  connection   : Rpc.Connection.t
+    -> worker_state : worker_state
+    -> connection_state_init_arg
+    -> connection_state Deferred.t
+end
+
+module type Creator = sig
+  type ('worker, 'query, 'response) _function
+  type ('worker, 'query, 'response) _direct
+
+  type worker
+
+  type worker_state
+  type connection_state
+
+  (** [create_rpc ?name ~f ~bin_input ~bin_output ()] will create an [Rpc.Rpc.t] with
+      [name] if specified and use [f] as an implementation for this Rpc. It returns back a
+      [_function], a type-safe Rpc protocol. *)
+  val create_rpc
+    :  ?name : string
+    -> f
+       : (worker_state : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> 'response Deferred.t)
+    -> bin_input : 'query Bin_prot.Type_class.t
+    -> bin_output : 'response Bin_prot.Type_class.t
+    -> unit
+    -> (worker, 'query, 'response) _function
+
+  (** [create_pipe ?name ~f ~bin_input ~bin_output ()] will create an [Rpc.Pipe_rpc.t]
+      with [name] if specified. The implementation for this Rpc is a function that creates
+      a [Pipe.Reader.t] and a [Pipe.Writer.t], then calls [f arg ~writer] and returns the
+      reader.
+
+      Notice that [aborted] is not exposed. The pipe is closed upon aborted. *)
+  val create_pipe
+    :  ?name : string
+    -> f
+       : (worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> 'response Pipe.Reader.t Deferred.t)
+    -> bin_input : 'query Bin_prot.Type_class.t
+    -> bin_output : 'response Bin_prot.Type_class.t
+    -> unit
+    -> (worker, 'query, 'response Pipe.Reader.t) _function
+
+  (** [create_direct_pipe ?name ~f ~bin_input ~bin_output ()] will create an
+      [Rpc.Pipe_rpc.t] with [name] if specified. *)
+  val create_direct_pipe
+    :  ?name : string
+    -> f
+       : (worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> 'response Rpc.Pipe_rpc.Direct_stream_writer.t
+          -> unit Deferred.t)
+    -> bin_input : 'query Bin_prot.Type_class.t
+    -> bin_output : 'response Bin_prot.Type_class.t
+    -> unit
+    -> (worker, 'query, 'response) _direct
+
+  (** [create_one_way ?name ~f ~bin_msg ()] will create an [Rpc.One_way.t] with [name] if
+      specified and use [f] as an implementation. *)
+  val create_one_way
+    :  ?name : string
+    -> f
+       : (worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          ->  unit)
+    -> bin_input : 'query Bin_prot.Type_class.t
+    -> unit
+    -> (worker, 'query, unit) _function
+
+  (** [create_reverse_pipe ?name ~f ~bin_query ~bin_update ~bin_response ()] generates a
+      function allowing you to send a [query] and a pipe of [update]s to a worker. The
+      worker will send back a [response]. It is up to you whether to send a [response]
+      before or after finishing with the pipe; Rpc_parallel doesn't care. *)
+  val create_reverse_pipe
+    :  ?name:string
+    -> f:(worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> 'update Pipe.Reader.t
+          -> 'response Deferred.t)
+    -> bin_query    : 'query    Bin_prot.Type_class.t
+    -> bin_update   : 'update   Bin_prot.Type_class.t
+    -> bin_response : 'response Bin_prot.Type_class.t
+    -> unit
+    -> (worker, 'query * 'update Pipe.Reader.t, 'response) _function
+
+  (** [of_async_rpc ~f rpc] is the analog to [create_rpc] but instead of creating an Rpc
+      protocol, it uses the supplied one *)
+  val of_async_rpc
+    :  f
+       : (worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> 'response Deferred.t)
+    -> ('query, 'response) Rpc.Rpc.t
+    -> (worker, 'query, 'response) _function
+
+  (** [of_async_pipe_rpc ~f rpc] is the analog to [create_pipe] but instead of creating a
+      Pipe rpc protocol, it uses the supplied one.
+
+      Notice that [aborted] is not exposed. The pipe is closed upon aborted. *)
+  val of_async_pipe_rpc
+    :  f
+       : (worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> 'response Pipe.Reader.t Deferred.t)
+    -> ('query, 'response, Error.t) Rpc.Pipe_rpc.t
+    -> (worker, 'query, 'response Pipe.Reader.t) _function
+
+  (** [of_async_direct_pipe_rpc ~f rpc] is the analog to [create_direct_pipe] but instead
+      of creating a Pipe rpc protocol, it uses the supplied one. *)
+  val of_async_direct_pipe_rpc
+    :  f
+       : (worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> 'response Rpc.Pipe_rpc.Direct_stream_writer.t
+          -> unit Deferred.t)
+    -> ('query, 'response, Error.t) Rpc.Pipe_rpc.t
+    -> (worker, 'query, 'response) _direct
+
+  (** [of_async_one_way_rpc ~f rpc] is the analog to [create_one_way] but instead of
+      creating a One_way rpc protocol, it uses the supplied one *)
+  val of_async_one_way_rpc
+    :  f
+       : (worker_state  : worker_state
+          -> conn_state : connection_state
+          -> 'query
+          -> unit)
+    -> 'query Rpc.One_way.t
+    -> (worker, 'query, unit) _function
+end
+
+(** Specification for the creation of a worker type *)
+module type Worker_spec = sig
+  type ('worker, 'query, 'response) _function
+  type ('worker, 'query, 'response) _direct
+
+  (** A type to encapsulate all the functions that can be run on this worker. Using a
+      record type here is often the most convenient and readable. *)
+  type 'worker functions
+
+  (** State associated with each [Worker.t]. If this state is mutable, you must
+      think carefully when making multiple connections to the same spawned worker. *)
+  module Worker_state : sig
+    type t
+    type init_arg [@@deriving bin_io]
+  end
+
+  (** State associated with each connection to a [Worker.t] *)
+  module Connection_state : sig
+    type t
+    type init_arg [@@deriving bin_io]
+  end
+
+  (** The functions that can be run on this worker type *)
+  module Functions
+      (C : Creator
+       with type worker_state            = Worker_state.t
+        and type connection_state        = Connection_state.t
+        and type ('w, 'q, 'r) _function := ('w, 'q, 'r) _function
+        and type ('w, 'q, 'r) _direct   := ('w, 'q, 'r) _direct)
+    : Functions
+      with type worker                    := C.worker
+       and type 'a functions              := 'a functions
+       and type worker_state              := Worker_state.t
+       and type worker_state_init_arg     := Worker_state.init_arg
+       and type connection_state          := Connection_state.t
+       and type connection_state_init_arg := Connection_state.init_arg
+end
+
+module type Parallel = sig
+  module Function : Function
+
+  module type Worker = Worker
+    with type ('w, 'q, 'r) _function := ('w, 'q, 'r) Function.t
+
+  module type Functions = Functions
+
+  module type Creator = Creator
+    with type ('w, 'q, 'r) _function := ('w, 'q, 'r) Function.t
+     and type ('w, 'q, 'r) _direct   := ('w, 'q, 'r) Function.Direct_pipe.t
+
+  module type Worker_spec = Worker_spec
+    with type ('w, 'q, 'r) _function := ('w, 'q, 'r) Function.t
+     and type ('w, 'q, 'r) _direct   := ('w, 'q, 'r) Function.Direct_pipe.t
+
+  (** module Worker = Make(T)
+
+      The [Worker] module has specialized functions to spawn workers and run functions on
+      workers. *)
+  module Make (S : Worker_spec) : Worker
+    with type 'a functions              := 'a S.functions
+     and type worker_state_init_arg     := S.Worker_state.init_arg
+     and type connection_state_init_arg := S.Connection_state.init_arg
+
+  (** [start_app command] should be called from the top-level in order to start the parallel
+      application. This function will parse certain environment variables and determine
+      whether to start as a master or a worker.
+
+      [rpc_max_message_size], [rpc_handshake_timeout], [rpc_heartbeat_config] can be used
+      to alter the rpc defaults. These rpc settings will be used for all connections.
+      This can be useful if you have long async jobs. *)
+  val start_app
+    :  ?rpc_max_message_size : int
+    -> ?rpc_handshake_timeout : Time.Span.t
+    -> ?rpc_heartbeat_config : Rpc.Connection.Heartbeat_config.t
+    -> Command.t
+    -> unit
+
+  (** Use [State.get] to query whether the current process has been initialized as an rpc
+      parallel master ([start_app] or [init_master_exn] has been called). We return a
+      [State.t] rather than a [bool] so that you can require evidence at the type level.
+      If you want to certify, as a precondition, for some function that [start_app] was
+      used, require a [State.t] as an argument. If you don't need the [State.t] anymore,
+      just pattern match on it. *)
+  module State : sig
+    type t = private [< `started ]
+
+    val get : unit -> t option
+  end
+
+  (** If you want more direct control over your executable, you can use the [Expert]
+      module instead of [start_app]. If you use [Expert], you are responsible for starting
+      the master and worker rpc servers. [worker_command_args] will be the arguments sent
+      to each spawned worker. Running your executable with these args must follow a code
+      path that calls [worker_init_before_async_exn] and then [start_worker_server_exn].
+      An easy way to do this is to use [worker_command]. *)
+  module Expert : sig
+    (** [start_master_server_exn] must be called in the single master process. It is
+        necessary to be able to spawn workers. Raises if the process was spawned. *)
+    val start_master_server_exn
+      :  ?rpc_max_message_size  : int
+      -> ?rpc_handshake_timeout : Time.Span.t
+      -> ?rpc_heartbeat_config : Rpc.Connection.Heartbeat_config.t
+      -> worker_command_args : string list
+      -> unit
+      -> unit
+
+    (** You have two options for implementing the worker process, a simple one and a
+        deprecated one.
+
+        Simple option: just make sure [worker_command] is somewhere in the command
+        hierarchy of the same executable in which [start_master_server_exn] is called,
+        with a subcommand path equal to [worker_command_args]. It is possible for multiple
+        calls to [start_master_server_exn] to share the same [worker_command_args].
+
+        Deprecated option: implement something at least as complicated yourself using
+        [worker_init_before_async_exn] and [start_worker_server_exn]. This option may go
+        away in the future. *)
+
+    val worker_command : Command.t
+
+
+    module Worker_env : sig
+      type t
+    end
+
+    (** [worker_init_before_async_exn] must be called in a spawned worker process before
+        the async scheduler has started. You must not read from stdin before this function
+        call.
+
+        This has the side effect of calling [chdir]. *)
+    val worker_init_before_async_exn : unit -> Worker_env.t
+
+    (** [start_worker_server_exn] must be called in each spawned process. It is illegal to
+        call both [start_master_server_exn] and [start_worker_server_exn] in the same
+        process. Raises if the process was not spawned.
+
+        This has the side effect of scheduling a job that completes the daemonization of
+        this process (if the process should daemonize). This includes redirecting stdout
+        and stderr according to [redirect_stdout] and [redirect_stderr]. All writes to
+        stdout before this job runs are blackholed. All writes to stderr before this job
+        runs are redirected to the spawning process's stderr. *)
+    val start_worker_server_exn : Worker_env.t -> unit
+  end
+end

--- a/src/external/rpc_parallel/src/parallel_managed.ml
+++ b/src/external/rpc_parallel/src/parallel_managed.ml
@@ -1,0 +1,171 @@
+open Core
+open Async
+
+module type Worker = sig
+  type t [@@deriving sexp_of]
+  type unmanaged_t
+
+  type 'a functions
+
+  val functions : unmanaged_t functions
+
+  type worker_state_init_arg
+  type connection_state_init_arg
+
+  module Id : Identifiable
+  val id : t -> Id.t
+
+  val spawn
+    :  ?where : Executable_location.t
+    -> ?name : string
+    -> ?env : (string * string) list
+    -> ?connection_timeout:Time.Span.t
+    -> ?cd : string
+    -> ?umask : int
+    -> redirect_stdout : Fd_redirection.t
+    -> redirect_stderr : Fd_redirection.t
+    -> worker_state_init_arg
+    -> connection_state_init_arg
+    -> on_failure : (Error.t -> unit)
+    -> t Or_error.t Deferred.t
+
+  val spawn_exn
+    :  ?where : Executable_location.t
+    -> ?name : string
+    -> ?env : (string * string) list
+    -> ?connection_timeout:Time.Span.t
+    -> ?cd : string
+    -> ?umask : int
+    -> redirect_stdout : Fd_redirection.t
+    -> redirect_stderr : Fd_redirection.t
+    -> worker_state_init_arg
+    -> connection_state_init_arg
+    -> on_failure : (Error.t -> unit)
+    -> t Deferred.t
+
+  val run
+    :  t
+    -> f: (unmanaged_t, 'query, 'response) Parallel.Function.t
+    -> arg: 'query
+    -> 'response Or_error.t Deferred.t
+
+  val run_exn
+    :  t
+    -> f: (unmanaged_t, 'query, 'response) Parallel.Function.t
+    -> arg: 'query
+    -> 'response Deferred.t
+
+  val kill     : t -> unit Or_error.t Deferred.t
+  val kill_exn : t -> unit Deferred.t
+end
+
+module Make (S : Parallel.Worker_spec) = struct
+  module Unmanaged = Parallel.Make (S)
+  module Id = Utils.Worker_id
+
+  type nonrec t =
+    { unmanaged : Unmanaged.t
+    ; connection_state_init_arg : S.Connection_state.init_arg
+    ; id : Id.t
+    }
+
+  type unmanaged_t = Unmanaged.t
+
+  type conn =
+    [ `Pending of Unmanaged.Connection.t Or_error.t Ivar.t
+    | `Connected of Unmanaged.Connection.t ]
+
+  let sexp_of_t t = [%sexp_of: Unmanaged.t] t.unmanaged
+
+  let id t = t.id
+
+  let functions = Unmanaged.functions
+
+  let workers : conn Id.Table.t = Id.Table.create ()
+
+  let get_connection { unmanaged = t; connection_state_init_arg; id } =
+    match Hashtbl.find workers id with
+    | Some (`Pending ivar) -> Ivar.read ivar
+    | Some (`Connected conn) -> Deferred.Or_error.return conn
+    | None ->
+      let ivar = Ivar.create () in
+      Hashtbl.add_exn workers ~key:id ~data:(`Pending ivar);
+      Unmanaged.Connection.client t connection_state_init_arg
+      >>| function
+      | Error e ->
+        Ivar.fill ivar (Error e);
+        Hashtbl.remove workers id;
+        Error e
+      | Ok conn ->
+        Ivar.fill ivar (Ok conn);
+        Hashtbl.set workers ~key:id ~data:(`Connected conn);
+        (Unmanaged.Connection.close_finished conn
+         >>> fun () ->
+         Hashtbl.remove workers id);
+        Ok conn
+  ;;
+
+  let with_shutdown_on_error worker ~f =
+    f ()
+    >>= function
+    | Ok _ as ret -> return ret
+    | Error _ as ret ->
+      Unmanaged.shutdown worker
+      >>= fun (_ : unit Or_error.t) ->
+      return ret
+  ;;
+
+  let spawn ?where ?name ?env
+        ?connection_timeout ?cd ?umask ~redirect_stdout ~redirect_stderr
+        worker_state_init_arg connection_state_init_arg ~on_failure =
+    Unmanaged.spawn ?where ?env ?name
+      ?connection_timeout ?cd ?umask ~shutdown_on:Heartbeater_timeout
+      ~redirect_stdout ~redirect_stderr worker_state_init_arg ~on_failure
+    >>=? fun worker ->
+    with_shutdown_on_error worker ~f:(fun () ->
+      Unmanaged.Connection.client worker connection_state_init_arg)
+    >>|? fun connection ->
+    let id = Id.create () in
+    Hashtbl.add_exn workers ~key:id ~data:(`Connected connection);
+    (Unmanaged.Connection.close_finished connection
+     >>> fun () ->
+     match Hashtbl.find workers id with
+     | None ->
+       (* [kill] was called, don't report closed connection *)
+       ()
+     | Some _ ->
+       Hashtbl.remove workers id;
+       let error =
+         Error.createf !"Lost connection with worker"
+       in
+       on_failure error);
+    { unmanaged = worker; connection_state_init_arg; id }
+  ;;
+
+  let spawn_exn ?where ?name ?env
+        ?connection_timeout ?cd ?umask ~redirect_stdout ~redirect_stderr
+        worker_state_init_arg connection_init_arg ~on_failure =
+    spawn ?where ?name ?env
+      ?connection_timeout ?cd ?umask ~redirect_stdout ~redirect_stderr
+      worker_state_init_arg connection_init_arg ~on_failure
+    >>| Or_error.ok_exn
+  ;;
+
+  let kill t =
+    Hashtbl.remove workers t.id;
+    Unmanaged.shutdown t.unmanaged
+  ;;
+
+  let kill_exn t = kill t >>| Or_error.ok_exn
+
+  let run t ~f ~arg =
+    get_connection t
+    >>=? fun conn ->
+    Unmanaged.Connection.run conn ~f ~arg
+  ;;
+
+  let run_exn t ~f ~arg =
+    run t ~f ~arg
+    >>| Or_error.ok_exn
+  ;;
+end

--- a/src/external/rpc_parallel/src/parallel_managed.mli
+++ b/src/external/rpc_parallel/src/parallel_managed.mli
@@ -1,0 +1,81 @@
+open Core
+open Async
+
+(** This module is primarily meant for backwards compatibility with code that used earlier
+    versions of [Rpc_parallel]. Please consider using the [Parallel.Make()] functor
+    instead as the semantics are more transparent and intuitive.
+
+    This functor keeps cached connections to workers and dispatches on these connections.
+    The semantics of reconnect are not currently well-defined. If you expect connections
+    to drop or want multiple connections to the same worker, using [Parallel.Make()] is
+    probably the better choice. If you are only holding one connection to each spawned
+    worker, using this functor might require less code. *)
+
+module type Worker = sig
+  type t [@@deriving sexp_of]
+  type unmanaged_t
+
+  type 'a functions
+
+  (** Accessor for the functions implemented by this worker type *)
+  val functions : unmanaged_t functions
+
+  type worker_state_init_arg
+  type connection_state_init_arg
+
+  module Id : Identifiable
+  val id : t -> Id.t
+
+  val spawn
+    :  ?where : Executable_location.t
+    -> ?name : string
+    -> ?env : (string * string) list
+    -> ?connection_timeout:Time.Span.t
+    -> ?cd : string  (** default / *)
+    -> ?umask : int  (** defaults to use existing umask *)
+    -> redirect_stdout : Fd_redirection.t
+    -> redirect_stderr : Fd_redirection.t
+    -> worker_state_init_arg
+    -> connection_state_init_arg
+    -> on_failure : (Error.t -> unit)
+    -> t Or_error.t Deferred.t
+
+  val spawn_exn
+    :  ?where : Executable_location.t
+    -> ?name : string
+    -> ?env : (string * string) list
+    -> ?connection_timeout:Time.Span.t
+    -> ?cd : string  (** default / *)
+    -> ?umask : int  (** defaults to use existing umask *)
+    -> redirect_stdout : Fd_redirection.t
+    -> redirect_stderr : Fd_redirection.t
+    -> worker_state_init_arg
+    -> connection_state_init_arg
+    -> on_failure : (Error.t -> unit)
+    -> t Deferred.t
+
+  (** [run t] and [run_exn t] will connect to [t] if there is not already a connection,
+      but if there is currently a connection that has gone stale, they will fail with an
+      error. Trying again will attempt a reconnection. *)
+  val run
+    :  t
+    -> f: (unmanaged_t, 'query, 'response) Parallel.Function.t
+    -> arg: 'query
+    -> 'response Or_error.t Deferred.t
+
+  val run_exn
+    :  t
+    -> f: (unmanaged_t, 'query, 'response) Parallel.Function.t
+    -> arg: 'query
+    -> 'response Deferred.t
+
+  (** Using these functions will not result in [on_failure] reporting a closed
+      connection, unlike running the [shutdown] function. *)
+  val kill     : t -> unit Or_error.t Deferred.t
+  val kill_exn : t -> unit Deferred.t
+end
+
+module Make (S : Parallel.Worker_spec) : Worker
+  with type 'a functions := 'a S.functions
+   and type worker_state_init_arg := S.Worker_state.init_arg
+   and type connection_state_init_arg := S.Connection_state.init_arg

--- a/src/external/rpc_parallel/src/remote_executable.ml
+++ b/src/external/rpc_parallel/src/remote_executable.ml
@@ -1,0 +1,65 @@
+open Core
+open Async
+
+type 'a t = {host: string; path: string; host_key_checking: string list}
+[@@deriving fields]
+
+let hostkey_checking_options opt =
+  match opt with
+  | None -> [ (* Use ssh default *) ]
+  | Some `Ask -> ["-o"; "StrictHostKeyChecking=ask"]
+  | Some `No -> ["-o"; "StrictHostKeyChecking=no"]
+  | Some `Yes -> ["-o"; "StrictHostKeyChecking=yes"]
+
+let existing_on_host ~executable_path ?strict_host_key_checking host =
+  { host
+  ; path= executable_path
+  ; host_key_checking= hostkey_checking_options strict_host_key_checking }
+
+let copy_to_host ~executable_dir ?strict_host_key_checking host =
+  let our_basename = Filename.basename Sys.executable_name in
+  Process.run ~prog:"mktemp"
+    ~args:["-u"; sprintf "%s.XXXXXXXX" our_basename]
+    ()
+  >>=? fun new_basename ->
+  let options = hostkey_checking_options strict_host_key_checking in
+  let path = String.strip (executable_dir ^/ new_basename) in
+  Utils.our_binary ()
+  >>=? fun our_binary ->
+  Process.run ~prog:"scp"
+    ~args:(options @ [our_binary; sprintf "%s:%s" host path])
+    ()
+  >>|? Fn.const {host; path; host_key_checking= options}
+
+let delete executable =
+  Process.run ~prog:"ssh"
+    ~args:
+      (executable.host_key_checking @ [executable.host; "rm"; executable.path])
+    ()
+  >>|? Fn.const ()
+
+let command env binary =
+  let cheesy_escape str = Sexp.to_string (String.sexp_of_t str) in
+  let env =
+    String.concat
+      (List.map env ~f:(fun (key, data) -> key ^ "=" ^ cheesy_escape data))
+      ~sep:" "
+  in
+  sprintf "%s %s" env binary
+
+let run exec ~env ~args =
+  Utils.our_md5 ()
+  >>=? fun md5 ->
+  Process.run ~prog:"ssh"
+    ~args:(exec.host_key_checking @ [exec.host; "md5sum"; exec.path])
+    ()
+  >>=? fun remote_md5 ->
+  let remote_md5, _ = String.lsplit2_exn ~on:' ' remote_md5 in
+  if md5 <> remote_md5 then
+    Deferred.Or_error.errorf
+      "The remote executable %s:%s does not match the local executable"
+      exec.host exec.path
+  else
+    Process.create ~prog:"ssh"
+      ~args:(exec.host_key_checking @ [exec.host; command env exec.path] @ args)
+      ()

--- a/src/external/rpc_parallel/src/remote_executable.mli
+++ b/src/external/rpc_parallel/src/remote_executable.mli
@@ -1,0 +1,43 @@
+open Core
+open Async
+
+(** This module is used to transfer the currently running executable to a remote server *)
+type 'a t
+
+(** [existing_on_host ~executable_path ?strict_host_key_checking host] will create a [t]
+    from the supplied host and path. The executable MUST be the exact same executable that
+    will be run in the master process. There will be a check for this in [spawn_worker].
+    Use [strict_host_key_checking] to change the StrictHostKeyChecking option used when
+    sshing into this host *)
+val existing_on_host
+  :  executable_path:string
+  -> ?strict_host_key_checking:[`No | `Ask | `Yes]
+  -> string
+  -> [`Undeletable] t
+
+(** [copy_to_host ~executable_dir ?strict_host_key_checking host] will copy the currently
+    running executable to the desired host and path. It will keep the same name but add a
+    suffix .XXXXXXXX. Use [strict_host_key_checking] to change the StrictHostKeyChecking
+    option used when sshing into this host *)
+val copy_to_host
+  :  executable_dir:string
+  -> ?strict_host_key_checking:[`No | `Ask | `Yes]
+  -> string
+  -> [`Deletable] t Or_error.t Deferred.t
+
+(** [delete t] will delete a remote executable that was copied over by a previous call to
+    [copy_to_host] *)
+val delete : [`Deletable] t -> unit Or_error.t Deferred.t
+
+(** Get the underlying path, host, and host_key_checking *)
+val path : _ t -> string
+val host : _ t -> string
+val host_key_checking : _ t -> string list
+
+(** Run the executable remotely with the given environment and arguments. This checks to
+    make sure [t] matches the currently running executable that [run] is called from. *)
+val run
+  :  _ t
+  -> env:(string * string) list
+  -> args:string list
+  -> Process.t Or_error.t Deferred.t

--- a/src/external/rpc_parallel/src/rpc_parallel.ml
+++ b/src/external/rpc_parallel/src/rpc_parallel.ml
@@ -1,0 +1,30 @@
+open! Core
+
+(** A type-safe parallel library built on top of Async_rpc.
+
+    {[
+      module Worker = Rpc_parallel.Make (T : Worker_spec)
+    ]}
+
+    The [Worker] module can be used to spawn new workers, either locally or remotely, and
+    run functions on these workers. [T] specifies which functions can be run on a
+    [Worker.t] as well as the implementations for these functions. In addition, [T]
+    specifies worker states and connection states. See README for more details *)
+
+module Remote_executable   = Remote_executable
+module Executable_location = Executable_location
+module Managed             = Parallel_managed
+module Map_reduce          = Map_reduce
+
+include Parallel
+
+(** Old [Std] style interface, which has slightly different module names. *)
+module Std = struct end
+[@@deprecated "[since 2016-11] Use [Rpc_parallel] instead of [Rpc_parallel.Std]"]
+
+module Parallel = Parallel
+[@@deprecated "[since 2016-11] Use [Rpc_parallel] instead of [Rpc_parallel.Parallel]"]
+
+module Parallel_managed = Parallel_managed
+[@@deprecated "[since 2016-11] Use [Rpc_parallel.Managed] instead of \
+               [Rpc_parallel.Parallel_managed]"]

--- a/src/external/rpc_parallel/src/utils.ml
+++ b/src/external/rpc_parallel/src/utils.ml
@@ -1,0 +1,108 @@
+open Core
+open Async
+
+module Worker_id = struct
+  let create = Uuid.create
+
+  (* If we do not use the stable sexp serialization, when running
+     inline tests, we will create UUIDs that fail tests *)
+  module T = Uuid.Stable.V1
+
+  type t = T.t [@@deriving sexp, bin_io]
+
+  include Comparable.Make_binable (T)
+  include Hashable.Make_binable (T)
+  include Sexpable.To_stringable (T)
+
+  let pp fmt t = String.pp fmt (Sexp.to_string ([%sexp_of: t] t))
+end
+
+module Worker_type_id = Unique_id.Int ()
+
+module Internal_connection_state = struct
+  type ('worker_state, 'conn_state) t1 =
+    { worker_state: 'worker_state
+    ; conn_state: 'conn_state
+    ; worker_id: Worker_id.t }
+
+  type ('worker_state, 'conn_state) t =
+    Rpc.Connection.t * ('worker_state, 'conn_state) t1 Set_once.t
+end
+
+let try_within ~monitor f =
+  let ivar = Ivar.create () in
+  Scheduler.within ~monitor (fun () ->
+      Monitor.try_with ~run:`Now ~rest:`Raise f
+      >>> fun r -> Ivar.fill ivar (Result.map_error r ~f:Error.of_exn) ) ;
+  Ivar.read ivar
+
+let try_within_exn ~monitor f =
+  try_within ~monitor f >>| function Ok x -> x | Error e -> Error.raise e
+
+(* To get the currently running executable:
+ * On Darwin:
+ * Use _NSGetExecutablePath via Ctypes
+ *
+ * On Linux:
+ * Use /proc/PID/exe
+   - argv[0] might have been deleted (this is quite common with jenga)
+   - `cp /proc/PID/exe dst` works as expected while `cp /proc/self/exe dst` does not *)
+let our_binary =
+  let our_binary_lazy =
+    lazy
+      (let open Deferred.Or_error.Let_syntax in
+      let%map os = Process.run ~prog:"uname" ~args:["-s"] () in
+      if os = "Darwin\n" then (
+        let open Ctypes in
+        let ns_get_executable_path =
+          Foreign.foreign "_NSGetExecutablePath"
+            (ptr char @-> ptr uint32_t @-> returning void)
+        in
+        let path_max = 1024 in
+        let buf = Ctypes.allocate_n char ~count:path_max in
+        let count =
+          Ctypes.allocate uint32_t (Unsigned.UInt32.of_int (path_max - 1))
+        in
+        ns_get_executable_path buf count ;
+        let s =
+          string_from_ptr buf ~length:(!@count |> Unsigned.UInt32.to_int)
+        in
+        List.hd_exn @@ String.split s ~on:(Char.of_int 0 |> Option.value_exn) )
+      else Unix.getpid () |> Pid.to_int |> sprintf "/proc/%d/exe")
+  in
+  fun () -> Lazy.force our_binary_lazy
+
+let our_md5 =
+  let our_md5_lazy =
+    lazy
+      (let open Deferred.Or_error.Let_syntax in
+      let%bind our_binary = our_binary () in
+      let%map our_md5 = Process.run ~prog:"md5sum" ~args:[our_binary] () in
+      let our_md5, _ = String.lsplit2_exn ~on:' ' our_md5 in
+      our_md5)
+  in
+  fun () -> Lazy.force our_md5_lazy
+
+let is_child_env_var = "ASYNC_PARALLEL_IS_CHILD_MACHINE"
+
+let whoami () =
+  match Sys.getenv is_child_env_var with Some _ -> `Worker | None -> `Master
+
+let clear_env () = Unix.unsetenv is_child_env_var
+
+let validate_env env =
+  match List.find env ~f:(fun (key, _) -> key = is_child_env_var) with
+  | Some e ->
+      Or_error.error
+        "Environment variable conflicts with Rpc_parallel machinery" e
+        [%sexp_of: string * string]
+  | None -> Ok ()
+
+let create_worker_env ~extra =
+  let open Or_error.Monad_infix in
+  validate_env extra >>| fun () -> extra @ [(is_child_env_var, "")]
+
+let to_daemon_fd_redirection = function
+  | `Dev_null -> `Dev_null
+  | `File_append s -> `File_append s
+  | `File_truncate s -> `File_truncate s

--- a/src/external/rpc_parallel/src/utils.mli
+++ b/src/external/rpc_parallel/src/utils.mli
@@ -1,0 +1,67 @@
+open Core
+open Async
+
+module Worker_id : sig
+  type t [@@deriving bin_io, sexp]
+
+  val create : unit -> t
+
+  include Identifiable.S with type t := t
+end
+
+module Worker_type_id : Unique_id
+
+(* The internal connection state we keep with every connection to a worker.
+
+   [conn_state] is the user supplied connection state (well there is really a [Set_once.t]
+   in there as well)
+
+   [worker_state] is the worker state associated with the given worker. A reference is
+   stored here to gracefully handle the cleanup needed when [close_server] is called when
+   there are still open connections.
+
+   [worker_id] is the id of the worker server that this connection is to. This is
+   needed because there can be multiple instances of a given worker server in a single
+   process.
+
+   The [Rpc.Connection.t] is the underlying connection that has this state *)
+module Internal_connection_state : sig
+  type ('worker_state, 'conn_state) t1 =
+    { worker_state: 'worker_state
+    ; conn_state: 'conn_state
+    ; worker_id: Worker_id.t }
+
+  type ('worker_state, 'conn_state) t =
+    Rpc.Connection.t * ('worker_state, 'conn_state) t1 Set_once.t
+end
+
+(* Like [Monitor.try_with], but raise any additional exceptions (raised after [f ()] has
+   been determined) to the specified monitor. *)
+val try_within :
+  monitor:Monitor.t -> (unit -> 'a Deferred.t) -> 'a Or_error.t Deferred.t
+
+(* Any exceptions that are raised before [f ()] is determined will be raised to the
+   current monitor. Exceptions raised after [f ()] is determined will be raised to the
+   passed in monitor *)
+val try_within_exn :
+  monitor:Monitor.t -> (unit -> 'a Deferred.t) -> 'a Deferred.t
+
+(* Get the location of the currently running binary. *)
+val our_binary : unit -> string Or_error.t Deferred.t
+
+(* Get an md5 hash of the currently running binary *)
+val our_md5 : unit -> string Or_error.t Deferred.t
+
+(* Determine in what context the current executable is running *)
+val whoami : unit -> [`Worker | `Master]
+
+(* Clear any environment variables that this library has set *)
+val clear_env : unit -> unit
+
+(* Create an environment for a spawned worker to run in *)
+val create_worker_env :
+  extra:(string * string) list -> (string * string) list Or_error.t
+
+val to_daemon_fd_redirection :
+     [`Dev_null | `File_append of string | `File_truncate of string]
+  -> Daemon.Fd_redirection.t


### PR DESCRIPTION
macOS doesn't have a procfs. The canonical way to get the full
executable path is to use the C-function _NSGetExecutablePath. I'm
branching on OS using `uname -s` and using _NSGetExecutablePath on
Darwin systems and keeping the default proc-lookup on other ones.

See `src/util.ml` for the big change that I made. The rest is just type-error fixups.

This is necessary for builds on macOS to not die after immediately starting up the coda daemon. After these changes, the build doesn't die (amongst other necessary changes not included in this PR).

See https://github.com/janestreet/rpc_parallel/pull/6 for a version of these patches on the master branch of rpc_parallel.