### PR TITLE
Rename to_coords to to_affine_coordinates, add some bindings

### DIFF
--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -51,7 +51,7 @@ let max_input_size = 20000
 
 let params =
   List.init (max_input_size / 4) ~f:(fun i ->
-      let t = Group.of_coords (random_point ()) in
+      let t = Group.of_affine_coordinates (random_point ()) in
       let tt = Group.double t in
       (t, tt, Group.add t tt, Group.double tt) )
 
@@ -65,13 +65,13 @@ let params ~loc =
       (List.map params ~f:(fun (g1, g2, g3, g4) ->
            E.pexp_tuple
              (List.map [g1; g2; g3; g4] ~f:(fun g ->
-                  let x, y = Group.to_coords g in
+                  let x, y = Group.to_affine_coordinates g in
                   E.pexp_tuple
                     [ estring (Impl.Field.to_string x)
                     ; estring (Impl.Field.to_string y) ] )) ))
   in
   let%expr conv (x, y) =
-    Tick_backend.Inner_curve.of_coords
+    Tick_backend.Inner_curve.of_affine_coordinates
       (Tick0.Field.of_string x, Tick0.Field.of_string y)
   in
   Array.map

--- a/src/lib/lite_compat/lite_compat.ml
+++ b/src/lib/lite_compat/lite_compat.ml
@@ -15,7 +15,7 @@ module Make (Blockchain_state : Coda_base.Blockchain_state.S) = struct
     (c 0, c 1, c 2)
 
   let g1 (t : Tick.Inner_curve.t) : LTock.G1.t =
-    let x, y = Tick.Inner_curve.to_coords t in
+    let x, y = Tick.Inner_curve.to_affine_coordinates t in
     {x= field x; y= field y; z= LTock.Fq.one}
 
   let g2 (t : Snarky.Libsnark.Mnt6.G2.t) : LTock.G2.t =
@@ -87,16 +87,16 @@ module Make (Blockchain_state : Coda_base.Blockchain_state.S) = struct
       Lite_base.Ledger_hash.t =
     digest (h :> Tick.Pedersen.Digest.t)
 
-  let staged_ledger_hash (h : Coda_base.Staged_ledger_hash.t) =
-    { Lite_base.Staged_ledger_hash.ledger_hash=
-        ledger_hash (Coda_base.Staged_ledger_hash.ledger_hash h)
-    ; aux_hash= Coda_base.Staged_ledger_hash.(Aux_hash.to_bytes (aux_hash h))
+  let ledger_builder_hash (h : Coda_base.Ledger_builder_hash.t) =
+    { Lite_base.Ledger_builder_hash.ledger_hash=
+        ledger_hash (Coda_base.Ledger_builder_hash.ledger_hash h)
+    ; aux_hash= Coda_base.Ledger_builder_hash.(Aux_hash.to_bytes (aux_hash h))
     }
 
   let blockchain_state
-      ({staged_ledger_hash= slh; ledger_hash= lh; timestamp} :
+      ({ledger_builder_hash= lbh; ledger_hash= lh; timestamp} :
         Blockchain_state.t) : Lite_base.Blockchain_state.t =
-    { staged_ledger_hash= staged_ledger_hash slh
+    { ledger_builder_hash= ledger_builder_hash lbh
     ; ledger_hash= frozen_ledger_hash lh
     ; timestamp= time timestamp }
 end

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -21,9 +21,9 @@ let typ : (var, t) Tick.Typ.t = Tick.Typ.(field * field)
 
 let ( = ) = equal
 
-let of_inner_curve_exn = Tick.Inner_curve.to_coords
+let of_inner_curve_exn = Tick.Inner_curve.to_affine_coordinates
 
-let to_inner_curve = Tick.Inner_curve.of_coords
+let to_inner_curve = Tick.Inner_curve.of_affine_coordinates
 
 let gen : t Quickcheck.Generator.t =
   Quickcheck.Generator.filter_map Tick.Field.gen ~f:(fun x ->
@@ -43,7 +43,7 @@ module Compressed = struct
     module V1 = struct
       module T = struct
         type t = (Field.t, bool) t_
-        [@@deriving sexp, bin_io, eq, compare, hash]
+        [@@deriving bin_io, sexp, eq, compare, hash]
       end
 
       include T
@@ -67,6 +67,10 @@ module Compressed = struct
   include Hashable.Make_binable (Stable.V1)
 
   let compress (x, y) : t = {x; is_odd= parity y}
+
+  let to_base64 t = Binable.to_string (module Stable.V1) t |> B64.encode
+
+  let of_base64_exn s = B64.decode s |> Binable.of_string (module Stable.V1)
 
   let empty = {x= Field.zero; is_odd= false}
 

--- a/src/lib/signature_lib/checked.ml
+++ b/src/lib/signature_lib/checked.ml
@@ -159,7 +159,7 @@ module Schnorr
 
         val scale : t -> Scalar.t -> t
 
-        val to_coords : t -> Field.t * Field.t
+        val to_affine_coordinates : t -> Field.t * Field.t
     end)
     (Message : Message_intf
                with type boolean_var := Impl.Boolean.var
@@ -195,7 +195,7 @@ module Schnorr
   end
 
   let compress (t : Curve.t) =
-    let x, _ = Curve.to_coords t in
+    let x, _ = Curve.to_affine_coordinates t in
     Field.unpack x
 
   module Public_key : sig

--- a/src/lib/snark_params/pedersen.ml
+++ b/src/lib/snark_params/pedersen.ml
@@ -53,7 +53,7 @@ end)
 (Bigint : Snarky.Bigint_intf.Extended with type field := Field.t) (Curve : sig
     type t
 
-    val to_coords : t -> Field.t * Field.t
+    val to_affine_coordinates : t -> Field.t * Field.t
 
     val zero : t
 
@@ -97,7 +97,7 @@ end) : S with type curve := Curve.t and type Digest.t = Field.t = struct
       {t with acc; triples_consumed}
 
     let digest t =
-      let x, _y = Curve.to_coords t.acc in
+      let x, _y = Curve.to_affine_coordinates t.acc in
       x
 
     let salt params s = update_fold (create params) (Fold.string_triples s)

--- a/src/lib/snark_params/pedersen.mli
+++ b/src/lib/snark_params/pedersen.mli
@@ -53,7 +53,7 @@ end)
 (Bigint : Snarky.Bigint_intf.Extended with type field := Field.t) (Curve : sig
     type t
 
-    val to_coords : t -> Field.t * Field.t
+    val to_affine_coordinates : t -> Field.t * Field.t
 
     val zero : t
 

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -136,9 +136,9 @@ module Tock = struct
               (struct
                 type nonrec t = t
 
-                let to_sexpable = to_coords
+                let to_sexpable = to_affine_coordinates
 
-                let of_sexpable = of_coords
+                let of_sexpable = of_affine_coordinates
               end)
 
     include Make_inner_curve_aux (Tock0) (Tick0)
@@ -200,9 +200,9 @@ module Tick = struct
               (struct
                 type nonrec t = t
 
-                let to_sexpable = to_coords
+                let to_sexpable = to_affine_coordinates
 
-                let of_sexpable = of_coords
+                let of_sexpable = of_affine_coordinates
               end)
 
     include Make_inner_curve_aux (Tick0) (Tock0)

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp4.hpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp4.hpp
@@ -66,6 +66,8 @@ public:
     Fp4_model unitary_inverse() const;
     Fp4_model cyclotomic_squared() const;
 
+    std::vector<my_Fp> all_base_field_elements() { return { c0.c0, c0.c1, c1.c0, c1.c1 }; }
+
     static my_Fp2 mul_by_non_residue(const my_Fp2 &elt);
 
     template<mp_size_t m>

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp6_2over3.hpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/depends/libff/libff/algebra/fields/fp6_2over3.hpp
@@ -69,6 +69,8 @@ public:
     Fp6_2over3_model unitary_inverse() const;
     Fp6_2over3_model cyclotomic_squared() const;
 
+    std::vector<my_Fp> all_base_field_elements() { return { c0.c0, c0.c1, c0.c2, c1.c0, c1.c1, c1.c2 }; }
+
     static my_Fp3 mul_by_non_residue(const my_Fp3 &elem);
 
     template<mp_size_t m>

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_bn128.cpp
@@ -632,6 +632,27 @@ r1cs_gg_ppzksnark_verification_key<ppT>* camlsnark_bn128_verification_key_of_str
   return vk;
 }
 
+std::vector<libff::G1<ppT>>*
+camlsnark_bn128_verification_key_query(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  std::vector<libff::G1<ppT>>* res = new std::vector<libff::G1<ppT>>();
+  res->emplace_back(vk->ABC_g1.first);
+  for (size_t i = 0; i < vk->ABC_g1.rest.values.size(); ++i)
+  {
+      res->emplace_back(vk->ABC_g1.rest.values[i]);
+  }
+  return res;
+}
+
+libff::G2<ppT>*
+camlsnark_bn128_verification_key_delta(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  return new libff::G2<ppT>(vk->delta_g2);
+}
+
+libff::Fqk<ppT>*
+camlsnark_bn128_verification_key_alpha_beta(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  return new libff::Fqk<ppT>(vk->alpha_g1_beta_g2);
+}
+
 r1cs_gg_ppzksnark_proving_key<ppT>* camlsnark_bn128_keypair_pk(r1cs_gg_ppzksnark_keypair<ppT>* keypair) {
   return new r1cs_gg_ppzksnark_proving_key<ppT>(keypair->pk);
 }
@@ -682,7 +703,20 @@ bool camlsnark_bn128_proof_verify(
     std::vector<FieldT>* primary_input) {
   return r1cs_gg_ppzksnark_verifier_weak_IC(*key, *primary_input, *proof);
 }
-// End ppzksnark specific code
+
+libff::G1<ppT>* camlsnark_bn128_proof_a(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G1<ppT>(proof->g_A);
+}
+
+libff::G2<ppT>* camlsnark_bn128_proof_b(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G2<ppT>(proof->g_B);
+}
+
+libff::G1<ppT>* camlsnark_bn128_proof_c(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G1<ppT>(proof->g_C);
+}
+
+// End gg_ppzksnark specific code
 
 // Begin Groth-Maller specific code
 r1cs_constraint_system<FieldT>* camlsnark_bn128_gm_proving_key_r1cs_constraint_system(
@@ -750,6 +784,13 @@ camlsnark_bn128_gm_verification_key_h_gamma (
     r1cs_se_ppzksnark_verification_key<ppT>* vk
 ) {
   return new libff::G2<ppT>(vk->H_gamma);
+}
+
+libff::Fqk<ppT>* 
+camlsnark_bn128_gm_verification_key_g_alpha_h_beta (
+    r1cs_se_ppzksnark_verification_key<ppT>* vk
+) {
+  return new libff::Fqk<ppT>(vk->G_alpha_H_beta);
 }
 
 std::vector< libff::G1<ppT> >*

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4.cpp
@@ -632,6 +632,29 @@ r1cs_gg_ppzksnark_verification_key<ppT>* camlsnark_mnt4_verification_key_of_stri
   return vk;
 }
 
+std::vector<libff::G1<ppT>>*
+camlsnark_mnt4_verification_key_query(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  std::vector<libff::G1<ppT>>* res = new std::vector<libff::G1<ppT>>();
+  printf("Test\n");
+  res->emplace_back(vk->ABC_g1.first);
+  for (size_t i = 0; i < vk->ABC_g1.rest.values.size(); ++i)
+  {
+  printf("Test %d\n", i);
+      res->emplace_back(vk->ABC_g1.rest.values[i]);
+  }
+  return res;
+}
+
+libff::G2<ppT>*
+camlsnark_mnt4_verification_key_delta(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  return new libff::G2<ppT>(vk->delta_g2);
+}
+
+libff::Fqk<ppT>*
+camlsnark_mnt4_verification_key_alpha_beta(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  return new libff::Fqk<ppT>(vk->alpha_g1_beta_g2);
+}
+
 r1cs_gg_ppzksnark_proving_key<ppT>* camlsnark_mnt4_keypair_pk(r1cs_gg_ppzksnark_keypair<ppT>* keypair) {
   return new r1cs_gg_ppzksnark_proving_key<ppT>(keypair->pk);
 }
@@ -682,7 +705,20 @@ bool camlsnark_mnt4_proof_verify(
     std::vector<FieldT>* primary_input) {
   return r1cs_gg_ppzksnark_verifier_weak_IC(*key, *primary_input, *proof);
 }
-// End ppzksnark specific code
+
+libff::G1<ppT>* camlsnark_mnt4_proof_a(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G1<ppT>(proof->g_A);
+}
+
+libff::G2<ppT>* camlsnark_mnt4_proof_b(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G2<ppT>(proof->g_B);
+}
+
+libff::G1<ppT>* camlsnark_mnt4_proof_c(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G1<ppT>(proof->g_C);
+}
+
+// End gg_ppzksnark specific code
 
 // Begin Groth-Maller specific code
 r1cs_constraint_system<FieldT>* camlsnark_mnt4_gm_proving_key_r1cs_constraint_system(
@@ -750,6 +786,13 @@ camlsnark_mnt4_gm_verification_key_h_gamma (
     r1cs_se_ppzksnark_verification_key<ppT>* vk
 ) {
   return new libff::G2<ppT>(vk->H_gamma);
+}
+
+libff::Fqk<ppT>* 
+camlsnark_mnt4_gm_verification_key_g_alpha_h_beta (
+    r1cs_se_ppzksnark_verification_key<ppT>* vk
+) {
+  return new libff::Fqk<ppT>(vk->G_alpha_H_beta);
 }
 
 std::vector< libff::G1<ppT> >*

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt4_specific.cpp
@@ -518,4 +518,12 @@ std::vector<libff::Fq<ppT>>* camlsnark_mnt4_g2_y(libff::G2<ppT>* a) {
   return new std::vector< libff::Fq<ppT> >(a->Y().all_base_field_elements());
 }
 
+void camlsnark_mnt4_fqk_delete(libff::Fqk<ppT>* a) {
+  delete a;
+}
+
+std::vector<libff::Fq<ppT>>* camlsnark_mnt4_fqk_to_elts(libff::Fqk<ppT>* a) {
+  return new std::vector<libff::Fq<ppT>>(a->all_base_field_elements());
+}
+
 }

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6.cpp
@@ -632,6 +632,29 @@ r1cs_gg_ppzksnark_verification_key<ppT>* camlsnark_mnt6_verification_key_of_stri
   return vk;
 }
 
+std::vector<libff::G1<ppT>>*
+camlsnark_mnt6_verification_key_query(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  std::vector<libff::G1<ppT>>* res = new std::vector<libff::G1<ppT>>();
+  printf("Test\n");
+  res->emplace_back(vk->ABC_g1.first);
+  for (size_t i = 0; i < vk->ABC_g1.rest.values.size(); ++i)
+  {
+  printf("Test %d\n", i);
+      res->emplace_back(vk->ABC_g1.rest.values[i]);
+  }
+  return res;
+}
+
+libff::G2<ppT>*
+camlsnark_mnt6_verification_key_delta(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  return new libff::G2<ppT>(vk->delta_g2);
+}
+
+libff::Fqk<ppT>*
+camlsnark_mnt6_verification_key_alpha_beta(r1cs_gg_ppzksnark_verification_key<ppT>* vk) {
+  return new libff::Fqk<ppT>(vk->alpha_g1_beta_g2);
+}
+
 r1cs_gg_ppzksnark_proving_key<ppT>* camlsnark_mnt6_keypair_pk(r1cs_gg_ppzksnark_keypair<ppT>* keypair) {
   return new r1cs_gg_ppzksnark_proving_key<ppT>(keypair->pk);
 }
@@ -682,7 +705,20 @@ bool camlsnark_mnt6_proof_verify(
     std::vector<FieldT>* primary_input) {
   return r1cs_gg_ppzksnark_verifier_weak_IC(*key, *primary_input, *proof);
 }
-// End ppzksnark specific code
+
+libff::G1<ppT>* camlsnark_mnt6_proof_a(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G1<ppT>(proof->g_A);
+}
+
+libff::G2<ppT>* camlsnark_mnt6_proof_b(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G2<ppT>(proof->g_B);
+}
+
+libff::G1<ppT>* camlsnark_mnt6_proof_c(r1cs_gg_ppzksnark_proof<ppT>* proof) {
+  return new libff::G1<ppT>(proof->g_C);
+}
+
+// End gg_ppzksnark specific code
 
 // Begin Groth-Maller specific code
 r1cs_constraint_system<FieldT>* camlsnark_mnt6_gm_proving_key_r1cs_constraint_system(
@@ -750,6 +786,13 @@ camlsnark_mnt6_gm_verification_key_h_gamma (
     r1cs_se_ppzksnark_verification_key<ppT>* vk
 ) {
   return new libff::G2<ppT>(vk->H_gamma);
+}
+
+libff::Fqk<ppT>* 
+camlsnark_mnt6_gm_verification_key_g_alpha_h_beta (
+    r1cs_se_ppzksnark_verification_key<ppT>* vk
+) {
+  return new libff::Fqk<ppT>(vk->G_alpha_H_beta);
 }
 
 std::vector< libff::G1<ppT> >*

--- a/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
+++ b/src/lib/snarky/src/camlsnark_c/libsnark-caml/libsnark/caml/caml_mnt6_specific.cpp
@@ -518,4 +518,12 @@ std::vector<libff::Fq<ppT>>* camlsnark_mnt6_g2_y(libff::G2<ppT>* a) {
   return new std::vector< libff::Fq<ppT> >(a->Y().all_base_field_elements());
 }
 
+void camlsnark_mnt6_fqk_delete(libff::Fqk<ppT>* a) {
+  delete a;
+}
+
+std::vector<libff::Fq<ppT>>* camlsnark_mnt6_fqk_to_elts(libff::Fqk<ppT>* a) {
+  return new std::vector<libff::Fq<ppT>>(a->all_base_field_elements());
+}
+
 }

--- a/src/lib/snarky/src/curves.ml
+++ b/src/lib/snarky/src/curves.ml
@@ -557,9 +557,9 @@ module Make_weierstrass_checked
 
       val random : unit -> t
 
-      val to_coords : t -> Impl.Field.t * Impl.Field.t
+      val to_affine_coordinates : t -> Impl.Field.t * Impl.Field.t
 
-      val of_coords : Impl.Field.t * Impl.Field.t -> t
+      val of_affine_coordinates : Impl.Field.t * Impl.Field.t -> t
 
       val double : t -> t
 
@@ -592,7 +592,7 @@ module Make_weierstrass_checked
     let unchecked =
       Typ.transport
         Typ.(tuple2 field field)
-        ~there:Curve.to_coords ~back:Curve.of_coords
+        ~there:Curve.to_affine_coordinates ~back:Curve.of_affine_coordinates
     in
     {unchecked with check= assert_on_curve}
 
@@ -600,7 +600,7 @@ module Make_weierstrass_checked
     (x, Field.Checked.scale y Field.(negate one))
 
   let constant (t : t) : var =
-    let x, y = Curve.to_coords t in
+    let x, y = Curve.to_affine_coordinates t in
     Field.Checked.(constant x, constant y)
 
   let assert_equal (x1, y1) (x2, y2) =
@@ -790,8 +790,8 @@ module Make_weierstrass_checked
     (bx, by)
 
   let if_value (cond : Boolean.var) ~then_ ~else_ =
-    let x1, y1 = Curve.to_coords then_ in
-    let x2, y2 = Curve.to_coords else_ in
+    let x1, y1 = Curve.to_affine_coordinates then_ in
+    let x2, y2 = Curve.to_affine_coordinates else_ in
     let cond = (cond :> Field.Checked.t) in
     let choose a1 a2 =
       let open Field.Checked in
@@ -835,10 +835,10 @@ module Make_weierstrass_checked
       +^ ((a3 - a1) * (b1 :> Field.Checked.t))
       +^ ((a4 + a1 - a2 - a3) * (b0_and_b1 :> Field.Checked.t))
     in
-    let x1, y1 = Curve.to_coords t1
-    and x2, y2 = Curve.to_coords t2
-    and x3, y3 = Curve.to_coords t3
-    and x4, y4 = Curve.to_coords t4 in
+    let x1, y1 = Curve.to_affine_coordinates t1
+    and x2, y2 = Curve.to_affine_coordinates t2
+    and x3, y3 = Curve.to_affine_coordinates t3
+    and x4, y4 = Curve.to_affine_coordinates t4 in
     (lookup_one (x1, x2, x3, x4), lookup_one (y1, y2, y3, y4))
 
   (* Similar to the above, but doing lookup in a size 1 table *)
@@ -847,7 +847,8 @@ module Make_weierstrass_checked
       let open Field.Checked.Infix in
       Field.Checked.constant a1 + (Field.sub a2 a1 * (b :> Field.Checked.t))
     in
-    let x1, y1 = Curve.to_coords t1 and x2, y2 = Curve.to_coords t2 in
+    let x1, y1 = Curve.to_affine_coordinates t1
+    and x2, y2 = Curve.to_affine_coordinates t2 in
     (lookup_one (x1, x2), lookup_one (y1, y2))
 
   let scale_known (type shifted)

--- a/src/lib/snarky/src/libsnark.ml
+++ b/src/lib/snarky/src/libsnark.ml
@@ -60,6 +60,8 @@ struct
 
     val add : t -> t -> t
 
+    val ( + ) : t -> t -> t
+
     val negate : t -> t
 
     val double : t -> t
@@ -72,9 +74,9 @@ struct
 
     val one : t
 
-    val to_coords : t -> Fq.t * Fq.t
+    val to_affine_coordinates : t -> Fq.t * Fq.t
 
-    val of_coords : Fq.t * Fq.t -> t
+    val of_affine_coordinates : Fq.t * Fq.t -> t
 
     val equal : t -> t -> bool
 
@@ -123,7 +125,7 @@ struct
         let x = stub () in
         schedule_delete x ; x
 
-    let of_coords =
+    let of_affine_coordinates =
       let stub =
         foreign (func_name "of_coords") (Fq.typ @-> Fq.typ @-> returning typ)
       in
@@ -149,6 +151,8 @@ struct
         let z = stub x y in
         schedule_delete z ; z
 
+    let ( + ) = add
+
     let scale =
       let stub =
         foreign (func_name "scale") (Bigint_r.typ @-> typ @-> returning typ)
@@ -167,7 +171,7 @@ struct
 
     let equal = foreign (func_name "equal") (typ @-> typ @-> returning bool)
 
-    let to_coords =
+    let to_affine_coordinates =
       let stub_to_affine =
         foreign (func_name "to_affine_coordinates") (typ @-> returning void)
       in
@@ -187,11 +191,13 @@ struct
     let to_repr t : Repr.t =
       if equal zero t then Zero
       else
-        let x, y = to_coords t in
+        let x, y = to_affine_coordinates t in
         Non_zero {x; y}
 
     let of_repr (r : Repr.t) =
-      match r with Zero -> zero | Non_zero {x; y} -> of_coords (x, y)
+      match r with
+      | Zero -> zero
+      | Non_zero {x; y} -> of_affine_coordinates (x, y)
 
     include Binable.Of_binable
               (Repr)
@@ -1335,6 +1341,38 @@ module Mnt6_0 = Make_full (struct
   let prefix = "camlsnark_mnt6"
 end)
 
+module Make_Groth16_verification_key_accessors (Prefix : sig
+  val prefix : string
+end)
+(Verification_key : Foreign_intf) (G1 : sig
+    include Deletable_intf
+
+    module Vector : Deletable_intf
+end)
+(G2 : Deletable_intf)
+(Fqk : Deletable_intf) =
+struct
+  open Prefix
+
+  let prefix = with_prefix prefix "verification_key"
+
+  let func_name = with_prefix prefix
+
+  let func name ret delete =
+    let stub =
+      foreign (func_name name) (Verification_key.typ @-> returning ret)
+    in
+    fun vk ->
+      let r = stub vk in
+      Caml.Gc.finalise delete r ; r
+
+  let delta = func "delta" G2.typ G2.delete
+
+  let query = func "query" G1.Vector.typ G1.Vector.delete
+
+  let alpha_beta = func "alpha_beta" Fqk.typ Fqk.delete
+end
+
 module Make_GM_verification_key_accessors (Prefix : sig
   val prefix : string
 end)
@@ -1343,7 +1381,8 @@ end)
 
     module Vector : Deletable_intf
 end)
-(G2 : Deletable_intf) =
+(G2 : Deletable_intf)
+(Fqk : Deletable_intf) =
 struct
   open Prefix
 
@@ -1370,9 +1409,11 @@ struct
   let h_gamma = func "h_gamma" G2.typ G2.delete
 
   let query = func "query" G1.Vector.typ G1.Vector.delete
+
+  let g_alpha_h_beta = func "g_alpha_h_beta" Fqk.typ Fqk.delete
 end
 
-module Make_GM_proof_accessors (Prefix : sig
+module Make_proof_accessors (Prefix : sig
   val prefix : string
 end)
 (Proof : Foreign_intf) (G1 : sig
@@ -1383,8 +1424,6 @@ end)
 (G2 : Deletable_intf) =
 struct
   open Prefix
-
-  let prefix = with_prefix prefix "gm_proof"
 
   let func_name = with_prefix prefix
 
@@ -1432,26 +1471,93 @@ struct
       (get_x t, get_y t)
 end
 
+module Make_fqk
+    (Prefix : Prefix_intf) (Fq : sig
+        include Deletable_intf
+
+        module Vector : Deletable_intf
+    end) =
+struct
+  include Make_foreign (struct
+    let prefix = with_prefix Prefix.prefix "fqk"
+  end)
+
+  let to_elts =
+    let stub =
+      foreign (func_name "to_elts") (typ @-> returning Fq.Vector.typ)
+    in
+    fun t ->
+      let v = stub t in
+      Caml.Gc.finalise Fq.Vector.delete v ;
+      v
+end
+
 module Mnt4 = struct
   include Mnt4_0
+  module Fqk = Make_fqk (Prefix) (Mnt6_0.Field)
   module G2 = Make_G2 (Prefix) (Mnt6_0.Field)
   include Make_G1 (Prefix) (Mnt4_0.Field) (Mnt4_0.Bigint.R) (Mnt6_0.Field)
+
   module GM_proof_accessors =
-    Make_GM_proof_accessors (Prefix) (GM.Proof) (Group) (G2)
+    Make_proof_accessors (struct
+        let prefix = with_prefix Prefix.prefix "gm_proof"
+      end)
+      (GM.Proof)
+      (Group)
+      (G2)
+
   module GM_verification_key_accessors =
     Make_GM_verification_key_accessors (Prefix) (GM.Verification_key) (Group)
       (G2)
+      (Fqk)
+
+  module Groth16_proof_accessors =
+    Make_proof_accessors (struct
+        let prefix = with_prefix Prefix.prefix "proof"
+      end)
+      (Default.Proof)
+      (Group)
+      (G2)
+
+  module Groth16_verification_key_accessors =
+    Make_Groth16_verification_key_accessors (Prefix) (Default.Verification_key)
+      (Group)
+      (G2)
+      (Fqk)
 end
 
 module Mnt6 = struct
   include Mnt6_0
+  module Fqk = Make_fqk (Prefix) (Mnt4_0.Field)
   module G2 = Make_G2 (Prefix) (Mnt4_0.Field)
   include Make_G1 (Prefix) (Mnt6_0.Field) (Mnt6_0.Bigint.R) (Mnt4_0.Field)
+
   module GM_proof_accessors =
-    Make_GM_proof_accessors (Prefix) (GM.Proof) (Group) (G2)
+    Make_proof_accessors (struct
+        let prefix = with_prefix Prefix.prefix "gm_proof"
+      end)
+      (GM.Proof)
+      (Group)
+      (G2)
+
   module GM_verification_key_accessors =
     Make_GM_verification_key_accessors (Prefix) (GM.Verification_key) (Group)
       (G2)
+      (Fqk)
+
+  module Groth16_proof_accessors =
+    Make_proof_accessors (struct
+        let prefix = with_prefix Prefix.prefix "proof"
+      end)
+      (Default.Proof)
+      (Group)
+      (G2)
+
+  module Groth16_verification_key_accessors =
+    Make_Groth16_verification_key_accessors (Prefix) (Default.Verification_key)
+      (Group)
+      (G2)
+      (Fqk)
 end
 
 module type S = sig

--- a/src/lib/snarky/src/pedersen.ml
+++ b/src/lib/snarky/src/pedersen.ml
@@ -11,7 +11,7 @@ module Make
 
         type t [@@deriving eq]
 
-        val to_coords : t -> Impl.Field.t * Impl.Field.t
+        val to_affine_coordinates : t -> Impl.Field.t * Impl.Field.t
 
         val typ : (var, t) Impl.Typ.t
 
@@ -105,10 +105,10 @@ end = struct
          Weierstrass_curve.t Quadruple.t
       -> Field.t Quadruple.t * Field.t Quadruple.t =
    fun (t1, t2, t3, t4) ->
-    let x1, y1 = Weierstrass_curve.to_coords t1
-    and x2, y2 = Weierstrass_curve.to_coords t2
-    and x3, y3 = Weierstrass_curve.to_coords t3
-    and x4, y4 = Weierstrass_curve.to_coords t4 in
+    let x1, y1 = Weierstrass_curve.to_affine_coordinates t1
+    and x2, y2 = Weierstrass_curve.to_affine_coordinates t2
+    and x3, y3 = Weierstrass_curve.to_affine_coordinates t3
+    and x4, y4 = Weierstrass_curve.to_affine_coordinates t4 in
     ((x1, x2, x3, x4), (y1, y2, y3, y4))
 
   let lookup ((s0, s1, s2) : Boolean.var Triple.t)

--- a/src/lib/vrf_lib/jbuild
+++ b/src/lib/vrf_lib/jbuild
@@ -13,6 +13,6 @@
 (library
  ((name tests)
   (inline_tests)
-  (libraries (core snarky test_util signature_lib snark_params vrf_lib coda_base sha256_lib fold_lib))
+  (libraries (core snarky snarky_curves test_util signature_lib snark_params vrf_lib coda_base sha256_lib fold_lib))
   (preprocess (pps (ppx_jane ppx_deriving.eq bisect_ppx -conditional)))
   (modules (integrated_test))))

--- a/src/lib/vrf_lib/standalone.ml
+++ b/src/lib/vrf_lib/standalone.ml
@@ -42,10 +42,10 @@ module Make
       val typ : (var, t) Impl.Typ.t
 
       module Checked :
-        Snarky.Curves.Weierstrass_checked_intf
+        Snarky_curves.Weierstrass_checked_intf
         with module Impl := Impl
-         and type t := t
-         and type var := var
+         and type unchecked := t
+         and type t = var
     end) (Message : sig
       open Impl
 
@@ -412,7 +412,8 @@ let%test_module "vrf-test" =
       include Snarky.Libsnark.Mnt6.Group
 
       module Checked = struct
-        include Snarky.Curves.Make_weierstrass_checked (Impl) (Scalar)
+        include Snarky_curves.Make_weierstrass_checked
+                  (Snarky_field_extensions.Field_extensions.F (Impl)) (Scalar)
                   (struct
                     include Snarky.Libsnark.Mnt6.Group
 
@@ -438,9 +439,9 @@ let%test_module "vrf-test" =
                   (struct
                     type t = Curve.t
 
-                    let to_sexpable = Curve.to_coords
+                    let to_sexpable = Curve.to_affine_coordinates
 
-                    let of_sexpable = Curve.of_coords
+                    let of_sexpable = Curve.of_affine_coordinates
                   end)
       end
 
@@ -464,7 +465,7 @@ let%test_module "vrf-test" =
       let typ = Curve.typ
 
       let to_bits (t : t) =
-        let x, y = Curve.to_coords t in
+        let x, y = Curve.to_affine_coordinates t in
         List.hd_exn (Field.unpack y) :: Field.unpack x
 
       let gen =
@@ -527,9 +528,9 @@ let%test_module "vrf-test" =
                 (struct
                   type t = Curve.t
 
-                  let to_sexpable = Curve.to_coords
+                  let to_sexpable = Curve.to_affine_coordinates
 
-                  let of_sexpable = Curve.of_coords
+                  let of_sexpable = Curve.of_affine_coordinates
                 end)
 
       type var = Curve.var
@@ -555,7 +556,7 @@ let%test_module "vrf-test" =
           Curve.add acc
             (Snarky.Pedersen.local_function ~negate:Curve.negate params.(i)
                triple) )
-      |> Curve.to_coords |> fst
+      |> Curve.to_affine_coordinates |> fst
 
     let hash_bits_checked bits =
       let open Impl.Let_syntax in


### PR DESCRIPTION
This PR

- renames `to_coords` to `to_affine_coordinates` for curves
- adds bindings for accessing the components of proofs.