### PR TITLE
macos compatible camlsnark_c

### DIFF
--- a/src/lib/snarky/src/camlsnark_c/camlsnark_linker_flags_gen.ml
+++ b/src/lib/snarky/src/camlsnark_c/camlsnark_linker_flags_gen.ml
@@ -1,0 +1,27 @@
+open Printf
+module C = Configurator.V1
+
+let () =
+  let cwd = Unix.getcwd () in
+  let uname_chan = Unix.open_process_in "uname" in
+  let l = input_line uname_chan in
+  C.Flags.write_sexp "flags.sexp"
+    ( match l with
+    | "Darwin" ->
+        [ sprintf "-Wl,-force_load,%s/libcamlsnark_c_stubs.a" cwd
+        ; "-lssl"
+        ; "-lcrypto"
+        ; "-lgmp"
+        ; "-lstdc++" ]
+    | "Linux" ->
+        [ "-Wl,-E"
+        ; "-Wl,--push-state,-whole-archive"
+        ; "-lcamlsnark_c_stubs"
+        ; "-Wl,--pop-state"
+        ; "-fopenmp"
+        ; "-lssl"
+        ; "-lcrypto"
+        ; "-lprocps"
+        ; "-lgmp"
+        ; "-lstdc++" ]
+    | s -> failwith (sprintf "don't know how to link on %s yet" s) )

--- a/src/lib/snarky/src/camlsnark_c/jbuild
+++ b/src/lib/snarky/src/camlsnark_c/jbuild
@@ -3,16 +3,28 @@
 ;; having to merge the .a and .so for libre2 and for the stubs of re2,
 ;; which is hard to do in a portable way
 
+(executable
+ ( (name camlsnark_linker_flags_gen)
+   (modules camlsnark_linker_flags_gen)
+   (libraries (dune.configurator))
+ ))
+
+ (rule
+  ( (targets (flags.sexp))
+    (action (run ./camlsnark_linker_flags_gen.exe) )
+  ))
+
+
 (library
  ((name        camlsnark_c)
   (libraries (core ctypes ctypes.foreign))
   (no_dynlink)
   (modes (native))
+  (modules (:standard \ camlsnark_linker_flags_gen))
   (public_name snarky.c)
   (preprocess no_preprocessing)
   (flags (:standard -short-paths -safe-string))
-  (c_library_flags (:standard -Wl,-E -Wl,-whole-archive -lcamlsnark_c_stubs -Wl,-no-whole-archive -fopenmp -lssl -lcrypto -lprocps -lgmp -lstdc++ 
-  ))
+  (c_library_flags (:standard (:include flags.sexp)))
   (self_build_stubs_archive (camlsnark_c))))
 
 (rule


### PR DESCRIPTION
This does changes similar to the ones made with rocksdb in https://github.com/CodaProtocol/coda/pull/1433. This should make the snarky build work ootb with dune on macos.