### PR TITLE
don't try and statically link to libsodium on mac

### DIFF
--- a/src/external/ocaml-sodium/myocamlbuild.ml
+++ b/src/external/ocaml-sodium/myocamlbuild.ml
@@ -3,9 +3,21 @@ open Ocamlbuild_pack;;
 
 let ctypes_libdir = Sys.getenv "CTYPES_LIB_DIR" in
 let ocaml_libdir = Sys.getenv "OCAML_LIB_DIR" in
-let lsodium = [A"-cclib"; A"-Wl,--push-state"; A"-cclib"; A"-Wl,-Bstatic"; 
-  A"-cclib"; A"-lsodium"; A"-cclib"; A"-Wl,--pop-state"] in
-
+let lsodium =
+  let cwd = Unix.getcwd () in
+  let uname_chan = Unix.open_process_in "uname" in
+  let l = input_line uname_chan in
+  match l with
+  | "Darwin" -> [A "-cclib"; A "-lsodium"]
+  | "Linux" ->
+      [ A "-cclib"
+      ; A "-Wl,--push-state,-Bstatic"
+      ; A "-cclib"
+      ; A "-lsodium"
+      ; A "-cclib"
+      ; A "-Wl,--pop-state" ]
+  | s -> failwith (Printf.sprintf "don't know how to link on %s yet" s)
+in
 dispatch begin
   function
   | After_rules ->


### PR DESCRIPTION
we don't build this dep ourselves, which makes the fixed path we'd need a
bit weird. for now, this seems to work on the frankenbuild. doesn't
break the container or linux builds.