### PR TITLE
working macos build

### DIFF
--- a/src/external/ocaml-sodium/myocamlbuild.ml
+++ b/src/external/ocaml-sodium/myocamlbuild.ml
@@ -3,9 +3,21 @@ open Ocamlbuild_pack;;
 
 let ctypes_libdir = Sys.getenv "CTYPES_LIB_DIR" in
 let ocaml_libdir = Sys.getenv "OCAML_LIB_DIR" in
-let lsodium = [A"-cclib"; A"-Wl,--push-state"; A"-cclib"; A"-Wl,-Bstatic"; 
-  A"-cclib"; A"-lsodium"; A"-cclib"; A"-Wl,--pop-state"] in
-
+let lsodium =
+  let cwd = Unix.getcwd () in
+  let uname_chan = Unix.open_process_in "uname" in
+  let l = input_line uname_chan in
+  match l with
+  | "Darwin" -> [A "-cclib"; A "-lsodium"]
+  | "Linux" ->
+      [ A "-cclib"
+      ; A "-Wl,--push-state,-Bstatic"
+      ; A "-cclib"
+      ; A "-lsodium"
+      ; A "-cclib"
+      ; A "-Wl,--pop-state" ]
+  | s -> failwith (Printf.sprintf "don't know how to link on %s yet" s)
+in
 dispatch begin
   function
   | After_rules ->

--- a/src/lib/snarky/src/camlsnark_c/camlsnark_linker_flags_gen.ml
+++ b/src/lib/snarky/src/camlsnark_c/camlsnark_linker_flags_gen.ml
@@ -9,6 +9,7 @@ let () =
     ( match l with
     | "Darwin" ->
         [ sprintf "-Wl,-force_load,%s/libcamlsnark_c_stubs.a" cwd
+        ; "-L/usr/local/Cellar/openssl/1.0.2q/lib"
         ; "-lssl"
         ; "-lcrypto"
         ; "-lgmp"

--- a/src/lib/snarky/src/camlsnark_c/camlsnark_linker_flags_gen.ml
+++ b/src/lib/snarky/src/camlsnark_c/camlsnark_linker_flags_gen.ml
@@ -9,7 +9,7 @@ let () =
     ( match l with
     | "Darwin" ->
         [ sprintf "-Wl,-force_load,%s/libcamlsnark_c_stubs.a" cwd
-        ; "-L/usr/local/Cellar/openssl/1.0.2q/lib"
+        ; "-L/usr/local/opt/openssl/lib"
         ; "-lssl"
         ; "-lcrypto"
         ; "-lgmp"

--- a/src/lib/snarky/src/camlsnark_c/jbuild
+++ b/src/lib/snarky/src/camlsnark_c/jbuild
@@ -31,7 +31,7 @@
  ((targets (libcamlsnark_c_stubs.a ))
   (deps ((files_recursively_in libsnark-caml)))
   (action (bash "
-  if [ $(uname) = "Linux" ]; then
+  if [ $(uname) = 'Linux' ]; then
     pushd libsnark-caml
     mkdir -p build
     pushd build
@@ -53,7 +53,7 @@
     popd
     popd
     mv libsnark-caml/build/libcamlsnark_c_stubs.a .
-elif [ $(uname) = "Darwin" ]; then
+elif [ $(uname) = 'Darwin' ]; then
   pushd libsnark-caml
     mkdir -p build
     pushd build
@@ -77,7 +77,7 @@ elif [ $(uname) = "Darwin" ]; then
   mv libsnark-caml/build/libcamlsnark_c_stubs.a .
     
 else
-    echo "I do not know how to build libsnark on $(uname)"
+    echo I do not know how to build libsnark on $(uname)
     exit 1
 fi
 "))))

--- a/src/lib/snarky/src/camlsnark_c/jbuild
+++ b/src/lib/snarky/src/camlsnark_c/jbuild
@@ -31,28 +31,55 @@
  ((targets (libcamlsnark_c_stubs.a ))
   (deps ((files_recursively_in libsnark-caml)))
   (action (bash "
-pwd
-pushd libsnark-caml
-  mkdir -p build
-  pushd build
-    cmake -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF ..
-    make -j$(nproc)
-
-    mkdir _stubs_build
-
-    mkdir _stubs_build/libff
-    pushd _stubs_build/libff/; ar -xv ../../depends/libff/libff/libff.a; popd
-
-    mkdir _stubs_build/libzm
-    pushd _stubs_build/libzm/; ar -xv ../../depends/libzm.a; popd
-
-    mkdir _stubs_build/libsnark
-    pushd _stubs_build/libsnark/; ar -xv ../../libsnark/libsnark.a; popd
-
-    ar -rc libcamlsnark_c_stubs.a _stubs_build/libff/*.o _stubs_build/libzm/*.o _stubs_build/libsnark/*.o
+  if [ $(uname) = "Linux" ]; then
+    pushd libsnark-caml
+    mkdir -p build
+    pushd build
+      cmake -DMULTICORE=ON -DUSE_PT_COMPRESSION=OFF ..
+      make -j$(nproc)
+  
+      mkdir _stubs_build
+  
+      mkdir _stubs_build/libff
+      pushd _stubs_build/libff/; ar -xv ../../depends/libff/libff/libff.a; popd
+  
+      mkdir _stubs_build/libzm
+      pushd _stubs_build/libzm/; ar -xv ../../depends/libzm.a; popd
+  
+      mkdir _stubs_build/libsnark
+      pushd _stubs_build/libsnark/; ar -xv ../../libsnark/libsnark.a; popd
+  
+      ar -rc libcamlsnark_c_stubs.a _stubs_build/libff/*.o _stubs_build/libzm/*.o _stubs_build/libsnark/*.o
+    popd
+    popd
+    mv libsnark-caml/build/libcamlsnark_c_stubs.a .
+elif [ $(uname) = "Darwin" ]; then
+  pushd libsnark-caml
+    mkdir -p build
+    pushd build
+      BOOST_ROOT=/usr/local/Cellar/boost/1.68.0_1 BOOST_INCLUDEDIR=/usr/local/Cellar/boost/1.68.0_1/include CPPFLAGS='-I/usr/local/opt/openssl/include -I/usr/local/opt/boost/include -I/usr/local/opt/gmp/include -I/usr/local/include -L/usr/local/lib -I/usr/local/include/gmp.h' CFLAGS='-I/usr/local/include' CXXFLAGS='-I/usr/local/include' LDFLAGS='-L/usr/local/opt/openssl/lib -L/usr/local/opt/boost/lib -L/usr/local/opt/gmp/lib' PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig cmake -DMULTICORE=OFF -DUSE_PT_COMPRESSION=OFF -DWITH_SUPERCOP=OFF -DWITH_PROCPS=OFF -DCMAKE_LIBRARY_PATH=/usr/local/opt/gmp/lib -DCMAKE_RULE_MESSAGES:BOOL=OFF -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON ..
+      make -j$(sysctl -n hw.ncpu)
+  
+      mkdir _stubs_build
+  
+      mkdir _stubs_build/libff
+      pushd _stubs_build/libff/; ar -xv ../../depends/libff/libff/libff.a; popd
+  
+      mkdir _stubs_build/libzm
+      pushd _stubs_build/libzm/; ar -xv ../../depends/libzm.a; popd
+  
+      mkdir _stubs_build/libsnark
+      pushd _stubs_build/libsnark/; ar -xv ../../libsnark/libsnark.a; popd
+  
+      libtool -static -o libcamlsnark_c_stubs.a _stubs_build/libff/*.o _stubs_build/libzm/*.o _stubs_build/libsnark/*.o
+    popd
   popd
-popd
-mv libsnark-caml/build/libcamlsnark_c_stubs.a .
+  mv libsnark-caml/build/libcamlsnark_c_stubs.a .
+    
+else
+    echo "I do not know how to build libsnark on $(uname)"
+    exit 1
+fi
 "))))
 
 (jbuild_version 1)


### PR DESCRIPTION
This dynamically links to libsodium on macos, and adds the necessary bash changes to build libsnark. Currently hardcodes some homebrew paths, which is unfortunate.