### PR TITLE
Add ml-docs target to Makefile (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,6 +284,12 @@ docs/res/%.tex.png: docs/res/%.tex.pdf
 doc_diagrams: $(addsuffix .png,$(wildcard docs/res/*.tex) $(wildcard docs/res/*.dot))
 
 ########################################
+# Generate odoc documentation
+
+ml-docs:
+	cd src; $(WRAPSRC) dune build --profile=$(DUNE_PROFILE) @doc
+
+########################################
 # To avoid unintended conflicts with file names, always add to .PHONY
 # unless there is a reason not to.
 # https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html


### PR DESCRIPTION
`make ml-docs` got removed from the Makefile. This re-adds it.

@bkase I think your commit removed it; was this causing problems for the mac build or something?

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them: