### PR TITLE
remove dune file that said to ignore now-removed pinned dune

### DIFF
--- a/src/external/dune
+++ b/src/external/dune
@@ -1,4 +1,0 @@
-;; code in these subdirectories may have sources
-;;  containing dune files for building packages, which
-;;  we don't want to use when building Coda
-(ignored_subdirs (ocaml-dune))


### PR DESCRIPTION
The directory `src/external` contained a `dune` file that told `dune` to ignore the `ocaml-dune` directory, which contained its own `dune` files.

Now that `ocaml-dune` is gone, we don't need this `dune` file.

Tested by building with `dune b`, which succeeded.
