### PR TITLE
ci: add separate build step to test-unit-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,9 @@ jobs:
        steps:
            - checkout
            - run:
+              name: Build OCaml
+              command: eval `opam config env` && DUNE_PROFILE=test_sigs make build 2>&1 | tee /tmp/buildocaml.log
+           - run:
               name: Test make test-runtest
               command: source ~/.profile && DUNE_PROFILE=test_sigs make test-runtest
 

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -122,6 +122,9 @@ jobs:
        steps:
            - checkout
            - run:
+              name: Build OCaml
+              command: eval `opam config env` && DUNE_PROFILE=test_sigs make build 2>&1 | tee /tmp/buildocaml.log
+           - run:
               name: Test make test-runtest
               command: source ~/.profile && DUNE_PROFILE=test_sigs make test-runtest
 


### PR DESCRIPTION
this might help alleviate possible memory pressure when
linkers/compilers are competing with tests to get memory.