### PR TITLE
DO NOT MERGE -- Debug num_accounts for client status

### DIFF
--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -112,6 +112,10 @@ module Make
   let to_list mdb = account_list_bin mdb Account.bin_read_t
 
   let keys mdb =
+    Printf.eprintf "IN DB: %s\n%!" (get_uuid mdb |> Uuid.to_string) ;
+    let db_keys = to_list mdb |> List.map ~f:Account.public_key in
+    Printf.eprintf "DB KEYS:\n%!" ;
+    List.iter db_keys ~f:(Printf.eprintf !"KEY:%{sexp:Key.t}\n%!") ;
     to_list mdb |> List.map ~f:Account.public_key |> Key.Set.of_list
 
   let set_raw {kvdb; _} location bin =
@@ -300,9 +304,12 @@ module Make
     |> Result.ok_exn
 
   let num_accounts t =
-    match Account_location.last_location_address t with
-    | None -> 0
-    | Some addr -> Addr.to_int addr + 1
+    let last_loc =
+      match Account_location.last_location_address t with
+      | None -> 0
+      | Some addr -> Addr.to_int addr + 1
+    in
+    last_loc
 
   let get_all_accounts_rooted_at_exn mdb address =
     let first_node, last_node = Addr.Range.subtree_range address in

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -347,7 +347,21 @@ struct
       |> Key.Set.of_list
 
     let num_accounts t =
-      Key.Set.union (Base.keys (get_parent t)) (keys t) |> Key.Set.length
+      let f = Printf.eprintf !"KEY: %{sexp:Key.t}\n%!" in
+      let base_keys = Base.keys (get_parent t) in
+      let mask_keys = keys t in
+      let all_keys = Key.Set.union (Base.keys (get_parent t)) (keys t) in
+      Printf.eprintf "IN MASK: %s\n%!" (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "NUM BASE KEYS: %d\n%!" (Key.Set.length base_keys) ;
+      Printf.eprintf "NUM MASK KEYS: %d\n%!" (Key.Set.length mask_keys) ;
+      Printf.eprintf "NUM ALL KEYS: %d\n%!" (Key.Set.length all_keys) ;
+      Printf.eprintf "BASE KEYS:\n%!" ;
+      Key.Set.iter base_keys ~f ;
+      Printf.eprintf "MASK KEYS:\n%!" ;
+      Key.Set.iter mask_keys ~f ;
+      Printf.eprintf "ALL KEYS:\n%!" ;
+      Key.Set.iter all_keys ~f ;
+      all_keys |> Key.Set.length
 
     let location_of_key t key =
       let mask_result = find_location t key in

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -286,6 +286,11 @@ struct
 
     (* transfer state from mask to parent; flush local state *)
     let commit t =
+      Printf.eprintf "COMMIT IN MASK: %s\n%!" (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "COMMIT STACK:\n%!" ;
+      Printf.eprintf "%s\n%!"
+        ( Stdlib.Printexc.get_callstack 20
+        |> Stdlib.Printexc.raw_backtrace_to_string ) ;
       let account_data = Location.Table.to_alist t.account_tbl in
       Base.set_batch (get_parent t) account_data ;
       Location.Table.clear t.account_tbl ;
@@ -410,6 +415,11 @@ struct
     (* Destroy intentionally does not commit before destroying
      * as sometimes this is desired behavior *)
     let close t =
+      Printf.eprintf "CLOSE IN MASK: %s\n%!" (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "CLOSE STACK:\n%!" ;
+      Printf.eprintf "%s\n%!"
+        ( Stdlib.Printexc.get_callstack 20
+        |> Stdlib.Printexc.raw_backtrace_to_string ) ;
       Location.Table.clear t.account_tbl ;
       Addr.Table.clear t.hash_tbl ;
       Key.Table.clear t.location_tbl

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -304,6 +304,11 @@ struct
 
     (* copy tables in t; use same parent *)
     let copy t =
+      Printf.eprintf "COPY IN MASK: %s\n%!" (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "COPY STACK:\n%!" ;
+      Printf.eprintf "%s\n%!"
+        ( Stdlib.Printexc.get_callstack 20
+        |> Stdlib.Printexc.raw_backtrace_to_string ) ;
       { uuid= Uuid.create ()
       ; parent= get_parent t
       ; account_tbl= Location.Table.copy t.account_tbl
@@ -467,6 +472,12 @@ struct
       mask_accounts @ in_parent_not_in_mask_accounts
 
     let foldi_with_ignored_keys t ignored_keys ~init ~f =
+      Printf.eprintf "FOLDI IGNORED KEYS IN MASK: %s\n%!"
+        (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "FOLDI IGNORED KEYS STACK:\n%!" ;
+      Printf.eprintf "%s\n%!"
+        ( Stdlib.Printexc.get_callstack 20
+        |> Stdlib.Printexc.raw_backtrace_to_string ) ;
       let locations_and_accounts = Location.Table.to_alist t.account_tbl in
       (* parent should ignore keys in this mask *)
       let mask_keys =
@@ -560,6 +571,11 @@ struct
       |> Result.ok_exn
 
     let foldi t ~init ~f =
+      Printf.eprintf "FOLDI IN MASK: %s\n%!" (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "FOLDI STACK:\n%!" ;
+      Printf.eprintf "%s\n%!"
+        ( Stdlib.Printexc.get_callstack 20
+        |> Stdlib.Printexc.raw_backtrace_to_string ) ;
       (* fold over parent, then mask *)
       let parent_result = Base.foldi (get_parent t) ~init ~f in
       Location.Table.fold t.account_tbl ~init:parent_result

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -352,6 +352,8 @@ struct
       let mask_keys = keys t in
       let all_keys = Key.Set.union (Base.keys (get_parent t)) (keys t) in
       Printf.eprintf "IN MASK: %s\n%!" (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "WITH BASE: %s\n%!"
+        (Base.get_uuid (get_parent t) |> Uuid.to_string) ;
       Printf.eprintf "NUM BASE KEYS: %d\n%!" (Key.Set.length base_keys) ;
       Printf.eprintf "NUM MASK KEYS: %d\n%!" (Key.Set.length mask_keys) ;
       Printf.eprintf "NUM ALL KEYS: %d\n%!" (Key.Set.length all_keys) ;

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -198,6 +198,12 @@ struct
       | None -> Base.merkle_root (get_parent t)
 
     let remove_account_and_update_hashes t location =
+      Printf.eprintf "REMOVE ACCOUNT / UPDATE HASHES, IN MASK: %s\n%!"
+        (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "REMOVE / UPDATE HASHES STACK:\n%!" ;
+      Printf.eprintf "%s\n%!"
+        ( Stdlib.Printexc.get_callstack 20
+        |> Stdlib.Printexc.raw_backtrace_to_string ) ;
       (* remove account and key from tables *)
       let account = Option.value_exn (find_account t location) in
       Location.Table.remove t.account_tbl location ;
@@ -384,6 +390,12 @@ struct
       get_hash t address |> Option.value_exn
 
     let remove_accounts_exn t keys =
+      Printf.eprintf "REMOVE ACCOUNTS IN MASK: %s\n%!"
+        (get_uuid t |> Uuid.to_string) ;
+      Printf.eprintf "REMOVE STACK:\n%!" ;
+      Printf.eprintf "%s\n%!"
+        ( Stdlib.Printexc.get_callstack 20
+        |> Stdlib.Printexc.raw_backtrace_to_string ) ;
       let rec loop keys parent_keys mask_locations =
         match keys with
         | [] -> (parent_keys, mask_locations)

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -439,6 +439,7 @@ module Make
         (desired_root_exn t, What_hash (Addr.child_exn addr Direction.Right)) )
 
   let num_accounts t n content_hash =
+    Printf.eprintf "SYNCABLE LEDGER NUM_ACCOUNTS\n%!" ;
     let rh = Root_hash.to_hash (desired_root_exn t) in
     let height = Int.ceil_log2 n in
     (* FIXME: bug when height=0 https://github.com/o1-labs/nanobit/issues/365 *)


### PR DESCRIPTION
DO NOT MERGE.

`num_accounts` prints some debug output to stderr, so we can fix the errors reported for `client status`.