### PR TITLE
Snarky submodule always ancestor of master (lint)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,19 @@ jobs:
                 name: Build trace-tool
                 command: cd src/app/trace-tool && cargo build --frozen
 
+    lint:
+        docker:
+        - image: codaprotocol/coda:toolchain-7df6b2b12bc316cb71592b12255d80e19396831e
+        steps:
+            - checkout
+            - run: git submodule sync && git submodule update --init --recursive
+            - run:
+                name: OCamlformat (make check-format)
+                command: eval `opam config env` && make check-format
+            - run:
+                name: Snarky tracks master (make check-snarky-submodule)
+                command: make check-snarky-submodule
+
     build:
         resource_class: large
         docker:
@@ -18,9 +31,6 @@ jobs:
         steps:
             - checkout
             - run: git submodule sync && git submodule update --init --recursive
-            - run:
-                name: Lint
-                command: eval `opam config env` && make check-format
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=dev make build 2>&1 | tee /tmp/buildocaml.log

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -11,6 +11,19 @@ jobs:
                 name: Build trace-tool
                 command: cd src/app/trace-tool && cargo build --frozen
 
+    lint:
+        docker:
+        - image: codaprotocol/coda:toolchain-7df6b2b12bc316cb71592b12255d80e19396831e
+        steps:
+            - checkout
+            - run: git submodule sync && git submodule update --init --recursive
+            - run:
+                name: OCamlformat (make check-format)
+                command: eval `opam config env` && make check-format
+            - run:
+                name: Snarky tracks master (make check-snarky-submodule)
+                command: make check-snarky-submodule
+
     build:
         resource_class: large
         docker:
@@ -18,9 +31,6 @@ jobs:
         steps:
             - checkout
             - run: git submodule sync && git submodule update --init --recursive
-            - run:
-                name: Lint
-                command: eval `opam config env` && make check-format
             - run:
                 name: Build OCaml
                 command: eval `opam config env` && DUNE_PROFILE=dev make build 2>&1 | tee /tmp/buildocaml.log

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ reformat: git_hooks
 check-format:
 	cd src; $(WRAPSRC) dune exec --profile=$(DUNE_PROFILE) app/reformat/reformat.exe -- -path . -check
 
+check-snarky-submodule:
+	./scripts/check-snarky-submodule.sh
+
 ########################################
 ## Merlin fixup for docker builds
 

--- a/scripts/check-snarky-submodule.sh
+++ b/scripts/check-snarky-submodule.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+cd src/lib/snarky
+
+CURR=$(git rev-parse HEAD)
+git fetch origin
+
+if ! git rev-list origin/master | grep -q $CURR; then
+  echo "Snarky submodule commit is not an ancestor of snarky/master"
+  exit 1
+fi
+


### PR DESCRIPTION
I wish we had a monorepo, but since we don't: In an attempt to prevent me (or anyone) from accidentally landing Coda with a version of Snarky that is off master, we can lint to make sure it's at least an ancestor (as sometimes Coda will be on an older version of snarky than the snarky repo)

I tested this script by changing the `git rev-parse origin/master` to `git rev-parse HEAD^^` and observing the make failure.