### PR TITLE
Use chunked hashing only in daemon

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -305,6 +305,7 @@ let daemon log =
          let%bind () = Async.Unix.mkdir ~p:() suspicious_dir in
          let%bind () = Async.Unix.mkdir ~p:() punished_dir in
          let%bind () = start_tracing () in
+         let () = Snark_params.Tick.Pedersen.State.set_chunked_fold true in
          let banlist =
            Coda_base.Banlist.create ~suspicious_dir ~punished_dir
          in

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -302,10 +302,10 @@ let daemon log =
          let%bind () = Async.Unix.mkdir ~p:() banlist_dir_name in
          let suspicious_dir = banlist_dir_name ^/ "suspicious" in
          let punished_dir = banlist_dir_name ^/ "banned" in
+         let () = Snark_params.set_chunked_hashing true in
          let%bind () = Async.Unix.mkdir ~p:() suspicious_dir in
          let%bind () = Async.Unix.mkdir ~p:() punished_dir in
          let%bind () = start_tracing () in
-         let () = Snark_params.Tick.Pedersen.State.set_chunked_fold true in
          let banlist =
            Coda_base.Banlist.create ~suspicious_dir ~punished_dir
          in

--- a/src/app/cli/src/jbuild
+++ b/src/app/cli/src/jbuild
@@ -28,6 +28,7 @@
       transaction_pool
       snarky
       snark_keys
+      snark_params
       snark_pool
       precomputed_values
       network_pool

--- a/src/lib/coda_base/hash_prefix.ml
+++ b/src/lib/coda_base/hash_prefix.ml
@@ -4,8 +4,7 @@ open Hash_prefixes
 let length_in_triples = length_in_triples
 
 let salt (s : t) =
-  Snark_params.Tick.Pedersen.(
-    State.salt params Curve_chunk_table.{curve_points_table} (s :> string))
+  Snark_params.Tick.Pedersen.(State.salt params ~get_chunk_table (s :> string))
 
 let protocol_state = salt protocol_state
 

--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -56,7 +56,7 @@ let merge ~height (h1 : t) (h2 : t) =
 let empty_hash =
   let open Tick.Pedersen in
   digest_fold
-    (State.create params Curve_chunk_table.{curve_points_table})
+    (State.create params ~get_chunk_table)
     (Fold.string_triples "nothing up my sleeve")
   |> of_hash
 

--- a/src/lib/coda_base/receipt.ml
+++ b/src/lib/coda_base/receipt.ml
@@ -19,10 +19,7 @@ module Chain_hash = struct
 
   let empty =
     of_hash
-      ( Pedersen.(
-          State.salt params
-            Curve_chunk_table.{curve_points_table}
-            "CodaReceiptEmpty")
+      ( Pedersen.(State.salt params ~get_chunk_table "CodaReceiptEmpty")
       |> Pedersen.State.digest )
 
   let cons payload t =

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -175,6 +175,7 @@ let chunk_table_structure ~loc =
         chunk_table_ref := result ;
         deserialized := true )
 
+    (** returns valid chunk table *)
     let get_chunk_table () = deserialize () ; !chunk_table_ref.table_data]
 
 let generate_ml_file filename structure =

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -157,14 +157,25 @@ let chunk_table_structure ~loc =
 
     let chunk_table_string_opt_ref = ref (Some [%e chunk_table_ast ~loc])
 
-    let chunk_table : Chunk_table.t =
-      let chunk_table_string = Option.value_exn !chunk_table_string_opt_ref in
-      let result = Binable.of_string (module Chunk_table) chunk_table_string in
-      (* allow string to be GCed *)
-      chunk_table_string_opt_ref := None ;
-      result
+    (** dummy empty table before deserialization *)
+    let chunk_table_ref : Chunk_table.t ref = ref (Chunk_table.create [||])
 
-    let curve_points_table = chunk_table.table_data]
+    let deserialized = ref false
+
+    let deserialize () =
+      if not !deserialized then (
+        let chunk_table_string =
+          Option.value_exn !chunk_table_string_opt_ref
+        in
+        let result =
+          Binable.of_string (module Chunk_table) chunk_table_string
+        in
+        (* allow string to be GCed *)
+        chunk_table_string_opt_ref := None ;
+        chunk_table_ref := result ;
+        deserialized := true )
+
+    let get_chunk_table () = deserialize () ; !chunk_table_ref.table_data]
 
 let generate_ml_file filename structure =
   let fmt = Format.formatter_of_out_channel (Out_channel.create filename) in

--- a/src/lib/snark_params/pedersen.ml
+++ b/src/lib/snark_params/pedersen.ml
@@ -29,7 +29,7 @@ module type S = sig
     type t = curve Quadruple.t array
   end
 
-  (* for the table returned by chunk_table_fun, item at index i, j is the curve element for a chunk 
+  (* for the table returned by get_chunk_table, the item at index i, j is the curve element for a chunk
      at position i within a list of chunks, and j is an integer representing the *reversed* chunk considered as bits
   *)
   module State : sig
@@ -207,12 +207,7 @@ end) : S with type curve := Curve.t and type Digest.t = Field.t = struct
     let update_fold_fun_ref = ref update_fold_unchunked
 
     let set_chunked_fold b =
-      (* even though the functor here allows different curves, it's always
-         the particular curve in the chunk table
-       *)
-      if b then (
-        Crypto_params.Pedersen_chunk_table.deserialize () ;
-        update_fold_fun_ref := update_fold_chunked )
+      if b then update_fold_fun_ref := update_fold_chunked
       else update_fold_fun_ref := update_fold_unchunked
 
     let update_fold t fold = !update_fold_fun_ref t fold

--- a/src/lib/snark_params/pedersen.mli
+++ b/src/lib/snark_params/pedersen.mli
@@ -51,10 +51,10 @@ module type S = sig
     (** compute hash one triple at a time *)
 
     val update_fold : t -> bool Triple.t Fold.t -> t
-    (** dispatches to chunked or unchunked (default) version; called by daemon startup to use chunked version *)
+    (** dispatches to chunked or unchunked (default) version *)
 
     val set_chunked_fold : bool -> unit
-    (** use chunked folding iff b *)
+    (** use chunked folding iff b; called by daemon startup to use chunked version *)
 
     val digest : t -> Digest.t
 

--- a/src/lib/snark_params/pedersen.mli
+++ b/src/lib/snark_params/pedersen.mli
@@ -46,7 +46,17 @@ module type S = sig
       -> Curve_chunk_table.t
       -> t
 
+    val update_fold_chunked : t -> bool Triple.t Fold.t -> t
+    (** use precomputed table of curve values *)
+
+    val update_fold_unchunked : t -> bool Triple.t Fold.t -> t
+    (** compute hash one triple at a time *)
+
     val update_fold : t -> bool Triple.t Fold.t -> t
+    (** dispatches to chunked or unchunked (default) version; called by daemon startup to use chunked version *)
+
+    val set_chunked_fold : bool -> unit
+    (** use chunked folding iff b *)
 
     val digest : t -> Digest.t
 

--- a/src/lib/snark_params/pedersen.mli
+++ b/src/lib/snark_params/pedersen.mli
@@ -28,22 +28,20 @@ module type S = sig
     type t = curve Quadruple.t array
   end
 
-  module Curve_chunk_table : sig
-    type t = {curve_points_table: curve array array}
-  end
-
   module State : sig
+    type chunk_table_fun = unit -> curve array array
+
     type t =
       { triples_consumed: int
       ; acc: curve
       ; params: Params.t
-      ; chunk_table: Curve_chunk_table.t }
+      ; get_chunk_table: chunk_table_fun }
 
     val create :
          ?triples_consumed:int
       -> ?init:curve
       -> Params.t
-      -> Curve_chunk_table.t
+      -> get_chunk_table:chunk_table_fun
       -> t
 
     val update_fold_chunked : t -> bool Triple.t Fold.t -> t
@@ -60,7 +58,7 @@ module type S = sig
 
     val digest : t -> Digest.t
 
-    val salt : Params.t -> Curve_chunk_table.t -> string -> t
+    val salt : Params.t -> get_chunk_table:chunk_table_fun -> string -> t
   end
 
   val hash_fold : State.t -> bool Triple.t Fold.t -> State.t

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -292,7 +292,9 @@ module Tick = struct
       let initial_state = State.create params ~get_chunk_table
 
       let run_updates fold =
-        (* deserialize chunk table before running test *)
+        (* make sure chunk table deserialized before running test;
+           actual deserialization happens just once
+         *)
         ignore (Crypto_params.Pedersen_chunk_table.deserialize ()) ;
         let result = State.update_fold_chunked initial_state fold in
         let unchunked_result =
@@ -344,6 +346,9 @@ let embed (x : Tick.Field.t) : Tock.Field.t =
         (i + 1)
   in
   go Tock.Field.one Tock.Field.zero 0
+
+(** enable/disable use of chunk table in Pedersen hashing *)
+let set_chunked_hashing b = Tick.Pedersen.State.set_chunked_fold b
 
 let ledger_depth = 30
 


### PR DESCRIPTION
In the client, the deserialization of the chunk table for Pedersen hashing was taking enough time to be annoying.

In this PR, `update_fold` dispatches to either a chunked or unchunked version through a reference. By default, it uses the unchunked version. In the daemon startup code, a call updates the reference to use the chunked version. Obtaining the chunk table is through a thunk, which does the deserialization the first time the thunk is run.

The time for running `coda client get-public-keys` is reduced from about 4 seconds to less than 0.5 seconds on my laptop.

Closes #1490.