### PR TITLE
Use account key to find account in parent_set_notify

### DIFF
--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -62,5 +62,5 @@ struct
     | None -> ()
     | Some masks ->
         List.iter masks ~f:(fun mask ->
-            Mask.Attached.parent_set_notify mask location account )
+            Mask.Attached.parent_set_notify mask account )
 end

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -238,17 +238,20 @@ struct
           set_hash t addr hash )
 
     (* if the mask's parent sets an account, we can prune an entry in the mask if the account in the parent
-     is the same in the mask
-       *)
-    let parent_set_notify t location account =
-      match find_account t location with
-      | Some existing_account ->
-          if
-            Key.equal
-              (Account.public_key account)
-              (Account.public_key existing_account)
-          then remove_account_and_update_hashes t location
+       is the same in the mask
+     *)
+    let parent_set_notify t account =
+      match find_location t (Account.public_key account) with
       | None -> ()
+      | Some location -> (
+        match find_account t location with
+        | Some existing_account ->
+            if
+              Key.equal
+                (Account.public_key account)
+                (Account.public_key existing_account)
+            then remove_account_and_update_hashes t location
+        | None -> () )
 
     (* as for accounts, we see if we have it in the mask, else delegate to parent *)
     let get_hash t addr =

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -46,7 +46,7 @@ module type S = sig
     val get_parent : t -> parent
     (** get mask parent *)
 
-    val parent_set_notify : t -> location -> account -> unit
+    val parent_set_notify : t -> account -> unit
     (** called when parent sets an account; update local state *)
 
     val copy : t -> t


### PR DESCRIPTION
A ledger with a mask notifies the mask when a `set` is done so that the mask can prune accounts that are out-of-date.

The mask was being passed the parent's location of the account, which has nothing to do with how the mask stores accounts. In this PR, the mask looks up the account passed in the notification by account key, and if found, prunes it.