### PR TITLE
Accumulate keys from ancestors

### DIFF
--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -341,13 +341,17 @@ struct
         | [] -> [] )
       |> ignore
 
+    (* keys from this mask and all ancestors *)
     let keys t =
-      Location.Table.data t.account_tbl
-      |> List.map ~f:Account.public_key
-      |> Key.Set.of_list
+      let mask_keys =
+        Location.Table.data t.account_tbl
+        |> List.map ~f:Account.public_key
+        |> Key.Set.of_list
+      in
+      let parent_keys = Base.keys (get_parent t) in
+      Key.Set.union parent_keys mask_keys
 
-    let num_accounts t =
-      Key.Set.union (Base.keys (get_parent t)) (keys t) |> Key.Set.length
+    let num_accounts t = keys t |> Key.Set.length
 
     let location_of_key t key =
       let mask_result = find_location t key in


### PR DESCRIPTION
`num_accounts` for masks gave incorrect results when masks were composed.

The solution is to have `keys` include keys from the mask and all of its ancestors.

@jkrauska has verified the fix works by repeating the experiment that failed in #1464.

Closes #1464.
