### PR TITLE
Hooked responder to both network and bootstrap_controller (Test does not pass)

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -774,32 +774,17 @@ struct
            ~sender:(Host_and_port.of_string "127.0.0.1:0"))
   end
 
-  module Sync_ledger =
-    Syncable_ledger.Make (Ledger.Addr) (Account)
-      (struct
-        include Ledger_hash
-
-        let hash_account = Fn.compose Ledger_hash.of_digest Account.digest
-
-        let empty_account = hash_account Account.empty
-      end)
-      (struct
-        include Ledger_hash
-
-        let to_hash (h : t) =
-          Ledger_hash.of_digest (h :> Snark_params.Tick.Pedersen.Digest.t)
-      end)
-      (struct
-        include Ledger
-
-        let f = Account.hash
-      end)
-      (struct
-        let subtree_height = 3
-      end)
-
-  module Sync_root_ledger =
-    Syncable_ledger.Make (Ledger.Db.Addr) (Account)
+  module Root_sync_ledger :
+    Syncable_ledger.S
+    with type addr := Ledger.Location.Addr.t
+     and type hash := Ledger_hash.t
+     and type root_hash := Ledger_hash.t
+     and type merkle_tree := Ledger.Db.t
+     and type account := Account.t
+     and type merkle_path := Ledger.path
+     and type query := Sync_ledger.query
+     and type answer := Sync_ledger.answer =
+    Syncable_ledger.Make (Ledger.Location.Addr) (Account)
       (struct
         include Ledger_hash
 
@@ -877,8 +862,7 @@ struct
     module Transaction_snark_work = Transaction_snark_work
     module Ledger_proof_statement = Ledger_proof_statement
     module Staged_ledger_aux_hash = Staged_ledger_aux_hash
-    module Syncable_ledger = Sync_root_ledger
-    module Merkle_address = Ledger.Db.Addr
+    module Root_sync_ledger = Root_sync_ledger
     module Consensus_mechanism = Consensus.Mechanism
     module Protocol_state_validator = Protocol_state_validator
     module Network = Net
@@ -890,7 +874,6 @@ struct
     module Transaction_snark_work = Transaction_snark_work
     module Syncable_ledger = Sync_ledger
     module Sync_handler = Sync_handler
-    module Merkle_address = Ledger.Addr
     module Catchup = Ledger_catchup
     module Transition_handler = Transition_handler
     module Staged_ledger_diff = Staged_ledger_diff
@@ -904,9 +887,8 @@ struct
   module Transition_router = Transition_router.Make (struct
     include Inputs0
     module Transaction_snark_work = Transaction_snark_work
-    module Syncable_ledger = Sync_root_ledger
+    module Syncable_ledger = Root_sync_ledger
     module Sync_handler = Sync_handler
-    module Merkle_address = Ledger.Addr
     module Catchup = Ledger_catchup
     module Transition_handler = Transition_handler
     module Staged_ledger_diff = Staged_ledger_diff

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -76,7 +76,6 @@ module Any_ledger :
 module Mask :
   Merkle_mask.Masking_merkle_tree_intf.S
   with module Location = Location_at_depth
-  with module Addr = Location_at_depth.Addr
    and module Attached.Addr = Location_at_depth.Addr
   with type account := Account.t
    and type key := Public_key.Compressed.t

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -24,7 +24,6 @@ module Any_ledger :
 module Mask :
   Merkle_mask.Masking_merkle_tree_intf.S
   with module Location = Location
-  with module Addr = Location.Addr
    and module Attached.Addr = Location.Addr
   with type account := Account.t
    and type key := Public_key.Compressed.t
@@ -49,6 +48,7 @@ module Maskable :
 include
   Merkle_mask.Maskable_merkle_tree_intf.S
   with module Location := Location
+  with module Addr = Location.Addr
   with type root_hash := Ledger_hash.t
    and type hash := Ledger_hash.t
    and type account := Account.t

--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -1,6 +1,6 @@
 open Core_kernel
 
-include Syncable_ledger.Make (Ledger.Addr) (Account)
+include Syncable_ledger.Make (Ledger.Location.Addr) (Account)
           (struct
             include Ledger_hash
 
@@ -22,3 +22,10 @@ include Syncable_ledger.Make (Ledger.Addr) (Account)
           (struct
             let subtree_height = 3
           end)
+
+type answer =
+  (Ledger.Location.Addr.t, Ledger_hash.t, Account.t) Syncable_ledger.answer
+[@@deriving bin_io, sexp]
+
+type query = Ledger.Location.Addr.t Syncable_ledger.query
+[@@deriving bin_io, sexp]

--- a/src/lib/ledger_catchup/inputs.ml
+++ b/src/lib/ledger_catchup/inputs.ml
@@ -30,6 +30,9 @@ module type S = sig
      and type external_transition := External_transition.t
      and type ancestor_proof_input := State_hash.t * int
      and type ancestor_proof := Ancestor.Proof.t
+     and type ledger_hash := Ledger_hash.t
+     and type sync_ledger_query := Ledger.Location.Addr.t Syncable_ledger.query
+     and type sync_ledger_answer := Sync_ledger.answer
 
   module Time : Time_intf
 

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -24,8 +24,7 @@ let%test_module "Test mask connected to underlying Merkle tree" =
 
       module Mask :
         Merkle_mask.Masking_merkle_tree_intf.S
-        with module Addr = Location.Addr
-         and module Location = Location
+        with module Location = Location
          and module Attached.Addr = Location.Addr
         with type account := Account.t
          and type location := Location.t
@@ -633,7 +632,6 @@ let%test_module "Test mask connected to underlying Merkle tree" =
       module Mask :
         Merkle_mask.Masking_merkle_tree_intf.S
         with module Location = Location
-         and module Addr = Location.Addr
          and module Attached.Addr = Location.Addr
         with type account := Account.t
          and type location := Location.t

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -19,7 +19,7 @@ module type S = sig
 
   module Location : Merkle_ledger.Location_intf.S
 
-  module Addr : Merkle_address.S
+  module Addr = Location.Addr
 
   val create : unit -> t
   (** create a mask with no parent *)
@@ -27,6 +27,7 @@ module type S = sig
   module Attached : sig
     include
       Base_merkle_tree_intf.S
+      with module Addr = Addr
       with module Location = Location
       with type account := account
        and type root_hash := hash

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -18,13 +18,33 @@ end
 
 module Make (Inputs : Inputs_intf) :
   Sync_handler_intf
-  with type hash := State_hash.t
+  with type state_hash := State_hash.t
+   and type ledger_hash := Ledger_hash.t
    and type transition_frontier := Inputs.Transition_frontier.t
    and type ancestor_proof := State_body_hash.t list
-   and type external_transition := Inputs.External_transition.t = struct
+   and type external_transition := Inputs.External_transition.t
+   and type syncable_ledger_query := Sync_ledger.query
+   and type syncable_ledger_answer := Sync_ledger.answer = struct
   open Inputs
 
-  let prove_ancestry ~frontier generations descendants =
+  let get_ledger_by_hash ~frontier ledger_hash =
+    List.find_map (Transition_frontier.all_breadcrumbs frontier) ~f:(fun b ->
+        let ledger =
+          Transition_frontier.Breadcrumb.staged_ledger b
+          |> Staged_ledger.ledger
+        in
+        if Ledger_hash.equal (Ledger.merkle_root ledger) ledger_hash then
+          Some ledger
+        else None )
+
+  let answer_query ~frontier hash query =
+    let open Option.Let_syntax in
+    let%map ledger = get_ledger_by_hash ~frontier hash in
+    let responder = Sync_ledger.Responder.create ledger ignore in
+    let answer = Sync_ledger.Responder.answer_query responder query in
+    (hash, answer)
+
+  let prove_ancestry ~frontier generations descendant =
     let open Option.Let_syntax in
     let rec create_proof acc iter_traversal state_hash =
       if iter_traversal = 0 then Some (state_hash, acc)
@@ -47,7 +67,7 @@ module Make (Inputs : Inputs_intf) :
         create_proof (state_body_hash :: acc) (iter_traversal - 1)
           previous_state_hash
     in
-    let%bind state_hash, proof = create_proof [] generations descendants in
+    let%bind state_hash, proof = create_proof [] generations descendant in
     let%map transition_with_hash =
       Transition_frontier.find frontier state_hash
     in

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -4,6 +4,15 @@ open Pipe_lib
 
 let rec funpow n f r = if n > 0 then funpow (n - 1) f (f r) else r
 
+type 'addr query = What_hash of 'addr | What_contents of 'addr | Num_accounts
+[@@deriving bin_io, sexp]
+
+type ('addr, 'hash, 'account) answer =
+  | Has_hash of 'addr * 'hash
+  | Contents_are of 'addr * 'account list
+  | Num_accounts of int * 'hash
+[@@deriving bin_io, sexp]
+
 module type S = sig
   type t [@@deriving sexp]
 
@@ -23,14 +32,9 @@ module type S = sig
 
   type index = int
 
-  type answer =
-    | Has_hash of addr * hash
-    | Contents_are of addr * account list
-    | Num_accounts of int * hash
-  [@@deriving bin_io, sexp]
+  type query
 
-  type query = What_hash of addr | What_contents of addr | Num_accounts
-  [@@deriving bin_io, sexp]
+  type answer
 
   module Responder : sig
     type t
@@ -173,7 +177,11 @@ module Make
    and type root_hash := Root_hash.t
    and type addr := Addr.t
    and type merkle_path := MT.path
-   and type account := Account.t = struct
+   and type account := Account.t
+   and type query := Addr.t query
+   and type answer := (Addr.t, Hash.t, Account.t) answer = struct
+  type addr = Addr.t
+
   type diff = unit
 
   type index = int
@@ -262,16 +270,12 @@ module Make
       | _ -> false
   end
 
-  type answer =
-    | Has_hash of Addr.t * Hash.t
-    | Contents_are of Addr.t * Account.t list
-    | Num_accounts of int * Hash.t
-    (* idea: make this verifiable by including the merkle path to the rightmost account, and verify that
-       filling in empty hashes for the rest amounts to the correct hash. *)
-  [@@deriving bin_io, sexp]
+  type nonrec answer = (Addr.t, Hash.t, Account.t) answer
 
-  type query = What_hash of Addr.t | What_contents of Addr.t | Num_accounts
-  [@@deriving bin_io, sexp]
+  type nonrec query = Addr.t query
+
+  (* idea: make this verifiable by including the merkle path to the rightmost account, and verify that
+       filling in empty hashes for the rest amounts to the correct hash. *)
 
   module Responder = struct
     type t = {mt: MT.t; f: query -> unit}

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -12,10 +12,13 @@ module type Inputs_intf = sig
 
   module Sync_handler :
     Sync_handler_intf
-    with type hash := State_hash.t
+    with type state_hash := State_hash.t
+     and type ledger_hash := Ledger_hash.t
      and type transition_frontier := Transition_frontier.t
      and type ancestor_proof := State_body_hash.t list
      and type external_transition := External_transition.t
+     and type syncable_ledger_query := Sync_ledger.query
+     and type syncable_ledger_answer := Sync_ledger.answer
 
   module Transition_handler :
     Transition_handler_intf
@@ -35,6 +38,9 @@ module type Inputs_intf = sig
      and type external_transition := External_transition.t
      and type ancestor_proof_input := State_hash.t * int
      and type ancestor_proof := Ancestor.Proof.t
+     and type ledger_hash := Ledger_hash.t
+     and type sync_ledger_query := Sync_ledger.query
+     and type sync_ledger_answer := Sync_ledger.answer
 
   module Catchup :
     Catchup_intf

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -27,6 +27,9 @@ module type Inputs_intf = sig
      and type external_transition := External_transition.t
      and type ancestor_proof_input := State_hash.t * int
      and type ancestor_proof := Ancestor.Proof.t
+     and type ledger_hash := Ledger_hash.t
+     and type sync_ledger_query := Sync_ledger.query
+     and type sync_ledger_answer := Sync_ledger.answer
 
   module Transition_frontier_controller :
     Transition_frontier_controller_intf

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -9,6 +9,12 @@ module type Network_intf = sig
 
   type state_hash
 
+  type ledger_hash
+
+  type sync_ledger_query
+
+  type sync_ledger_answer
+
   type external_transition
 
   type ancestor_proof_input
@@ -28,6 +34,14 @@ module type Network_intf = sig
     -> peer
     -> ancestor_proof_input
     -> (external_transition * ancestor_proof) Deferred.Or_error.t
+
+  (* TODO: Change this to strict_pipe *)
+  val glue_sync_ledger :
+       t
+    -> (ledger_hash * sync_ledger_query) Pipe_lib.Linear_pipe.Reader.t
+    -> (ledger_hash * sync_ledger_answer) Envelope.Incoming.t
+       Pipe_lib.Linear_pipe.Writer.t
+    -> unit
 end
 
 module type Transition_frontier_base_intf = sig
@@ -266,7 +280,9 @@ module type Transition_handler_intf = sig
 end
 
 module type Sync_handler_intf = sig
-  type hash
+  type state_hash
+
+  type ledger_hash
 
   type transition_frontier
 
@@ -274,11 +290,21 @@ module type Sync_handler_intf = sig
 
   type external_transition
 
+  type syncable_ledger_query
+
+  type syncable_ledger_answer
+
   val prove_ancestry :
        frontier:transition_frontier
     -> int
-    -> hash
+    -> state_hash
     -> (external_transition * ancestor_proof) option
+
+  val answer_query :
+       frontier:transition_frontier
+    -> ledger_hash
+    -> syncable_ledger_query
+    -> (ledger_hash * syncable_ledger_answer) option
 end
 
 module type Bootstrap_controller_intf = sig


### PR DESCRIPTION
- Fixed the signatures of Address in Ledger Modules so that all ledgers
now refer to the same Address
- Made the `query` and `answer` type identical to all modules
- All modules now refer to the same Sync_ledger in coda_base, except
root_sync_ledger
- Moved coda_lib's answer_query into sync_handler

Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

Explain your changes here.

Explain how you tested your changes here.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
