### PR TITLE
Envelopes contain Peer.t

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -243,7 +243,7 @@ let daemon log =
          match ip with None -> Find_ip.find () | Some ip -> return ip
        in
        let me =
-         Kademlia.Peer.create
+         Network_peer.Peer.create
            (Unix.Inet_addr.of_string ip)
            ~discovery_port ~communication_port:external_port
        in

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -337,7 +337,7 @@ module type Main_intf = sig
   val best_tip :
     t -> Inputs.Transition_frontier.Breadcrumb.t Participating_state.t
 
-  val peers : t -> Kademlia.Peer.t list
+  val peers : t -> Network_peer.Peer.t list
 
   val strongest_ledgers :
        t
@@ -771,7 +771,7 @@ struct
                 ( List.map res.spec.instances ~f:Single.Spec.statement
                 , { Diff.proof= res.proofs
                   ; fee= {fee= res.spec.fee; prover= res.prover} } ))
-           ~sender:(Host_and_port.of_string "127.0.0.1:0"))
+           ~sender:Network_peer.Peer.local)
   end
 
   module Sync_ledger =
@@ -1296,7 +1296,7 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
     ; conf_dir= Config_in.conf_dir
     ; peers=
         List.map (peers t) ~f:(fun peer ->
-            Kademlia.Peer.to_discovery_host_and_port peer
+            Network_peer.Peer.to_discovery_host_and_port peer
             |> Host_and_port.to_string )
     ; user_commands_sent= !txn_count
     ; run_snark_worker= run_snark_worker t

--- a/src/app/cli/src/coda_peers_test.ml
+++ b/src/app/cli/src/coda_peers_test.ml
@@ -28,14 +28,15 @@ let main () =
     (List.map2_exn workers expected_peers ~f:(fun worker expected_peers ->
          let%map peers = Coda_process.peers_exn worker in
          Logger.debug log
-           !"got peers %{sexp: Kademlia.Peer.t list} %{sexp: Host_and_port.t \
-             list}\n"
+           !"got peers %{sexp: Network_peer.Peer.t list} %{sexp: \
+             Host_and_port.t list}\n"
            peers expected_peers ;
          let module S = Host_and_port.Set in
          assert (
            S.equal
              (S.of_list
-                (peers |> List.map ~f:Kademlia.Peer.to_discovery_host_and_port))
+                ( peers
+                |> List.map ~f:Network_peer.Peer.to_discovery_host_and_port ))
              (S.of_list expected_peers) ) ))
 
 let command =

--- a/src/app/cli/src/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/coda_transitive_peers_test.ml
@@ -40,12 +40,13 @@ let main () =
   let%bind _ = after (Time.Span.of_sec 10.) in
   let%map peers = Coda_process.peers_exn worker in
   Logger.debug log
-    !"got peers %{sexp: Kademlia.Peer.t list} %{sexp: Host_and_port.t list}\n"
+    !"got peers %{sexp: Network_peer.Peer.t list} %{sexp: Host_and_port.t list}\n"
     peers expected_peers ;
   let module S = Host_and_port.Set in
   assert (
     S.equal
-      (S.of_list (peers |> List.map ~f:Kademlia.Peer.to_discovery_host_and_port))
+      (S.of_list
+         (peers |> List.map ~f:Network_peer.Peer.to_discovery_host_and_port))
       (S.of_list expected_peers) )
 
 let command =

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -56,7 +56,7 @@ end
 
 module T = struct
   module Peers = struct
-    type t = Kademlia.Peer.t List.t [@@deriving bin_io]
+    type t = Network_peer.Peer.t List.t [@@deriving bin_io]
   end
 
   module State_hashes = struct
@@ -234,7 +234,7 @@ module T = struct
             ; conf_dir
             ; initial_peers= peers
             ; me=
-                Kademlia.Peer.create
+                Network_peer.Peer.create
                   (Unix.Inet_addr.of_string host)
                   ~discovery_port ~communication_port:external_port
             ; parent_log= log

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -92,8 +92,8 @@ let run_test () : unit Deferred.t =
         ; initial_peers= []
         ; conf_dir= temp_conf_dir
         ; me=
-            Kademlia.Peer.create Unix.Inet_addr.localhost ~discovery_port:8001
-              ~communication_port:8000
+            Network_peer.Peer.create Unix.Inet_addr.localhost
+              ~discovery_port:8001 ~communication_port:8000
         ; banlist } }
   in
   let%bind coda =

--- a/src/app/cli/src/jbuild
+++ b/src/app/cli/src/jbuild
@@ -31,6 +31,7 @@
       snark_params
       snark_pool
       precomputed_values
+      network_peer
       network_pool
       snark_worker_lib
       keys_lib

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -30,7 +30,7 @@ module type Inputs_intf = sig
 
   module Network :
     Network_intf
-    with type peer := Kademlia.Peer.t
+    with type peer := Network_peer.Peer.t
      and type state_hash := State_hash.t
      and type external_transition := External_transition.t
      and type ancestor_proof_input := State_hash.t * int
@@ -212,17 +212,7 @@ module Make (Inputs : Inputs_intf) :
         let (transition : External_transition.Verified.t) =
           Envelope.Incoming.data incoming_transition
         in
-        (* #TODO : the 0 ports below are dummies
-           the port in the envelope is an ephemeral port which 
-             won't appear in a bonafide Peer.t
-           see issue #1367
-         *)
-        let sender =
-          let host_and_port = Envelope.Incoming.sender incoming_transition in
-          Kademlia.Peer.create
-            (Host_and_port.host host_and_port |> Unix.Inet_addr.of_string)
-            ~discovery_port:0 ~communication_port:0
-        in
+        let sender = Envelope.Incoming.sender incoming_transition in
         let protocol_state =
           External_transition.Verified.protocol_state transition
         in

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -69,13 +69,13 @@ module type Network_intf = sig
   val states :
     t -> (state_with_witness Envelope.Incoming.t * time) Linear_pipe.Reader.t
 
-  val peers : t -> Kademlia.Peer.t list
+  val peers : t -> Network_peer.Peer.t list
 
-  val random_peers : t -> int -> Kademlia.Peer.t list
+  val random_peers : t -> int -> Network_peer.Peer.t list
 
   val catchup_transition :
        t
-    -> Kademlia.Peer.t
+    -> Network_peer.Peer.t
     -> state_hash
     -> state_with_witness list option Or_error.t Deferred.t
 

--- a/src/lib/envelope/dune
+++ b/src/lib/envelope/dune
@@ -1,5 +1,5 @@
 (library
   (name envelope)
   (public_name envelope)
-  (libraries core_kernel)
+  (libraries core_kernel network_peer)
   (preprocess (pps ppx_jane)))

--- a/src/lib/envelope/envelope.ml
+++ b/src/lib/envelope/envelope.ml
@@ -1,7 +1,8 @@
-open Core_kernel
+open Core
+open Network_peer
 
 module Incoming = struct
-  type 'a t = {data: 'a; sender: Host_and_port.t}
+  type 'a t = {data: 'a; sender: Peer.t}
 
   let sender {sender; _} = sender
 
@@ -11,5 +12,10 @@ module Incoming = struct
 
   let map ~f t = {t with data= f t.data}
 
-  let local data = {data; sender= Host_and_port.of_string "127.0.0.1:0"}
+  let local data =
+    let sender =
+      Peer.create Unix.Inet_addr.localhost ~discovery_port:0
+        ~communication_port:0
+    in
+    {data; sender}
 end

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -1,6 +1,7 @@
 open Core
 open Async
 open Pipe_lib
+open Network_peer
 open Kademlia
 open O1trace
 module Membership = Membership.Haskell
@@ -9,12 +10,18 @@ type ('q, 'r) dispatch =
   Versioned_rpc.Connection_with_menu.t -> 'q -> 'r Deferred.Or_error.t
 
 module type Message_intf = sig
+  type content
+
   type msg
 
   include
     Versioned_rpc.Both_convert.One_way.S
     with type callee_msg := msg
      and type caller_msg := msg
+
+  val content : msg -> content
+
+  val peer : msg -> Peer.t
 end
 
 module type Config_intf = sig
@@ -30,16 +37,25 @@ module type Config_intf = sig
 end
 
 module type S = sig
+  type content
+
   type msg
 
-  type t
+  type t =
+    { timeout: Time.Span.t
+    ; log: Logger.t
+    ; target_peer_count: int
+    ; broadcast_writer: msg Linear_pipe.Writer.t
+    ; received_reader: content Envelope.Incoming.t Linear_pipe.Reader.t
+    ; me: Peer.t
+    ; peers: Peer.Hash_set.t }
 
   module Config : Config_intf
 
   val create :
     Config.t -> Host_and_port.t Rpc.Implementation.t list -> t Deferred.t
 
-  val received : t -> msg Envelope.Incoming.t Linear_pipe.Reader.t
+  val received : t -> content Envelope.Incoming.t Linear_pipe.Reader.t
 
   val broadcast : t -> msg Linear_pipe.Writer.t
 
@@ -59,13 +75,15 @@ module type S = sig
     t -> int -> ('q, 'r) dispatch -> 'q -> 'r Or_error.t Deferred.t List.t
 end
 
-module Make (Message : Message_intf) : S with type msg := Message.msg = struct
+module Make (Message : Message_intf) :
+  S with type msg := Message.msg and type content := Message.content = struct
   type t =
     { timeout: Time.Span.t
     ; log: Logger.t
     ; target_peer_count: int
     ; broadcast_writer: Message.msg Linear_pipe.Writer.t
-    ; received_reader: Message.msg Envelope.Incoming.t Linear_pipe.Reader.t
+    ; received_reader: Message.content Envelope.Incoming.t Linear_pipe.Reader.t
+    ; me: Peer.t
     ; peers: Peer.Hash_set.t }
 
   module Config = struct
@@ -88,10 +106,10 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
     | Error exn -> return (Or_error.of_exn exn)
     | Ok conn -> Versioned_rpc.Connection_with_menu.create conn
 
-  let try_call_rpc peer timeout dispatch query =
+  let try_call_rpc t peer dispatch query =
     try_with (fun () ->
         Tcp.with_connection (Tcp.Where_to_connect.of_host_and_port peer)
-          ~timeout (fun _ r w ->
+          ~timeout:t.timeout (fun _ r w ->
             create_connection_with_menu peer r w
             >>=? fun conn -> dispatch conn query ) )
     >>| function
@@ -104,7 +122,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
       List.map peers ~f:(fun peer -> Peer.to_communications_host_and_port peer)
     in
     let send peer =
-      try_call_rpc peer t.timeout
+      try_call_rpc t peer
         (fun conn m -> return (Message.dispatch_multi conn m))
         msg
     in
@@ -144,6 +162,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
           ; target_peer_count= config.target_peer_count
           ; broadcast_writer
           ; received_reader
+          ; me= config.me
           ; peers= Peer.Hash_set.create () }
         in
         trace_task "rebroadcasting messages" (fun () ->
@@ -156,11 +175,12 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
         let implementations =
           let implementations =
             Versioned_rpc.Menu.add
-              ( Message.implement_multi (fun peer ~version:_ msg ->
+              ( Message.implement_multi (fun _dummy_peer ~version:_ msg ->
                     Linear_pipe.force_write_maybe_drop_head
                       ~capacity:broadcast_received_capacity received_writer
                       received_reader
-                      (Envelope.Incoming.wrap ~data:msg ~sender:peer) )
+                      (Envelope.Incoming.wrap ~data:(Message.content msg)
+                         ~sender:(Message.peer msg)) )
               @ implementations )
           in
           Rpc.Implementations.create_exn ~implementations
@@ -186,10 +206,10 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                (`Call
                  (fun _ exn -> Logger.error log "%s" (Exn.to_string_mach exn)))
              (Tcp.Where_to_listen.of_port config.me.Peer.communication_port)
-             (fun peer reader writer ->
+             (fun client reader writer ->
                Rpc.Connection.server_with_close reader writer ~implementations
                  ~connection_state:(fun _ ->
-                   Socket.Address.Inet.to_host_and_port peer )
+                   Socket.Address.Inet.to_host_and_port client )
                  ~on_handshake_error:
                    (`Call
                      (fun exn ->
@@ -220,7 +240,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
   let query_peer t (peer : Peer.t) rpc query =
     Logger.trace t.log !"Querying peer %{sexp: Peer.t}" peer ;
     let peer = Peer.to_communications_host_and_port peer in
-    try_call_rpc peer t.timeout rpc query
+    try_call_rpc t peer rpc query
 
   let query_random_peers t n rpc query =
     let peers = random_sublist (Hash_set.to_list t.peers) n in

--- a/src/lib/kademlia/jbuild
+++ b/src/lib/kademlia/jbuild
@@ -6,7 +6,7 @@
   (flags (:standard -short-paths -warn-error -58))
   (library_flags (-linkall))
   (inline_tests)
-  (libraries (core logger pipe_lib async async_extra file_system banlist_lib coda_base))
+  (libraries (core logger pipe_lib async async_extra file_system banlist_lib network_peer coda_base))
   (preprocess (pps (ppx_jane bisect_ppx -conditional)))
   (synopsis "Kademlia DHT -- only being used for it's membership")))
 

--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -2,6 +2,7 @@ open Async_kernel
 open Core_kernel
 open Banlist_lib
 open Pipe_lib
+open Network_peer
 
 exception Child_died
 

--- a/src/lib/kademlia/membership.mli
+++ b/src/lib/kademlia/membership.mli
@@ -1,6 +1,7 @@
 open Async_kernel
 open Core_kernel
 open Pipe_lib
+open Network_peer
 
 exception Child_died
 

--- a/src/lib/ledger_catchup/inputs.ml
+++ b/src/lib/ledger_catchup/inputs.ml
@@ -25,7 +25,7 @@ module type S = sig
 
   module Network :
     Network_intf
-    with type peer := Kademlia.Peer.t
+    with type peer := Network_peer.Peer.t
      and type state_hash := State_hash.t
      and type external_transition := External_transition.t
      and type ancestor_proof_input := State_hash.t * int

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -60,7 +60,7 @@ module Make (Inputs : Inputs.S) :
         let message =
           sprintf
             !"Could not find root hash, %{sexp:State_hash.t}.Peer \
-              %{sexp:Kademlia.Peer.t} is seen as malicious"
+              %{sexp:Network_peer.Peer.t} is seen as malicious"
             initial_state_hash peer
         in
         Logger.faulty_peer logger !"%s" message ;
@@ -81,12 +81,12 @@ module Make (Inputs : Inputs.S) :
         | None ->
             Deferred.return
             @@ Or_error.errorf
-                 !"Peer %{sexp:Kademlia.Peer.t} did not have transition"
+                 !"Peer %{sexp:Network_peer.Peer.t} did not have transition"
                  peer
         | Some [] ->
             let message =
               sprintf
-                !"Peer %{sexp:Kademlia.Peer.t} gave an empty list of \
+                !"Peer %{sexp:Network_peer.Peer.t} gave an empty list of \
                   transitions. They should respond with none"
                 peer
             in

--- a/src/lib/network_peer/dune
+++ b/src/lib/network_peer/dune
@@ -1,0 +1,5 @@
+(library
+  (name network_peer)
+  (public_name network_peer)
+  (libraries core)
+  (preprocess (pps ppx_jane)))

--- a/src/lib/network_peer/peer.ml
+++ b/src/lib/network_peer/peer.ml
@@ -21,6 +21,10 @@ include Comparable.Make_binable (T)
 let create host ~discovery_port ~communication_port =
   {host; discovery_port; communication_port}
 
+(** localhost with dummy ports *)
+let local =
+  create Unix.Inet_addr.localhost ~discovery_port:0 ~communication_port:0
+
 let to_discovery_host_and_port t =
   Host_and_port.create
     ~host:(Unix.Inet_addr.to_string t.host)

--- a/src/lib/network_peer/peered.ml
+++ b/src/lib/network_peer/peered.ml
@@ -1,0 +1,5 @@
+(* peered.ml -- pair some data with a Peer.t *)
+
+type 'a t = {data: 'a; peer: Peer.t} [@@deriving bin_io, sexp, fields]
+
+let create data peer = {data; peer}

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -474,7 +474,7 @@ module Make
             | Error e ->
                 Logger.faulty_peer t.log
                   !"Got error from when trying to add child_hash %{sexp: \
-                    Hash.t} %s %{sexp: Host_and_port.t}"
+                    Hash.t} %s %{sexp: Network_peer.Peer.t}"
                   h' (Error.to_string_hum e)
                   (Envelope.Incoming.sender env) ;
                 ()

--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -63,7 +63,7 @@ struct
             match Payment.check txn with
             | None ->
                 Logger.faulty_peer t.log
-                  !"Transaction doesn't check %{sexp: Host_and_port.t}"
+                  !"Transaction doesn't check %{sexp: Network_peer.Peer.t}"
                   (Envelope.Incoming.sender env) ;
                 (pool, acc)
             | Some txn ->

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -29,7 +29,7 @@ module type Inputs_intf = sig
 
   module Network :
     Network_intf
-    with type peer := Kademlia.Peer.t
+    with type peer := Network_peer.Peer.t
      and type state_hash := State_hash.t
      and type external_transition := External_transition.t
      and type ancestor_proof_input := State_hash.t * int

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -73,7 +73,7 @@ module Make (Inputs : Inputs.S) :
              | Error (`Invalid reason) ->
                  Logger.warn logger
                    !"rejecting transitions because \"%s\" -- sent by %{sexp: \
-                     Host_and_port.t}"
+                     Network_peer.Peer.t}"
                    reason
                    (Envelope.Incoming.sender transition_env) ) ))
 end

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -64,8 +64,8 @@ module Make (Inputs : Inputs_intf) :
             |> Writer.write valid_transition_writer
         | Error e ->
             Logger.warn logger
-              !"Got an invalid transition from peer : %{sexp:Host_and_port.t} \
-                %{sexp:Error.t}"
+              !"Got an invalid transition from peer : \
+                %{sexp:Network_peer.Peer.t} %{sexp:Error.t}"
               sender e )
     |> don't_wait_for
 end

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -22,7 +22,7 @@ module type Inputs_intf = sig
 
   module Network :
     Network_intf
-    with type peer := Kademlia.Peer.t
+    with type peer := Network_peer.Peer.t
      and type state_hash := State_hash.t
      and type external_transition := External_transition.t
      and type ancestor_proof_input := State_hash.t * int

--- a/src/network_peer.opam
+++ b/src/network_peer.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]


### PR DESCRIPTION
To date, envelopes contained a connection state consisting of the IP address and the automatically-created ephemeral port of the connection to the client. That's not enough to uniquely identify a peer.

In this PR, clients  put their peer information (IP/discovery port/comms port) information in their messages sent via RPC. That allows envelopes to contain that peer information. 

There's a new module `Peered`, where `Peered.t` contains arbitrary data and a `Peer.t`. The module `Peer` is moved from kademlia to a library network_peer, so it can be used by `Envelope`.

In `Coda_networking`, the `Message.msg` type consists of `content` (the old `msg` type`), with a `Peer.t`. This type is used when broadcasting messages, so those messages include the sender's peer information.

 Closes #1367.
