### PR TITLE
renaming ledger_hash to snarked_ledger_hash

### DIFF
--- a/src/lib/blockchain_snark/blockchain_state.ml
+++ b/src/lib/blockchain_snark/blockchain_state.ml
@@ -63,9 +63,9 @@ module Make (Consensus_mechanism : Consensus.Mechanism.S) :
             T.verify_complete_merge
               (Snark_transition.sok_digest transition)
               ( previous_state |> Protocol_state.blockchain_state
-              |> Blockchain_state.ledger_hash )
+              |> Blockchain_state.snarked_ledger_hash )
               ( transition |> Snark_transition.blockchain_state
-              |> Blockchain_state.ledger_hash )
+              |> Blockchain_state.snarked_ledger_hash )
               supply_increase
               (As_prover.return
                  (Option.value ~default:Tock.Proof.dummy
@@ -73,9 +73,9 @@ module Make (Consensus_mechanism : Consensus.Mechanism.S) :
           and ledger_hash_didn't_change =
             Frozen_ledger_hash.equal_var
               ( previous_state |> Protocol_state.blockchain_state
-              |> Blockchain_state.ledger_hash )
+              |> Blockchain_state.snarked_ledger_hash )
               ( transition |> Snark_transition.blockchain_state
-              |> Blockchain_state.ledger_hash )
+              |> Blockchain_state.snarked_ledger_hash )
           in
           let%bind correct_snark =
             Boolean.(correct_transaction_snark || ledger_hash_didn't_change)

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -174,7 +174,7 @@ module Make (Inputs : Inputs_intf) :
                   Protocol_state.blockchain_state
                     (External_transition.Proof_verified.protocol_state
                        verified_ancestor_transition)
-                  |> Blockchain_state.ledger_hash
+                  |> Blockchain_state.snarked_ledger_hash
                   |> Frozen_ledger_hash.to_ledger_hash)
               in
               Syncable_ledger.new_goal t.syncable_ledger ledger_hash |> ignore

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1194,7 +1194,7 @@ module Make (Inputs : Intf.Proof_of_stake.Inputs.S) : Intf.S = struct
         prev_state_hash ~supply_increase
         ~previous_blockchain_state_ledger_hash:
           ( Protocol_state.blockchain_state prev_state
-          |> Blockchain_state.ledger_hash )
+          |> Blockchain_state.snarked_ledger_hash )
   end
 
   let select ~existing ~candidate ~logger =

--- a/src/lib/external_transition_validation/external_transition_validation.ml
+++ b/src/lib/external_transition_validation/external_transition_validation.ml
@@ -254,7 +254,7 @@ module Make (Inputs : Inputs_intf) :
     Deferred.return
       ( if
         Frozen_ledger_hash.equal target_ledger_hash
-          (Blockchain_state.ledger_hash blockchain_state)
+          (Blockchain_state.snarked_ledger_hash blockchain_state)
         && Staged_ledger_hash.equal staged_ledger_hash
              (Blockchain_state.staged_ledger_hash blockchain_state)
       then

--- a/src/lib/lite_compat/lite_compat.ml
+++ b/src/lib/lite_compat/lite_compat.ml
@@ -94,7 +94,7 @@ module Make (Blockchain_state : Coda_base.Blockchain_state.S) = struct
     }
 
   let blockchain_state
-      ({staged_ledger_hash= lbh; ledger_hash= lh; timestamp} :
+      ({staged_ledger_hash= lbh; snarked_ledger_hash= lh; timestamp} :
         Blockchain_state.t) : Lite_base.Blockchain_state.t =
     { staged_ledger_hash= ledger_builder_hash lbh
     ; ledger_hash= frozen_ledger_hash lh

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -196,7 +196,7 @@ module Make (Inputs : Inputs_intf) :
       lift_sync (fun () ->
           let previous_ledger_hash =
             previous_protocol_state |> Protocol_state.blockchain_state
-            |> Blockchain_state.ledger_hash
+            |> Blockchain_state.snarked_ledger_hash
           in
           let next_ledger_hash =
             Option.value_map ledger_proof_opt
@@ -212,7 +212,7 @@ module Make (Inputs : Inputs_intf) :
           in
           let blockchain_state =
             Blockchain_state.create_value ~timestamp:(Time.now time_controller)
-              ~ledger_hash:next_ledger_hash
+              ~snarked_ledger_hash:next_ledger_hash
               ~staged_ledger_hash:next_staged_ledger_hash
           in
           let time =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -121,7 +121,8 @@ struct
               Consensus.Mechanism.Protocol_state.blockchain_state
                 transition_protocol_state
             in
-            ( Consensus.Mechanism.Blockchain_state.ledger_hash blockchain_state
+            ( Consensus.Mechanism.Blockchain_state.snarked_ledger_hash
+                blockchain_state
             , Consensus.Mechanism.Blockchain_state.staged_ledger_hash
                 blockchain_state )
           in
@@ -211,7 +212,8 @@ struct
       Protocol_state.blockchain_state root_protocol_state
     in
     let root_blockchain_state_ledger_hash, root_blockchain_staged_ledger_hash =
-      ( Protocol_state.Blockchain_state.ledger_hash root_blockchain_state
+      ( Protocol_state.Blockchain_state.snarked_ledger_hash
+          root_blockchain_state
       , Protocol_state.Blockchain_state.staged_ledger_hash
           root_blockchain_state )
     in

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -231,7 +231,7 @@ let gen_breadcrumb ~logger :
     in
     let previous_ledger_hash =
       previous_protocol_state |> Protocol_state.blockchain_state
-      |> Protocol_state.Blockchain_state.ledger_hash
+      |> Protocol_state.Blockchain_state.snarked_ledger_hash
     in
     let next_ledger_hash =
       Option.value_map ledger_proof_opt
@@ -241,7 +241,7 @@ let gen_breadcrumb ~logger :
     in
     let next_blockchain_state =
       Blockchain_state.create_value ~timestamp:(Block_time.now ())
-        ~ledger_hash:next_ledger_hash
+        ~snarked_ledger_hash:next_ledger_hash
         ~staged_ledger_hash:next_staged_ledger_hash
     in
     let previous_state_hash =

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -877,13 +877,13 @@ module type Blockchain_state_intf = sig
 
   val create_value :
        staged_ledger_hash:staged_ledger_hash
-    -> ledger_hash:frozen_ledger_hash
+    -> snarked_ledger_hash:frozen_ledger_hash
     -> timestamp:time
     -> value
 
   val staged_ledger_hash : value -> staged_ledger_hash
 
-  val ledger_hash : value -> frozen_ledger_hash
+  val snarked_ledger_hash : value -> frozen_ledger_hash
 
   val timestamp : value -> time
 end


### PR DESCRIPTION
In this PR, I did a refactor which renamed `ledger_hash` to `snarked_ledger_hash`.

Closes #1530