### PR TITLE
Remove peered.ml

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -361,7 +361,7 @@ module Make (Inputs : Inputs_intf) = struct
       =
     let log = Logger.child config.parent_log "coda networking" in
     (* TODO: for following functions, could check that IP in _conn matches
-       the sender IP in envelope, punish if mismatch
+       the sender IP in envelope, punish if mismatch due to IP forgery
      *)
     let get_staged_ledger_aux_at_hash_rpc _conn ~version:_ hash_in_envelope =
       get_staged_ledger_aux_at_hash hash_in_envelope

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -177,7 +177,9 @@ module Make (Message : Message_intf) :
             Versioned_rpc.Menu.add
               ( Message.implement_multi
                   (fun _client_host_and_port ~version:_ msg ->
-                    (* TODO: maybe check client host matches IP in msg, punish if mismatch *)
+                    (* TODO: maybe check client host matches IP in msg, punish if
+                       mismatch due to forgery
+                     *)
                     Linear_pipe.force_write_maybe_drop_head
                       ~capacity:broadcast_received_capacity received_writer
                       received_reader

--- a/src/lib/network_peer/peered.ml
+++ b/src/lib/network_peer/peered.ml
@@ -1,5 +1,0 @@
-(* peered.ml -- pair some data with a Peer.t *)
-
-type 'a t = {data: 'a; peer: Peer.t} [@@deriving bin_io, sexp, fields]
-
-let create data peer = {data; peer}


### PR DESCRIPTION
Somehow, PR #1534 didn't remove the file `peered.ml`, which is no longer needed.

This PR does the removal.

Also, mention IP forgery in comments.