### PR TITLE
Empty chunk table for fake hash

### DIFF
--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -1,3 +1,6 @@
+[%%import
+"../../../config.mlh"]
+
 open Ppxlib
 open Asttypes
 open Parsetree
@@ -111,6 +114,15 @@ let compute_chunk_value ~start n =
      for each possible chunk (2 ** (size * 3) of them)
        store its value in the array
 *)
+
+[%%if
+fake_hash]
+
+(* don't bother building table *)
+let get_chunk_table () = [||]
+
+[%%else]
+
 let get_chunk_table () =
   let num_params = Array.length params_array in
   let max_chunks = num_params / Chunk.size in
@@ -126,6 +138,8 @@ let get_chunk_table () =
   in
   let result = loop ~chunk:0 [] in
   result
+
+[%%endif]
 
 (* the AST representation of the chunk table is its string serialization
    - an AST for the table itself, using string representations of


### PR DESCRIPTION
When `fake_hash` is true, don't build the hash chunk table, which takes 8 seconds of compile time on my laptop.