### PR TITLE
QUICKFIX: CODA_CONSENSUS removed, use DUNE_PROFILE

### DIFF
--- a/scripts/getkeys.sh
+++ b/scripts/getkeys.sh
@@ -12,7 +12,7 @@ if [[ $CIRCLE_BRANCH == 'master' ]]; then
 
     # Get cached keys
     PINNED_KEY_COMMIT=temporary_hack
-    TARBALL="keys-${PINNED_KEY_COMMIT}-${CODA_CONSENSUS}.tar.bz2"
+    TARBALL="keys-${PINNED_KEY_COMMIT}-${DUNE_PROFILE}.tar.bz2"
     /usr/bin/gsutil cp gs://proving-keys-stable/$TARBALL /tmp/.
 
     # Unpack keys


### PR DESCRIPTION
Master build broken -- variable was removed, use a similar variable.
