### PR TITLE
Remove wrong version of foldi

### DIFF
--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -529,11 +529,7 @@ let%test_module "Test mask connected to underlying Merkle tree" =
             List.iter mask_accounts ~f:(fun account ->
                 ignore @@ create_existing_account_exn attached_mask account ) ;
             let mask_sum =
-              Mask.Attached.foldi_with_ignored_keys attached_mask
-                ( Key.Set.of_list
-                @@ List.map parent_accounts ~f:(fun {Account.public_key; _} ->
-                       public_key ) )
-                ~init:0 ~f:balance_summer
+              Mask.Attached.foldi attached_mask ~init:0 ~f:balance_summer
             in
             (* sum should not include any parent balances *)
             assert (Int.equal mask_sum 0) )

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -451,7 +451,7 @@ struct
       in
       List.fold locations_and_accounts ~init:parent_result ~f:f'
 
-    let _foldi t ~init ~f = foldi_with_ignored_keys t Key.Set.empty ~init ~f
+    let foldi t ~init ~f = foldi_with_ignored_keys t Key.Set.empty ~init ~f
 
     (* we would want fold_until to combine results from the parent and the mask
        way (1): use the parent result as the init of the mask fold (or vice-versa)
@@ -521,15 +521,6 @@ struct
       get_or_create_account t key account
       |> Result.map_error ~f:(fun err -> raise (Error.to_exn err))
       |> Result.ok_exn
-
-    let foldi t ~init ~f =
-      (* fold over parent, then mask *)
-      let parent_result = Base.foldi (get_parent t) ~init ~f in
-      Location.Table.fold t.account_tbl ~init:parent_result
-        ~f:(fun ~key:loc ~data:acct accum ->
-          (* loc is an account location, no exception can be raised here *)
-          let addr = Location.to_path_exn loc in
-          f addr accum acct )
 
     let sexp_of_location = Location.sexp_of_t
 


### PR DESCRIPTION
Somehow, the correct version of `foldi` for the mask wasn't actually being used.

Removed the old, invalid version, fixed the name of the correct one.

Closes #1563.
