### PR TITLE
More fixes for Kademlia tests

### DIFF
--- a/src/dummy.sh
+++ b/src/dummy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 while true; do
   sleep 0.3


### PR DESCRIPTION
Use /usr/bin/env bash over /bin/bash for systems (e.g. NixOS) where it's in a
different place. Search for dune-project rather than README-dev.md because dune
copies that file into _build/default when you build the executable. Fix finding
the kademlia executable when outside the Coda source tree.

Tested by running the tests inside and outside of `src` and running `coda daemon` inside and outside a source tree.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:
