### PR TITLE
[easy] Don't check the current time when using null logger

### DIFF
--- a/src/lib/logger/logger.ml
+++ b/src/lib/logger/logger.ml
@@ -108,18 +108,18 @@ let null () =
 let log ~level ?loc ?(attrs = []) t fmt =
   ksprintf
     (fun message ->
-      let m : Message.t =
-        { attributes= attrs
-        ; path= t.path
-        ; pid= t.pid
-        ; host= t.host
-        ; timestamp= Time.now ()
-        ; level
-        ; message
-        ; location= loc }
-      in
       if t.null then ifprintf stdout ""
       else
+        let m : Message.t =
+          { attributes= attrs
+          ; path= t.path
+          ; pid= t.pid
+          ; host= t.host
+          ; timestamp= Time.now ()
+          ; level
+          ; message
+          ; location= loc }
+        in
         let output =
           if get_sexp_logging () then
             (* S-expression output *)


### PR DESCRIPTION
Saves a syscall, which is significant in some tests.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them: