### PR TITLE
Turn on snark debugging in prod temporarily

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -469,5 +469,8 @@ let () =
   Random.self_init () ;
   let log = Logger.create () in
   don't_wait_for (ensure_testnet_id_still_good log) ;
+  (* Turn on snark debugging in prod for now *)
+  Snark_params.Tick.set_eval_constraints true ;
+  Snark_params.Tock.set_eval_constraints true ;
   Command.run (Command.group ~summary:"Coda" (coda_commands log)) ;
   Core.exit 0


### PR DESCRIPTION
This way when a SNARK fails in testnets we'll know why. We believe the performance cost of this is ~20% slower, but haven't measured recently.