### PR TITLE
SIMPLE: use bash expansion to look for files

### DIFF
--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -49,7 +49,7 @@ then
     mkdir -p ${BUILDDIR}/var/lib/coda
     cp /tmp/coda_cache_dir/* ${BUILDDIR}/var/lib/coda
 else
-    # Look instead for packaged keys 
+    # Look instead for packaged keys (downloaded before build time)
     var_keys=$(shopt -s nullglob dotglob; echo /var/lib/coda/*)
     if (( ${#var_keys} ))
     then
@@ -57,7 +57,6 @@ else
 	cp /var/lib/coda/* ${BUILDDIR}/var/lib/coda
     fi
 fi
-
 
 # Bash autocompletion
 # NOTE: We do not list bash-completion as a required package,

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -39,16 +39,25 @@ mkdir -p ${BUILDDIR}/usr/local/bin
 cp ./default/app/cli/src/coda.exe ${BUILDDIR}/usr/local/bin/coda
 cp ./default/app/logproc/src/logproc.exe ${BUILDDIR}/usr/local/bin/logproc
 
-# Include keys
-if [ -d "/var/lib/coda" ]; then
+
+# Include proving/verifying
+
+# Look in tmp first (compile time generated keys)
+tmp_keys=$(shopt -s nullglob dotglob; echo /tmp/coda_cache_dir/*)
+if (( ${#tmp_keys} ))
+then
     mkdir -p ${BUILDDIR}/var/lib/coda
-    cp /var/lib/coda/* ${BUILDDIR}/var/lib/coda
+    cp /tmp/coda_cache_dir/* ${BUILDDIR}/var/lib/coda
 else
-    if [ -d "/tmp/coda_cache_dir" ]; then
-        mkdir -p ${BUILDDIR}/var/lib/coda
-        cp /tmp/coda_cache_dir/* ${BUILDDIR}/var/lib/coda
+    # Look instead for packaged keys 
+    var_keys=$(shopt -s nullglob dotglob; echo /var/lib/coda/*)
+    if (( ${#var_keys} ))
+    then
+	mkdir -p ${BUILDDIR}/var/lib/coda
+	cp /var/lib/coda/* ${BUILDDIR}/var/lib/coda
     fi
 fi
+
 
 # Bash autocompletion
 # NOTE: We do not list bash-completion as a required package,


### PR DESCRIPTION
We were preferring files in /var to /tmp (swapped).
Also using a more careful check to look for files in a directory instead of just existence of dir.
