### PR TITLE
Make sure that ppx tests are run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,8 @@ test-withsnark: SHELL := /bin/bash
 test-withsnark:
 	source scripts/test_all.sh ; cd src; WITH_SNARKS=true DUNE_PROFILE=test_posig run_integration_test full-test
 
-test-ppx: SHELL := /bin/bash
 test-ppx:
-	make -C src/lib/ppx_coda/tests
+	$(MAKE) -C src/lib/ppx_coda/tests
 
 web:
 	./scripts/web.sh

--- a/scripts/test_all.sh
+++ b/scripts/test_all.sh
@@ -19,7 +19,7 @@ run_unit_tests() {
 
 run_ppx_tests() {
   date
-  make ppx_tests
+  make test-ppx
 }
 
 run_unit_tests_with_coverage() {


### PR DESCRIPTION
This tweaks `run_ppx_tests` from #1609 to make sure the tests get run.

/cc @psteckler

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:
