### PR TITLE
Mention versioned modules in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ Checklist:
 
 - [ ] Tests were added for the new behavior
 - [ ] All tests pass (CI will check this if you didn't)
+- [ ] Serialized types are in stable-versioned modules
 - [ ] Does this close issues? List them:
 
 Closes #0000


### PR DESCRIPTION
The PR template mentions putting serialized types in stable-versioned modules.

That's mentioned in RFC 0013 for versioned modules (not yet merged). This is a first step to implementing that RFC.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:
