### PR TITLE
Refine module versioning

### DIFF
--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -38,33 +38,34 @@ module Nonce = Account_nonce
 
 module Stable = struct
   module V1 = struct
-    let version = 1
+    module T = struct
+      let version = 1
 
-    type ('pk, 'amount, 'nonce, 'receipt_chain_hash) t_ =
-      { public_key: 'pk
-      ; balance: 'amount
-      ; nonce: 'nonce
-      ; receipt_chain_hash: 'receipt_chain_hash
-      ; delegate: 'pk }
-    [@@deriving fields, sexp, bin_io, eq, compare, hash]
+      type ('pk, 'amount, 'nonce, 'receipt_chain_hash) t_ =
+        { public_key: 'pk
+        ; balance: 'amount
+        ; nonce: 'nonce
+        ; receipt_chain_hash: 'receipt_chain_hash
+        ; delegate: 'pk }
+      [@@deriving fields, sexp, bin_io, eq, compare, hash]
 
-    type key = Public_key.Compressed.Stable.V1.t
-    [@@deriving sexp, bin_io, eq, hash, compare]
+      type key = Public_key.Compressed.Stable.V1.t
+      [@@deriving sexp, bin_io, eq, hash, compare]
 
-    type t =
-      ( key
-      , Balance.Stable.V1.t
-      , Nonce.Stable.V1.t
-      , Receipt.Chain_hash.Stable.V1.t )
-      t_
-    [@@deriving sexp, bin_io, eq, hash, compare]
+      type t =
+        ( key
+        , Balance.Stable.V1.t
+        , Nonce.Stable.V1.t
+        , Receipt.Chain_hash.Stable.V1.t )
+        t_
+      [@@deriving sexp, bin_io, eq, hash, compare]
+    end
 
-    type latest = t
+    include T
+    include Module_version.Registration.Make_latest_version (T)
 
     (* monomorphize field selector *)
     let public_key (t : t) : key = t.public_key
-
-    let to_latest = Fn.id
   end
 
   (* module version registration *)
@@ -78,7 +79,7 @@ module Stable = struct
   end
 
   module Registrar = Module_version.Registration.Make (Module_decl)
-  include Registrar.Register (V1)
+  module Registered_V1 = Registrar.Register (V1)
 end
 
 include Stable.Latest

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -6,7 +6,7 @@ include Sparse_ledger_lib.Sparse_ledger.Make
           (Ledger_hash)
           (Public_key.Compressed.Stable.V1)
           (struct
-            include Account.Stable.V1
+            include Account.Stable.Latest
 
             let hash = Fn.compose Ledger_hash.of_digest Account.digest
           end)

--- a/src/lib/module_version/registration.ml
+++ b/src/lib/module_version/registration.ml
@@ -1,5 +1,8 @@
 (* registration.ml -- register module versions *)
 
+(* see RFC 0014 for design discussion; see tests below for usage
+ *)
+
 open Core_kernel
 
 module type Module_decl_intf = sig
@@ -16,10 +19,19 @@ module type Versioned_module_intf = sig
   val version : int
 
   val to_latest : t -> latest
+
+  module With_version : sig
+    type nonrec t = {version: int; t: t} [@@deriving bin_io]
+  end
 end
 
-module Make (Module_decl : Module_decl_intf) = struct
-  (* creates a registrar that can
+module type Version_intf = sig
+  type t [@@deriving bin_io]
+
+  val version : int
+end
+
+(* functor to create a registrar that can
 
      - register versioned modules
      - deserialize data to latest version
@@ -27,8 +39,9 @@ module Make (Module_decl : Module_decl_intf) = struct
    N.B.: data must be serialized using registered modules
 
    see tests below for an example of usage
-  *)
+ *)
 
+module Make (Module_decl : Module_decl_intf) = struct
   module type Versioned_with_latest_intf =
     Versioned_module_intf with type latest = Module_decl.latest
 
@@ -45,19 +58,24 @@ module Make (Module_decl : Module_decl_intf) = struct
     List.find_map !registered
       ~f:(fun (module M : Versioned_with_latest_intf) ->
         let pos_ref = ref 0 in
-        let data_version = Bin_prot.Std.bin_read_int ~pos_ref buf in
+        (* rely on layout, first element of record is first item in buf *)
+        let version = Bin_prot.Std.bin_read_int ~pos_ref buf in
         (* sanity check *)
-        if not (is_registered_version data_version) then
+        if not (is_registered_version version) then
           failwith
             (sprintf
                "deserialize_binary_opt: version %d in serialized data is not \
                 a registered version"
-               data_version) ;
-        if Int.equal data_version M.version then
+               version) ;
+        if Int.equal version M.version then
+          (* start at 0 again, because M.bin_read_t is reading the version *)
+          let pos_ref = ref 0 in
           Some (M.bin_read_t ~pos_ref buf |> M.to_latest)
         else None )
 
   module Register (Versioned_module : Versioned_with_latest_intf) = struct
+    open Versioned_module
+
     let () =
       if is_registered_version Versioned_module.version then
         failwith
@@ -67,44 +85,107 @@ module Make (Module_decl : Module_decl_intf) = struct
         Int.Set.add !registered_versions Versioned_module.version ;
       registered := (module Versioned_module) :: !registered
 
-    (** creates serialized version of an instance of the date with version prepended *)
-    let serialize_binary (t : Versioned_module.t) =
-      let open Versioned_module in
-      let sz = Bin_prot.Std.bin_size_int version + bin_size_t t in
-      let buf = Bin_prot.Common.create_buf sz in
-      let pos = Bin_prot.Std.bin_write_int buf ~pos:0 version in
-      ignore (bin_write_t ~pos buf t) ;
-      buf
+    module With_version = struct
+      type nonrec t = {version: int; t: Versioned_module.t} [@@deriving bin_io]
+
+      let create t = {version; t}
+    end
   end
+end
+
+(* functor to generate With_version and bin_io boilerplate *)
+module Make_version (Version : Version_intf) = struct
+  module With_version = struct
+    type nonrec t = {version: int; t: Version.t} [@@deriving bin_io]
+
+    let create t = {version= Version.version; t}
+  end
+
+  (* shadow derived bin_io code for Version.t
+
+     serializing an instance of Version.t includes the version number,
+      for use by deserialize_binary_opt, above
+
+     deserializing gives back just t, without the version
+
+     that allows use of a versioned module in data structures that themselves
+       derive bin_io
+   *)
+
+  let bin_read_t buf ~pos_ref =
+    let With_version.({version= read_version; t}) =
+      With_version.bin_read_t buf ~pos_ref
+    in
+    (* sanity check *)
+    assert (Int.equal read_version Version.version) ;
+    t
+
+  let __bin_read_t__ = With_version.__bin_read_t__
+
+  let bin_reader_t =
+    Bin_prot.Type_class.{read= bin_read_t; vtag_read= __bin_read_t__}
+
+  let bin_size_t t = With_version.create t |> With_version.bin_size_t
+
+  let bin_write_t buf ~pos t =
+    With_version.create t |> With_version.bin_write_t buf ~pos
+
+  let bin_writer_t = Bin_prot.Type_class.{size= bin_size_t; write= bin_write_t}
+
+  let bin_shape_t = With_version.bin_shape_t
+
+  let bin_t =
+    Bin_prot.Type_class.
+      {shape= bin_shape_t; writer= bin_writer_t; reader= bin_reader_t}
+end
+
+(* like Make_version, but for special case of latest version *)
+module Make_latest_version (Version : Version_intf) = struct
+  type latest = Version.t
+
+  let to_latest t = t
+
+  include Make_version (Version)
 end
 
 let%test_module "Test versioned modules" =
   ( module struct
     module Stable = struct
+      (* define module versions *)
+
       module V2 = struct
-        let version = 2
+        module T = struct
+          let version = 2
 
-        (* string, int swapped in tuple from V1's t *)
-        type t = string * int [@@deriving bin_io]
+          (* string, int swapped in tuple from V1's t *)
+          type t = string * int [@@deriving bin_io]
+        end
 
-        type latest = t
-
-        let to_latest = Fn.id
+        include T
+        include Make_latest_version (T)
       end
 
       module Latest = V2
 
       module V1 = struct
-        let version = 1
+        module T = struct
+          let version = 1
 
-        type t = int * string [@@deriving bin_io]
+          type t = int * string [@@deriving bin_io]
+        end
+
+        include T
+
+        (* latest and to_latest need to be defined for older versions *)
 
         type latest = Latest.t
 
         let to_latest (n, s) = (s, n)
+
+        include Make_version (T)
       end
 
-      (* registration *)
+      (* declare the module, register the versions *)
 
       module Module_decl = struct
         let name = "module_version_example"
@@ -115,24 +196,27 @@ let%test_module "Test versioned modules" =
       module Registrar = Make (Module_decl)
       module Registered_V1 = Registrar.Register (V1)
       module Registered_V2 = Registrar.Register (V2)
-      module Registered_Latest = Registered_V2
     end
 
     open Stable
 
     let%test "serialize, deserialize with latest version" =
       let ((s, n) as t) = ("hello, world", 42) in
-      let serialized = Registered_Latest.serialize_binary t in
-      match Registrar.deserialize_binary_opt serialized with
+      let sz = Latest.bin_size_t t in
+      let buf = Bin_prot.Common.create_buf sz in
+      ignore (Latest.bin_write_t buf ~pos:0 t) ;
+      match Registrar.deserialize_binary_opt buf with
       | None -> false
       | Some (s', n') -> String.equal s s' && Int.equal n n'
 
     let%test "serialize with older version, deserialize to latest version" =
       let ((n, s) as t) = (42, "hello, world") in
       (* serialize as V1.t *)
-      let serialized = Registered_V1.serialize_binary t in
+      let sz = V1.bin_size_t t in
+      let buf = Bin_prot.Common.create_buf sz in
+      ignore (V1.bin_write_t buf ~pos:0 t) ;
       (* but deserialized to Latest.t *)
-      match Registrar.deserialize_binary_opt serialized with
+      match Registrar.deserialize_binary_opt buf with
       | None -> false
       | Some (s', n') -> String.equal s s' && Int.equal n n'
   end )


### PR DESCRIPTION
Refined the module versioning mechanism:

  - added functors to generate bin_io boilerplate, one for older versions, one for latest version
  - the boilerplate goes in the *unregistered* module, so it can contain arbitrary other code
  - registration is just for taking old bin_io strings and deserializing them to the latest version type
  - in code, you just use the latest unregistered module

The module version tests were modified accordingly.

Will update the RFC to match this implementation.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules (in `coda_base/account.ml`)
- [ ] Does this close issues? List them:
