### PR TITLE
remove unused opens, move buildlog to artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
                   command: scripts/getkeys.sh
             - run:
                   name: Build OCaml
-                  command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log
+                  command: eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log
             - run:
                   name: Build deb Package with keys
                   command: make deb
@@ -120,7 +120,7 @@ jobs:
                   command: scripts/getkeys.sh
             - run:
                   name: Build OCaml
-                  command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log
+                  command: eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log
             - run:
                   name: Build deb Package with keys
                   command: make deb
@@ -149,7 +149,7 @@ jobs:
                   command: scripts/getkeys.sh
             - run:
                   name: Build OCaml
-                  command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log
+                  command: eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log
             - run:
                   name: Build deb Package with keys
                   command: make deb
@@ -178,7 +178,7 @@ jobs:
                   command: scripts/getkeys.sh
             - run:
                   name: Build OCaml
-                  command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log
+                  command: eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log
             - run:
                   name: Build deb Package with keys
                   command: make deb
@@ -207,7 +207,7 @@ jobs:
                   command: scripts/getkeys.sh
             - run:
                   name: Build OCaml
-                  command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log
+                  command: eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log
             - run:
                   name: Build deb Package with keys
                   command: make deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
             DUNE_PROFILE: dev
         steps:
             - checkout
+            - run: mkdir -p /tmp/artifacts
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Stable Proving Keys
@@ -114,6 +115,7 @@ jobs:
             DUNE_PROFILE: testnet_posig
         steps:
             - checkout
+            - run: mkdir -p /tmp/artifacts
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Stable Proving Keys
@@ -143,6 +145,7 @@ jobs:
             DUNE_PROFILE: testnet_postake
         steps:
             - checkout
+            - run: mkdir -p /tmp/artifacts
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Stable Proving Keys
@@ -172,6 +175,7 @@ jobs:
             DUNE_PROFILE: testnet_public
         steps:
             - checkout
+            - run: mkdir -p /tmp/artifacts
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Stable Proving Keys
@@ -201,6 +205,7 @@ jobs:
             DUNE_PROFILE: testnet_postake_snarkless_fake_hash
         steps:
             - checkout
+            - run: mkdir -p /tmp/artifacts
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Stable Proving Keys

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -93,7 +93,7 @@ jobs:
                   command: scripts/getkeys.sh
             - run:
                   name: Build OCaml
-                  command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log
+                  command: eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log
             - run:
                   name: Build deb Package with keys
                   command: make deb

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -87,6 +87,7 @@ jobs:
             DUNE_PROFILE: {{profile}}
         steps:
             - checkout
+            - run: mkdir -p /tmp/artifacts
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Stable Proving Keys

--- a/src/lib/blockchain_snark/dune
+++ b/src/lib/blockchain_snark/dune
@@ -1,7 +1,7 @@
 (library
  (name blockchain_snark)
  (public_name blockchain_snark)
- (flags :standard -short-paths -warn-error -32-33-27-58)
+ (flags :standard -short-paths -warn-error -32-27-58)
  (library_flags -linkall)
  (libraries core cached cache_dir protocols snarky snark_params coda_base
    transaction_snark bignum_bigint consensus)

--- a/src/lib/coda_base/banlist.ml
+++ b/src/lib/coda_base/banlist.ml
@@ -1,7 +1,5 @@
 open Core
-open Async
 open Banlist_lib.Banlist
-open Unsigned
 
 module Punishment_record = struct
   type time = Time.t

--- a/src/lib/coda_base/blockchain_state.ml
+++ b/src/lib/coda_base/blockchain_state.ml
@@ -1,6 +1,4 @@
 open Core_kernel
-open Coda_numbers
-open Util
 open Snark_params
 open Tick
 open Let_syntax

--- a/src/lib/coda_base/dune
+++ b/src/lib/coda_base/dune
@@ -1,7 +1,7 @@
 (library
  (name coda_base)
  (public_name coda_base)
- (flags :standard -short-paths -warn-error -35-32-33-9-27-34-58-39)
+ (flags :standard -short-paths -warn-error -35-32-9-27-34-58-39)
  (inline_tests)
  (library_flags -linkall)
  (libraries lite_base linked_tree hash_prefixes syncable_ledger base64

--- a/src/lib/coda_base/frozen_ledger_hash.ml
+++ b/src/lib/coda_base/frozen_ledger_hash.ml
@@ -1,6 +1,4 @@
-open Import
 open Snark_params
-open Tick
 include Ledger_hash
 
 let of_ledger_hash (h : Ledger_hash.t) : t = h

--- a/src/lib/coda_base/frozen_ledger_hash.ml
+++ b/src/lib/coda_base/frozen_ledger_hash.ml
@@ -1,7 +1,5 @@
-open Core_kernel
 open Import
 open Snark_params
-open Snarky
 open Tick
 include Ledger_hash
 

--- a/src/lib/coda_base/frozen_ledger_hash.ml
+++ b/src/lib/coda_base/frozen_ledger_hash.ml
@@ -1,4 +1,3 @@
-open Snark_params
 include Ledger_hash
 
 let of_ledger_hash (h : Ledger_hash.t) : t = h

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -1,6 +1,5 @@
 open Core
 open Snark_params
-open Currency
 open Signature_lib
 open Merkle_ledger
 

--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -4,7 +4,6 @@ open Snark_params
 open Snarky
 open Tick
 open Let_syntax
-open Currency
 open Fold_lib
 
 module Merkle_tree =

--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -21,7 +21,6 @@ module Merkle_tree =
           Bitstring_lib.Bitstring.pad_to_triple_list ~default:Boolean.false_
             (bs :> Boolean.var list)
         in
-        let open Let_syntax in
         (* TODO: Think about if choose_preimage_var is ok *)
         let%bind h1 = Pedersen.Checked.Digest.choose_preimage h1
         and h2 = Pedersen.Checked.Digest.choose_preimage h2 in

--- a/src/lib/coda_base/payment_payload.ml
+++ b/src/lib/coda_base/payment_payload.ml
@@ -1,10 +1,8 @@
 open Core
 open Fold_lib
-open Coda_numbers
 open Snark_params.Tick
 open Let_syntax
 open Import
-open Sha256_lib
 module Amount = Currency.Amount
 module Fee = Currency.Fee
 

--- a/src/lib/coda_base/payment_payload.mli
+++ b/src/lib/coda_base/payment_payload.mli
@@ -2,7 +2,6 @@ open Core
 open Fold_lib
 open Tuple_lib
 open Snark_params.Tick
-open Sha256_lib
 open Import
 
 type ('pk, 'amount) t_ = {receiver: 'pk; amount: 'amount}

--- a/src/lib/coda_base/payment_payload.mli
+++ b/src/lib/coda_base/payment_payload.mli
@@ -1,7 +1,6 @@
 open Core
 open Fold_lib
 open Tuple_lib
-open Coda_numbers
 open Snark_params.Tick
 open Sha256_lib
 open Import

--- a/src/lib/coda_base/target.ml
+++ b/src/lib/coda_base/target.ml
@@ -59,7 +59,6 @@ module Bits =
     end)
 
 open Tick
-open Let_syntax
 
 let var_to_unpacked (x : Field.Var.t) =
   Field.Checked.unpack ~length:bit_length x

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -1,8 +1,6 @@
 open Core
-open Snark_params
 open Currency
 open Signature_lib
-open Merkle_ledger
 
 module type S = sig
   type ledger

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -1,6 +1,8 @@
 open Core
+open Snark_params
 open Currency
 open Signature_lib
+open Merkle_ledger
 
 module type S = sig
   type ledger

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -155,7 +155,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
 
     let transaction : t -> Transaction.t Or_error.t =
      fun {varying; _} ->
-      let open Or_error.Let_syntax in
       match varying with
       | User_command tr ->
           Option.value_map ~default:(Or_error.error_string "Bad signature")

--- a/src/lib/coda_base/transaction_union_tag.ml
+++ b/src/lib/coda_base/transaction_union_tag.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Fold_lib
 open Tuple_lib
-open Signature_lib
 open Snark_params.Tick
 
 type t = Payment | Stake_delegation | Fee_transfer | Coinbase

--- a/src/lib/coda_base/transition_system.ml
+++ b/src/lib/coda_base/transition_system.ml
@@ -111,7 +111,6 @@ struct
       >>| Or_error.ok_exn >>| fst
 
     let%snarkydef prev_state_valid wrap_vk_section wrap_vk prev_state_hash =
-      let open Let_syntax in
       (* TODO: Should build compositionally on the prev_state hash (instead of converting to bits) *)
       let%bind prev_state_hash_trips =
         State.Hash.var_to_triples prev_state_hash

--- a/src/lib/coda_base/user_command.mli
+++ b/src/lib/coda_base/user_command.mli
@@ -1,6 +1,5 @@
 open Core
 open Import
-open Snark_params.Tick
 module Payload = User_command_payload
 
 type ('payload, 'pk, 'signature) t_ =

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -1,7 +1,5 @@
-open Signature_lib
 open Core_kernel
 open Snark_params.Tick
-open Tuple_lib
 open Fold_lib
 module Account_nonce = Coda_numbers.Account_nonce
 module Memo = User_command_memo

--- a/src/lib/distributed_dsl/dune
+++ b/src/lib/distributed_dsl/dune
@@ -1,7 +1,7 @@
 (library
  (name distributed_dsl)
  (public_name distributed_dsl)
- (flags :standard -short-paths -warn-error -33-34-32-27-9-58)
+ (flags :standard -short-paths -warn-error -34-32-27-9-58)
  (library_flags -linkall)
  (inline_tests)
  (libraries logger core pipe_lib async async_extra extlib)

--- a/src/lib/merkle_ledger/dune
+++ b/src/lib/merkle_ledger/dune
@@ -1,7 +1,7 @@
 (library
  (name merkle_ledger)
  (public_name merkle_ledger)
- (flags :standard -short-paths -warn-error -6-33-34-27-9-58)
+ (flags :standard -short-paths -warn-error -6-34-27-9-58)
  (library_flags -linkall)
  (libraries core bitstring integers extlib signature_lib immutable_array
    dyn_array merkle_address direction rocks key_value_database empty_hashes)

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -1,7 +1,7 @@
 (library
  (name merkle_ledger_tests)
  (public_name merkle_ledger_tests)
- (flags :standard -short-paths -warn-error -6-33-27-9-58)
+ (flags :standard -short-paths -warn-error -6-27-9-58)
  (library_flags -linkall)
  (libraries core merkle_ledger merkle_mask coda_base signature_lib extlib)
  (preprocess

--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -1,7 +1,7 @@
 (library
  (name merkle_mask)
  (public_name merkle_mask)
- (flags :standard -short-paths -warn-error -6-33-27-9-58)
+ (flags :standard -short-paths -warn-error -6-27-9-58)
  (library_flags -linkall)
  (libraries core debug_assert bitstring integers extlib immutable_array
    dyn_array merkle_ledger merkle_address)

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -6,6 +6,6 @@
  (libraries core extlib async pipe_lib snark_pool)
  (preprocess
   (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
- (flags :standard -short-paths -warn-error -33-6-27-34-32-9-58)
+ (flags :standard -short-paths -warn-error -6-27-34-32-9-58)
  (synopsis
    "Network pool is an interface that processes incoming diffs and then broadcasts them"))

--- a/src/lib/snark_bits/bits.ml
+++ b/src/lib/snark_bits/bits.ml
@@ -191,7 +191,6 @@ module Snarkable = struct
           init ~f:(fun i -> Bigint.test_bit n i)
         in
         let store t =
-          let open Store.Let_syntax in
           let rec go two_to_the_i i acc =
             if i = V.length then acc
             else

--- a/src/lib/snark_bits/dune
+++ b/src/lib/snark_bits/dune
@@ -1,7 +1,7 @@
 (library
  (name snark_bits)
  (public_name snark_bits)
- (flags :standard -short-paths -warn-error -6-33-32-58)
+ (flags :standard -short-paths -warn-error -6-32-58)
  (library_flags -linkall)
  (inline_tests)
  (libraries fold_lib core_kernel snarky)

--- a/src/lib/snark_pool/dune
+++ b/src/lib/snark_pool/dune
@@ -6,6 +6,6 @@
  (libraries core extlib protocols async coda_base dyn_array)
  (preprocess
   (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
- (flags :standard -short-paths -warn-error -6-33-32-34-58)
+ (flags :standard -short-paths -warn-error -6-32-34-58)
  (synopsis
    "Snark pool manages work and snarks amongst all nodes in the network"))

--- a/src/lib/snark_pool/snark_pool.ml
+++ b/src/lib/snark_pool/snark_pool.ml
@@ -1,5 +1,4 @@
 open Core_kernel
-open Async_kernel
 
 module Priced_proof = struct
   type ('proof, 'fee) t = {proof: 'proof; fee: 'fee}

--- a/src/lib/snark_pool/snark_pool.ml
+++ b/src/lib/snark_pool/snark_pool.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Async_kernel
 
 module Priced_proof = struct
   type ('proof, 'fee) t = {proof: 'proof; fee: 'fee}

--- a/src/lib/snark_pool/snark_pool.mli
+++ b/src/lib/snark_pool/snark_pool.mli
@@ -1,5 +1,4 @@
 open Core_kernel
-open Async_kernel
 
 module Priced_proof : sig
   type ('proof, 'fee) t = {proof: 'proof; fee: 'fee}

--- a/src/lib/snark_worker_lib/dune
+++ b/src/lib/snark_worker_lib/dune
@@ -1,7 +1,7 @@
 (library
  (name snark_worker_lib)
  (public_name snark_worker_lib)
- (flags :standard -short-paths -warn-error -33-58)
+ (flags :standard -short-paths -warn-error -58)
  (library_flags -linkall)
  (inline_tests)
  (libraries core async cli_lib currency snark_work_lib coda_base

--- a/src/lib/test_util/dune
+++ b/src/lib/test_util/dune
@@ -1,7 +1,7 @@
 (library
  (name test_util)
  (public_name test_util)
- (flags :standard -short-paths -warn-error -6-33-32-58)
+ (flags :standard -short-paths -warn-error -6-32-58)
  (library_flags -linkall)
  (inline_tests)
  (libraries snark_params fold_lib core_kernel snarky)

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -1,7 +1,7 @@
 (library
  (name transaction_snark)
  (public_name transaction_snark)
- (flags :standard -short-paths -warn-error -9-33-32-27-58)
+ (flags :standard -short-paths -warn-error -9-32-27-58)
  (library_flags -linkall)
  (inline_tests)
  (libraries core cache_dir cached snarky coda_base bignum)

--- a/src/lib/web_client_pipe/dune
+++ b/src/lib/web_client_pipe/dune
@@ -1,7 +1,7 @@
 (library
  (name web_client_pipe)
  (public_name web_client_pipe)
- (flags :standard -short-paths -warn-error -9-33-32-27-58)
+ (flags :standard -short-paths -warn-error -9-32-27-58)
  (library_flags -linkall)
  (inline_tests)
  (libraries core async pipe_lib logger web_request)


### PR DESCRIPTION
Quick pass at removing some of the Warning 33: unused opens in our codebase

Also adding the build log to artifacts for archiving.