### PR TITLE
Version blockchain_state module

### DIFF
--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -13,19 +13,6 @@ module Ledger_inner = struct
 
   module Location_at_depth = Location0
 
-  (*
-module Key = struct
-  module T = struct
-    type t = Account.key [@@deriving sexp, bin_io, compare, hash, eq]
-  end
-
-  let empty = Account.empty.public_key
-
-  include T
-  include Hashable.Make_binable (T)
-end
-*)
-
   module Kvdb : Intf.Key_value_database = Rocksdb.Database
 
   module Storage_locations : Intf.Storage_locations = struct


### PR DESCRIPTION
Use new module versioning for `Coda_base.Blockchain_state`.

Also removed a commented-out module in `Coda_base.Ledger`, which no longer seemed relevant.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
