### PR TITLE
Version Currency modules

### DIFF
--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -21,6 +21,8 @@ module type Basic = sig
     module V1 : sig
       type nonrec t = t [@@deriving bin_io, sexp, compare, eq, hash, yojson]
     end
+
+    module Latest = V1
   end
 
   include Bits_intf.S with type t := t

--- a/src/lib/currency/dune
+++ b/src/lib/currency/dune
@@ -5,7 +5,7 @@
  (library_flags -linkall)
  (inline_tests)
  (libraries core fold_lib tuple_lib snark_bits sgn snark_params
-   unsigned_extended test_util codable)
+   unsigned_extended test_util codable module_version)
  (preprocess
   (pps ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx --
     -conditional))


### PR DESCRIPTION
Use versioning for modules in `Currency`.

Note that one of those modules is inside a functor, which is a little funny. But that functor, `Make`, is not exported. It is applied twice internally, and with the same arguments in both cases.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
