### PR TITLE
Version data_hash modules

### DIFF
--- a/src/lib/coda_base/data_hash.mli
+++ b/src/lib/coda_base/data_hash.mli
@@ -24,6 +24,8 @@ module type Basic = sig
 
       include Hashable_binable with type t := t
     end
+
+    module Latest : module type of V1
   end
 
   type var

--- a/src/lib/coda_base/receipt.ml
+++ b/src/lib/coda_base/receipt.ml
@@ -5,9 +5,9 @@ open Fold_lib
 module Chain_hash = struct
   include Data_hash.Make_full_size ()
 
-  let to_string t = Binable.to_string (module Stable.V1) t |> B64.encode
+  let to_string t = Binable.to_string (module Stable.Latest) t |> B64.encode
 
-  let of_string s = B64.decode s |> Binable.of_string (module Stable.V1)
+  let of_string s = B64.decode s |> Binable.of_string (module Stable.Latest)
 
   include Codable.Make_of_string (struct
     type nonrec t = t


### PR DESCRIPTION
Version modules in `coda_base/data_hash`

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
