### PR TITLE
Version sok_message modules

### DIFF
--- a/src/lib/coda_base/sok_message.ml
+++ b/src/lib/coda_base/sok_message.ml
@@ -1,9 +1,11 @@
 open Core
 open Import
+open Module_version
 
 module T = struct
   type t =
-    {fee: Currency.Fee.Stable.V1.t; prover: Public_key.Compressed.Stable.V1.t}
+    { fee: Currency.Fee.Stable.Latest.t
+    ; prover: Public_key.Compressed.Stable.Latest.t }
   [@@deriving bin_io, sexp]
 end
 
@@ -14,11 +16,29 @@ let create ~fee ~prover = {fee; prover}
 module Digest = struct
   module Stable = struct
     module V1 = struct
-      include Random_oracle.Digest
+      module T = struct
+        let version = 1
+
+        include Random_oracle.Digest
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
     end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "sok_message_digest"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
   end
 
-  include Stable.V1
+  include Stable.Latest
 
   let default = of_string (String.init length_in_bytes ~f:(fun _ -> '\000'))
 end


### PR DESCRIPTION
Version modules in `coda_base/sok_message`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
