### PR TITLE
Latest versions in Transaction_snark

### DIFF
--- a/src/lib/coda_base/sok_message.mli
+++ b/src/lib/coda_base/sok_message.mli
@@ -17,6 +17,8 @@ module Digest : sig
     module V1 : sig
       type nonrec t = t [@@deriving sexp, bin_io, hash, compare, eq]
     end
+
+    module Latest = V1
   end
 
   module Checked : sig

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -17,8 +17,8 @@ let exists' typ ~f = Tick.(exists typ ~compute:As_prover.(map get_state ~f))
 
 module Input = struct
   type t =
-    { source: Frozen_ledger_hash.Stable.V1.t
-    ; target: Frozen_ledger_hash.Stable.V1.t
+    { source: Frozen_ledger_hash.Stable.Latest.t
+    ; target: Frozen_ledger_hash.Stable.Latest.t
     ; fee_excess: Currency.Amount.Signed.t }
   [@@deriving bin_io]
 end
@@ -32,10 +32,10 @@ end
 module Statement = struct
   module T = struct
     type t =
-      { source: Coda_base.Frozen_ledger_hash.Stable.V1.t
-      ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
-      ; supply_increase: Currency.Amount.Stable.V1.t
-      ; fee_excess: Currency.Fee.Signed.Stable.V1.t
+      { source: Coda_base.Frozen_ledger_hash.Stable.Latest.t
+      ; target: Coda_base.Frozen_ledger_hash.Stable.Latest.t
+      ; supply_increase: Currency.Amount.Stable.Latest.t
+      ; fee_excess: Currency.Fee.Signed.Stable.Latest.t
       ; proof_type: Proof_type.t }
     [@@deriving sexp, bin_io, hash, compare, eq, fields]
 
@@ -73,12 +73,12 @@ module Statement = struct
 end
 
 type t =
-  { source: Frozen_ledger_hash.Stable.V1.t
-  ; target: Frozen_ledger_hash.Stable.V1.t
+  { source: Frozen_ledger_hash.Stable.Latest.t
+  ; target: Frozen_ledger_hash.Stable.Latest.t
   ; proof_type: Proof_type.t
-  ; supply_increase: Amount.Stable.V1.t
-  ; fee_excess: Amount.Signed.Stable.V1.t
-  ; sok_digest: Sok_message.Digest.Stable.V1.t
+  ; supply_increase: Amount.Stable.Latest.t
+  ; fee_excess: Amount.Signed.Stable.Latest.t
+  ; sok_digest: Sok_message.Digest.Stable.Latest.t
   ; proof: Proof.Stable.V1.t }
 [@@deriving fields, sexp, bin_io]
 

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -8,10 +8,10 @@ end
 
 module Statement : sig
   type t =
-    { source: Coda_base.Frozen_ledger_hash.Stable.V1.t
-    ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
-    ; supply_increase: Currency.Amount.Stable.V1.t
-    ; fee_excess: Currency.Fee.Signed.Stable.V1.t
+    { source: Coda_base.Frozen_ledger_hash.Stable.Latest.t
+    ; target: Coda_base.Frozen_ledger_hash.Stable.Latest.t
+    ; supply_increase: Currency.Amount.Stable.Latest.t
+    ; fee_excess: Currency.Fee.Signed.Stable.Latest.t
     ; proof_type: Proof_type.t }
   [@@deriving sexp, bin_io, hash, compare, eq, fields]
 


### PR DESCRIPTION
Changed mentions of `Stable.V1` in `Transaction_snark` to `Stable.Latest`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
