### PR TITLE
Version Parallel_scan.State

### DIFF
--- a/src/lib/parallel_scan/state.ml
+++ b/src/lib/parallel_scan/state.ml
@@ -2,18 +2,18 @@ open Core_kernel
 open Coda_digestif
 
 module Job = struct
-  type sequence_no = int [@@deriving sexp, bin_io]
-
-  (*A merge can have zero components, one component (either the left or the right), or two components in which case there is an integer (sequence_no) representing a set of (completed)jobs in a sequence of (completed)jobs created*)
-  type 'a merge =
-    | Empty
-    | Lcomp of 'a
-    | Rcomp of 'a
-    | Bcomp of ('a * 'a * sequence_no)
-  [@@deriving sexp, bin_io]
-
   module Stable = struct
     module V1 = struct
+      type sequence_no = int [@@deriving sexp, bin_io]
+
+      (*A merge can have zero components, one component (either the left or the right), or two components in which case there is an integer (sequence_no) representing a set of (completed)jobs in a sequence of (completed)jobs created*)
+      type 'a merge =
+        | Empty
+        | Lcomp of 'a
+        | Rcomp of 'a
+        | Bcomp of ('a * 'a * sequence_no)
+      [@@deriving sexp, bin_io]
+
       (* don't use version number and module registration here, because of type parameters *)
       type ('a, 'd) t = Merge of 'a merge | Base of ('d * sequence_no) option
       [@@deriving sexp, bin_io]
@@ -47,7 +47,16 @@ module Job = struct
 end
 
 module Completed_job = struct
-  type 'a t = Lifted of 'a | Merged of 'a [@@deriving bin_io, sexp]
+  module Stable = struct
+    module V1 = struct
+      (* don't use version number and module registration here, because of type parameter *)
+      type 'a t = Lifted of 'a | Merged of 'a [@@deriving bin_io, sexp]
+    end
+
+    module Latest = V1
+  end
+
+  include Stable.Latest
 end
 
 module Stable = struct


### PR DESCRIPTION
Add versioning of types in `Parallel_scan.State`.

Because these types have parameters, the existing serialization-with-version and module registration mechanism won't work. 

And because serialization and deserialization need to work with data for particular instantiations of those type parameters, we really can't do the serialization-with-version and module registration when those parameters are left uninstantiated. Will work on making those work for the case that the parameters are known.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
