### PR TITLE
Version Transaction_snark_scan_state modules

### DIFF
--- a/src/lib/transaction_snark_scan_state/dune
+++ b/src/lib/transaction_snark_scan_state/dune
@@ -5,7 +5,7 @@
  (library_flags -linkall)
  (libraries pipe_lib core async async_extra sgn parallel_scan
    transaction_snark coda_base protocols logger ppx_deriving_yojson.runtime
-   yojson)
+   yojson module_version)
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_base ppx_let ppx_sexp_conv ppx_bin_prot ppx_custom_printf

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -79,7 +79,31 @@ end = struct
   end
 
   module Ledger_proof_with_sok_message = struct
-    type t = Ledger_proof.t * Sok_message.t [@@deriving sexp, bin_io]
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          let version = 1
+
+          type t = Ledger_proof.t * Sok_message.t [@@deriving sexp, bin_io]
+        end
+
+        include T
+        include Registration.Make_latest_version (T)
+      end
+
+      module Latest = V1
+
+      module Module_decl = struct
+        let name = "transaction_snark_scan_state_ledger_proof_with_sok_message"
+
+        type latest = Latest.t
+      end
+
+      module Registrar = Registration.Make (Module_decl)
+      module Registered_V1 = Registrar.Register (V1)
+    end
+
+    include Stable.Latest
   end
 
   module Available_job = struct


### PR DESCRIPTION
Versioned modules in `Transaction_snark_scan_state`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
