### PR TITLE
Use specific versioned modules within other versioned modules

### DIFF
--- a/src/lib/coda_base/sok_message.ml
+++ b/src/lib/coda_base/sok_message.ml
@@ -2,14 +2,34 @@ open Core
 open Import
 open Module_version
 
-module T = struct
-  type t =
-    { fee: Currency.Fee.Stable.Latest.t
-    ; prover: Public_key.Compressed.Stable.Latest.t }
-  [@@deriving bin_io, sexp]
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      let version = 1
+
+      type t =
+        { fee: Currency.Fee.Stable.V1.t
+        ; prover: Public_key.Compressed.Stable.V1.t }
+      [@@deriving bin_io, sexp]
+    end
+
+    include T
+    include Registration.Make_latest_version (T)
+  end
+
+  module Latest = V1
+
+  module Module_decl = struct
+    let name = "sok_message"
+
+    type latest = Latest.t
+  end
+
+  module Registrar = Registration.Make (Module_decl)
+  module Registered_V1 = Registrar.Register (V1)
 end
 
-include T
+include Stable.Latest
 
 let create ~fee ~prover = {fee; prover}
 

--- a/src/lib/coda_base/transaction_union.ml
+++ b/src/lib/coda_base/transaction_union.ml
@@ -9,6 +9,7 @@ type ('payload, 'pk, 'signature) t_ =
   {payload: 'payload; sender: 'pk; signature: 'signature}
 [@@deriving bin_io, eq, sexp, hash]
 
+(* OK to use Latest, rather than Vn, because t is not bin_io'ed *)
 type t = (Payload.t, Public_key.Stable.Latest.t, Signature.Stable.Latest.t) t_
 
 type var = (Payload.var, Public_key.var, Signature.var) t_

--- a/src/lib/coda_base/user_command.mli
+++ b/src/lib/coda_base/user_command.mli
@@ -16,7 +16,7 @@ module Stable : sig
       {payload: 'payload; sender: 'pk; signature: 'signature}
     [@@deriving bin_io, eq, sexp, hash, yojson]
 
-    type t = (Payload.Stable.Latest.t, Public_key.t, Signature.t) t_
+    type t = (Payload.Stable.V1.t, Public_key.t, Signature.t) t_
     [@@deriving bin_io, eq, sexp, hash, yojson]
 
     val compare : seed:string -> t -> t -> int
@@ -40,15 +40,23 @@ val gen :
   -> t Quickcheck.Generator.t
 
 module With_valid_signature : sig
-  type nonrec t = private t [@@deriving sexp, eq, bin_io]
+  module Stable : sig
+    module V1 : sig
+      type nonrec t = private t [@@deriving sexp, eq, bin_io]
 
-  val compare : seed:string -> t -> t -> int
+      val compare : seed:string -> t -> t -> int
 
-  val gen :
-       keys:Signature_keypair.t array
-    -> max_amount:int
-    -> max_fee:int
-    -> t Quickcheck.Generator.t
+      val gen :
+           keys:Signature_keypair.t array
+        -> max_amount:int
+        -> max_fee:int
+        -> t Quickcheck.Generator.t
+    end
+
+    module Latest : module type of V1
+  end
+
+  include module type of Stable.Latest
 end
 
 val sign : Signature_keypair.t -> Payload.t -> With_valid_signature.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -17,8 +17,8 @@ let exists' typ ~f = Tick.(exists typ ~compute:As_prover.(map get_state ~f))
 
 module Input = struct
   type t =
-    { source: Frozen_ledger_hash.Stable.Latest.t
-    ; target: Frozen_ledger_hash.Stable.Latest.t
+    { source: Frozen_ledger_hash.Stable.V1.t
+    ; target: Frozen_ledger_hash.Stable.V1.t
     ; fee_excess: Currency.Amount.Signed.t }
   [@@deriving bin_io]
 end
@@ -32,10 +32,10 @@ end
 module Statement = struct
   module T = struct
     type t =
-      { source: Coda_base.Frozen_ledger_hash.Stable.Latest.t
-      ; target: Coda_base.Frozen_ledger_hash.Stable.Latest.t
-      ; supply_increase: Currency.Amount.Stable.Latest.t
-      ; fee_excess: Currency.Fee.Signed.Stable.Latest.t
+      { source: Coda_base.Frozen_ledger_hash.Stable.V1.t
+      ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
+      ; supply_increase: Currency.Amount.Stable.V1.t
+      ; fee_excess: Currency.Fee.Signed.Stable.V1.t
       ; proof_type: Proof_type.t }
     [@@deriving sexp, bin_io, hash, compare, eq, fields]
 
@@ -73,12 +73,12 @@ module Statement = struct
 end
 
 type t =
-  { source: Frozen_ledger_hash.Stable.Latest.t
-  ; target: Frozen_ledger_hash.Stable.Latest.t
+  { source: Frozen_ledger_hash.Stable.V1.t
+  ; target: Frozen_ledger_hash.Stable.V1.t
   ; proof_type: Proof_type.t
-  ; supply_increase: Amount.Stable.Latest.t
-  ; fee_excess: Amount.Signed.Stable.Latest.t
-  ; sok_digest: Sok_message.Digest.Stable.Latest.t
+  ; supply_increase: Amount.Stable.V1.t
+  ; fee_excess: Amount.Signed.Stable.V1.t
+  ; sok_digest: Sok_message.Digest.Stable.V1.t
   ; proof: Proof.Stable.V1.t }
 [@@deriving fields, sexp, bin_io]
 

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -8,10 +8,10 @@ end
 
 module Statement : sig
   type t =
-    { source: Coda_base.Frozen_ledger_hash.Stable.Latest.t
-    ; target: Coda_base.Frozen_ledger_hash.Stable.Latest.t
-    ; supply_increase: Currency.Amount.Stable.Latest.t
-    ; fee_excess: Currency.Fee.Signed.Stable.Latest.t
+    { source: Coda_base.Frozen_ledger_hash.Stable.V1.t
+    ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
+    ; supply_increase: Currency.Amount.Stable.V1.t
+    ; fee_excess: Currency.Fee.Signed.Stable.V1.t
     ; proof_type: Proof_type.t }
   [@@deriving sexp, bin_io, hash, compare, eq, fields]
 


### PR DESCRIPTION
When a versioned module refers to types within other versioned modules, those types must belong to a specific version (specifically, not `Latest`). Otherwise, the same-versioned module might produce varying serializations.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
