### PR TITLE
Version blockchain_snark module

### DIFF
--- a/src/lib/blockchain_snark/blockchain.ml
+++ b/src/lib/blockchain_snark/blockchain.ml
@@ -1,6 +1,7 @@
 module State = Blockchain_state
 open Core_kernel
 open Coda_base
+open Module_version
 
 module type S = sig
   type t = {state: Consensus.Protocol_state.value; proof: Proof.Stable.V1.t}
@@ -14,11 +15,29 @@ module Protocol_state = Consensus.Protocol_state
 
 module Stable = struct
   module V1 = struct
-    type t = {state: Protocol_state.value; proof: Proof.Stable.V1.t}
-    [@@deriving bin_io, fields]
+    module T = struct
+      let version = 1
+
+      type t = {state: Protocol_state.value; proof: Proof.Stable.V1.t}
+      [@@deriving bin_io, fields]
+    end
+
+    include T
+    include Registration.Make_latest_version (T)
   end
+
+  module Latest = V1
+
+  module Module_decl = struct
+    let name = "blockchain"
+
+    type latest = Latest.t
+  end
+
+  module Registrar = Registration.Make (Module_decl)
+  module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.V1
+include Stable.Latest
 
 let create ~state ~proof = {state; proof}

--- a/src/lib/blockchain_snark/dune
+++ b/src/lib/blockchain_snark/dune
@@ -4,7 +4,7 @@
  (flags :standard -short-paths -warn-error -32-27-58)
  (library_flags -linkall)
  (libraries core cached cache_dir protocols snarky snark_params coda_base
-   transaction_snark bignum_bigint consensus)
+   transaction_snark bignum_bigint consensus module_version)
  (inline_tests)
  (preprocess
   (pps ppx_snarky ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))


### PR DESCRIPTION
Versioning for `Blockchain_snark` module.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
