### PR TITLE
Record async backtraces for the daemon

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -458,5 +458,7 @@ let () =
   don't_wait_for (ensure_testnet_id_still_good log) ;
   (* Turn on snark debugging in prod for now *)
   Snarky.Snark.set_eval_constraints true ;
+  (* Turn on async backtraces *)
+  Async.Scheduler.set_record_backtraces true ;
   Command.run (Command.group ~summary:"Coda" (coda_commands log)) ;
   Core.exit 0


### PR DESCRIPTION
In order to better diagnose the "dangling reference" error we'll need to see async backtraces. I don't know the performance penalty for recording them, but I suspect we can just bump up the slot time a bit if we see really strange things happening in testnets.