### PR TITLE
Revert "Record async backtraces for the daemon (#1729)"

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -458,7 +458,5 @@ let () =
   don't_wait_for (ensure_testnet_id_still_good log) ;
   (* Turn on snark debugging in prod for now *)
   Snarky.Snark.set_eval_constraints true ;
-  (* Turn on async backtraces *)
-  Async.Scheduler.set_record_backtraces true ;
   Command.run (Command.group ~summary:"Coda" (coda_commands log)) ;
   Core.exit 0


### PR DESCRIPTION
This reverts commit f2085d1f22ee01659a82a23ae3af634b4502dcdd.

It seems as though this could be responsible for flaking fulltest-withsnark. Hopefully we'll figure out how to repro dangling ref assertion locally to better debug it.