### PR TITLE
Move messy logs to trace

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1215,11 +1215,11 @@ let select ~existing ~candidate ~logger =
     let msg = Printf.sprintf "(%s) && (%s)" precondition_msg choice_msg in
     log_result choice msg
   in
-  Logger.info logger "SELECTING BEST CONSENSUS STATE" ;
-  Logger.info logger
+  Logger.info logger "Selecting best consensus state" ;
+  Logger.trace logger
     !"existing consensus state: %{sexp:Consensus_state.value}"
     existing ;
-  Logger.info logger
+  Logger.trace logger
     !"candidate consensus state: %{sexp:Consensus_state.value}"
     candidate ;
   (* TODO: add fork_before_checkpoint check *)

--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -64,7 +64,7 @@ struct
   let apply_and_broadcast t pool_diff =
     match%bind Pool_diff.apply t.pool pool_diff with
     | Ok diff' ->
-        Logger.debug t.log "Broadcasting %s" (Pool_diff.summary diff') ;
+        Logger.trace t.log "Broadcasting %s" (Pool_diff.summary diff') ;
         Linear_pipe.write t.write_broadcasts diff'
     | Error e ->
         Logger.info t.log "Pool diff apply feedback: %s"

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -276,7 +276,7 @@ module Make (Inputs : Inputs_intf) :
           | None -> Interruptible.return (log_bootstrap_mode ())
           | Some frontier -> (
               let crumb = Transition_frontier.best_tip frontier in
-              Logger.info logger
+              Logger.trace logger
                 !"Begining to propose off of crumb %{sexp: Breadcrumb.t}%!"
                 crumb ;
               Core.printf !"%!" ;


### PR DESCRIPTION
From now on, all large sexps within %s's should be relgated to trace calls. In
the future we will print these in a more structured manner.