### PR TITLE
No bin_io for Account.t

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -756,7 +756,7 @@ struct
      and type merkle_path := Ledger.path
      and type query := Sync_ledger.query
      and type answer := Sync_ledger.answer =
-    Syncable_ledger.Make (Ledger.Location.Addr) (Account)
+    Syncable_ledger.Make (Ledger.Location.Addr) (Account.Stable.V1)
       (struct
         include Ledger_hash
 

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -7,6 +7,7 @@ open Let_syntax
 open Currency
 open Snark_bits
 open Fold_lib
+open Module_version
 
 module Index = struct
   include Int
@@ -36,18 +37,18 @@ end
 
 module Nonce = Account_nonce
 
+type ('pk, 'amount, 'nonce, 'receipt_chain_hash) t_ =
+  { public_key: 'pk
+  ; balance: 'amount
+  ; nonce: 'nonce
+  ; receipt_chain_hash: 'receipt_chain_hash
+  ; delegate: 'pk }
+[@@deriving fields, sexp, bin_io, eq, compare, hash]
+
 module Stable = struct
   module V1 = struct
     module T = struct
       let version = 1
-
-      type ('pk, 'amount, 'nonce, 'receipt_chain_hash) t_ =
-        { public_key: 'pk
-        ; balance: 'amount
-        ; nonce: 'nonce
-        ; receipt_chain_hash: 'receipt_chain_hash
-        ; delegate: 'pk }
-      [@@deriving fields, sexp, bin_io, eq, compare, hash]
 
       type key = Public_key.Compressed.Stable.V1.t
       [@@deriving sexp, bin_io, eq, hash, compare]
@@ -62,7 +63,7 @@ module Stable = struct
     end
 
     include T
-    include Module_version.Registration.Make_latest_version (T)
+    include Registration.Make_latest_version (T)
 
     (* monomorphize field selector *)
     let public_key (t : t) : key = t.public_key
@@ -78,11 +79,14 @@ module Stable = struct
     type latest = Latest.t
   end
 
-  module Registrar = Module_version.Registration.Make (Module_decl)
+  module Registrar = Registration.Make (Module_decl)
   module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.Latest
+(* DO NOT ADD bin_io to the list of deriving *)
+type t = Stable.Latest.t [@@deriving sexp, eq, hash, compare]
+
+type key = Stable.Latest.key
 
 type var =
   ( Public_key.Compressed.var

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -36,6 +36,16 @@ module Ledger_inner = struct
     let empty_account = hash_account Account.empty
   end
 
+  module Account = struct
+    type t = Account.Stable.V1.t [@@deriving bin_io, eq, compare, sexp]
+
+    let empty = Account.empty
+
+    let public_key = Account.public_key
+
+    let initialize = Account.initialize
+  end
+
   module Db :
     Merkle_ledger.Database_intf.S
     with module Location = Location_at_depth

--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -1,6 +1,6 @@
 open Core_kernel
 
-include Syncable_ledger.Make (Ledger.Location.Addr) (Account)
+include Syncable_ledger.Make (Ledger.Location.Addr) (Account.Stable.V1)
           (struct
             include Ledger_hash
 
@@ -24,7 +24,10 @@ include Syncable_ledger.Make (Ledger.Location.Addr) (Account)
           end)
 
 type answer =
-  (Ledger.Location.Addr.t, Ledger_hash.t, Account.t) Syncable_ledger.answer
+  ( Ledger.Location.Addr.t
+  , Ledger_hash.t
+  , Account.Stable.V1.t )
+  Syncable_ledger.answer
 [@@deriving bin_io, sexp]
 
 type query = Ledger.Location.Addr.t Syncable_ledger.query

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -238,7 +238,7 @@ end
 module Get_ledger = struct
   type query = Staged_ledger_hash.Stable.Latest.t [@@deriving bin_io]
 
-  type response = Account.t list Or_error.t [@@deriving bin_io]
+  type response = Account.Stable.V1.t list Or_error.t [@@deriving bin_io]
 
   type error = unit [@@deriving bin_io]
 

--- a/src/lib/merkle_ledger_tests/test.ml
+++ b/src/lib/merkle_ledger_tests/test.ml
@@ -37,8 +37,8 @@ let%test_module "Database integration test" =
                            @ List.map acc ~f:(List.cons Direction.Left)
                            @ List.map acc ~f:(List.cons Direction.Right) )
                   in
-                  List.iter accounts
-                    ~f:(fun ({Account.public_key; _} as account) ->
+                  List.iter accounts ~f:(fun account ->
+                      let public_key = Account.public_key account in
                       ignore
                       @@ DB.get_or_create_account_exn db public_key account ;
                       ignore

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -32,7 +32,8 @@ let%test_module "test functor on in memory databases" =
             Quickcheck.test MT.For_tests.gen_account_location
               ~f:(fun location -> assert (MT.get mdb location = None) ) )
 
-      let create_new_account_exn mdb ({Account.public_key; _} as account) =
+      let create_new_account_exn mdb account =
+        let public_key = Account.public_key account in
         let action, location =
           MT.get_or_create_account_exn mdb public_key account
         in
@@ -122,7 +123,8 @@ let%test_module "test functor on in memory databases" =
             in
             let accounts = Quickcheck.random_value accounts_gen in
             Sequence.of_list accounts
-            |> Sequence.iter ~f:(fun ({Account.public_key; _} as account) ->
+            |> Sequence.iter ~f:(fun account ->
+                   let public_key = Account.public_key account in
                    let _, location =
                      MT.get_or_create_account_exn mdb public_key account
                    in

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -78,7 +78,8 @@ let%test_module "Test mask connected to underlying Merkle tree" =
 
       let dummy_account = Quickcheck.random_value Account.gen
 
-      let create_new_account_exn mask ({Account.public_key; _} as account) =
+      let create_new_account_exn mask account =
+        let public_key = Account.public_key account in
         let action, location =
           Mask.Attached.get_or_create_account_exn mask public_key account
         in
@@ -86,8 +87,8 @@ let%test_module "Test mask connected to underlying Merkle tree" =
         | `Existed -> failwith "Expected to allocate a new account"
         | `Added -> location
 
-      let create_existing_account_exn mask ({Account.public_key; _} as account)
-          =
+      let create_existing_account_exn mask account =
+        let public_key = Account.public_key account in
         let action, location =
           Mask.Attached.get_or_create_account_exn mask public_key account
         in
@@ -97,8 +98,8 @@ let%test_module "Test mask connected to underlying Merkle tree" =
             location
         | `Added -> failwith "Expected to re-use an existing account"
 
-      let parent_create_new_account_exn parent
-          ({Account.public_key; _} as account) =
+      let parent_create_new_account_exn parent account =
+        let public_key = Account.public_key account in
         let action, location =
           Maskable.get_or_create_account_exn parent public_key account
         in
@@ -543,7 +544,7 @@ let%test_module "Test mask connected to underlying Merkle tree" =
             (* all accounts in parent to_list *)
             let parent_list = Maskable.to_list maskable in
             let zero_balance account =
-              {account with Account.balance= Balance.zero}
+              Account.update_balance account Balance.zero
             in
             (* put same accounts in mask, but with zero balance *)
             let mask_accounts = List.map parent_accounts ~f:zero_balance in
@@ -589,7 +590,7 @@ let%test_module "Test mask connected to underlying Merkle tree" =
             (* non-zero sum of parent account balances *)
             assert (Int.equal parent_sum 55) (* HT Gauss *) ;
             let zero_balance account =
-              {account with Account.balance= Balance.zero}
+              Account.update_balance account Balance.zero
             in
             (* put same accounts in mask, but with zero balance *)
             let mask_accounts = List.map parent_accounts ~f:zero_balance in

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -1,7 +1,30 @@
 open Core
 open Unsigned
-module Account = Coda_base.Account
 module Balance = Currency.Balance
+
+module Account = struct
+  (* want bin_io, not available with Account.t *)
+  type t = Coda_base.Account.Stable.V1.t
+  [@@deriving bin_io, sexp, eq, compare, hash]
+
+  type key = Coda_base.Account.Stable.V1.key
+  [@@deriving bin_io, sexp, eq, compare, hash]
+
+  (* use Account items needed *)
+  let empty = Coda_base.Account.empty
+
+  let public_key = Coda_base.Account.public_key
+
+  let key_gen = Coda_base.Account.key_gen
+
+  let gen = Coda_base.Account.gen
+
+  let create = Coda_base.Account.create
+
+  let balance = Coda_base.Account.balance
+
+  let update_balance t bal = {t with Coda_base.Account.balance= bal}
+end
 
 (* below are alternative modules that use strings as public keys and UInt64 as balances for
    in accounts

--- a/src/lib/transition_frontier_controller_tests/test_bootstrap_controller.ml
+++ b/src/lib/transition_frontier_controller_tests/test_bootstrap_controller.ml
@@ -9,7 +9,7 @@ end)
 open Stubs
 
 module Root_sync_ledger =
-  Syncable_ledger.Make (Ledger.Db.Addr) (Account)
+  Syncable_ledger.Make (Ledger.Db.Addr) (Account.Stable.V1)
     (struct
       include Ledger_hash
 


### PR DESCRIPTION
`Account.t` should not be used in types with `bin_io`. To prevent that, in `account.ml`, instead of
```
include Stable.Latest
```
we define
```
type t = Stable.Latest.t [@@deriving ...]
```
where the `deriving` list does not include `bin_io`.

In the places in the code where `Account.t` required `bin_io`, we use `Account.Stable.V1` instead. In some places, we construct a Frankenstein `Account` consisting of `Stable.V1.t` plus some functionality from `Account`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
