### PR TITLE
integrate root history into ledger catchup

### DIFF
--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -26,8 +26,8 @@ module Make (Inputs : Inputs.S) :
     |> External_transition.Protocol_state.previous_state_hash
 
   (* We would like the async scheduler to context switch between each iteration 
-  of external transitions when trying to build breadcrumb_path. Therefore, this 
-  function needs to return a Deferred *)
+     of external transitions when trying to build breadcrumb_path. Therefore, this 
+     function needs to return a Deferred *)
   let construct_breadcrumb_path ~logger initial_breadcrumb external_transitions
       =
     let open Deferred.Or_error.Let_syntax in
@@ -64,10 +64,10 @@ module Make (Inputs : Inputs.S) :
     in
     List.rev breadcrumbs
 
-  let materialize_breadcrumbs ~frontier ~logger ~peer
-      peer_child_root_transition external_transitions =
+  let materialize_breadcrumbs ~frontier ~logger ~peer foreign_transition_head
+      foreign_transition_tail =
     let initial_state_hash =
-      With_hash.data peer_child_root_transition
+      With_hash.data foreign_transition_head
       |> External_transition.Verified.protocol_state
       |> External_transition.Protocol_state.previous_state_hash
     in
@@ -83,7 +83,7 @@ module Make (Inputs : Inputs.S) :
         Deferred.return @@ Or_error.error_string message
     | Some initial_breadcrumb ->
         construct_breadcrumb_path ~logger initial_breadcrumb
-          (peer_child_root_transition :: external_transitions)
+          (foreign_transition_head :: foreign_transition_tail)
 
   let verify_transition ~logger ~frontier transition =
     let verified_transition =
@@ -94,10 +94,10 @@ module Make (Inputs : Inputs.S) :
                `Invalid (Error.to_string_hum error) )
       in
       (* We need to coerce the transition from a proof_verified 
-        transition to a fully verified in 
-        order to add the transition to be added to the 
-        transition frontier and to be fed through the 
-        transition_handler_validator. *)
+         transition to a fully verified in 
+         order to add the transition to be added to the 
+         transition frontier and to be fed through the 
+         transition_handler_validator. *)
       let (`I_swear_this_is_safe_see_my_comment verified_transition) =
         External_transition.to_verified transition
       in
@@ -127,6 +127,21 @@ module Make (Inputs : Inputs.S) :
           reason ;
         Error (Error.of_string reason)
 
+  let take_while_map_result_rev ~f list =
+    let open Deferred.Or_error.Let_syntax in
+    let%map result, _ =
+      Deferred.Or_error.List.fold list ~init:([], true)
+        ~f:(fun (acc, should_continue) elem ->
+          let open Deferred.Let_syntax in
+          if not should_continue then Deferred.Or_error.return (acc, false)
+          else
+            match%bind f elem with
+            | Error e -> Deferred.return (Error e)
+            | Ok None -> Deferred.Or_error.return (acc, false)
+            | Ok (Some y) -> Deferred.Or_error.return (y :: acc, true) )
+    in
+    result
+
   let get_transitions_and_compute_breadcrumbs ~logger ~network ~frontier
       ~num_peers hash =
     let peers = Network.random_peers network num_peers in
@@ -140,8 +155,10 @@ module Make (Inputs : Inputs.S) :
                  peer
         | Some queried_transitions ->
             let%bind queried_transitions_verified =
-              Deferred.Or_error.List.filter_map
-                (Non_empty_list.to_list queried_transitions)
+              let rev_queries =
+                Non_empty_list.(to_list @@ rev queried_transitions)
+              in
+              take_while_map_result_rev rev_queries
                 ~f:(verify_transition ~logger ~frontier)
             in
             let%bind head_transition, tail_transitions =

--- a/src/lib/non_empty_list/non_empty_list.ml
+++ b/src/lib/non_empty_list/non_empty_list.ml
@@ -46,3 +46,8 @@ let length = C.length
 let to_list (x, xs) = x :: xs
 
 let append (x, xs) ys = (x, xs @ to_list ys)
+
+let take (x, xs) = function
+  | 0 -> None
+  | 1 -> Some (x, [])
+  | n -> Some (x, List.take xs (n - 1))

--- a/src/lib/non_empty_list/non_empty_list.mli
+++ b/src/lib/non_empty_list/non_empty_list.mli
@@ -49,3 +49,5 @@ val to_list : 'a t -> 'a list
 (** Note: This is O(1) not O(n) like on most container *)
 
 val append : 'a t -> 'a t -> 'a t
+
+val take : 'a t -> int -> 'a t option

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -66,13 +66,20 @@ module Make (Inputs : Inputs_intf) :
     let answer = Sync_ledger.Responder.answer_query responder query in
     (hash, answer)
 
-  let transition_catchup ~frontier hash =
+  let transition_catchup ~frontier state_hash =
     let open Option.Let_syntax in
-    let%bind breadcrumb = Transition_frontier.find frontier hash in
-    Transition_frontier.path_map
-      ~f:(fun b ->
-        Transition_frontier.Breadcrumb.transition_with_hash b
-        |> With_hash.data |> External_transition.of_verified )
-      frontier breadcrumb
-    |> Non_empty_list.of_list_opt
+    let%bind transitions =
+      Transition_frontier.root_history_path_map frontier
+        ~f:(fun b ->
+          Transition_frontier.Breadcrumb.transition_with_hash b
+          |> With_hash.data |> External_transition.of_verified )
+        state_hash
+    in
+    let length =
+      Int.min
+        (Non_empty_list.length transitions)
+        (2 * Transition_frontier.max_length)
+    in
+    Non_empty_list.take (Non_empty_list.rev transitions) length
+    >>| Non_empty_list.rev
 end

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -112,6 +112,31 @@ module Make (Inputs : Inputs_intf) :
       With_hash.data transition_with_hash
       |> Inputs.External_transition.Verified.protocol_state
       |> Consensus.Protocol_state.blockchain_state
+
+    let name t =
+      Visualization.display_short_sexp (module State_hash) @@ state_hash t
+
+    type display =
+      { state_hash: string
+      ; blockchain_state:
+          Inputs.External_transition.Protocol_state.Blockchain_state.display
+      ; consensus_state: Consensus.Consensus_state.display
+      ; parent: string }
+    [@@deriving yojson]
+
+    let display t =
+      let blockchain_state =
+        Inputs.External_transition.Protocol_state.Blockchain_state.display
+          (blockchain_state t)
+      in
+      let consensus_state = consensus_state t in
+      let parent =
+        Visualization.display_short_sexp (module State_hash) @@ parent_hash t
+      in
+      { state_hash= name t
+      ; blockchain_state
+      ; consensus_state= Consensus.Consensus_state.display consensus_state
+      ; parent }
   end
 
   module type Transition_frontier_extension_intf =
@@ -180,20 +205,13 @@ module Make (Inputs : Inputs_intf) :
     let compare node1 node2 =
       Breadcrumb.compare node1.breadcrumb node2.breadcrumb
 
-    let name t =
-      Visualization.display_short_sexp (module State_hash)
-      @@ Breadcrumb.state_hash t.breadcrumb
+    let name t = Breadcrumb.name t.breadcrumb
 
     let display t =
-      let blockchain_state =
-        Breadcrumb.blockchain_state t.breadcrumb
-        |> Inputs.External_transition.Protocol_state.Blockchain_state.display
+      let {Breadcrumb.state_hash; consensus_state; blockchain_state; _} =
+        Breadcrumb.display t.breadcrumb
       in
-      let consensus_state = Breadcrumb.consensus_state t.breadcrumb in
-      { state_hash= name t
-      ; blockchain_state
-      ; length= t.length
-      ; consensus_state= Consensus.Consensus_state.display consensus_state }
+      {state_hash; blockchain_state; length= t.length; consensus_state}
   end
 
   let breadcrumb_of_node {Node.breadcrumb; _} = breadcrumb

--- a/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
+++ b/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
@@ -1,8 +1,9 @@
 open Core
 open Pipe_lib
 open Async
+open Coda_base
 
-let max_length = 8
+let max_length = 4
 
 module Stubs = Stubs.Make (struct
   let max_length = max_length
@@ -28,6 +29,33 @@ end)
 
 let%test_module "Ledger catchup" =
   ( module struct
+    let test_catchup ~logger ~network (me : Transition_frontier.t) transition
+        expected_breadcrumbs =
+      let catchup_job_reader, catchup_job_writer =
+        Pipe_lib.Strict_pipe.create
+          (Buffered (`Capacity 10, `Overflow Drop_head))
+      in
+      let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
+        Strict_pipe.create Synchronous
+      in
+      Strict_pipe.Writer.write catchup_job_writer (With_hash.hash transition) ;
+      Ledger_catchup.run ~logger ~network ~frontier:me
+        ~catchup_breadcrumbs_writer ~catchup_job_reader ;
+      let result_ivar = Ivar.create () in
+      Strict_pipe.Reader.iter catchup_breadcrumbs_reader ~f:(fun rose_tree ->
+          Deferred.return @@ Ivar.fill result_ivar rose_tree )
+      |> don't_wait_for ;
+      let%map catchup_breadcrumbs = Ivar.read result_ivar >>| List.hd_exn in
+      Rose_tree.equal expected_breadcrumbs catchup_breadcrumbs
+        ~f:(fun breadcrumb_tree1 breadcrumb_tree2 ->
+          let to_transition =
+            Transition_frontier.(
+              Fn.compose With_hash.data Breadcrumb.transition_with_hash)
+          in
+          External_transition.Verified.equal
+            (to_transition breadcrumb_tree1)
+            (to_transition breadcrumb_tree2) )
+
     let%test "catchup to a peer" =
       let logger = Logger.create () in
       Thread_safe.block_on_async_exn (fun () ->
@@ -37,40 +65,42 @@ let%test_module "Ledger catchup" =
               ~target_accounts:Genesis_ledger.accounts
               ~num_breadcrumbs:(max_length / 2)
           in
-          let catchup_job_reader, catchup_job_writer =
-            Pipe_lib.Strict_pipe.create
-              (Buffered (`Capacity 10, `Overflow Drop_head))
+          let best_breadcrumb = Transition_frontier.best_tip peer.frontier in
+          let best_transition =
+            Transition_frontier.Breadcrumb.transition_with_hash best_breadcrumb
           in
-          let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-            Strict_pipe.create Synchronous
+          test_catchup ~logger ~network me best_transition
+            ( Transition_frontier.path_map peer.frontier best_breadcrumb
+                ~f:Fn.id
+            |> Rose_tree.of_list_exn ) )
+
+    let%test_unit "peers can provide transitions with length between \
+                   max_length to 2 * max_length" =
+      let logger = Logger.create () in
+      Thread_safe.block_on_async_exn (fun () ->
+          let num_breadcrumbs =
+            Int.gen_incl max_length (2 * max_length) |> Quickcheck.random_value
+          in
+          let%bind me, peer, network =
+            Network_builder.setup_me_and_a_peer ~logger
+              ~source_accounts:Genesis_ledger.accounts
+              ~target_accounts:Genesis_ledger.accounts ~num_breadcrumbs
           in
           let best_breadcrumb = Transition_frontier.best_tip peer.frontier in
           let best_transition =
             Transition_frontier.Breadcrumb.transition_with_hash best_breadcrumb
           in
-          Strict_pipe.Writer.write catchup_job_writer
-            (With_hash.hash best_transition) ;
-          Ledger_catchup.run ~logger ~network ~frontier:me
-            ~catchup_breadcrumbs_writer ~catchup_job_reader ;
-          let expected_breadcrumbs =
-            Transition_frontier.path_map peer.frontier best_breadcrumb ~f:Fn.id
-            |> Rose_tree.of_list_exn
+          Logger.info logger !"Best transition of peer: %{sexp:State_hash.t}"
+          @@ With_hash.hash best_transition ;
+          let history =
+            Transition_frontier.root_history_path_map peer.frontier
+              (With_hash.hash best_transition)
+              ~f:Fn.id
+            |> Option.value_exn
           in
-          let result_ivar = Ivar.create () in
-          Strict_pipe.Reader.iter catchup_breadcrumbs_reader
-            ~f:(fun rose_tree ->
-              Deferred.return @@ Ivar.fill result_ivar rose_tree )
-          |> don't_wait_for ;
-          let%map catchup_breadcrumbs =
-            Ivar.read result_ivar >>| List.hd_exn
+          let%map result =
+            test_catchup ~logger ~network me best_transition
+              (Rose_tree.of_list_exn @@ Non_empty_list.tail history)
           in
-          Rose_tree.equal expected_breadcrumbs catchup_breadcrumbs
-            ~f:(fun breadcrumb_tree1 breadcrumb_tree2 ->
-              let to_transition =
-                Transition_frontier.(
-                  Fn.compose With_hash.data Breadcrumb.transition_with_hash)
-              in
-              External_transition.Verified.equal
-                (to_transition breadcrumb_tree1)
-                (to_transition breadcrumb_tree2) ) )
+          assert result )
   end )

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -90,7 +90,9 @@ module type Network_intf = sig
 end
 
 module type Transition_frontier_Breadcrumb_intf = sig
-  type t [@@deriving sexp, eq]
+  type t [@@deriving sexp, eq, compare]
+
+  type display [@@deriving yojson]
 
   type state_hash
 
@@ -116,6 +118,12 @@ module type Transition_frontier_Breadcrumb_intf = sig
     t -> (external_transition_verified, state_hash) With_hash.t
 
   val staged_ledger : t -> staged_ledger
+
+  val hash : t -> int
+
+  val display : t -> display
+
+  val name : t -> string
 end
 
 module type Transition_frontier_base_intf = sig


### PR DESCRIPTION
I also wrote more code for visualizations to help me debug my tests. Namely, I created a visualization for a list of breadcrumbs and a rose_tree of breadcrumbs.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #1745
