### PR TITLE
No recent blocks check should obey stake semantics

### DIFF
--- a/src/app/cli/src/coda_worker_testnet.ml
+++ b/src/app/cli/src/coda_worker_testnet.ml
@@ -107,7 +107,16 @@ let start_prefix_check log workers events testnet ~acceptable_delay =
      let rec go () =
        let diff = Time.diff (Time.now ()) !last_time in
        let diff = Time.Span.to_sec diff in
-       if not (diff < Time.Span.to_sec acceptable_delay +. epsilon) then (
+       if
+         not
+           ( diff
+           < Time.Span.to_sec acceptable_delay
+             +. epsilon
+             +. Int.to_float
+                  ( (Consensus.Constants.c - 1)
+                  * Consensus.Constants.block_window_duration_ms )
+                /. 1000. )
+       then (
          Logger.fatal log "no recent blocks" ;
          ignore (exit 1) ) ;
        let%bind () = after (Time.Span.of_sec 1.0) in

--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -37,4 +37,6 @@ consensus_mechanism = "proof_of_stake"]
 
 let delta = 1
 
+let c = 1
+
 [%%endif]

--- a/src/lib/consensus/constants.mli
+++ b/src/lib/consensus/constants.mli
@@ -18,9 +18,6 @@ val block_window_duration : Coda_base.Block_time.Span.t
 val delta : int
 (** [delta] is the number of slots in the valid window for receiving blocks over the network *)
 
-[%%if consensus_mechanism = "proof_of_stake"]
-
 val c : int
-(** [c] is the number of slots in which we can probalistically expect at least 1 block *)
-
-[%%endif]
+(** [c] is the number of slots in which we can probalistically expect at least 1
+ * block. In sig, it's exactly 1 as blocks should be produced every slot. *)


### PR DESCRIPTION
In integration tests, we need to make sure to handle the case where
all nodes lose some `i < c` slots in a row. This can and does happen
frequently and comes up specifically when the slot time is pushed a bit
low.

In the "no recent blocks", check we should also wait an extra `c-1`
slots before reporting an error.

Here we're using `c = 1` for sig as sig does expect a block to be
created every slot (and therefore doesn't change the old check).

Checklist:

- [ ] Tests were added for the new behavior
- [x] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
