### PR TITLE
Remove transactions from pool when they're committed to a block

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -298,6 +298,7 @@ module type Main_intf = sig
        and type staged_ledger_diff := Staged_ledger_diff.t
        and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
        and type consensus_local_state := Consensus.Local_state.t
+       and type user_command := User_command.t
   end
 
   module Config : sig
@@ -605,14 +606,15 @@ struct
   end)
 
   module Transaction_pool = struct
-    module Pool = Transaction_pool.Make (User_command)
-    include Network_pool.Make (Pool) (Pool.Diff)
+    module Pool = Transaction_pool.Make (User_command) (Transition_frontier)
+    include Network_pool.Make (Transition_frontier) (Pool) (Pool.Diff)
 
     type pool_diff = Pool.Diff.t [@@deriving bin_io]
 
     (* TODO *)
-    let load ~parent_log ~disk_location:_ ~incoming_diffs =
-      return (create ~parent_log ~incoming_diffs)
+    let load ~parent_log ~disk_location:_ ~incoming_diffs
+        ~frontier_broadcast_pipe =
+      return (create ~parent_log ~incoming_diffs ~frontier_broadcast_pipe)
 
     let transactions t = Pool.transactions (pool t)
 
@@ -711,12 +713,12 @@ struct
             {fee; prover} )
     end
 
-    module Pool = Snark_pool.Make (Proof) (Fee) (Work)
+    module Pool = Snark_pool.Make (Proof) (Fee) (Work) (Transition_frontier)
     module Diff = Network_pool.Snark_pool_diff.Make (Proof) (Fee) (Work) (Pool)
 
     type pool_diff = Diff.t
 
-    include Network_pool.Make (Pool) (Diff)
+    include Network_pool.Make (Transition_frontier) (Pool) (Diff)
 
     let get_completed_work t statement =
       Option.map
@@ -725,10 +727,11 @@ struct
           Transaction_snark_work.Checked.create_unsafe
             {Transaction_snark_work.fee; proofs= proof; prover} )
 
-    let load ~parent_log ~disk_location ~incoming_diffs =
+    let load ~parent_log ~disk_location ~incoming_diffs
+        ~frontier_broadcast_pipe =
       match%map Reader.load_bin_prot disk_location Pool.bin_reader_t with
       | Ok pool -> of_pool_and_diffs pool ~parent_log ~incoming_diffs
-      | Error _e -> create ~parent_log ~incoming_diffs
+      | Error _e -> create ~parent_log ~incoming_diffs ~frontier_broadcast_pipe
 
     open Snark_work_lib.Work
     open Network_pool.Snark_pool_diff

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -17,6 +17,7 @@ module type Inputs_intf = sig
      and type staged_ledger_diff := Staged_ledger_diff.t
      and type staged_ledger := Staged_ledger.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 
   module Root_sync_ledger :
     Syncable_ledger.S

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -135,3 +135,5 @@ let%test_unit "json" =
   )
 
 let check t = Option.some_if (check_signature t) t
+
+let forget_check t = t

--- a/src/lib/coda_base/user_command.mli
+++ b/src/lib/coda_base/user_command.mli
@@ -63,4 +63,7 @@ val sign : Signature_keypair.t -> Payload.t -> With_valid_signature.t
 
 val check : t -> With_valid_signature.t option
 
+val forget_check : With_valid_signature.t -> t
+(** Forget the signature check. *)
+
 val accounts_accessed : t -> Public_key.Compressed.t list

--- a/src/lib/ledger_catchup/inputs.ml
+++ b/src/lib/ledger_catchup/inputs.ml
@@ -15,6 +15,7 @@ module type S = sig
      and type staged_ledger_diff := Staged_ledger_diff.t
      and type staged_ledger := Staged_ledger.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 
   module Transition_handler_validator :
     Transition_handler_validator_intf

--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -5,7 +5,13 @@ open Pipe_lib
 module type Pool_intf = sig
   type t
 
-  val create : parent_log:Logger.t -> t
+  type transition_frontier
+
+  val create :
+       parent_log:Logger.t
+    -> frontier_broadcast_pipe:transition_frontier Option.t
+                               Broadcast_pipe.Reader.t
+    -> t
 end
 
 module type Pool_diff_intf = sig
@@ -25,9 +31,13 @@ module type Network_pool_intf = sig
 
   type pool_diff
 
+  type transition_frontier
+
   val create :
        parent_log:Logger.t
     -> incoming_diffs:pool_diff Envelope.Incoming.t Linear_pipe.Reader.t
+    -> frontier_broadcast_pipe:transition_frontier Option.t
+                               Broadcast_pipe.Reader.t
     -> t
 
   val of_pool_and_diffs :
@@ -44,13 +54,20 @@ module type Network_pool_intf = sig
     t -> pool_diff Envelope.Incoming.t -> unit Deferred.t
 end
 
+module type Transition_frontier_intf = sig
+  type t
+end
+
 module Snark_pool_diff = Snark_pool_diff
 
 module Make
-    (Pool : Pool_intf)
+    (Transition_frontier : Transition_frontier_intf)
+    (Pool : Pool_intf with type transition_frontier := Transition_frontier.t)
     (Pool_diff : Pool_diff_intf with type pool := Pool.t) :
-  Network_pool_intf with type pool := Pool.t and type pool_diff := Pool_diff.t =
-struct
+  Network_pool_intf
+  with type pool := Pool.t
+   and type pool_diff := Pool_diff.t
+   and type transition_frontier := Transition_frontier.t = struct
   type t =
     { pool: Pool.t
     ; log: Logger.t
@@ -80,9 +97,11 @@ struct
     |> ignore ;
     network_pool
 
-  let create ~parent_log ~incoming_diffs =
+  let create ~parent_log ~incoming_diffs ~frontier_broadcast_pipe =
     let log = Logger.child parent_log __MODULE__ in
-    of_pool_and_diffs (Pool.create ~parent_log:log) ~parent_log ~incoming_diffs
+    of_pool_and_diffs
+      (Pool.create ~parent_log:log ~frontier_broadcast_pipe)
+      ~parent_log ~incoming_diffs
 end
 
 let%test_module "network pool test" =
@@ -97,11 +116,17 @@ let%test_module "network pool test" =
       let gen = Int.gen
     end
 
+    module Mock_transition_frontier = struct
+      type t = unit
+    end
+
     module Mock_work = Int
-    module Mock_snark_pool = Snark_pool.Make (Mock_proof) (Mock_work) (Int)
+    module Mock_snark_pool =
+      Snark_pool.Make (Mock_proof) (Mock_work) (Int) (Mock_transition_frontier)
     module Mock_snark_pool_diff =
       Snark_pool_diff.Make (Mock_proof) (Mock_work) (Int) (Mock_snark_pool)
-    module Mock_network_pool = Make (Mock_snark_pool) (Mock_snark_pool_diff)
+    module Mock_network_pool =
+      Make (Mock_transition_frontier) (Mock_snark_pool) (Mock_snark_pool_diff)
 
     let%test_unit "Work that gets fed into apply_and_broadcast will be \
                    recieved in the pool's reader" =
@@ -109,6 +134,7 @@ let%test_module "network pool test" =
       let network_pool =
         Mock_network_pool.create ~parent_log:(Logger.create ())
           ~incoming_diffs:pool_reader
+          ~frontier_broadcast_pipe:(fst @@ Broadcast_pipe.create None)
       in
       let work = 1 in
       let priced_proof = {Mock_snark_pool_diff.proof= 0; fee= 0} in
@@ -140,6 +166,7 @@ let%test_module "network pool test" =
         let network_pool =
           Mock_network_pool.create ~parent_log:(Logger.create ())
             ~incoming_diffs:work_diffs
+            ~frontier_broadcast_pipe:(fst @@ Broadcast_pipe.create None)
         in
         don't_wait_for
         @@ Linear_pipe.iter (Mock_network_pool.broadcasts network_pool)

--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -54,16 +54,13 @@ module type Network_pool_intf = sig
     t -> pool_diff Envelope.Incoming.t -> unit Deferred.t
 end
 
-module type Transition_frontier_intf = sig
-  type t
-end
-
 module Snark_pool_diff = Snark_pool_diff
 
-module Make
-    (Transition_frontier : Transition_frontier_intf)
-    (Pool : Pool_intf with type transition_frontier := Transition_frontier.t)
-    (Pool_diff : Pool_diff_intf with type pool := Pool.t) :
+module Make (Transition_frontier : sig
+  type t
+end)
+(Pool : Pool_intf with type transition_frontier := Transition_frontier.t)
+(Pool_diff : Pool_diff_intf with type pool := Pool.t) :
   Network_pool_intf
   with type pool := Pool.t
    and type pool_diff := Pool_diff.t

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -24,6 +24,7 @@ module type Inputs_intf = sig
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
      and type masked_ledger := Masked_ledger.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 
   module Transaction_pool :
     Coda_lib.Transaction_pool_read_intf

--- a/src/lib/root_prover/root_prover.ml
+++ b/src/lib/root_prover/root_prover.ml
@@ -17,6 +17,7 @@ module type Inputs_intf = sig
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
      and type staged_ledger_diff := Staged_ledger_diff.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 
   module Time : Protocols.Coda_pow.Time_intf
 

--- a/src/lib/snark_pool/snark_pool.mli
+++ b/src/lib/snark_pool/snark_pool.mli
@@ -1,4 +1,5 @@
 open Core_kernel
+open Pipe_lib
 
 module Priced_proof : sig
   type ('proof, 'fee) t = {proof: 'proof; fee: 'fee}
@@ -12,9 +13,15 @@ module type S = sig
 
   type fee
 
+  type transition_frontier
+
   type t [@@deriving bin_io]
 
-  val create : parent_log:Logger.t -> t
+  val create :
+       parent_log:Logger.t
+    -> frontier_broadcast_pipe:transition_frontier Option.t
+                               Broadcast_pipe.Reader.t
+    -> t
 
   val add_snark :
        t
@@ -36,5 +43,11 @@ end) (Work : sig
   type t [@@deriving sexp, bin_io]
 
   include Hashable.S_binable with type t := t
+end) (Transition_frontier : sig
+  type t
 end) :
-  S with type work := Work.t and type proof := Proof.t and type fee := Fee.t
+  S
+  with type work := Work.t
+   and type proof := Proof.t
+   and type fee := Fee.t
+   and type transition_frontier = Transition_frontier.t

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -15,6 +15,7 @@ module type Inputs_intf = sig
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
      and type staged_ledger_diff := Staged_ledger_diff.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 
   module Time : Protocols.Coda_pow.Time_intf
 

--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -1,5 +1,35 @@
 open Core_kernel
-open Async_kernel
+open Async
+open Protocols.Coda_transition_frontier
+open Pipe_lib
+
+module type Transition_frontier_intf = sig
+  type t
+
+  type user_command
+
+  module Breadcrumb : sig
+    type t [@@deriving sexp]
+
+    val equal : t -> t -> bool
+
+    val to_user_commands : t -> user_command list
+  end
+
+  val successors : t -> Breadcrumb.t -> Breadcrumb.t list
+
+  module Extensions : sig
+    module Best_tip_diff : sig
+      type view = Breadcrumb.t Best_tip_diff_view.t Option.t
+    end
+
+    type readers
+
+    val best_tip_diff : readers -> Best_tip_diff.view Broadcast_pipe.Reader.t
+  end
+
+  val extension_pipes : t -> Extensions.readers
+end
 
 (*
  * TODO: Remove could be really slow, we need to deal with this:
@@ -18,7 +48,7 @@ open Async_kernel
  *
  * For now we are removing lazily when we look for the next transactions
  *)
-module Make (Payment : sig
+module Make (User_command : sig
   type t [@@deriving compare, bin_io, sexp]
 
   module With_valid_signature : sig
@@ -28,19 +58,109 @@ module Make (Payment : sig
   end
 
   val check : t -> With_valid_signature.t option
-end) =
+
+  val forget_check : With_valid_signature.t -> t
+end)
+(Transition_frontier : Transition_frontier_intf
+                       with type user_command := User_command.t) =
 struct
+  module Breadcrumb = Transition_frontier.Breadcrumb
+
   type pool =
-    { heap: Payment.With_valid_signature.t Fheap.t
-    ; set: Payment.With_valid_signature.Set.t }
+    { heap: User_command.With_valid_signature.t Fheap.t
+    ; set: User_command.With_valid_signature.Set.t }
 
-  type t = {mutable pool: pool; log: Logger.t}
+  type t =
+    { mutable pool: pool
+    ; log: Logger.t
+    ; mutable diff_reader: unit Deferred.t Option.t }
 
-  let create ~parent_log =
-    { pool=
-        { heap= Fheap.create ~cmp:Payment.With_valid_signature.compare
-        ; set= Payment.With_valid_signature.Set.empty }
-    ; log= Logger.child parent_log __MODULE__ }
+  (* FIXME terrible hack *)
+  let remove_tx t tx =
+    let filter_out_tx =
+      (* The user commands in the breadcrumbs we get *have* been checked for
+         valid signatures, but we don't express that with types yet. *)
+      List.filter ~f:(fun tx' ->
+          User_command.compare tx (User_command.forget_check tx') <> 0 )
+    in
+    t.pool
+    <- { heap=
+           Fheap.to_list t.pool.heap |> filter_out_tx
+           |> Fheap.of_list ~cmp:User_command.With_valid_signature.compare
+       ; set=
+           User_command.With_valid_signature.Set.to_list t.pool.set
+           |> filter_out_tx |> User_command.With_valid_signature.Set.of_list }
+
+  let handle_diff t frontier
+      (diff_opt : Transition_frontier.Extensions.Best_tip_diff.view) =
+    match diff_opt with
+    | None ->
+        Logger.debug t.log "Got empty best tip diff" ;
+        Deferred.unit
+    | Some {old_best_tip; new_best_tip} ->
+        if
+          List.mem
+            (Transition_frontier.successors frontier old_best_tip)
+            new_best_tip ~equal:Breadcrumb.equal
+        then (
+          let new_user_commands = Breadcrumb.to_user_commands new_best_tip in
+          Logger.trace t.log
+            !"Diff: old: %{sexp:User_command.t list} new: \
+              %{sexp:User_command.t list}"
+            (Breadcrumb.to_user_commands old_best_tip)
+            new_user_commands ;
+          List.iter new_user_commands ~f:(fun tx -> remove_tx t tx) ;
+          printf !"removed txs\n%!" )
+        else
+          Logger.warn t.log
+            "Got a new best tip breadcrumb that wasn't a direct descendant of \
+             the old best tip. Handling this case is unimplemented." ;
+        Logger.trace t.log
+          !"Current transaction pool: \
+            %{sexp:User_command.With_valid_signature.t list}"
+          (Fheap.to_list t.pool.heap) ;
+        Deferred.unit
+
+  let create ~parent_log ~frontier_broadcast_pipe =
+    let t =
+      { pool=
+          { heap= Fheap.create ~cmp:User_command.With_valid_signature.compare
+          ; set= User_command.With_valid_signature.Set.empty }
+      ; log= Logger.child parent_log __MODULE__
+      ; diff_reader= None }
+    in
+    don't_wait_for
+      ( fst
+      @@ Broadcast_pipe.Reader.iter frontier_broadcast_pipe
+           ~f:(fun frontier_opt ->
+             match frontier_opt with
+             | None -> (
+                 Logger.debug t.log "no frontier" ;
+                 (* Sanity check: the view pipe should have been closed before
+                    the frontier was destroyed. *)
+                 match t.diff_reader with
+                 | None -> Deferred.unit
+                 | Some hdl ->
+                     Deferred.any_unit
+                       [ (let%map () = hdl in
+                          t.diff_reader <- None)
+                       ; (let%map () = Async.after (Time.Span.of_sec 5.) in
+                          Logger.fatal t.log
+                            "Transition frontier closed without first closing \
+                             best tip view pipe" ;
+                          assert false) ] )
+             | Some frontier ->
+                 Logger.debug t.log "Got frontier!\n" ;
+                 (* TODO check current pool contents are valid against best tip here *)
+                 t.diff_reader
+                 <- Some
+                      ( fst
+                      @@ Broadcast_pipe.Reader.iter
+                           ( Transition_frontier.extension_pipes frontier
+                           |> Transition_frontier.Extensions.best_tip_diff )
+                           ~f:(handle_diff t frontier) ) ;
+                 Deferred.unit ) ) ;
+    t
 
   let add' pool txn = {heap= Fheap.add pool.heap txn; set= Set.add pool.set txn}
 
@@ -49,18 +169,17 @@ struct
   let transactions t = Sequence.unfold ~init:t.pool.heap ~f:Fheap.pop
 
   module Diff = struct
-    type t = Payment.t list [@@deriving bin_io, sexp]
+    type t = User_command.t list [@@deriving bin_io, sexp]
 
     let summary t =
       Printf.sprintf "Transaction diff of length %d" (List.length t)
 
-    (* TODO: Check signatures *)
     let apply t env =
       let txns = Envelope.Incoming.data env in
       let pool0 = t.pool in
       let pool', res =
         List.fold txns ~init:(pool0, []) ~f:(fun (pool, acc) txn ->
-            match Payment.check txn with
+            match User_command.check txn with
             | None ->
                 Logger.faulty_peer t.log
                   !"Transaction doesn't check %{sexp: Network_peer.Peer.t}"
@@ -69,16 +188,17 @@ struct
             | Some txn ->
                 if Set.mem pool.set txn then (
                   Logger.debug t.log
-                    !"Skipping txn %{sexp: Payment.With_valid_signature.t} \
-                      because I've already seen it"
+                    !"Skipping txn %{sexp: \
+                      User_command.With_valid_signature.t} because I've \
+                      already seen it"
                     txn ;
                   (pool, acc) )
                 else (
                   Logger.debug t.log
-                    !"Adding %{sexp: Payment.With_valid_signature.t} to my \
-                      pool locally, and scheduling for rebroadcast"
+                    !"Adding %{sexp: User_command.With_valid_signature.t} to \
+                      my pool locally, and scheduling for rebroadcast"
                     txn ;
-                  (add' pool txn, (txn :> Payment.t) :: acc) ) )
+                  (add' pool txn, (txn :> User_command.t) :: acc) ) )
       in
       t.pool <- pool' ;
       match res with
@@ -89,3 +209,98 @@ struct
   (* TODO: Actually back this by the file-system *)
   let load ~disk_location:_ ~parent_log = return (create ~parent_log)
 end
+
+let%test_module _ =
+  ( module struct
+    module Mock_transition_frontier = struct
+      module Breadcrumb = struct
+        type t = {successors: t list; commands: int list} [@@deriving sexp]
+
+        let equal b1 b2 = b1 = b2
+
+        let to_user_commands {commands; _} = commands
+      end
+
+      type t =
+        Breadcrumb.t Best_tip_diff_view.t Option.t Broadcast_pipe.Reader.t
+
+      let successors _ ({successors; _} : Breadcrumb.t) = successors
+
+      module Extensions = struct
+        module Best_tip_diff = struct
+          type view = Breadcrumb.t Best_tip_diff_view.t Option.t
+        end
+
+        type readers = Best_tip_diff.view Broadcast_pipe.Reader.t
+
+        let best_tip_diff = Fn.id
+      end
+
+      let extension_pipes pipe = pipe
+
+      let create () :
+          t
+          * Breadcrumb.t Best_tip_diff_view.t Option.t Broadcast_pipe.Writer.t
+          =
+        Broadcast_pipe.create None
+    end
+
+    module Test =
+      Make (struct
+          include Int
+          module With_valid_signature = Int
+
+          let check = Option.some
+
+          let forget_check = Fn.id
+        end)
+        (Mock_transition_frontier)
+
+    (* This test is broken because of #1748, fix it and uncomment when that's
+       done. *)
+    (*   (\* We only test the transaction removal logic here, since this whole
+   *      module needs rewriting, it doesn't make sense to test it all. *\)
+   *   let%test _ =
+   *     Thread_safe.block_on_async_exn (fun () ->
+   *         let tf, best_tip_diff_w = Mock_transition_frontier.create () in
+   *         let tf_pipe_r, tf_pipe_w = Broadcast_pipe.create @@ Some tf in
+   *         let pool =
+   *           Test.create ~parent_log:(Logger.create ())
+   *             ~frontier_broadcast_pipe:tf_pipe_r
+   *         in
+   *         let%bind () = after @@ Time.Span.of_sec 1. in
+   *         let assert_pool_txs txs =
+   *           [%test_eq: int Sequence.t] (Test.transactions pool)
+   *           @@ Sequence.of_list txs
+   *         in
+   *         assert_pool_txs [] ;
+   *         let txs = [0; 1; 2; 3] in
+   *         List.iter ~f:(Test.add pool) txs ;
+   *         assert_pool_txs txs ;
+   *         let second_bc : Test.Breadcrumb.t =
+   *           {successors= []; commands= [2]}
+   *         in
+   *         let first_bc : Test.Breadcrumb.t =
+   *           {successors= [second_bc]; commands= []}
+   *         in
+   *         (\* printf "%B\n"
+   *          *   (List.mem
+   *          *      (Mock_transition_frontier.successors tf first_bc)
+   *          *      second_bc ~equal:Mock_transition_frontier.Breadcrumb.equal) ; *\)
+   *         printf !"first write\n%!" ;
+   *         let%bind () =
+   *           Broadcast_pipe.Writer.write best_tip_diff_w
+   *             (Some {new_best_tip= first_bc; old_best_tip= first_bc})
+   *         in
+   *         assert_pool_txs txs ;
+   *         printf !"second write\n%!" ;
+   *         let%bind () =
+   *           Broadcast_pipe.Writer.write best_tip_diff_w
+   *             (Some {new_best_tip= second_bc; old_best_tip= first_bc})
+   *         in
+   *         (\* let%bind () = after (Time.Span.of_sec 2.) in *\)
+   *         printf !"about to assert\n%!" ;
+   *         assert_pool_txs [0; 1; 3] ;
+   *         Deferred.return true )
+  *)
+  end )

--- a/src/lib/transition_frontier/best_tip_diff.ml
+++ b/src/lib/transition_frontier/best_tip_diff.ml
@@ -1,0 +1,33 @@
+(** A transition frontier extension that exposes the changes in the best tip. *)
+
+open Core
+open Protocols.Coda_transition_frontier
+
+module Make (Breadcrumb : sig
+  type t
+end) :
+  Transition_frontier_extension_intf0
+  with type transition_frontier_breadcrumb := Breadcrumb.t
+   and type input = unit
+   and type view = Breadcrumb.t Best_tip_diff_view.t Option.t = struct
+  type t = unit
+
+  type input = unit
+
+  type view = Breadcrumb.t Best_tip_diff_view.t Option.t
+
+  let create () = ()
+
+  let initial_view = None
+
+  (* View is only None when there haven't been any diffs yet. This is sort of an
+     unfortunate hack. *)
+  let handle_diff () diff : Breadcrumb.t Best_tip_diff_view.t Option.t Option.t
+      =
+    Some
+      (let open Transition_frontier_diff in
+      match diff with
+      | New_breadcrumb _ -> None (* We only care about the best tip *)
+      | New_best_tip {new_best_tip; old_best_tip; _} ->
+          Some {new_best_tip; old_best_tip})
+end

--- a/src/lib/transition_frontier/snark_pool_refcount.ml
+++ b/src/lib/transition_frontier/snark_pool_refcount.ml
@@ -10,6 +10,7 @@ module type Inputs_intf = sig
     with type state_hash := State_hash.t
      and type external_transition_verified := External_transition.Verified.t
      and type staged_ledger := Staged_ledger.t
+     and type user_command := User_command.t
 end
 
 module Make (Inputs : Inputs_intf) :

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -322,7 +322,6 @@ module Make (Inputs : Inputs_intf) :
         ; extension_readers
         ; extension_writers }
 
-  (* TODO call this when bootstrapping starts and frontier is destroyed! *)
   let close {extension_writers; _} = Extensions.close_pipes extension_writers
 
   let max_length = Inputs.max_length

--- a/src/lib/transition_handler/inputs.ml
+++ b/src/lib/transition_handler/inputs.ml
@@ -21,4 +21,5 @@ module type S = sig
      and type staged_ledger_diff := Staged_ledger_diff.t
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 end

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -24,6 +24,7 @@ module type Inputs_intf = sig
      and type staged_ledger_diff := Staged_ledger_diff.t
      and type masked_ledger := Coda_base.Ledger.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 
   module Protocol_state_validator :
     Protocol_state_validator_intf

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -20,6 +20,7 @@ module type Inputs_intf = sig
      and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
      and type masked_ledger := Coda_base.Ledger.t
      and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
 
   module Network :
     Network_intf
@@ -200,6 +201,7 @@ module Make (Inputs : Inputs_intf) :
               don't_wait_for
                 (Broadcast_pipe.Writer.write frontier_w (Some frontier))
           | `Bootstrap_controller (_, _) ->
+              Transition_frontier.close (peek_exn frontier_r) ;
               don't_wait_for (Broadcast_pipe.Writer.write frontier_w None))
     in
     let ( valid_protocol_state_transition_reader


### PR DESCRIPTION
Remove transactions from the pool when we see a new best tip that contains them. This is a hacky solution to unblock running longer PoS tests with transactions. There are a few things wrong with it: removing transactions is super inefficient, we don't handle backtracking in external transitions, and we don't do anything special when bootstrapping is engaged. See also #1734.

Tested at the command line by running a proposer and submitting transactions, then watching the log to verify they're dropped. There's a commented out automated test that is broken because of #1748.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: