### PR TITLE
Set up a Nix cache for the Mac builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,6 @@ jobs:
                   keys:
                       - opam-v1-{{ checksum "src/opam.export" }}
                       - opam-v1-
-            - restore_cache:
-                  keys:
-                      - nix-v3-{{ checksum "src/app/kademlia-haskell/packages.nix" }}
-                      - nix-v3-
-                      - nix-v2-
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Deps -- make macos-setup-download
@@ -68,10 +63,6 @@ jobs:
                   key: opam-v1-{{ checksum "src/opam.export" }}
                   paths:
                       - "/Users/distiller/.opam"
-            - save_cache:
-                  key: nix-v3-{{ checksum "src/app/kademlia-haskell/packages.nix" }}
-                  paths:
-                      - "/nix"
             - run:
                   name: Build OCaml
                   command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -47,11 +47,6 @@ jobs:
                   keys:
                       - opam-v1-{{'{{'}} checksum "src/opam.export" {{'}}'}}
                       - opam-v1-
-            - restore_cache:
-                  keys:
-                      - nix-v3-{{'{{'}} checksum "src/app/kademlia-haskell/packages.nix" {{'}}'}}
-                      - nix-v3-
-                      - nix-v2-
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Download Deps -- make macos-setup-download
@@ -68,10 +63,6 @@ jobs:
                   key: opam-v1-{{'{{'}} checksum "src/opam.export" {{'}}'}}
                   paths:
                       - "/Users/distiller/.opam"
-            - save_cache:
-                  key: nix-v3-{{'{{'}} checksum "src/app/kademlia-haskell/packages.nix" {{'}}'}}
-                  paths:
-                      - "/nix"
             - run:
                   name: Build OCaml
                   command: eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -78,6 +78,9 @@ EOF
   make kademlia
   if [[ "$CIRCLE_BUILD_NUM" ]]; then
       nix copy --to s3://o1-nix-cache src/app/kademlia-haskell/result/
+      # Incantation to copy build dependencies. We instantiate the nix
+      # expression to a derivation, get a list of the derivations it references,
+      # and copy the outputs of those derivations to our cache.
       nix copy --to s3://o1-nix-cache $(nix-store -r $(nix-store -q --references $(nix-instantiate src/app/kademlia-haskell/release2.nix)))
   fi
   set -u

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -67,6 +67,7 @@ if [[ $COMPILE_THINGS == "YES" ]]; then
   set +u
   . ~/.nix-profile/etc/profile.d/nix.sh
   if [[ "$CIRCLE_BUILD_NUM" ]]; then
+      mkdir -p ~/.config/nix
       cat > ~/.config/nix/nix.conf <<EOF
 substituters = https://cache.nixos.org s3://o1-nix-cache
 # Checking signatures is broken with S3 based Nix caches, see

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -80,7 +80,7 @@ EOF
   building_kad=$?
   set -e
   make kademlia
-  if [[ "$CIRCLE_BUILD_NUM" && [[ "$building_kad" = 0 ]]]]; then
+  if [[ "$CIRCLE_BUILD_NUM" && "$building_kad" = 0 ]]; then
       nix copy --to s3://o1-nix-cache src/app/kademlia-haskell/result/
       # Incantation to copy build dependencies. We instantiate the nix
       # expression to a derivation, get a list of the derivations it references,

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -66,8 +66,7 @@ if [[ $COMPILE_THINGS == "YES" ]]; then
   touch ~/.profile
   set +u
   . ~/.nix-profile/etc/profile.d/nix.sh
-  set -u
-  if [[ "$CIRCLECI_BUILD_NUM" ]]; then
+  if [[ "$CIRCLE_BUILD_NUM" ]]; then
       cat > ~/.config/nix/nix.conf <<EOF
 substituters = https://cache.nixos.org s3://o1-nix-cache
 # Checking signatures is broken with S3 based Nix caches, see
@@ -76,10 +75,11 @@ require-sigs = false
 EOF
   fi
   make kademlia
-  if [[ "$CIRCLECI_BUILD_NUM" ]]; then
+  if [[ "$CIRCLE_BUILD_NUM" ]]; then
       nix copy --to s3://o1-nix-cache src/app/kademlia-haskell/result/
       nix copy --to s3://o1-nix-cache $(nix-store -r $(nix-store -q --references $(nix-instantiate src/app/kademlia-haskell/release2.nix)))
   fi
+  set -u
 else
   echo 'Not running compile step.'
 fi

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -75,8 +75,12 @@ substituters = https://cache.nixos.org s3://o1-nix-cache
 require-sigs = false
 EOF
   fi
+  set +e
+  nix-build --dry-run src/app/kademlia-haskell/release2.nix 2>&1 | grep -q 'these derivations will be built'
+  building_kad=$?
+  set -e
   make kademlia
-  if [[ "$CIRCLE_BUILD_NUM" ]]; then
+  if [[ "$CIRCLE_BUILD_NUM" && [[ "$building_kad" = 0 ]]]]; then
       nix copy --to s3://o1-nix-cache src/app/kademlia-haskell/result/
       # Incantation to copy build dependencies. We instantiate the nix
       # expression to a derivation, get a list of the derivations it references,

--- a/src/app/kademlia-haskell/README.md
+++ b/src/app/kademlia-haskell/README.md
@@ -1,2 +1,1 @@
 # kademlia-haskell
-rebuild pls

--- a/src/app/kademlia-haskell/README.md
+++ b/src/app/kademlia-haskell/README.md
@@ -1,1 +1,2 @@
 # kademlia-haskell
+rebuild pls

--- a/src/app/kademlia-haskell/README.md
+++ b/src/app/kademlia-haskell/README.md
@@ -1,1 +1,1 @@
-# kademlia-haskell
+rasientoaiersntoinei# kademlia-haskell

--- a/src/app/kademlia-haskell/README.md
+++ b/src/app/kademlia-haskell/README.md
@@ -1,1 +1,1 @@
-rasientoaiersntoinei# kademlia-haskell
+# kademlia-haskell


### PR DESCRIPTION
Set up a Nix binary cache on S3. Mac build times go from 1h01m to 19m, and the cache won't become broken every time nixpkgs changes. The new paths will be built and added to S3, and future builds will be fast.

We can start using Nix for getting Kademlia on Linux too, rather than having the docker images + .deb packages, but that's a problem for another day.

Tested by running the build, changing something, seeing that it cached the dependencies, then running it again after changing nothing and seeing it cached the whole thing.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
