### PR TITLE
fix the "empty epoch bug"

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1326,7 +1326,7 @@ let next_proposal now (state : Consensus_state.value) ~local_state ~keypair
        * transitions), use the last epoch data.
       *)
       if
-        (Epoch.equal epoch state.curr_epoch)
+        Epoch.equal epoch state.curr_epoch
         || Length.equal state.epoch_length Length.zero
       then state.last_epoch_data
         (* If we are in the next epoch, use the current epoch data. *)

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -596,26 +596,15 @@ module Vrf = struct
         ; delegator= 0 }
   end
 
-  let check ~local_state ~epoch ~slot ~seed ~private_key ~total_stake
-      ~ledger_hash ~logger =
+  let check ~epoch ~slot ~seed ~private_key ~total_stake ~logger
+      ~epoch_snapshot =
     let open Message in
     let open Local_state in
     let open Snapshot in
     let open Option.Let_syntax in
-    let%bind epoch_snapshot =
-      let snapshot =
-        if Coda_base.Frozen_ledger_hash.equal ledger_hash genesis_ledger_hash
-        then Some local_state.Local_state.genesis_epoch_snapshot
-        else local_state.Local_state.last_epoch_snapshot
-      in
-      if snapshot = None then
-        Logger.info logger
-          "Unable to check vrf evaluation: last_epoch_ledger does not exist \
-           in local state" ;
-      snapshot
-    in
     Logger.info logger "Checking vrf evaluations at %d:%d" (Epoch.to_int epoch)
       (Epoch.Slot.to_int slot) ;
+    let%bind epoch_snapshot = epoch_snapshot in
     with_return (fun {return} ->
         Hashtbl.iteri epoch_snapshot.delegators
           ~f:(fun ~key:delegator ~data:balance ->
@@ -1005,6 +994,7 @@ module Consensus_state = struct
         ~epoch_ledger:last_data.ledger ~epoch:transition_data.epoch
         ~slot:transition_data.slot ~seed:last_data.seed
     in
+    let%bind new_total_currency = Currency.Amount.Checked.add previous_state.total_currency supply_increase in
     let%bind curr_data =
       let%map seed =
         let%bind in_seed_update_range =
@@ -1029,7 +1019,7 @@ module Consensus_state = struct
       and ledger =
         Epoch_ledger.if_ epoch_increased
           ~then_:
-            { total_currency= previous_state.total_currency
+            { total_currency= new_total_currency
             ; hash= previous_blockchain_state_ledger_hash }
           ~else_:previous_state.curr_epoch_data.ledger
       and start_checkpoint =
@@ -1316,6 +1306,7 @@ let next_proposal now (state : Consensus_state.value) ~local_state ~keypair
     (Int64.to_int now) (Epoch.to_int epoch) (Epoch.Slot.to_int slot)
     ( Int64.to_int @@ Time.Span.to_ms @@ Time.to_span_since_epoch
     @@ Epoch.start_time epoch ) ;
+  let epoch_transitioning = Epoch.equal epoch (Epoch.succ state.curr_epoch) in
   let next_slot =
     (* When we first enter an epoch, the protocol state may still be a previous
      * epoch. If that is the case, we need to select the staged vrf inputs
@@ -1333,11 +1324,11 @@ let next_proposal now (state : Consensus_state.value) ~local_state ~keypair
        * transitions), use the last epoch data.
       *)
       if
-        Epoch.equal epoch state.curr_epoch
-        || Length.equal state.epoch_length Length.zero
+        (not epoch_transitioning)
+        || Length.equal state.epoch_length Length.zero (* ??? *)
       then state.last_epoch_data
         (* If we are in the next epoch, use the current epoch data. *)
-      else if Epoch.equal epoch (Epoch.succ state.curr_epoch) then
+      else if epoch_transitioning then
         state.curr_epoch_data
         (* If the epoch we are in is none of the above, something is wrong. *)
       else (
@@ -1346,10 +1337,32 @@ let next_proposal now (state : Consensus_state.value) ~local_state ~keypair
         failwith "System time is out of sync. (hint: setup NTP if you haven't)" )
     in
     let total_stake = epoch_data.ledger.total_currency in
+    let epoch_snapshot =
+      let source, snapshot =
+        if
+          Coda_base.Frozen_ledger_hash.equal epoch_data.ledger.hash
+            genesis_ledger_hash
+        then ("genesis", Some local_state.Local_state.genesis_epoch_snapshot)
+        else if epoch_transitioning || state.curr_epoch_data.length <= Length.of_int Constants.k then
+          ("curr", local_state.curr_epoch_snapshot)
+        else ("last", local_state.Local_state.last_epoch_snapshot)
+      in
+      ( match snapshot with
+      | None ->
+          Logger.info logger
+            "Unable to check vrf evaluation: %s_epoch_ledger does not exist \
+             in local state"
+            source
+      | Some snapshot ->
+          Logger.info logger
+            !"using %s_epoch_snapshot root hash %{sexp:Coda_base.Ledger_hash.t}"
+            source
+            (Coda_base.Sparse_ledger.merkle_root snapshot.ledger) ) ;
+      snapshot
+    in
     let proposal_data slot =
-      Vrf.check ~epoch ~slot ~seed:epoch_data.seed ~local_state
-        ~private_key:keypair.private_key ~total_stake
-        ~ledger_hash:epoch_data.ledger.hash ~logger
+      Vrf.check ~epoch ~slot ~seed:epoch_data.seed ~epoch_snapshot
+        ~private_key:keypair.private_key ~total_stake ~logger
     in
     let rec find_winning_slot slot =
       if UInt32.of_int (Epoch.Slot.to_int slot) >= Constants.Epoch.size then

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -994,7 +994,9 @@ module Consensus_state = struct
         ~epoch_ledger:last_data.ledger ~epoch:transition_data.epoch
         ~slot:transition_data.slot ~seed:last_data.seed
     in
-    let%bind new_total_currency = Currency.Amount.Checked.add previous_state.total_currency supply_increase in
+    let%bind new_total_currency =
+      Currency.Amount.Checked.add previous_state.total_currency supply_increase
+    in
     let%bind curr_data =
       let%map seed =
         let%bind in_seed_update_range =
@@ -1325,11 +1327,11 @@ let next_proposal now (state : Consensus_state.value) ~local_state ~keypair
       *)
       if
         (not epoch_transitioning)
-        || Length.equal state.epoch_length Length.zero (* ??? *)
+        || Length.equal state.epoch_length Length.zero
+        (* ??? *)
       then state.last_epoch_data
         (* If we are in the next epoch, use the current epoch data. *)
-      else if epoch_transitioning then
-        state.curr_epoch_data
+      else if epoch_transitioning then state.curr_epoch_data
         (* If the epoch we are in is none of the above, something is wrong. *)
       else (
         Logger.error logger
@@ -1343,8 +1345,10 @@ let next_proposal now (state : Consensus_state.value) ~local_state ~keypair
           Coda_base.Frozen_ledger_hash.equal epoch_data.ledger.hash
             genesis_ledger_hash
         then ("genesis", Some local_state.Local_state.genesis_epoch_snapshot)
-        else if epoch_transitioning || state.curr_epoch_data.length <= Length.of_int Constants.k then
-          ("curr", local_state.curr_epoch_snapshot)
+        else if
+          epoch_transitioning
+          || state.curr_epoch_data.length <= Length.of_int Constants.k
+        then ("curr", local_state.curr_epoch_snapshot)
         else ("last", local_state.Local_state.last_epoch_snapshot)
       in
       ( match snapshot with

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1326,9 +1326,8 @@ let next_proposal now (state : Consensus_state.value) ~local_state ~keypair
        * transitions), use the last epoch data.
       *)
       if
-        (not epoch_transitioning)
+        (Epoch.equal epoch state.curr_epoch)
         || Length.equal state.epoch_length Length.zero
-        (* ??? *)
       then state.last_epoch_data
         (* If we are in the next epoch, use the current epoch data. *)
       else if epoch_transitioning then state.curr_epoch_data

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -229,11 +229,8 @@ module Make (Inputs : Inputs_intf) :
                   ( Staged_ledger_diff.With_valid_signatures_and_proofs
                     .user_commands diff
                     :> User_command.t list )
-                ~snarked_ledger_hash:
-                  (Option.value_map ledger_proof_opt
-                     ~default:previous_ledger_hash ~f:(fun (proof, _) ->
-                       Ledger_proof.(statement proof |> statement_target) ))
-                ~supply_increase ~logger ) )
+                ~snarked_ledger_hash:previous_ledger_hash ~supply_increase
+                ~logger ) )
     in
     lift_sync (fun () ->
         measure "making Snark and Internal transitions" (fun () ->

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -679,17 +679,6 @@ module Make (Inputs : Inputs_intf) :
                 , heir_node.breadcrumb.just_emitted_a_proof )
               with
             | Some txns, true ->
-                (* r.other_tree_data |> last == r' |> proof_txns *)
-                [%test_result: Transaction.t list]
-                  ~equal:(List.equal ~equal:Transaction.equal)
-                  ~message:
-                    "last other trees data in old root is not proof txns in \
-                     new root"
-                  ~expect:
-                    ( root_staged_ledger
-                    |> Inputs.Staged_ledger.other_trees_data |> List.last_exn
-                    |> List.rev )
-                  (txns |> Non_empty_list.to_list) ;
                 let proof_data =
                   Inputs.Staged_ledger.current_ledger_proof
                     new_root_staged_ledger

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -695,8 +695,6 @@ module Make (Inputs : Inputs_intf) :
                 Non_empty_list.iter txns ~f:(fun txn ->
                     (* TODO: @cmr use the ignore-hash ledger here as well *)
                     TL.apply_transaction t.root_snarked_ledger txn
-                    |> Or_error.ok_exn |> ignore ;
-                    Ledger.apply_transaction db_mask txn
                     |> Or_error.ok_exn |> ignore ) ;
                 (* TODO: See issue #1606 to make this faster *)
                 

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -24,6 +24,20 @@ module Make (Inputs : Inputs_intf) :
 
   exception Already_exists of State_hash.t
 
+  module Fake_db = struct
+    include Coda_base.Ledger.Db
+    type location = Location.t
+    let get_or_create ledger key =
+      let key, loc =
+        match get_or_create_account_exn ledger key (Account.initialize key) with
+        | `Existed, loc -> ([], loc)
+        | `Added, loc -> ([key], loc)
+      in
+      (key, get ledger loc |> Option.value_exn, loc)
+  end
+
+  module TL = Coda_base.Transaction_logic.Make(Fake_db)
+
   module Breadcrumb = struct
     (* TODO: external_transition should be type : External_transition.With_valid_protocol_state.t #1344 *)
     type t =
@@ -661,6 +675,12 @@ module Make (Inputs : Inputs_intf) :
                 , heir_node.breadcrumb.just_emitted_a_proof )
               with
             | Some txns, true ->
+                (* r.other_tree_data |> last == r' |> proof_txns *)
+                [%test_result: Transaction.t list]
+                  ~equal:(List.equal ~equal:Transaction.equal)
+                  ~message:"last other trees data in old root is not proof txns in new root"
+                  ~expect:(root_staged_ledger |> Inputs.Staged_ledger.other_trees_data |> List.last_exn |> List.rev)
+                  (txns |> Non_empty_list.to_list) ;
                 let proof_data =
                   Inputs.Staged_ledger.current_ledger_proof
                     new_root_staged_ledger
@@ -673,13 +693,18 @@ module Make (Inputs : Inputs_intf) :
                   ~expect:(Inputs.Ledger_proof.statement proof_data).source
                   ( Ledger.Db.merkle_root t.root_snarked_ledger
                   |> Frozen_ledger_hash.of_ledger_hash ) ;
+
                 let db_mask = Ledger.of_database t.root_snarked_ledger in
+
                 Non_empty_list.iter txns ~f:(fun txn ->
                     (* TODO: @cmr use the ignore-hash ledger here as well *)
+                    TL.apply_transaction t.root_snarked_ledger txn |> Or_error.ok_exn |> ignore;
                     Ledger.apply_transaction db_mask txn
                     |> Or_error.ok_exn |> ignore ) ;
                 (* TODO: See issue #1606 to make this faster *)
-                Ledger.commit db_mask ;
+
+
+                (*Ledger.commit db_mask ;*)
                 ignore
                   (Ledger.Maskable.unregister_mask_exn
                      (Ledger.Any_ledger.cast


### PR DESCRIPTION
This one is potentially-mergeable but note that it is very inefficient with updating the db.

1. supply_increase was accidentally ignored on (some?) epoch boundaries.
2. a bug with epoch snapshot selection in the first `k` blocks of an epoch. 
3. something undiagnosed that makes the `db_mask` we used to construct have the wrong merkle root the second time we go to update the db. i'll resume investigating this in the morning.
4. wrong snarked ledger hash in blockchain state