### PR TITLE
No bin_io in blocktime

### DIFF
--- a/src/lib/coda_base/block_time.ml
+++ b/src/lib/coda_base/block_time.ml
@@ -39,7 +39,8 @@ module Controller = struct
   let create () = ()
 end
 
-include Stable.Latest
+(* DO NOT add bin_io the deriving list *)
+type t = Stable.Latest.t [@@deriving sexp, compare, eq, hash]
 
 type t0 = t
 


### PR DESCRIPTION
No `bin_io` for `Block_time.t`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
