### PR TITLE
Remove bin_io for Coinbase.t

### DIFF
--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -30,6 +30,9 @@ module Stable = struct
                 let to_binable t = t
 
                 let of_binable t =
+                  (* TODO: maliciously invalid data will halt the node
+                     should this be just logged?
+                  *)
                   assert (is_valid t) ;
                   t
               end)

--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -15,6 +15,24 @@ module Stable = struct
 
     include T
     include Module_version.Registration.Make_latest_version (T)
+
+    let is_valid {proposer= _; amount; fee_transfer} =
+      match fee_transfer with
+      | None -> true
+      | Some (_, fee) -> Currency.Amount.(of_fee fee <= amount)
+
+    (* check validity when deserializing *)
+    include Binable.Of_binable
+              (T)
+              (struct
+                type nonrec t = t
+
+                let to_binable t = t
+
+                let of_binable t =
+                  assert (is_valid t) ;
+                  t
+              end)
   end
 
   module Latest = V1
@@ -29,24 +47,14 @@ module Stable = struct
   module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.Latest
+(* DO NOT add bin_io to the deriving list *)
+type t = Stable.Latest.t =
+  { proposer: Public_key.Compressed.t
+  ; amount: Currency.Amount.t
+  ; fee_transfer: Fee_transfer.single option }
+[@@deriving sexp, compare, eq]
 
-let is_valid {proposer= _; amount; fee_transfer} =
-  match fee_transfer with
-  | None -> true
-  | Some (_, fee) -> Currency.Amount.(of_fee fee <= amount)
-
-include Binable.Of_binable
-          (T)
-          (struct
-            type nonrec t = t
-
-            let to_binable = Fn.id
-
-            let of_binable t =
-              assert (is_valid t) ;
-              t
-          end)
+let is_valid = Stable.Latest.is_valid
 
 let create ~amount ~proposer ~fee_transfer =
   let t = {proposer; amount; fee_transfer} in

--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -32,6 +32,7 @@ module Stable = struct
                 let of_binable t =
                   (* TODO: maliciously invalid data will halt the node
                      should this be just logged?
+                     See issue #1767.
                   *)
                   assert (is_valid t) ;
                   t

--- a/src/lib/coda_base/coinbase.mli
+++ b/src/lib/coda_base/coinbase.mli
@@ -1,11 +1,24 @@
 open Core
 open Import
 
-type t = private
+module Stable : sig
+  module V1 : sig
+    type t = private
+      { proposer: Public_key.Compressed.t
+      ; amount: Currency.Amount.t
+      ; fee_transfer: Fee_transfer.single option }
+    [@@deriving sexp, bin_io, compare, eq]
+  end
+
+  module Latest = V1
+end
+
+(* bin_io intentionally omitted in deriving list *)
+type t = Stable.Latest.t = private
   { proposer: Public_key.Compressed.t
   ; amount: Currency.Amount.t
   ; fee_transfer: Fee_transfer.single option }
-[@@deriving sexp, bin_io, compare, eq]
+[@@deriving sexp, compare, eq]
 
 val create :
      amount:Currency.Amount.t

--- a/src/lib/coda_base/transaction.ml
+++ b/src/lib/coda_base/transaction.ml
@@ -5,7 +5,7 @@ type fee_transfer = Fee_transfer.t [@@deriving bin_io, sexp]
 type t =
   | User_command of User_command.With_valid_signature.t
   | Fee_transfer of Fee_transfer.t
-  | Coinbase of Coinbase.t
+  | Coinbase of Coinbase.Stable.V1.t
 [@@deriving bin_io, sexp]
 
 let fee_excess = function

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -28,7 +28,7 @@ module type S = sig
     [@@deriving sexp, bin_io]
 
     type coinbase =
-      { coinbase: Coinbase.t
+      { coinbase: Coinbase.Stable.V1.t
       ; previous_empty_accounts: Public_key.Compressed.t list }
     [@@deriving sexp, bin_io]
 
@@ -140,7 +140,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
     [@@deriving sexp, bin_io]
 
     type coinbase =
-      { coinbase: Coinbase.t
+      { coinbase: Coinbase.Stable.V1.t
       ; previous_empty_accounts: Public_key.Compressed.t list }
     [@@deriving sexp, bin_io]
 

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -132,8 +132,8 @@ struct
     module Sparse_ledger = Coda_base.Sparse_ledger
   end)
 
-  (* Generate valid payments for each blockchain state by having 
-     each user send a payment of one coin to another random 
+  (* Generate valid payments for each blockchain state by having
+     each user send a payment of one coin to another random
      user if they at least one coin*)
   let gen_payments accounts_with_secret_keys :
       User_command.With_valid_signature.t Sequence.t =

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -335,7 +335,7 @@ module type Coinbase_intf = sig
     { proposer: public_key
     ; amount: Currency.Amount.t
     ; fee_transfer: fee_transfer option }
-  [@@deriving sexp, bin_io, compare, eq]
+  [@@deriving sexp, compare, eq]
 
   val create :
        amount:Currency.Amount.t


### PR DESCRIPTION
Remove `bin_io` for `Coinbase.t`.

That forces `Stable.V1` to be used for some type definitions, which should eventually be versioned.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
