### PR TITLE
Fix #1748: writing to a broadcast pipe waits for all consumers before returning

### DIFF
--- a/src/lib/pipe_lib/broadcast_pipe.ml
+++ b/src/lib/pipe_lib/broadcast_pipe.ml
@@ -2,30 +2,45 @@ open Core_kernel
 open Async_kernel
 
 type 'a t =
-  { root_pipe:
-      ('a, Strict_pipe.synchronous, unit Deferred.t) Strict_pipe.Writer.t
+  { root_pipe: 'a Pipe.Writer.t
   ; mutable cache: 'a
   ; mutable reader_id: int
-  ; pipes:
-      ( 'a Strict_pipe.Reader.t
-      * ('a, Strict_pipe.synchronous, unit Deferred.t) Strict_pipe.Writer.t )
-      Int.Table.t }
+  ; pipes: 'a Pipe.Writer.t Int.Table.t }
 
 let create a =
-  let r, w = Strict_pipe.create Strict_pipe.Synchronous in
-  let t = {root_pipe= w; cache= a; reader_id= 0; pipes= Int.Table.create ()} in
+  let root_r, root_w = Pipe.create () in
+  let t =
+    {root_pipe= root_w; cache= a; reader_id= 0; pipes= Int.Table.create ()}
+  in
+  let downstream_flushed_v : unit Ivar.t ref = ref @@ Ivar.create () in
+  let consumer =
+    Pipe.add_consumer root_r ~downstream_flushed:(fun () ->
+        let%map () = Ivar.read !downstream_flushed_v in
+        (* Sub-pipes are never closed without closing the master pipe. *)
+        `Ok )
+  in
   don't_wait_for
-    (Strict_pipe.Reader.iter r ~f:(fun a ->
-         t.cache <- a ;
-         Deferred.List.iter ~how:`Parallel (Int.Table.data t.pipes)
-           ~f:(fun (_, w) -> Strict_pipe.Writer.write w a ) )) ;
+    (Pipe.iter ~consumer root_r ~f:(fun v ->
+         t.cache <- v ;
+         downstream_flushed_v := Ivar.create () ;
+         let inner_pipes = Int.Table.data t.pipes in
+         let%bind () =
+           Deferred.List.iter ~how:`Parallel inner_pipes ~f:(fun p ->
+               Pipe.write p v )
+         in
+         Pipe.Consumer.values_sent_downstream consumer ;
+         let%bind () =
+           Deferred.List.iter ~how:`Parallel inner_pipes ~f:(fun p ->
+               Deferred.ignore @@ Pipe.downstream_flushed p )
+         in
+         Ivar.fill !downstream_flushed_v () ;
+         Deferred.unit )) ;
   (t, t)
 
 exception Already_closed
 
 let guard_already_closed t k =
-  if Strict_pipe.Writer.is_closed t.root_pipe then raise Already_closed
-  else k ()
+  if Pipe.is_closed t.root_pipe then raise Already_closed else k ()
 
 module Reader = struct
   type nonrec 'a t = 'a t
@@ -38,68 +53,71 @@ module Reader = struct
 
   let prepare_pipe t ~f =
     guard_already_closed t (fun () ->
-        let r, w = Strict_pipe.create Strict_pipe.Synchronous in
+        let r, w = Pipe.create () in
+        Pipe.write_without_pushback w (peek t) ;
         let reader_id = fresh_reader_id t in
-        Int.Table.add_exn t.pipes ~key:reader_id ~data:(r, w) ;
+        Int.Table.add_exn t.pipes ~key:reader_id ~data:w ;
         let d =
-          don't_wait_for (Strict_pipe.Writer.write w (peek t)) ;
           let%map b = f r in
           Int.Table.remove t.pipes reader_id ;
           b
         in
-        (d, w) )
+        d )
+
+  (* The sub-pipes have no downstream consumer, so the downstream flushed should
+     always be determined and return `Ok. *)
+  let add_trivial_consumer p =
+    Pipe.add_consumer p ~downstream_flushed:(fun () -> Deferred.return `Ok)
 
   let fold t ~init ~f =
-    prepare_pipe t ~f:(fun r -> Strict_pipe.Reader.fold r ~init ~f)
+    prepare_pipe t ~f:(fun r ->
+        let consumer = add_trivial_consumer r in
+        Pipe.fold r ~init ~f:(fun acc v ->
+            let%map res = f acc v in
+            Pipe.Consumer.values_sent_downstream consumer ;
+            res ) )
 
-  let iter t ~f = prepare_pipe t ~f:(fun r -> Strict_pipe.Reader.iter r ~f)
+  let iter t ~f =
+    prepare_pipe t ~f:(fun r ->
+        let consumer = add_trivial_consumer r in
+        Pipe.iter ~consumer r ~f:(fun v ->
+            let%map () = f v in
+            Pipe.Consumer.values_sent_downstream consumer ) )
 end
 
 module Writer = struct
   type nonrec 'a t = 'a t
 
   let write t x =
-    guard_already_closed t (fun () -> Strict_pipe.Writer.write t.root_pipe x)
+    guard_already_closed t (fun () ->
+        let%bind () = Pipe.write t.root_pipe x in
+        let%bind _ = Pipe.downstream_flushed t.root_pipe in
+        Deferred.unit )
 
   let close t =
     guard_already_closed t (fun () ->
-        Strict_pipe.Writer.close t.root_pipe ;
-        Int.Table.iter t.pipes ~f:(fun (_, w) -> Strict_pipe.Writer.close w) ;
+        Pipe.close t.root_pipe ;
+        Int.Table.iter t.pipes ~f:(fun w -> Pipe.close w) ;
         Int.Table.clear t.pipes )
 end
-
-(*
-let start dir =
-  O1trace.forget_tid (fun () ->
-      Async.Writer.open_file ~append:true
-        (dir ^ "/" ^ sprintf "%d.trace" (Async.Unix.getpid () |> Pid.to_int))
-      >>| O1trace.start_tracing )
-
-let () = start "/tmp"
-*)
 
 (*
  * 1. Cached value is keeping peek working
  * 2. Multiple listeners receive the first mvar value
  * 3. Multiple listeners receive updates after changes
- * 4. Listeners can be closed, and other listeners still work
- * 5. Peek sees the latest value
- * 6. If we close the shared_mvar, all listeners stop
+ * 4. Peek sees the latest value
+ * 5. If we close the broadcast pipe, all listeners stop
 *)
 let%test_unit "listeners properly receive updates" =
   let expect_pipe t expected =
-    let got_rev, pipe =
+    let got_rev =
       Reader.fold t ~init:[] ~f:(fun acc a1 -> return @@ (a1 :: acc))
     in
-    let d =
-      let%map got = got_rev >>| List.rev in
-      [%test_result: int list]
-        ~message:"Expected the following values from the pipe" ~expect:expected
-        got
-    in
-    (d, pipe)
+    let%map got = got_rev >>| List.rev in
+    [%test_result: int list]
+      ~message:"Expected the following values from the pipe" ~expect:expected
+      got
   in
-  let yield () = Async.after (Time.Span.of_ms 10.) in
   Async.Thread_safe.block_on_async_exn (fun () ->
       let initial = 0 in
       let r, w = create initial in
@@ -107,25 +125,78 @@ let%test_unit "listeners properly receive updates" =
       [%test_result: int] ~message:"Initial value not observed when peeking"
         ~expect:initial (Reader.peek r) ;
       (* 2-3 *)
-      let d1, p1 = expect_pipe r [0; 1] in
-      let d2, _ = expect_pipe r [0; 1; 2] in
+      let d1 = expect_pipe r [0; 1; 2] in
+      let d2 = expect_pipe r [0; 1; 2] in
       don't_wait_for d1 ;
       don't_wait_for d2 ;
-      let%bind () = yield () in
       let next_value = 1 in
       (*3*)
       let%bind () = Writer.write w next_value in
       (*4*)
-      Strict_pipe.Writer.close p1 ;
-      let%bind () = yield () in
       let next_value = 2 in
       let%bind () = Writer.write w next_value in
-      let%bind () = yield () in
       (*5*)
       [%test_result: int] ~message:"Latest value is observed when peeking"
         ~expect:next_value (Reader.peek r) ;
       (*6*)
-      let%bind () = yield () in
       Writer.close w ;
-      let%bind () = yield () in
       Deferred.both d1 d2 >>| Fn.ignore )
+
+let%test_module _ =
+  ( module struct
+    type iter_counts =
+      {mutable immediate_iterations: int; mutable deferred_iterations: int}
+
+    let zero_counts () = {immediate_iterations= 0; deferred_iterations= 0}
+
+    let assert_immediate counts expected =
+      [%test_eq: int] counts.immediate_iterations expected
+
+    let assert_deferred counts expected =
+      [%test_eq: int] counts.deferred_iterations expected
+
+    let assert_both counts expected =
+      assert_immediate counts expected ;
+      assert_deferred counts expected
+
+    let%test "Writing is synchronous" =
+      Async.Thread_safe.block_on_async_exn (fun () ->
+          Core.Backtrace.elide := false ;
+          Async.Scheduler.set_record_backtraces true ;
+          let pipe_r, pipe_w = create () in
+          let counts1, counts2 = (zero_counts (), zero_counts ()) in
+          let setup_reader counts =
+            don't_wait_for
+            @@ Reader.iter pipe_r ~f:(fun () ->
+                   counts.immediate_iterations
+                   <- counts.immediate_iterations + 1 ;
+                   let%map () = Async.after @@ Time.Span.of_sec 1. in
+                   counts.deferred_iterations <- counts.deferred_iterations + 1
+               )
+          in
+          setup_reader counts1 ;
+          (* The reader doesn't run until we yield. *)
+          assert_both counts1 0 ;
+          (* Once we yield, the reader has run, but has returned to the
+             scheduler before setting deferred_iterations. *)
+          let%bind () = Async.after @@ Time.Span.of_sec 0.1 in
+          assert_immediate counts1 1 ;
+          assert_deferred counts1 0 ;
+          (* After we yield for long enough, deferred_iterations has been
+             set. *)
+          let%bind () = Async.after @@ Time.Span.of_sec 1.1 in
+          assert_both counts1 1 ;
+          (* Writing to the pipe blocks until the reader is finished. *)
+          let%bind () = Writer.write pipe_w () in
+          assert_both counts1 2 ;
+          (* A second reader gets the current value, and all values written
+             after its creation. *)
+          setup_reader counts2 ;
+          assert_both counts2 0 ;
+          let%bind () = Async.after @@ Time.Span.of_sec 0.1 in
+          assert_immediate counts2 1 ;
+          assert_deferred counts2 0 ;
+          let%bind () = Writer.write pipe_w () in
+          assert_both counts1 3 ; assert_both counts2 2 ; Deferred.return true
+      )
+  end )

--- a/src/lib/pipe_lib/broadcast_pipe.mli
+++ b/src/lib/pipe_lib/broadcast_pipe.mli
@@ -1,4 +1,6 @@
-(** A broadcast_pipe allows multiple readers for a single writer without needing to fork explicitly. It is always synchronous and always has at least one value in it. *)
+(** A broadcast_pipe allows multiple readers for a single writer without needing
+to fork explicitly. It is always synchronous and always has at least one value
+in it. *)
 
 open Async_kernel
 
@@ -8,22 +10,14 @@ module Reader : sig
   (** The read side of the broadcast pipe *)
   type 'a t
 
-  val iter :
-       'a t
-    -> f:('a -> unit Deferred.t)
-    -> unit Deferred.t
-       * ('a, Strict_pipe.synchronous, unit Deferred.t) Strict_pipe.Writer.t
-  (** Same semantics as [Strict_pipe.iter], close the returned pipe to stop this
-   * iter. *)
+  val iter : 'a t -> f:('a -> unit Deferred.t) -> unit Deferred.t
+  (** Iterate over the items in the pipe. The returned deferred is determined
+      when the pipe closes. The first item f sees is the current item i.e. the
+      one that would be returned by peek. If you use this with don't_wait_for, f
+      will not be invoked until execution returns to the scheduler .*)
 
-  val fold :
-       'a t
-    -> init:'b
-    -> f:('b -> 'a -> 'b Deferred.t)
-    -> 'b Deferred.t
-       * ('a, Strict_pipe.synchronous, unit Deferred.t) Strict_pipe.Writer.t
-  (** Same semantics as [Strict_pipe.fold], close the returned pipe to stop this
-   * fold. *)
+  val fold : 'a t -> init:'b -> f:('b -> 'a -> 'b Deferred.t) -> 'b Deferred.t
+  (** Fold over the items in the pipe. Same notes as iter. *)
 
   val peek : 'a t -> 'a
   (** Peek at the latest value in the pipe. *)
@@ -34,6 +28,9 @@ module Writer : sig
   type 'a t
 
   val write : 'a t -> 'a -> unit Deferred.t
+  (** Write an item to the pipe. The returned Deferred with be determined when
+      all downstream consumers have finished processing.
+  *)
 
   val close : 'a t -> unit
   (** Stop listening to the underlying pipe. This cascades to all listeners *)

--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -109,8 +109,7 @@ struct
               %{sexp:User_command.t list}"
             (Breadcrumb.to_user_commands old_best_tip)
             new_user_commands ;
-          List.iter new_user_commands ~f:(fun tx -> remove_tx t tx) ;
-          printf !"removed txs\n%!" )
+          List.iter new_user_commands ~f:(fun tx -> remove_tx t tx) )
         else
           Logger.warn t.log
             "Got a new best tip breadcrumb that wasn't a direct descendant of \
@@ -130,36 +129,34 @@ struct
       ; diff_reader= None }
     in
     don't_wait_for
-      ( fst
-      @@ Broadcast_pipe.Reader.iter frontier_broadcast_pipe
-           ~f:(fun frontier_opt ->
-             match frontier_opt with
-             | None -> (
-                 Logger.debug t.log "no frontier" ;
-                 (* Sanity check: the view pipe should have been closed before
-                    the frontier was destroyed. *)
-                 match t.diff_reader with
-                 | None -> Deferred.unit
-                 | Some hdl ->
-                     Deferred.any_unit
-                       [ (let%map () = hdl in
-                          t.diff_reader <- None)
-                       ; (let%map () = Async.after (Time.Span.of_sec 5.) in
-                          Logger.fatal t.log
-                            "Transition frontier closed without first closing \
-                             best tip view pipe" ;
-                          assert false) ] )
-             | Some frontier ->
-                 Logger.debug t.log "Got frontier!\n" ;
-                 (* TODO check current pool contents are valid against best tip here *)
-                 t.diff_reader
-                 <- Some
-                      ( fst
-                      @@ Broadcast_pipe.Reader.iter
-                           ( Transition_frontier.extension_pipes frontier
-                           |> Transition_frontier.Extensions.best_tip_diff )
-                           ~f:(handle_diff t frontier) ) ;
-                 Deferred.unit ) ) ;
+      (Broadcast_pipe.Reader.iter frontier_broadcast_pipe
+         ~f:(fun frontier_opt ->
+           match frontier_opt with
+           | None -> (
+               Logger.debug t.log "no frontier" ;
+               (* Sanity check: the view pipe should have been closed before the
+                    frontier was destroyed. *)
+               match t.diff_reader with
+               | None -> Deferred.unit
+               | Some hdl ->
+                   Deferred.any_unit
+                     [ (let%map () = hdl in
+                        t.diff_reader <- None)
+                     ; (let%map () = Async.after (Time.Span.of_sec 5.) in
+                        Logger.fatal t.log
+                          "Transition frontier closed without first closing \
+                           best tip view pipe" ;
+                        assert false) ] )
+           | Some frontier ->
+               Logger.debug t.log "Got frontier!\n" ;
+               (* TODO check current pool contents are valid against best tip here *)
+               t.diff_reader
+               <- Some
+                    (Broadcast_pipe.Reader.iter
+                       ( Transition_frontier.extension_pipes frontier
+                       |> Transition_frontier.Extensions.best_tip_diff )
+                       ~f:(handle_diff t frontier)) ;
+               Deferred.unit )) ;
     t
 
   let add' pool txn = {heap= Fheap.add pool.heap txn; set= Set.add pool.set txn}
@@ -210,98 +207,93 @@ struct
   let load ~disk_location:_ ~parent_log = return (create ~parent_log)
 end
 
-(* This test is broken because of #1748, fix it and uncomment when that's
-done. *)
+let%test_module _ =
+  ( module struct
+    module Mock_transition_frontier = struct
+      module Breadcrumb = struct
+        type t = {successors: t list; commands: int list} [@@deriving sexp]
 
-(* let%test_module _ =
- *   ( module struct
- *     module Mock_transition_frontier = struct
- *       module Breadcrumb = struct
- *         type t = {successors: t list; commands: int list} [@@deriving sexp]
- * 
- *         let equal b1 b2 = b1 = b2
- * 
- *         let to_user_commands {commands; _} = commands
- *       end
- * 
- *       type t =
- *         Breadcrumb.t Best_tip_diff_view.t Option.t Broadcast_pipe.Reader.t
- * 
- *       let successors _ ({successors; _} : Breadcrumb.t) = successors
- * 
- *       module Extensions = struct
- *         module Best_tip_diff = struct
- *           type view = Breadcrumb.t Best_tip_diff_view.t Option.t
- *         end
- * 
- *         type readers = Best_tip_diff.view Broadcast_pipe.Reader.t
- * 
- *         let best_tip_diff = Fn.id
- *       end
- * 
- *       let extension_pipes pipe = pipe
- * 
- *       let create () :
- *           t
- *           * Breadcrumb.t Best_tip_diff_view.t Option.t Broadcast_pipe.Writer.t
- *           =
- *         Broadcast_pipe.create None
- *     end
- * 
- *     module Test =
- *       Make (struct
- *           include Int
- *           module With_valid_signature = Int
- * 
- *           let check = Option.some
- * 
- *           let forget_check = Fn.id
- *         end)
- *         (Mock_transition_frontier)
- * 
- *     (\*   (\\* We only test the transaction removal logic here, since this whole
- *    *      module needs rewriting, it doesn't make sense to test it all. *\\)
- *    *   let%test _ =
- *    *     Thread_safe.block_on_async_exn (fun () ->
- *    *         let tf, best_tip_diff_w = Mock_transition_frontier.create () in
- *    *         let tf_pipe_r, tf_pipe_w = Broadcast_pipe.create @@ Some tf in
- *    *         let pool =
- *    *           Test.create ~parent_log:(Logger.create ())
- *    *             ~frontier_broadcast_pipe:tf_pipe_r
- *    *         in
- *    *         let%bind () = after @@ Time.Span.of_sec 1. in
- *    *         let assert_pool_txs txs =
- *    *           [%test_eq: int Sequence.t] (Test.transactions pool)
- *    *           @@ Sequence.of_list txs
- *    *         in
- *    *         assert_pool_txs [] ;
- *    *         let txs = [0; 1; 2; 3] in
- *    *         List.iter ~f:(Test.add pool) txs ;
- *    *         assert_pool_txs txs ;
- *    *         let second_bc : Test.Breadcrumb.t =
- *    *           {successors= []; commands= [2]}
- *    *         in
- *    *         let first_bc : Test.Breadcrumb.t =
- *    *           {successors= [second_bc]; commands= []}
- *    *         in
- *    *         (\\* printf "%B\n"
- *    *          *   (List.mem
- *    *          *      (Mock_transition_frontier.successors tf first_bc)
- *    *          *      second_bc ~equal:Mock_transition_frontier.Breadcrumb.equal) ; *\\)
- *    *         printf !"first write\n%!" ;
- *    *         let%bind () =
- *    *           Broadcast_pipe.Writer.write best_tip_diff_w
- *    *             (Some {new_best_tip= first_bc; old_best_tip= first_bc})
- *    *         in
- *    *         assert_pool_txs txs ;
- *    *         printf !"second write\n%!" ;
- *    *         let%bind () =
- *    *           Broadcast_pipe.Writer.write best_tip_diff_w
- *    *             (Some {new_best_tip= second_bc; old_best_tip= first_bc})
- *    *         in
- *    *         (\\* let%bind () = after (Time.Span.of_sec 2.) in *\\)
- *    *         printf !"about to assert\n%!" ;
- *    *         assert_pool_txs [0; 1; 3] ;
- *    *         Deferred.return true )
- *   *\)
- *   end ) *)
+        let equal b1 b2 = b1 = b2
+
+        let to_user_commands {commands; _} = commands
+      end
+
+      type t =
+        Breadcrumb.t Best_tip_diff_view.t Option.t Broadcast_pipe.Reader.t
+
+      let successors _ ({successors; _} : Breadcrumb.t) = successors
+
+      module Extensions = struct
+        module Best_tip_diff = struct
+          type view = Breadcrumb.t Best_tip_diff_view.t Option.t
+        end
+
+        type readers = Best_tip_diff.view Broadcast_pipe.Reader.t
+
+        let best_tip_diff = Fn.id
+      end
+
+      let extension_pipes pipe = pipe
+
+      let create () :
+          t
+          * Breadcrumb.t Best_tip_diff_view.t Option.t Broadcast_pipe.Writer.t
+          =
+        Broadcast_pipe.create None
+    end
+
+    module Test =
+      Make (struct
+          include Int
+          module With_valid_signature = Int
+
+          let check = Option.some
+
+          let forget_check = Fn.id
+        end)
+        (Mock_transition_frontier)
+
+    (* We only test the transaction removal logic here, since this whole
+       module needs rewriting, it doesn't make sense to test it all. *)
+    let%test _ =
+      Thread_safe.block_on_async_exn (fun () ->
+          let tf, best_tip_diff_w = Mock_transition_frontier.create () in
+          let tf_pipe_r, _tf_pipe_w = Broadcast_pipe.create @@ Some tf in
+          let pool =
+            Test.create ~parent_log:(Logger.null ())
+              ~frontier_broadcast_pipe:tf_pipe_r
+          in
+          let assert_pool_txs txs =
+            [%test_eq: int Sequence.t] (Test.transactions pool)
+            @@ Sequence.of_list txs
+          in
+          assert_pool_txs [] ;
+          let txs = [0; 1; 2; 3] in
+          List.iter ~f:(Test.add pool) txs ;
+          assert_pool_txs txs ;
+          let third_bc : Test.Breadcrumb.t =
+            {successors= []; commands= [0; 3]}
+          in
+          let second_bc : Test.Breadcrumb.t =
+            {successors= [third_bc]; commands= [2]}
+          in
+          let first_bc : Test.Breadcrumb.t =
+            {successors= [second_bc]; commands= []}
+          in
+          let%bind () =
+            Broadcast_pipe.Writer.write best_tip_diff_w
+              (Some {new_best_tip= first_bc; old_best_tip= first_bc})
+          in
+          assert_pool_txs txs ;
+          let%bind () =
+            Broadcast_pipe.Writer.write best_tip_diff_w
+              (Some {new_best_tip= second_bc; old_best_tip= first_bc})
+          in
+          assert_pool_txs [0; 1; 3] ;
+          let%bind () =
+            Broadcast_pipe.Writer.write best_tip_diff_w
+              (Some {new_best_tip= third_bc; old_best_tip= second_bc})
+          in
+          assert_pool_txs [1] ;
+          Deferred.return true )
+  end )


### PR DESCRIPTION
Checklist:

- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #1748
