### PR TITLE
fix Mask.Attached.commit assert

### DIFF
--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -340,8 +340,8 @@ struct
       Debug_assert.debug_assert (fun () ->
           [%test_result: Hash.t]
             ~message:
-              "Parent merkle root after committing should be the same as the old one \
-               in the mask"
+              "Parent merkle root after committing should be the same as the \
+               old one in the mask"
             ~expect:old_root_hash
             (Base.merkle_root (get_parent t)) ;
           [%test_result: Hash.t]

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -340,14 +340,14 @@ struct
       Debug_assert.debug_assert (fun () ->
           [%test_result: Hash.t]
             ~message:
-              "Merkle root after committing should be the same as the old one \
+              "Parent merkle root after committing should be the same as the old one \
                in the mask"
             ~expect:old_root_hash
             (Base.merkle_root (get_parent t)) ;
           [%test_result: Hash.t]
             ~message:
               "Merkle root of the mask should delegate to the parent now"
-            ~expect:old_root_hash
+            ~expect:(merkle_root t)
             (Base.merkle_root (get_parent t)) )
 
     (* copy tables in t; use same parent *)


### PR DESCRIPTION
This second assert is supposed to look up the new merkle root of the mask, not use the old cached value.