### PR TITLE
Add ability to just reformat modified files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ kademlia:
 # Alias
 dht: kademlia
 
-build: git_hooks
+build: git_hooks reformat-diff
 	$(info Starting Build)
 	ulimit -s 65532 && (ulimit -n 10240 || true) && (ulimit -u 2128 || true) && cd src && $(WRAPSRC) env CODA_COMMIT_SHA1=$(GITLONGHASH) dune build --profile=$(DUNE_PROFILE)
 	$(info Build complete)
@@ -77,6 +77,9 @@ dev: codabuilder containerstart build
 
 reformat: git_hooks
 	cd src; $(WRAPSRC) dune exec --profile=$(DUNE_PROFILE) app/reformat/reformat.exe -- -path .
+
+reformat-diff: git_hooks
+	ocamlformat --inplace $(shell git diff --name-only HEAD | grep '.mli\?$$' | while IFS= read -r f; do stat "$$f" &>/dev/null && echo "$$f"; done)
 
 check-format:
 	cd src; $(WRAPSRC) dune exec --profile=$(DUNE_PROFILE) app/reformat/reformat.exe -- -path . -check

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ dev: codabuilder containerstart build
 reformat: git_hooks
 	cd src; $(WRAPSRC) dune exec --profile=$(DUNE_PROFILE) app/reformat/reformat.exe -- -path .
 
-reformat-diff: git_hooks
-	ocamlformat --inplace $(shell git diff --name-only HEAD | grep '.mli\?$$' | while IFS= read -r f; do stat "$$f" &>/dev/null && echo "$$f"; done)
+reformat-diff:
+	ocamlformat --inplace $(shell git diff --name-only HEAD | grep '.mli\?$$' | while IFS= read -r f; do stat "$$f" &>/dev/null && echo "$$f"; done) || true
 
 check-format:
 	cd src; $(WRAPSRC) dune exec --profile=$(DUNE_PROFILE) app/reformat/reformat.exe -- -path . -check


### PR DESCRIPTION
Asks git which files have been updated since last commit and reformats just those. The bash stuff just filters out files that were deleted because otherwise ocamlformat gets upset.
Also added reformat before build because otherwise I always forget to reformat and then build and then have to build again after reformatting.

Thought I'd share in case anyone was interested. On my machine it's like 30x faster than running `make reformat`.