### PR TITLE
Use best tip path changes in transaction pool

### DIFF
--- a/src/lib/non_empty_list/non_empty_list.ml
+++ b/src/lib/non_empty_list/non_empty_list.ml
@@ -15,6 +15,8 @@ let head (x, _) = x
 
 let tail (_, xs) = xs
 
+let last (x, xs) = if List.is_empty xs then x else List.last_exn xs
+
 let of_list_opt = function [] -> None | x :: xs -> Some (x, xs)
 
 let tail_opt t = of_list_opt (tail t)

--- a/src/lib/non_empty_list/non_empty_list.mli
+++ b/src/lib/non_empty_list/non_empty_list.mli
@@ -20,6 +20,8 @@ val head : 'a t -> 'a
 val tail : 'a t -> 'a list
 (** The zero or more tail elements of the container *)
 
+val last : 'a t -> 'a
+
 val rev : 'a t -> 'a t
 (** The reverse ordered list *)
 

--- a/src/lib/transition_frontier/best_tip_diff.ml
+++ b/src/lib/transition_frontier/best_tip_diff.ml
@@ -1,33 +1,40 @@
-(** A transition frontier extension that exposes the changes in the best tip. *)
+(** A transition frontier extension that exposes the changes in the transactions
+    in the best tip. *)
 
 open Core
+open Coda_base
 open Protocols.Coda_transition_frontier
 
 module Make (Breadcrumb : sig
   type t
+
+  val to_user_commands : t -> User_command.t list
 end) :
   Transition_frontier_extension_intf0
   with type transition_frontier_breadcrumb := Breadcrumb.t
    and type input = unit
-   and type view = Breadcrumb.t Best_tip_diff_view.t Option.t = struct
+   and type view = User_command.t Best_tip_diff_view.t = struct
   type t = unit
 
   type input = unit
 
-  type view = Breadcrumb.t Best_tip_diff_view.t Option.t
+  type view = User_command.t Best_tip_diff_view.t
 
   let create () = ()
 
-  let initial_view = None
+  let initial_view : view = {new_user_commands= []; removed_user_commands= []}
 
-  (* View is only None when there haven't been any diffs yet. This is sort of an
-     unfortunate hack. *)
-  let handle_diff () diff : Breadcrumb.t Best_tip_diff_view.t Option.t Option.t
-      =
-    Some
-      (let open Transition_frontier_diff in
-      match diff with
-      | New_breadcrumb _ -> None (* We only care about the best tip *)
-      | New_best_tip {new_best_tip; old_best_tip; _} ->
-          Some {new_best_tip; old_best_tip})
+  let handle_diff () diff : User_command.t Best_tip_diff_view.t Option.t =
+    let open Transition_frontier_diff in
+    match diff with
+    | New_breadcrumb _ -> None (* We only care about the best tip *)
+    | New_best_tip {added_to_best_tip_path; removed_from_best_tip_path; _} ->
+        Some
+          { new_user_commands=
+              List.bind
+                (Non_empty_list.to_list added_to_best_tip_path)
+                ~f:Breadcrumb.to_user_commands
+          ; removed_user_commands=
+              List.bind removed_from_best_tip_path
+                ~f:Breadcrumb.to_user_commands }
 end

--- a/src/lib/transition_frontier/snark_pool_refcount.ml
+++ b/src/lib/transition_frontier/snark_pool_refcount.ml
@@ -72,8 +72,12 @@ struct
       match (diff : Inputs.Breadcrumb.t Transition_frontier_diff.t) with
       | New_breadcrumb breadcrumb ->
           (0, add_breadcrumb_to_ref_table t breadcrumb)
-      | New_best_tip {old_root; new_root; new_best_tip; garbage; _} ->
-          let added = add_breadcrumb_to_ref_table t new_best_tip in
+      | New_best_tip {old_root; new_root; added_to_best_tip_path; garbage; _}
+        ->
+          let added =
+            add_breadcrumb_to_ref_table t
+            @@ Non_empty_list.last added_to_best_tip_path
+          in
           let all_garbage =
             if phys_equal old_root new_root then garbage
             else old_root :: garbage

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -11,9 +11,9 @@ module Transition_frontier_diff = struct
         { old_root: 'a
         ; old_root_length: int
         ; new_root: 'a  (** Same as old root if the root doesn't change *)
-        ; new_best_tip: 'a
+        ; added_to_best_tip_path: 'a Non_empty_list.t (* oldest first *)
         ; new_best_tip_length: int
-        ; old_best_tip: 'a
+        ; removed_from_best_tip_path: 'a list (* also oldest first *)
         ; garbage: 'a list }
         (** Triggered when a new breadcrumb is added, causing a new best_tip *)
   [@@deriving sexp]
@@ -50,7 +50,7 @@ end
 (** The type of the view onto the changes to the current best tip. This type
     needs to be here to avoid dependency cycles. *)
 module Best_tip_diff_view = struct
-  type 'b t = {new_best_tip: 'b; old_best_tip: 'b}
+  type 'b t = {new_user_commands: 'b list; removed_user_commands: 'b list}
 end
 
 module type Network_intf = sig
@@ -256,7 +256,7 @@ module type Transition_frontier_intf = sig
 
     module Best_tip_diff :
       Transition_frontier_extension_intf
-      with type view = Breadcrumb.t Best_tip_diff_view.t Option.t
+      with type view = user_command Best_tip_diff_view.t
 
     type readers =
       { snark_pool: Snark_pool_refcount.view Broadcast_pipe.Reader.t


### PR DESCRIPTION
I modified the transition frontier extension interface to expose changes in the
best tip path, modified the best tip diff view to expose changes in the user
commands, and used the data in the transaction pool. This should do the right
thing when the best tip change involves backtracking now.

I wrote tests for the transaction pool logic with mocks, and did some informal testing of the daemon, but there are a bunch of bugs in other stuff which prevent you from running test networks with transactions for very long so I'm not totally confident this is correct.

Checklist:

- [x] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: