### PR TITLE
fake system time

### DIFF
--- a/src/lib/coda_base/block_time.ml
+++ b/src/lib/coda_base/block_time.ml
@@ -1,6 +1,5 @@
 open Util
 open Core_kernel
-open Async_kernel
 open Snark_params
 open Tick
 open Unsigned_extended
@@ -8,60 +7,14 @@ open Snark_bits
 open Fold_lib
 open Module_version
 
-(* Milliseconds since epoch *)
-module Stable = struct
-  module V1 = struct
-    module T = struct
-      let version = 1
-
-      type t = UInt64.t [@@deriving bin_io, sexp, compare, eq, hash]
-    end
-
-    include T
-    include Registration.Make_latest_version (T)
-  end
-
-  module Latest = V1
-
-  module Module_decl = struct
-    let name = "block_time"
-
-    type latest = Latest.t
-  end
-
-  module Registrar = Registration.Make (Module_decl)
-  module Registered_V1 = Registrar.Register (V1)
-end
-
-module Controller = struct
-  type t = unit
-
-  let create () = ()
-end
-
-(* DO NOT add bin_io the deriving list *)
-type t = Stable.Latest.t [@@deriving sexp, compare, eq, hash]
-
-type t0 = t
-
-module B = Bits
-
-let bit_length = 64
-
-let length_in_triples = bit_length_to_triple_length bit_length
-
-module Bits = Bits.UInt64
-include B.Snarkable.UInt64 (Tick)
-
-let fold t = Fold.group3 ~default:false (Bits.fold t)
-
-module Span = struct
+module Time = struct
+  (* Milliseconds since epoch *)
   module Stable = struct
     module V1 = struct
       module T = struct
         let version = 1
 
-        type t = UInt64.t [@@deriving bin_io, sexp, compare]
+        type t = UInt64.t [@@deriving bin_io, sexp, compare, eq, hash]
       end
 
       include T
@@ -71,7 +24,7 @@ module Span = struct
     module Latest = V1
 
     module Module_decl = struct
-      let name = "block_time_span"
+      let name = "block_time"
 
       type latest = Latest.t
     end
@@ -80,24 +33,82 @@ module Span = struct
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  include Stable.Latest
-  module Bits = B.UInt64
+  module Controller = struct
+    type t = unit
+
+    let create () = ()
+  end
+
+  (* DO NOT add bin_io the deriving list *)
+  type t = Stable.Latest.t [@@deriving sexp, compare, eq, hash]
+
+  type t0 = t
+
+  module B = Bits
+
+  let bit_length = 64
+
+  let length_in_triples = bit_length_to_triple_length bit_length
+
+  module Bits = Bits.UInt64
   include B.Snarkable.UInt64 (Tick)
 
-  let of_time_span s = UInt64.of_int64 (Int64.of_float (Time.Span.to_ms s))
+  let fold t = Fold.group3 ~default:false (Bits.fold t)
 
-  let to_time_ns_span s =
-    Time_ns.Span.of_ms (Int64.to_float (UInt64.to_int64 s))
+  module Span = struct
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          let version = 1
 
-  let to_ms = UInt64.to_int64
+          type t = UInt64.t [@@deriving bin_io, sexp, compare]
+        end
 
-  let of_ms = UInt64.of_int64
+        include T
+        include Registration.Make_latest_version (T)
+      end
 
-  let ( + ) = UInt64.Infix.( + )
+      module Latest = V1
 
-  let ( - ) = UInt64.Infix.( - )
+      module Module_decl = struct
+        let name = "block_time_span"
 
-  let ( * ) = UInt64.Infix.( * )
+        type latest = Latest.t
+      end
+
+      module Registrar = Registration.Make (Module_decl)
+      module Registered_V1 = Registrar.Register (V1)
+    end
+
+    include Stable.Latest
+    module Bits = B.UInt64
+    include B.Snarkable.UInt64 (Tick)
+
+    let of_time_span s = UInt64.of_int64 (Int64.of_float (Time.Span.to_ms s))
+
+    let to_time_ns_span s =
+      Time_ns.Span.of_ms (Int64.to_float (UInt64.to_int64 s))
+
+    let to_ms = UInt64.to_int64
+
+    let of_ms = UInt64.of_int64
+
+    let ( + ) = UInt64.Infix.( + )
+
+    let ( - ) = UInt64.Infix.( - )
+
+    let ( * ) = UInt64.Infix.( * )
+
+    let ( < ) = UInt64.( < )
+
+    let ( > ) = UInt64.( > )
+
+    let ( = ) = UInt64.( = )
+
+    let ( <= ) = UInt64.( <= )
+
+    let ( >= ) = UInt64.( >= )
+  end
 
   let ( < ) = UInt64.( < )
 
@@ -108,81 +119,42 @@ module Span = struct
   let ( <= ) = UInt64.( <= )
 
   let ( >= ) = UInt64.( >= )
+
+  let of_time t =
+    UInt64.of_int64
+      (Int64.of_float (Time.Span.to_ms (Time.to_span_since_epoch t)))
+
+  let to_time t =
+    Time.of_span_since_epoch
+      (Time.Span.of_ms (Int64.to_float (UInt64.to_int64 t)))
+
+  let now _ = of_time (Time.now ())
+
+  let field_var_to_unpacked (x : Tick.Field.Var.t) =
+    Tick.Field.Checked.unpack ~length:64 x
+
+  let epoch = of_time Time.epoch
+
+  let add x y = UInt64.add x y
+
+  let diff x y = UInt64.sub x y
+
+  let sub x y = UInt64.sub x y
+
+  let to_span_since_epoch t = diff t epoch
+
+  let of_span_since_epoch s = UInt64.add s epoch
+
+  let diff_checked x y =
+    let pack = Tick.Field.Var.project in
+    Span.unpack_var Tick.Field.Checked.Infix.(pack x - pack y)
+
+  let modulus t span = UInt64.rem t span
+
+  let unpacked_to_number var =
+    let bits = Span.Unpacked.var_to_bits var in
+    Number.of_bits (bits :> Boolean.var list)
 end
 
-let ( < ) = UInt64.( < )
-
-let ( > ) = UInt64.( > )
-
-let ( = ) = UInt64.( = )
-
-let ( <= ) = UInt64.( <= )
-
-let ( >= ) = UInt64.( >= )
-
-let of_time t =
-  UInt64.of_int64
-    (Int64.of_float (Time.Span.to_ms (Time.to_span_since_epoch t)))
-
-let to_time t =
-  Time.of_span_since_epoch
-    (Time.Span.of_ms (Int64.to_float (UInt64.to_int64 t)))
-
-let now () = of_time (Time.now ())
-
-module Timeout = struct
-  type 'a t =
-    { deferred: 'a Deferred.t
-    ; cancel: 'a -> unit
-    ; start_time: Time.t
-    ; span: Span.t }
-
-  let create () span ~f:action =
-    let open Async_kernel.Deferred.Let_syntax in
-    let cancel_ivar = Ivar.create () in
-    let timeout = after (Span.to_time_ns_span span) >>| fun () -> None in
-    let deferred =
-      Deferred.any [Ivar.read cancel_ivar; timeout]
-      >>| function None -> action (now ()) | Some x -> x
-    in
-    let cancel value = Ivar.fill_if_empty cancel_ivar (Some value) in
-    {deferred; cancel; start_time= Time.now (); span}
-
-  let to_deferred {deferred; _} = deferred
-
-  let peek {deferred; _} = Deferred.peek deferred
-
-  let cancel () {cancel; _} value = cancel value
-
-  let remaining_time {deferred : _; cancel : _; start_time; span} =
-    let current_time = Time.now () in
-    let time_elapsed =
-      Span.of_time_span @@ Time.diff current_time start_time
-    in
-    Span.(span - time_elapsed)
-end
-
-let field_var_to_unpacked (x : Tick.Field.Var.t) =
-  Tick.Field.Checked.unpack ~length:64 x
-
-let epoch = of_time Time.epoch
-
-let add x y = UInt64.add x y
-
-let diff x y = UInt64.sub x y
-
-let sub x y = UInt64.sub x y
-
-let to_span_since_epoch t = diff t epoch
-
-let of_span_since_epoch s = UInt64.add s epoch
-
-let diff_checked x y =
-  let pack = Tick.Field.Var.project in
-  Span.unpack_var Tick.Field.Checked.Infix.(pack x - pack y)
-
-let modulus t span = UInt64.rem t span
-
-let unpacked_to_number var =
-  let bits = Span.Unpacked.var_to_bits var in
-  Number.of_bits (bits :> Boolean.var list)
+include Time
+module Timeout = Timeout.Make (Time)

--- a/src/lib/coda_base/block_time.mli
+++ b/src/lib/coda_base/block_time.mli
@@ -4,57 +4,73 @@ open Snark_bits
 open Tuple_lib
 open Fold_lib
 
-type t [@@deriving sexp, eq]
+module Time : sig
+  type t [@@deriving sexp, eq]
 
-type t0 = t
+  type t0 = t
 
-module Controller : sig
-  type t = unit
+  module Controller : sig
+    type t = unit
 
-  val create : unit -> t
-end
-
-module Stable : sig
-  module V1 : sig
-    type nonrec t = t [@@deriving sexp, bin_io, compare, eq, hash]
+    val create : unit -> t
   end
-end
-
-val length_in_triples : int
-
-module Bits : Bits_intf.S with type t := t
-
-val fold : t -> bool Triple.t Fold.t
-
-include
-  Tick.Snarkable.Bits.Faithful
-  with type Unpacked.value = t
-   and type Packed.value = t
-   and type Packed.var = private Tick.Field.Var.t
-
-module Span : sig
-  type t [@@deriving sexp, compare]
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, sexp, compare]
+      type nonrec t = t [@@deriving sexp, bin_io, compare, eq, hash]
     end
   end
 
-  val of_time_span : Time.Span.t -> t
+  val length_in_triples : int
+
+  module Bits : Bits_intf.S with type t := t
+
+  val fold : t -> bool Triple.t Fold.t
 
   include
     Tick.Snarkable.Bits.Faithful
     with type Unpacked.value = t
      and type Packed.value = t
+     and type Packed.var = private Tick.Field.Var.t
 
-  val to_ms : t -> Int64.t
+  module Span : sig
+    type t [@@deriving sexp, compare]
 
-  val of_ms : Int64.t -> t
+    module Stable : sig
+      module V1 : sig
+        type nonrec t = t [@@deriving bin_io, sexp, compare]
+      end
+    end
 
-  val ( + ) : t -> t -> t
+    val of_time_span : Time.Span.t -> t
 
-  val ( * ) : t -> t -> t
+    include
+      Tick.Snarkable.Bits.Faithful
+      with type Unpacked.value = t
+       and type Packed.value = t
+
+    val to_time_ns_span : t -> Core.Time_ns.Span.t
+
+    val to_ms : t -> Int64.t
+
+    val of_ms : Int64.t -> t
+
+    val ( + ) : t -> t -> t
+
+    val ( - ) : t -> t -> t
+
+    val ( * ) : t -> t -> t
+
+    val ( < ) : t -> t -> bool
+
+    val ( > ) : t -> t -> bool
+
+    val ( = ) : t -> t -> bool
+
+    val ( <= ) : t -> t -> bool
+
+    val ( >= ) : t -> t -> bool
+  end
 
   val ( < ) : t -> t -> bool
 
@@ -65,7 +81,35 @@ module Span : sig
   val ( <= ) : t -> t -> bool
 
   val ( >= ) : t -> t -> bool
+
+  val field_var_to_unpacked :
+    Tick.Field.Var.t -> (Unpacked.var, _) Tick.Checked.t
+
+  val diff_checked :
+    Unpacked.var -> Unpacked.var -> (Span.Unpacked.var, _) Tick.Checked.t
+
+  val unpacked_to_number : Span.Unpacked.var -> Tick.Number.t
+
+  val add : t -> Span.t -> t
+
+  val diff : t -> t -> Span.t
+
+  val sub : t -> Span.t -> t
+
+  val to_span_since_epoch : t -> Span.t
+
+  val of_span_since_epoch : Span.t -> t
+
+  val modulus : t -> Span.t -> Span.t
+
+  val of_time : Time.t -> t
+
+  val to_time : t -> Time.t
+
+  val now : Controller.t -> t
 end
+
+include module type of Time
 
 module Timeout : sig
   type 'a t
@@ -80,39 +124,3 @@ module Timeout : sig
 
   val remaining_time : 'a t -> Span.t
 end
-
-val ( < ) : t -> t -> bool
-
-val ( > ) : t -> t -> bool
-
-val ( = ) : t -> t -> bool
-
-val ( <= ) : t -> t -> bool
-
-val ( >= ) : t -> t -> bool
-
-val field_var_to_unpacked :
-  Tick.Field.Var.t -> (Unpacked.var, _) Tick.Checked.t
-
-val diff_checked :
-  Unpacked.var -> Unpacked.var -> (Span.Unpacked.var, _) Tick.Checked.t
-
-val unpacked_to_number : Span.Unpacked.var -> Tick.Number.t
-
-val add : t -> Span.t -> t
-
-val diff : t -> t -> Span.t
-
-val sub : t -> Span.t -> t
-
-val to_span_since_epoch : t -> Span.t
-
-val of_span_since_epoch : Span.t -> t
-
-val modulus : t -> Span.t -> Span.t
-
-val of_time : Time.t -> t
-
-val to_time : t -> Time.t
-
-val now : Controller.t -> t

--- a/src/lib/coda_base/fake_time.ml
+++ b/src/lib/coda_base/fake_time.ml
@@ -1,13 +1,12 @@
 module Make (Offset : sig
   val offset : Core_kernel.Time.Span.t
-end) =
-struct
-  module Time : module type of Block_time.Time = struct
+end) : Protocols.Coda_pow.Time_intf = struct
+  module Time = struct
     include Block_time.Time
 
-    let now _ =
-      sub (of_time (Core_kernel.Time.now ())) (Span.of_time_span Offset.offset)
+    let now _ = sub (now ()) (Span.of_time_span Offset.offset)
   end
 
+  include Time
   module Timeout = Timeout.Make (Time)
 end

--- a/src/lib/coda_base/fake_time.ml
+++ b/src/lib/coda_base/fake_time.ml
@@ -1,0 +1,13 @@
+module Make (Offset : sig
+  val offset : Core_kernel.Time.Span.t
+end) =
+struct
+  module Time : module type of Block_time.Time = struct
+    include Block_time.Time
+
+    let now _ =
+      sub (of_time (Core_kernel.Time.now ())) (Span.of_time_span Offset.offset)
+  end
+
+  module Timeout = Timeout.Make (Time)
+end

--- a/src/lib/coda_base/timeout.ml
+++ b/src/lib/coda_base/timeout.ml
@@ -1,0 +1,68 @@
+open Async_kernel
+
+module type Time_intf = sig
+  type t
+
+  module Span : sig
+    type t
+
+    val to_time_ns_span : t -> Core.Time_ns.Span.t
+
+    val ( - ) : t -> t -> t
+  end
+
+  module Controller : sig
+    type t
+  end
+
+  val now : Controller.t -> t
+
+  val diff : t -> t -> Span.t
+end
+
+module Timeout_intf (Time : Time_intf) = struct
+  module type S = sig
+    type 'a t
+
+    val create : Time.Controller.t -> Time.Span.t -> f:(Time.t -> 'a) -> 'a t
+
+    val to_deferred : 'a t -> 'a Async_kernel.Deferred.t
+
+    val peek : 'a t -> 'a option
+
+    val cancel : Time.Controller.t -> 'a t -> 'a -> unit
+
+    val remaining_time : 'a t -> Time.Span.t
+  end
+end
+
+module Make (Time : Time_intf) : Timeout_intf(Time).S = struct
+  type 'a t =
+    { deferred: 'a Deferred.t
+    ; cancel: 'a -> unit
+    ; start_time: Time.t
+    ; span: Time.Span.t
+    ; ctrl: Time.Controller.t }
+
+  let create ctrl span ~f:action =
+    let open Deferred.Let_syntax in
+    let cancel_ivar = Ivar.create () in
+    let timeout = after (Time.Span.to_time_ns_span span) >>| fun () -> None in
+    let deferred =
+      Deferred.any [Ivar.read cancel_ivar; timeout]
+      >>| function None -> action (Time.now ctrl) | Some x -> x
+    in
+    let cancel value = Ivar.fill_if_empty cancel_ivar (Some value) in
+    {ctrl; deferred; cancel; start_time= Time.now ctrl; span}
+
+  let to_deferred {deferred; _} = deferred
+
+  let peek {deferred; _} = Deferred.peek deferred
+
+  let cancel _ {cancel; _} value = cancel value
+
+  let remaining_time {ctrl : _; deferred : _; cancel : _; start_time; span} =
+    let current_time = Time.now ctrl in
+    let time_elapsed = Time.diff current_time start_time in
+    Time.Span.(span - time_elapsed)
+end


### PR DESCRIPTION
This PR creates a new time functor `fake_time` that basically the same as the existing `block_time.ml`, except that when `now` is called, `fake_time` would returns the `current time - offset`, where `offset` is the input of this functor.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
