### PR TITLE
Make reformat-diff not depend on bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ reformat: git_hooks
 	cd src; $(WRAPSRC) dune exec --profile=$(DUNE_PROFILE) app/reformat/reformat.exe -- -path .
 
 reformat-diff:
-	ocamlformat --inplace $(shell git diff --name-only HEAD | grep '.mli\?$$' | while IFS= read -r f; do stat "$$f" &>/dev/null && echo "$$f"; done) || true
+	ocamlformat --inplace $(shell git diff --name-only HEAD | grep '.mli\?$$' | while IFS= read -r f; do stat "$$f" >/dev/null 2>&1 && echo "$$f"; done) || true
 
 check-format:
 	cd src; $(WRAPSRC) dune exec --profile=$(DUNE_PROFILE) app/reformat/reformat.exe -- -path . -check


### PR DESCRIPTION
Was causing an issue with gnu make having a different default shell, this seems to make it work.
Was using `&>` which wasn't redirecting properly when build on a non-mac machine.