### PR TITLE
A one-line fix to avoid using add-exn

### DIFF
--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -166,10 +166,11 @@ module Make (Inputs : Inputs.S) = struct
           ~data:[cached_transition] ;
         Hashtbl.update t.collected_transitions hash
           ~f:(Option.value ~default:[]) ;
-        Hashtbl.add_exn t.parent_root_timeouts ~key:parent_hash
+        Hashtbl.add t.parent_root_timeouts ~key:parent_hash
           ~data:
             (make_timeout
                (Option.value remaining_time ~default:timeout_duration))
+        |> ignore
     | Some cached_sibling_transitions ->
         if
           List.exists cached_sibling_transitions


### PR DESCRIPTION
The current implementation might have bug that `collected_transitions` and `parent_root_timeouts` do not sync. This PR is an easy fix to avoid crashing the program because of this bug.
