### PR TITLE
A one-line change for the integration test of ledger catchup and another one-line change in ledger_catchup itself

### DIFF
--- a/src/app/cli/src/coda_restart_node_test.ml
+++ b/src/app/cli/src/coda_restart_node_test.ml
@@ -49,7 +49,7 @@ let main () =
   in
   let%bind () = after (Time.Span.of_sec 5.) in
   let%bind () = Coda_worker_testnet.Api.start testnet 1 in
-  let%map () = after (Time.Span.of_sec 20.) in
+  let%map () = after (Time.Span.of_sec 240.) in
   ()
 
 let command =

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -88,9 +88,7 @@ module Make (Inputs : Inputs.S) :
                       let%map crumb =
                         breadcrumb_if_present () |> Deferred.return
                       in
-                      (* We make a copy now so the mask can't be detached while we're
-                          * in the middle of applying it later *)
-                      crumb |> Transition_frontier.Breadcrumb.copy
+                      crumb
                   | `Constructed parent -> Deferred.Or_error.return parent
                 in
                 let parent_state_hash =


### PR DESCRIPTION
In this PR, I made 2 changes:

1. I make the test time for ledger catchup to 4 min instead of 30 sec.
2. I delete the unnecessary `Breadcrumb.copy` in ledger catchup.

For 2, `copy` is unwanted because it would create extra layers of mask, which may cause move-root to fail. And since we already did the checks for dangling mask, we don't have to make a copy anyway.
