### PR TITLE
Holy grail test in place, share logic

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -448,6 +448,8 @@ let coda_commands log =
     ; (Coda_five_nodes_test.name, Coda_five_nodes_test.command)
     ; (Coda_restart_node_test.name, Coda_restart_node_test.command)
     ; (Coda_receipt_chain_test.name, Coda_receipt_chain_test.command)
+    ; ( Coda_restarts_and_transactions_holy_grail.name
+      , Coda_restarts_and_transactions_holy_grail.command )
     ; ("full-test", Full_test.command)
     ; ("transaction-snark-profiler", Transaction_snark_profiler.command) ]
   in

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -448,8 +448,8 @@ let coda_commands log =
     ; (Coda_five_nodes_test.name, Coda_five_nodes_test.command)
     ; (Coda_restart_node_test.name, Coda_restart_node_test.command)
     ; (Coda_receipt_chain_test.name, Coda_receipt_chain_test.command)
-    ; ( Coda_restarts_and_transactions_holy_grail.name
-      , Coda_restarts_and_transactions_holy_grail.command )
+    ; ( Coda_restarts_and_txns_holy_grail.name
+      , Coda_restarts_and_txns_holy_grail.command )
     ; ("full-test", Full_test.command)
     ; ("transaction-snark-profiler", Transaction_snark_profiler.command) ]
   in

--- a/src/app/cli/src/coda_five_nodes_restarts_txns.ml
+++ b/src/app/cli/src/coda_five_nodes_restarts_txns.ml
@@ -1,0 +1,70 @@
+open Core
+open Async
+open Coda_worker
+open Coda_main
+open Coda_base
+
+let name = "coda-n-nodes-restarts-txns"
+
+let main n () =
+  assert (n > 1) ;
+  let log = Logger.create () in
+  let log = Logger.child log name in
+  let snark_work_public_keys = function
+    | 0 ->
+        Some
+          (List.nth_exn Genesis_ledger.accounts 5 |> snd |> Account.public_key)
+    | _ -> None
+  in
+  let%bind testnet =
+    Coda_worker_testnet.test log n Option.some snark_work_public_keys
+      Protocols.Coda_pow.Work_selection.Seq
+  in
+  (* SEND TXNS *)
+  let sender_sk =
+    Genesis_ledger.largest_account_exn () |> fst |> Option.value_exn
+  in
+  let receiver_pk =
+    Genesis_ledger.largest_account_exn () |> snd |> Account.public_key
+  in
+  don't_wait_for
+  @@ Coda_worker_testnet.Payments.send_several_payments testnet ~node:0
+       ~src:sender_sk ~dest:receiver_pk ;
+  (* RESTART NODES *)
+  (* catchup *)
+  let idx = Quickcheck.random_value (Int.gen_incl 1 (n - 1)) in
+  let%bind () =
+    Coda_worker_testnet.Restarts.trigger_catchup testnet
+      ~largest_account_keypair:(Genesis_ledger.largest_account_keypair_exn ())
+      ~log ~node:idx
+      ~payment_receiver:(n - 1 - idx)
+  in
+  (* bootstrap *)
+  let idx = Quickcheck.random_value (Int.gen_incl 1 (n - 1)) in
+  let%bind () =
+    Coda_worker_testnet.Restarts.trigger_bootstrap testnet
+      ~largest_account_keypair:(Genesis_ledger.largest_account_keypair_exn ())
+      ~log ~node:idx
+      ~payment_receiver:(n - 1 - idx)
+  in
+  (* random *)
+  let idx = Quickcheck.random_value (Int.gen_incl 1 (n - 1)) in
+  let duration =
+    Quickcheck.(
+      random_value
+        Generator.(Float.gen_incl 1. 5. >>| fun x -> Time.Span.of_min x))
+  in
+  let%bind () =
+    Coda_worker_testnet.Restarts.restart_node testnet ~log ~node:idx
+      ~action:(Fn.const Deferred.unit) ~duration
+  in
+  (* settle for a few more min *)
+  after (Time.Span.of_min 3.)
+
+let command =
+  let open Command.Let_syntax in
+  let%map_open who_proposes =
+    flag "who-proposes" ~doc:"ID node number which will be proposing"
+      (required int)
+  in
+  main who_proposes

--- a/src/app/cli/src/coda_five_nodes_test.ml
+++ b/src/app/cli/src/coda_five_nodes_test.ml
@@ -20,7 +20,7 @@ let main () =
     Coda_worker_testnet.test log n Option.some snark_work_public_keys
       Protocols.Coda_pow.Work_selection.Seq
   in
-  after (Time.Span.of_min 45.)
+  after (Time.Span.of_min 10.)
 
 let command =
   let open Command.Let_syntax in

--- a/src/app/cli/src/coda_restart_node_test.ml
+++ b/src/app/cli/src/coda_restart_node_test.ml
@@ -22,35 +22,18 @@ let main () =
   let n = 2 in
   let proposers i = if i = 0 then Some i else None in
   let snark_work_public_keys i =
-    if i = 0 then Some (Public_key.compress largest_account_keypair.public_key)
+    if i = 0 then Some (Public_key.compress another_account_keypair.public_key)
     else None
   in
-  let send_new = true in
-  let receiver_pk =
-    Public_key.compress
-      ( if send_new then
-        let keypair = Keypair.create () in
-        keypair.public_key
-      else another_account_keypair.public_key )
-  in
-  let sender_sk = largest_account_keypair.private_key in
-  let send_amount = Currency.Amount.of_int 10 in
-  let fee = Currency.Fee.of_int 0 in
   let%bind testnet =
     Coda_worker_testnet.test log n proposers snark_work_public_keys
       Protocols.Coda_pow.Work_selection.Seq
   in
-  let%bind () = after (Time.Span.of_sec 5.) in
-  Logger.info log "Stopping %d" 1 ;
-  let%bind () = Coda_worker_testnet.Api.stop testnet 1 in
   let%bind () =
-    Coda_worker_testnet.Api.send_payment testnet 0 sender_sk receiver_pk
-      send_amount fee
+    Coda_worker_testnet.Restarts.trigger_catchup testnet
+      ~largest_account_keypair ~log ~node:1 ~payment_receiver:0
   in
-  let%bind () = after (Time.Span.of_sec 5.) in
-  let%bind () = Coda_worker_testnet.Api.start testnet 1 in
-  let%map () = after (Time.Span.of_sec 240.) in
-  ()
+  after (Time.Span.of_sec 240.)
 
 let command =
   let open Command.Let_syntax in

--- a/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
+++ b/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
@@ -4,7 +4,7 @@ open Coda_worker
 open Coda_main
 open Coda_base
 
-let name = "coda-n-nodes-restarts-txns"
+let name = "coda-restarts-and-txns-holy-grail"
 
 let main n () =
   assert (n > 1) ;
@@ -63,8 +63,12 @@ let main n () =
 
 let command =
   let open Command.Let_syntax in
-  let%map_open who_proposes =
-    flag "who-proposes" ~doc:"ID node number which will be proposing"
-      (required int)
-  in
-  main who_proposes
+  Command.async
+    ~summary:
+      "Test the holy grail for n nodes: All sorts of restarts and \
+       transactions work"
+    (let%map_open who_proposes =
+       flag "who-proposes" ~doc:"ID node number which will be proposing"
+         (required int)
+     in
+     main who_proposes)

--- a/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
+++ b/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
@@ -59,6 +59,7 @@ let main n () =
       ~action:(Fn.const Deferred.unit) ~duration
   in
   (* settle for a few more min *)
+  (* TODO: Make sure to check that catchup actually worked *)
   after (Time.Span.of_min 3.)
 
 let command =

--- a/src/app/cli/src/coda_shared_state_test.ml
+++ b/src/app/cli/src/coda_shared_state_test.ml
@@ -25,23 +25,14 @@ let main () =
     if i = 0 then Some (Public_key.compress largest_account_keypair.public_key)
     else None
   in
-  let receiver_pk = Public_key.compress another_account_keypair.public_key in
-  let sender_sk = largest_account_keypair.private_key in
-  let send_amount = Currency.Amount.of_int 10 in
-  let fee = Currency.Fee.of_int 0 in
   let%bind testnet =
     Coda_worker_testnet.test log n proposers snark_work_public_keys
       Protocols.Coda_pow.Work_selection.Seq
   in
-  let rec go i =
-    let%bind () = after (Time.Span.of_sec 1.) in
-    let%bind () =
-      Coda_worker_testnet.Api.send_payment testnet 0 sender_sk receiver_pk
-        send_amount fee
-    in
-    if i > 0 then go (i - 1) else return ()
-  in
-  go 40
+  let receiver_pk = Public_key.compress another_account_keypair.public_key in
+  let sender_sk = largest_account_keypair.private_key in
+  Coda_worker_testnet.Payments.send_several_payments testnet ~node:0
+    ~src:sender_sk ~dest:receiver_pk
 
 let command =
   let open Command.Let_syntax in


### PR DESCRIPTION
Shared logic between integration tests is moved into functions under
submodules of `Coda_worker_testnet`, those are all mixed together to
make the holy-grail test.

The goal is for the holy grail test to work under 2 proposers with check
on and 5 proposers with fast-hash.

Note that with this in place + the bootstrap test @ghost-not-in-the-shell 
is working on and the txn test @enolan is working on, we should have 
essentially have coverage on the scaffolding.

These tests are intentionally not turned on for CI at this time.