### PR TITLE
"Participated" bit

### DIFF
--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -37,12 +37,13 @@ end
 
 module Nonce = Account_nonce
 
-type ('pk, 'amount, 'nonce, 'receipt_chain_hash) t_ =
+type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'bool) t_ =
   { public_key: 'pk
   ; balance: 'amount
   ; nonce: 'nonce
   ; receipt_chain_hash: 'receipt_chain_hash
-  ; delegate: 'pk }
+  ; delegate: 'pk
+  ; participated: 'bool }
 [@@deriving fields, sexp, bin_io, eq, compare, hash]
 
 module Stable = struct
@@ -57,7 +58,8 @@ module Stable = struct
         ( key
         , Balance.Stable.V1.t
         , Nonce.Stable.V1.t
-        , Receipt.Chain_hash.Stable.V1.t )
+        , Receipt.Chain_hash.Stable.V1.t
+        , bool )
         t_
       [@@deriving sexp, bin_io, eq, hash, compare]
     end
@@ -92,11 +94,12 @@ type var =
   ( Public_key.Compressed.var
   , Balance.var
   , Nonce.Unpacked.var
-  , Receipt.Chain_hash.var )
+  , Receipt.Chain_hash.var
+  , Boolean.var )
   t_
 
 type value =
-  (Public_key.Compressed.t, Balance.t, Nonce.t, Receipt.Chain_hash.t) t_
+  (Public_key.Compressed.t, Balance.t, Nonce.t, Receipt.Chain_hash.t, bool) t_
 [@@deriving sexp]
 
 let key_gen = Public_key.Compressed.gen
@@ -106,7 +109,8 @@ let initialize public_key : t =
   ; balance= Balance.zero
   ; nonce= Nonce.zero
   ; receipt_chain_hash= Receipt.Chain_hash.empty
-  ; delegate= public_key }
+  ; delegate= public_key
+  ; participated= false }
 
 let typ : (var, value) Typ.t =
   let spec =
@@ -115,55 +119,68 @@ let typ : (var, value) Typ.t =
     ; Balance.typ
     ; Nonce.Unpacked.typ
     ; Receipt.Chain_hash.typ
-    ; Public_key.Compressed.typ ]
+    ; Public_key.Compressed.typ
+    ; Boolean.typ ]
   in
   let of_hlist
-        : 'a 'b 'c 'd.    (unit, 'a -> 'b -> 'c -> 'd -> 'a -> unit) H_list.t
-          -> ('a, 'b, 'c, 'd) t_ =
+        : 'a 'b 'c 'd 'e.    ( unit
+                             , 'a -> 'b -> 'c -> 'd -> 'a -> 'e -> unit )
+                             H_list.t -> ('a, 'b, 'c, 'd, 'e) t_ =
     let open H_list in
-    fun [public_key; balance; nonce; receipt_chain_hash; delegate] ->
-      {public_key; balance; nonce; receipt_chain_hash; delegate}
+    fun [public_key; balance; nonce; receipt_chain_hash; delegate; participated]
+        ->
+      {public_key; balance; nonce; receipt_chain_hash; delegate; participated}
   in
-  let to_hlist {public_key; balance; nonce; receipt_chain_hash; delegate} =
-    H_list.[public_key; balance; nonce; receipt_chain_hash; delegate]
+  let to_hlist
+      {public_key; balance; nonce; receipt_chain_hash; delegate; participated}
+      =
+    H_list.
+      [public_key; balance; nonce; receipt_chain_hash; delegate; participated]
   in
   Typ.of_hlistable spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
     ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
 
 let var_of_t
-    ({public_key; balance; nonce; receipt_chain_hash; delegate} : value) =
+    ({public_key; balance; nonce; receipt_chain_hash; delegate; participated} :
+      value) =
   { public_key= Public_key.Compressed.var_of_t public_key
   ; balance= Balance.var_of_t balance
   ; nonce= Nonce.Unpacked.var_of_value nonce
   ; receipt_chain_hash= Receipt.Chain_hash.var_of_t receipt_chain_hash
-  ; delegate= Public_key.Compressed.var_of_t delegate }
+  ; delegate= Public_key.Compressed.var_of_t delegate
+  ; participated= Boolean.var_of_value participated }
 
-let var_to_triples {public_key; balance; nonce; receipt_chain_hash; delegate} =
+let var_to_triples
+    {public_key; balance; nonce; receipt_chain_hash; delegate; participated} =
   let%map public_key = Public_key.Compressed.var_to_triples public_key
   and receipt_chain_hash = Receipt.Chain_hash.var_to_triples receipt_chain_hash
   and delegate = Public_key.Compressed.var_to_triples delegate in
   let balance = Balance.var_to_triples balance in
   let nonce = Nonce.Unpacked.var_to_triples nonce in
   public_key @ balance @ nonce @ receipt_chain_hash @ delegate
+  @ [(participated, Boolean.false_, Boolean.false_)]
 
-let fold_bits ({public_key; balance; nonce; receipt_chain_hash; delegate} : t)
-    =
+let fold
+    ({public_key; balance; nonce; receipt_chain_hash; delegate; participated} :
+      t) =
   let open Fold in
   Public_key.Compressed.fold public_key
   +> Balance.fold balance +> Nonce.fold nonce
   +> Receipt.Chain_hash.fold receipt_chain_hash
   +> Public_key.Compressed.fold delegate
+  +> Fold.return (participated, false, false)
 
 let crypto_hash_prefix = Hash_prefix.account
 
-let crypto_hash t = Pedersen.hash_fold crypto_hash_prefix (fold_bits t)
+let crypto_hash t = Pedersen.hash_fold crypto_hash_prefix (fold t)
 
 let empty =
   { public_key= Public_key.Compressed.empty
   ; balance= Balance.zero
   ; nonce= Nonce.zero
   ; receipt_chain_hash= Receipt.Chain_hash.empty
-  ; delegate= Public_key.Compressed.empty }
+  ; delegate= Public_key.Compressed.empty
+  ; participated= false }
 
 let digest t = Pedersen.State.digest (crypto_hash t)
 
@@ -172,7 +189,8 @@ let create public_key balance =
   ; balance
   ; nonce= Nonce.zero
   ; receipt_chain_hash= Receipt.Chain_hash.empty
-  ; delegate= public_key }
+  ; delegate= public_key
+  ; participated= false }
 
 let gen =
   let open Quickcheck.Let_syntax in

--- a/src/lib/lite_base/account.ml
+++ b/src/lib/lite_base/account.ml
@@ -1,3 +1,5 @@
+open Core_kernel
+
 module Balance = Nat.Make64 ()
 
 module Nonce = Nat.Make32 ()
@@ -7,12 +9,15 @@ type t =
   ; balance: Balance.t
   ; nonce: Nonce.t
   ; receipt_chain_hash: Receipt.Chain_hash.t
-  ; delegate: Public_key.Compressed.t }
+  ; delegate: Public_key.Compressed.t
+  ; participated: bool }
 [@@deriving bin_io, sexp, eq]
 
-let fold {public_key; balance; nonce; receipt_chain_hash; delegate} =
+let fold
+    {public_key; balance; nonce; receipt_chain_hash; delegate; participated} =
   let open Fold_lib.Fold in
   Public_key.Compressed.fold public_key
   +> Balance.fold balance +> Nonce.fold nonce
   +> Receipt.Chain_hash.fold receipt_chain_hash
   +> Public_key.Compressed.fold delegate
+  +> Fold_lib.Fold.return (participated, false, false)

--- a/src/lib/lite_compat/lite_compat.ml
+++ b/src/lib/lite_compat/lite_compat.ml
@@ -80,7 +80,8 @@ module Make (Blockchain_state : Coda_base.Blockchain_state.S) = struct
     ; balance= balance account.balance
     ; delegate= public_key account.delegate
     ; receipt_chain_hash=
-        digest (account.receipt_chain_hash :> Tick.Pedersen.Digest.t) }
+        digest (account.receipt_chain_hash :> Tick.Pedersen.Digest.t)
+    ; participated= account.participated }
 
   let ledger_hash (h : Coda_base.Ledger_hash.t) : Lite_base.Ledger_hash.t =
     digest (h :> Tick.Pedersen.Digest.t)

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -256,7 +256,8 @@ module Base = struct
              ; public_key= sender_compressed
              ; nonce= next_nonce
              ; receipt_chain_hash
-             ; delegate }) )
+             ; delegate
+             ; participated= account.participated }) )
     in
     let%bind receiver =
       (* A stake delegation only uses the sender *)


### PR DESCRIPTION
This adds a field `participated : bool` to `Account.t`. It is currently always false. It is to be used to track whether an account has won a block in a given epoch.