### PR TITLE
SIMPLE: Only publish postake to stable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ publish_kademlia_deb:
 
 publish_deb:
 	@if [ $(AWS_ACCESS_KEY_ID) ] ; then \
-		if [ "$(CIRCLE_BRANCH)" = "master" ] && [ "$(CIRCLE_BRANCH)" = "build_testnet_postake" ] ; then \
+		if [ "$(CIRCLE_BRANCH)" = "master" ] && [ "$(CIRCLE_JOB)" = "build_testnet_postake" ] ; then \
             echo "Publishing to stable" ; \
 			$(DEBS3) --codename stable   --component main src/_build/coda.deb ; \
 		else \

--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,11 @@ publish_kademlia_deb:
 
 publish_deb:
 	@if [ $(AWS_ACCESS_KEY_ID) ] ; then \
-		if [ "$(CIRCLE_BRANCH)" = "master" ] ; then \
+		if [ "$(CIRCLE_BRANCH)" = "master" ] && [ "$(CIRCLE_BRANCH)" = "build_testnet_postake" ] ; then \
+            echo "Publishing to stable" ; \
 			$(DEBS3) --codename stable   --component main src/_build/coda.deb ; \
 		else \
+            echo "Publishing to unstable" ; \
 			$(DEBS3) --codename unstable --component main src/_build/coda.deb ; \
 		fi ; \
 	else  \


### PR DESCRIPTION
We were merging debs in from all master builds.  Only publish postake to stable.