### PR TITLE
SIMPLE: minor change, use fully spec deb name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ deb:
 	@cp src/_build/coda.deb /tmp/artifacts/.
 
 # deb-s3 https://github.com/krobertson/deb-s3
-DEBS3 = deb-s3 upload --s3-region=us-west-2 --bucket packages.o1test.net --preserve-versions --cache-control=120
+DEBS3 = deb-s3 upload --s3-region=us-west-2 --bucket packages.o1test.net --preserve-versions --cache-control=max-age=120
 
 publish_kademlia_deb:
 	@if [ $(AWS_ACCESS_KEY_ID) ] ; then \

--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,9 @@ publish_kademlia_deb:
 publish_deb:
 	@if [ $(AWS_ACCESS_KEY_ID) ] ; then \
 		if [ "$(CIRCLE_BRANCH)" = "master" ] ; then \
-			$(DEBS3) --codename stable   --component main src/_build/coda.deb ; \
+			$(DEBS3) --codename stable   --component main src/_build/coda-*.deb ; \
 		else \
-			$(DEBS3) --codename unstable --component main src/_build/coda.deb ; \
+			$(DEBS3) --codename unstable --component main src/_build/coda-*.deb ; \
 		fi ; \
 	else  \
 		echo "WARNING: AWS_ACCESS_KEY_ID not set, deb-s3 commands not run" ; \


### PR DESCRIPTION
Use the full path'd deb file name (to maintain multiple versions)

eg.
coda-testnet-postake_0.1.56007-CI.deb

vs
coda.deb

