### PR TITLE
Fix bootstrap check

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1529,7 +1529,7 @@ module For_tests = struct
       ; curr_epoch_data }
 end
 
-let should_bootstrap_len ~exisiting ~candidate =
+let should_bootstrap_len ~existing ~candidate =
   let length = Length.to_int in
   length candidate - length existing > (2 * Constants.k) + Constants.delta
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1531,7 +1531,7 @@ end
 
 let should_bootstrap ~existing ~candidate =
   let length = Fn.compose Length.to_int Consensus_state.length in
-  length existing - length candidate > (2 * Constants.k) + Constants.delta
+  length candidate - length existing > (2 * Constants.k) + Constants.delta
 
 let to_unix_timestamp recieved_time =
   recieved_time |> Time.to_span_since_epoch |> Time.Span.to_ms

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1529,9 +1529,19 @@ module For_tests = struct
       ; curr_epoch_data }
 end
 
-let should_bootstrap ~existing ~candidate =
-  let length = Fn.compose Length.to_int Consensus_state.length in
+let should_bootstrap_len ~exisiting ~candidate =
+  let length = Length.to_int in
   length candidate - length existing > (2 * Constants.k) + Constants.delta
+
+let should_bootstrap ~existing ~candidate =
+  should_bootstrap_len
+    ~existing:(Consensus_state.length existing)
+    ~candidate:(Consensus_state.length candidate)
+
+let%test "should_bootstrap is sane" =
+  (* Even when consensus constants are of prod sizes, candidate should still trigger a bootstrap *)
+  should_bootstrap_len ~existing:Length.zero
+    ~candidate:(Length.of_int 100_000_000)
 
 let to_unix_timestamp recieved_time =
   recieved_time |> Time.to_span_since_epoch |> Time.Span.to_ms


### PR DESCRIPTION
Should_bootstrap check had the wrong equation in it. The left-hand side of the `>` was always negative, so `should_bootstrap` was always false. This means we have never _once_ actually tested bootstrap in a real network or integration test.

I added a unit test so this doesn't regress.

- [x] Tests were added for the new behavior
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules