### PR TITLE
increase default payment fee

### DIFF
--- a/src/lib/cli_lib/fee.ml
+++ b/src/lib/cli_lib/fee.ml
@@ -1,4 +1,5 @@
 (* Default fees applied *)
-let default_transaction = Currency.Fee.of_int 1
+(* A payment requires 2 SNARKS, so this should always >= 2x the snark fee. *)
+let default_transaction = Currency.Fee.of_int 2
 
 let default_snark_worker = Currency.Fee.of_int 1


### PR DESCRIPTION
Increase default payment fee so they don't get stuck when the scan state is full

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them
