### PR TITLE
Newline in histogram title

### DIFF
--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -25,7 +25,7 @@ module Types = struct
             sprintf "%s: %s %s" s padding x )
         |> String.concat ~sep:"\n"
       in
-      title ^ output ^ "\n"
+      title ^ "\n" ^ output ^ "\n"
 
     let summarize_report
         {Perf_histograms.Report.values; intervals; overflow; underflow} =


### PR DESCRIPTION
For the longest time this annoying things was happening:

```
Histograms:                 Performance HistogramsAccepted remote block Latencies (hist.):  Total: 212 (overflow:0) (underflow:0)
```

Now it's not