### PR TITLE
Don't reformat in the node_modules subdir

### DIFF
--- a/src/app/reformat/reformat.ml
+++ b/src/app/reformat/reformat.ml
@@ -25,7 +25,8 @@ let main dry_run check path =
             && (not (String.is_suffix ~suffix:"stationary" path))
             && (not (String.is_suffix ~suffix:".un~" path))
             && (not (String.is_suffix ~suffix:"external" path))
-            && not (String.is_suffix ~suffix:"ocamlformat" path)
+            && (not (String.is_suffix ~suffix:"ocamlformat" path))
+            && not (String.is_suffix ~suffix:"node_modules" path)
         | `File ->
             (not
                (List.exists whitelist ~f:(fun s ->


### PR DESCRIPTION
This PR stops us from trying to reformat files within a `node_modules` subdirectory.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: