### PR TITLE
Transition router set phase copy-paste error

### DIFF
--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -127,7 +127,7 @@ module Make (Inputs : Inputs_intf) :
 
   let set_transition_frontier_controller_phase ~controller_type new_frontier
       reader writer =
-    assert (not @@ is_bootstrapping (Broadcaster.get controller_type)) ;
+    assert (is_bootstrapping (Broadcaster.get controller_type)) ;
     Broadcaster.broadcast controller_type
       (`Transition_frontier_controller (new_frontier, reader, writer))
 


### PR DESCRIPTION
When we transition from bootstrap -> not bootstrap we should assert the
opposite as the other case.

This was found while trying to get the bootstrap integration test to
work. The bootstrap integration test will exercise this code when it
lands.

- [x] Tests were added for the new behavior

They will be added when bootstrap integration test finishes

- [x] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: