### PR TITLE
Coda bootstrap test (disabled for now)

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -452,6 +452,7 @@ let coda_commands log =
     ; (Coda_receipt_chain_test.name, Coda_receipt_chain_test.command)
     ; ( Coda_restarts_and_txns_holy_grail.name
       , Coda_restarts_and_txns_holy_grail.command )
+    ; (Coda_bootstrap_test.name, Coda_bootstrap_test.command)
     ; ("full-test", Full_test.command)
     ; ("transaction-snark-profiler", Transaction_snark_profiler.command) ]
   in

--- a/src/app/cli/src/coda_bootstrap_test.ml
+++ b/src/app/cli/src/coda_bootstrap_test.ml
@@ -1,0 +1,38 @@
+open Core
+open Async
+open Coda_worker
+open Coda_main
+open Coda_base
+open Signature_lib
+
+let name = "coda-bootstrap-test"
+
+let main () =
+  let open Keypair in
+  let log = Logger.create () in
+  let log = Logger.child log name in
+  let largest_account_keypair =
+    Genesis_ledger.largest_account_keypair_exn ()
+  in
+  let n = 2 in
+  let proposers i = if i = 0 then Some i else None in
+  let snark_work_public_keys i =
+    if i = 0 then Some (Public_key.compress largest_account_keypair.public_key)
+    else None
+  in
+  let%bind testnet =
+    Coda_worker_testnet.test log n proposers snark_work_public_keys
+      Protocols.Coda_pow.Work_selection.Seq
+  in
+  let%bind () =
+    Coda_worker_testnet.Restarts.trigger_bootstrap testnet ~log ~node:1
+      ~largest_account_keypair ~payment_receiver:0
+  in
+  let%map () = after (Time.Span.of_sec 60.) in
+  Logger.info log "SUCCEEDED" ;
+  ()
+
+let command =
+  let open Command.Let_syntax in
+  Command.async ~summary:"Test that triggers bootstrap once"
+    (Command.Param.return main)

--- a/src/config/test_postake_bootstrap.mlh
+++ b/src/config/test_postake_bootstrap.mlh
@@ -1,0 +1,16 @@
+[%%import "config/ledger_depth/tiny.mlh"]
+[%%import "config/coinbase/standard.mlh"]
+[%%import "config/consensus/postake_tiny.mlh"]
+[%%import "config/scan_state/small.mlh"]
+[%%import "config/debug_level/some.mlh"]
+[%%import "config/proof_level/none.mlh"]
+
+[%%define time_offsets true]
+[%%define fake_hash true]
+
+[%%define genesis_ledger "test"]
+[%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
+[%%define block_window_duration 1000]
+
+[%%define integration_tests true]
+[%%define force_updates false]


### PR DESCRIPTION
Use the test_postake_boostrap.mlh config file

This will be enabled after we fix all the bugs with it.