### PR TITLE
Use null logger in unit tests

### DIFF
--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -32,7 +32,7 @@ module Keys = struct
 
     let load ({step; wrap} : Location.t) =
       let open Storage in
-      let parent_log = Logger.create () in
+      let parent_log = Logger.null () in
       let tick_controller =
         Controller.create ~parent_log (module Tick.Groth16.Proving_key)
       in
@@ -71,7 +71,7 @@ module Keys = struct
 
     let load ({step; wrap} : Location.t) =
       let open Storage in
-      let parent_log = Logger.create () in
+      let parent_log = Logger.null () in
       let tick_controller =
         Controller.create ~parent_log (module Tick.Groth16.Verification_key)
       in

--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -194,7 +194,7 @@ let%test_module "cache_lib test instance" =
     let%test_unit "cached objects do not trigger unconsumption hook when \
                    invalidated" =
       setup () ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       with_cache ~logger ~f:(fun cache ->
           with_item ~f:(fun data ->
               let x = Or_error.ok_exn (Cache.register cache data) in
@@ -205,7 +205,7 @@ let%test_module "cache_lib test instance" =
     let%test_unit "cached objects are garbage collected independently of caches"
         =
       setup () ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       with_cache ~logger ~f:(fun cache ->
           with_item ~f:(fun data ->
               ignore (Or_error.ok_exn (Cache.register cache data)) ) ;
@@ -215,7 +215,7 @@ let%test_module "cache_lib test instance" =
     let%test_unit "cached objects are garbage collected independently of data"
         =
       setup () ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       with_item ~f:(fun data ->
           with_cache ~logger ~f:(fun cache ->
               ignore (Or_error.ok_exn (Cache.register cache data)) ) ;
@@ -224,7 +224,7 @@ let%test_module "cache_lib test instance" =
 
     let%test_unit "cached objects are not unexpectedly garbage collected" =
       setup () ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       with_cache ~logger ~f:(fun cache ->
           with_item ~f:(fun data ->
               let cached = Or_error.ok_exn (Cache.register cache data) in
@@ -237,7 +237,7 @@ let%test_module "cache_lib test instance" =
     let%test_unit "garbage collection of derived cached objects do not \
                    trigger unconsumption handler for parents" =
       setup () ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       with_cache ~logger ~f:(fun cache ->
           with_item ~f:(fun data ->
               Cache.register cache data |> Or_error.ok_exn
@@ -250,7 +250,7 @@ let%test_module "cache_lib test instance" =
     let%test_unit "properly invalidated derived cached objects do not trigger \
                    any unconsumption handler calls" =
       setup () ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       with_cache ~logger ~f:(fun cache ->
           with_item ~f:(fun data ->
               Cache.register cache data |> Or_error.ok_exn
@@ -263,7 +263,7 @@ let%test_module "cache_lib test instance" =
     let%test_unit "deriving a cached object consumes it's parent, disallowing \
                    use of it" =
       setup () ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       with_cache ~logger ~f:(fun cache ->
           with_item ~f:(fun data ->
               let src = Or_error.ok_exn (Cache.register cache data) in

--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -382,7 +382,7 @@ end = struct
   module For_tests = struct
     let node (me : Peer.t) (peers : Host_and_port.t list) conf_dir trust_system
         =
-      connect ~initial_peers:peers ~me ~parent_log:(Logger.create ()) ~conf_dir
+      connect ~initial_peers:peers ~me ~parent_log:(Logger.null ()) ~conf_dir
         ~trust_system
       >>| Or_error.ok_exn
   end
@@ -427,7 +427,7 @@ let%test_module "Tests" =
               ~me:
                 (Peer.create Unix.Inet_addr.localhost ~discovery_port:3001
                    ~communication_port:3000)
-              ~parent_log:(Logger.create ())
+              ~parent_log:(Logger.null ())
               ~conf_dir:(Filename.temp_dir_name ^/ "membership-test")
           with
           | Ok t ->

--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -145,7 +145,7 @@ let%test_module "network pool test" =
         Broadcast_pipe.create (Some (Mock_transition_frontier.create ()))
       in
       let network_pool =
-        Mock_network_pool.create ~parent_log:(Logger.create ())
+        Mock_network_pool.create ~parent_log:(Logger.null ())
           ~incoming_diffs:pool_reader
           ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
       in
@@ -180,7 +180,7 @@ let%test_module "network pool test" =
           Broadcast_pipe.create (Some (Mock_transition_frontier.create ()))
         in
         let network_pool =
-          Mock_network_pool.create ~parent_log:(Logger.create ())
+          Mock_network_pool.create ~parent_log:(Logger.null ())
             ~incoming_diffs:work_diffs
             ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
         in

--- a/src/lib/snark_pool/snark_pool.ml
+++ b/src/lib/snark_pool/snark_pool.ml
@@ -224,7 +224,7 @@ let%test_module "random set test" =
         Broadcast_pipe.create (Some (Mock_transition_frontier.create ()))
       in
       let pool =
-        Mock_snark_pool.create ~parent_log:(Logger.create ())
+        Mock_snark_pool.create ~parent_log:(Logger.null ())
           ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
       in
       List.iter sample_solved_work ~f:(fun (work, proof, fee) ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2010,7 +2010,7 @@ let%test_module "test" =
 
     let%test_unit "Max throughput" =
       (*Always at worst case number of provers. This is enforced by creating proof bundles *)
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let p =
         Int.pow 2
           Transaction_snark_scan_state.Constants.transaction_capacity_log_2
@@ -2049,7 +2049,7 @@ let%test_module "test" =
     let%test_unit "Be able to include random number of user_commands" =
       (*Always at worst case number of provers*)
       Backtrace.elide := false ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let p =
         Int.pow 2
           Transaction_snark_scan_state.Constants.transaction_capacity_log_2
@@ -2095,7 +2095,7 @@ let%test_module "test" =
           ; prover= "P" }
       in
       Backtrace.elide := false ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let p =
         Int.pow 2
           Transaction_snark_scan_state.Constants.transaction_capacity_log_2
@@ -2142,7 +2142,7 @@ let%test_module "test" =
               ; proofs= stmts
               ; prover= "P" }
           in
-          let logger = Logger.create () in
+          let logger = Logger.null () in
           let txns =
             List.init 6 ~f:(fun _ -> [])
             @ [[(1, 0); (1, 0); (1, 0)]] @ [[(1, 0); (1, 0)]]
@@ -2191,7 +2191,7 @@ let%test_module "test" =
       Quickcheck.test g ~trials:50 ~f:(fun i ->
           Async.Thread_safe.block_on_async_exn (fun () ->
               let open Deferred.Let_syntax in
-              let logger = Logger.create () in
+              let logger = Logger.null () in
               let txns = txns i (fun x -> (x + 1) * 100) (fun _ -> 4) in
               let scan_state = Sl.scan_state !sl in
               let work =
@@ -2227,7 +2227,7 @@ let%test_module "test" =
 
     let%test_unit "Snarked ledger" =
       Backtrace.elide := false ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let p =
         Int.pow 2
           Transaction_snark_scan_state.Constants.transaction_capacity_log_2
@@ -2259,7 +2259,7 @@ let%test_module "test" =
     let%test_unit "max throughput-random number of proofs-worst case provers" =
       (*Always at worst case number of provers*)
       Backtrace.elide := false ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let p =
         Int.pow 2
           Transaction_snark_scan_state.Constants.transaction_capacity_log_2
@@ -2309,7 +2309,7 @@ let%test_module "test" =
                    case provers" =
       (*Always at worst case number of provers*)
       Backtrace.elide := false ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let p =
         Int.pow 2
           Transaction_snark_scan_state.Constants.transaction_capacity_log_2
@@ -2376,7 +2376,7 @@ let%test_module "test" =
         else None
       in
       Backtrace.elide := false ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let p =
         Int.pow 2
           Transaction_snark_scan_state.Constants.transaction_capacity_log_2

--- a/src/lib/transition_frontier_controller_tests/test_bootstrap_controller.ml
+++ b/src/lib/transition_frontier_controller_tests/test_bootstrap_controller.ml
@@ -38,7 +38,7 @@ let%test_module "Bootstrap Controller" =
         Bootstrap_controller.For_tests.Transition_cache.create ()
       in
       let num_breadcrumbs = (Transition_frontier.max_length * 2) + 2 in
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let network =
         Network.create ~logger ~peers:(Network_peer.Peer.Table.of_alist_exn [])
       in
@@ -134,7 +134,7 @@ let%test_module "Bootstrap Controller" =
 
     let%test_unit "reconstruct staged_ledgers using \
                    of_scan_state_and_snarked_ledger" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let num_breadcrumbs = 10 in
       let accounts = Genesis_ledger.accounts in
       Thread_safe.block_on_async_exn (fun () ->
@@ -170,7 +170,7 @@ let%test_module "Bootstrap Controller" =
     let%test "sync with one node correctly" =
       Backtrace.elide := false ;
       Printexc.record_backtrace true ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let num_breadcrumbs = 10 in
       Thread_safe.block_on_async_exn (fun () ->
           let%bind syncing_frontier, peer, network =
@@ -196,7 +196,7 @@ let%test_module "Bootstrap Controller" =
               that we are syncing from, than we should retarget our root" =
       Backtrace.elide := false ;
       Printexc.record_backtrace true ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let small_peer_num_breadcrumbs = 6 in
       let large_peer_num_breadcrumbs = small_peer_num_breadcrumbs * 2 in
       let source_accounts = [List.hd_exn Genesis_ledger.accounts] in
@@ -239,7 +239,7 @@ let%test_module "Bootstrap Controller" =
             (root_hash large_peer.frontier) )
 
     let%test "`on_transition` should deny outdated transitions" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let num_breadcrumbs = 10 in
       Thread_safe.block_on_async_exn (fun () ->
           let%bind syncing_frontier, peer, network =

--- a/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
+++ b/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
@@ -117,7 +117,7 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
 
     let%test_unit "if a linear sequence of transitions in reverse order, \
                    catchup scheduler should not create duplicate jobs" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let _catchup_job_reader, catchup_job_writer =
         Strict_pipe.create Synchronous
       in

--- a/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
+++ b/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
@@ -78,7 +78,7 @@ let%test_module "Ledger catchup" =
     let%test "catchup to a peer" =
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Thread_safe.block_on_async_exn (fun () ->
           let%bind me, peer, network =
             Network_builder.setup_me_and_a_peer
@@ -97,7 +97,7 @@ let%test_module "Ledger catchup" =
 
     let%test_unit "peers can provide transitions with length between \
                    max_length to 2 * max_length" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Thread_safe.block_on_async_exn (fun () ->
           let num_breadcrumbs =
             Int.gen_incl max_length (2 * max_length) |> Quickcheck.random_value

--- a/src/lib/transition_frontier_controller_tests/test_root_prover.ml
+++ b/src/lib/transition_frontier_controller_tests/test_root_prover.ml
@@ -14,7 +14,7 @@ let%test_module "Root_prover" =
       |> With_hash.data |> External_transition.of_verified
 
     let%test "a node should be able to give a valid proof of their root" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       let max_length = 4 in
       (* Generating this many breadcrumbs will ernsure the transition_frontier to be full  *)
       let num_breadcrumbs = max_length + 2 in

--- a/src/lib/transition_frontier_controller_tests/test_sync_handler.ml
+++ b/src/lib/transition_frontier_controller_tests/test_sync_handler.ml
@@ -17,7 +17,7 @@ let%test_module "Sync_handler" =
     let%test "sync with ledgers from another peer via glue_sync_ledger" =
       Backtrace.elide := false ;
       Printexc.record_backtrace true ;
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Ledger.with_ephemeral_ledger ~f:(fun dest_ledger ->
           Thread_safe.block_on_async_exn (fun () ->
               let%bind frontier =

--- a/src/lib/transition_frontier_controller_tests/test_transition_frontier.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transition_frontier.ml
@@ -28,7 +28,7 @@ let%test_module "Root_history and Transition_frontier" =
 
     let%test "If a transition does not exists in the transition_frontier or \
               in the root_history, then we should not get an answer" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let%bind frontier = create_root_frontier ~logger in
           let root = Transition_frontier.root frontier in
@@ -52,7 +52,7 @@ let%test_module "Root_history and Transition_frontier" =
 
     let%test "Query transition only from transition_frontier if the \
               root_history is empty" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let%bind frontier = create_root_frontier ~logger in
           let root = Transition_frontier.root frontier in
@@ -82,7 +82,7 @@ let%test_module "Root_history and Transition_frontier" =
           breadcrumb_trail_equals expected_breadcrumbs queried_breadcrumbs )
 
     let%test "Query transitions only from root_history" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let%bind frontier = create_root_frontier ~logger in
           let root = Transition_frontier.root frontier in
@@ -111,7 +111,7 @@ let%test_module "Root_history and Transition_frontier" =
             |> Option.value_exn |> Non_empty_list.to_list ) )
 
     let%test "Transitions get popped off from root history" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let%bind frontier = create_root_frontier ~logger in
           let root = Transition_frontier.root frontier in
@@ -133,7 +133,7 @@ let%test_module "Root_history and Transition_frontier" =
           Transition_frontier.find frontier root_hash |> Option.is_empty )
 
     let%test "Get transitions from both transition frontier and root history" =
-      let logger = Logger.create () in
+      let logger = Logger.null () in
       Async.Thread_safe.block_on_async_exn (fun () ->
           let%bind frontier = create_root_frontier ~logger in
           let root = Transition_frontier.root frontier in


### PR DESCRIPTION
Noisy tests are annoying and rarely informative. A few of the tests already did this, but most didn't.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: