### PR TITLE
Remove bin_io from Ledger_proof

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -393,11 +393,13 @@ end
 module Fee_transfer = Coda_base.Fee_transfer
 module Ledger_proof_statement = Transaction_snark.Statement
 module Transaction_snark_work =
-  Staged_ledger.Make_completed_work (Public_key.Compressed) (Ledger_proof)
+  Staged_ledger.Make_completed_work
+    (Public_key.Compressed)
+    (Ledger_proof.Stable.V1)
     (Ledger_proof_statement)
 
 module Staged_ledger_diff = Staged_ledger.Make_diff (struct
-  module Ledger_proof = Ledger_proof
+  module Ledger_proof = Ledger_proof.Stable.V1
   module Ledger_hash = Ledger_hash
   module Staged_ledger_hash = Staged_ledger_hash
   module Staged_ledger_aux_hash = Staged_ledger_aux_hash
@@ -525,7 +527,7 @@ struct
   module Sparse_ledger = Coda_base.Sparse_ledger
 
   module Transaction_snark_work_proof = struct
-    type t = Ledger_proof.t list [@@deriving sexp, bin_io]
+    type t = Ledger_proof.Stable.V1.t list [@@deriving sexp, bin_io]
   end
 
   module Staged_ledger = struct

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -10,7 +10,8 @@
    transition_frontier_controller sync_handler ledger_catchup
    transition_handler bootstrap_controller transition_router async
    async_extra rpc_parallel async_ssl cohttp o1trace cohttp-async parallel
-   file_system yojson web_client_pipe work_selector graphql-async graphql-cohttp root_prover)
+   file_system yojson web_client_pipe work_selector graphql-async graphql-cohttp root_prover
+   module_version)
  (preprocessor_deps ../../../config.mlh)
  (preprocess
   (pps ppx_deriving.eq ppx_deriving.make ppx_inline_test ppx_coda

--- a/src/app/cli/src/ledger_proof.ml
+++ b/src/app/cli/src/ledger_proof.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Async_kernel
 open Coda_base
+open Module_version
 
 let to_signed_amount signed_fee =
   let magnitude =
@@ -15,7 +16,31 @@ module Prod :
    and type sok_digest := Sok_message.Digest.t
    and type ledger_hash := Frozen_ledger_hash.t
    and type proof := Proof.t = struct
-  type t = Transaction_snark.t [@@deriving bin_io, sexp]
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        let version = 1
+
+        type t = Transaction_snark.t [@@deriving bin_io, sexp]
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "ledger_proof_prod"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
+  end
+
+  type t = Stable.Latest.t [@@deriving sexp]
 
   type statement = Transaction_snark.Statement.t
 
@@ -45,8 +70,32 @@ module Debug :
    and type sok_digest := Sok_message.Digest.t
    and type ledger_hash := Frozen_ledger_hash.t
    and type proof := Proof.t = struct
-  type t = Transaction_snark.Statement.t * Sok_message.Digest.Stable.V1.t
-  [@@deriving sexp, bin_io]
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        let version = 1
+
+        type t = Transaction_snark.Statement.t * Sok_message.Digest.Stable.V1.t
+        [@@deriving sexp, bin_io]
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "ledger_proof_debug"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
+  end
+
+  type t = Stable.Latest.t [@@deriving sexp]
 
   type statement = Transaction_snark.Statement.t
 

--- a/src/lib/staged_ledger/inputs.ml
+++ b/src/lib/staged_ledger/inputs.ml
@@ -50,8 +50,6 @@ module type S = sig
        and type proof := Proof.t
        and type sok_digest := Sok_message.Digest.t
 
-    include Binable.S with type t := t
-
     include Sexpable.S with type t := t
   end
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1596,7 +1596,12 @@ let%test_module "test" =
 
       module Ledger_proof = struct
         (*A proof here is a statement *)
-        include Ledger_proof_statement
+        module Stable = struct
+          module V1 = Ledger_proof_statement
+          module Latest = V1
+        end
+
+        type t = Stable.Latest.t [@@deriving sexp]
 
         type ledger_hash = Ledger_hash.t
 
@@ -1756,7 +1761,8 @@ let%test_module "test" =
       module Transaction_snark_work = struct
         let proofs_length = 2
 
-        type proof = Ledger_proof.t [@@deriving sexp, bin_io, compare]
+        type proof = Ledger_proof.Stable.V1.t
+        [@@deriving sexp, bin_io, compare]
 
         type statement = Ledger_proof_statement.t
         [@@deriving sexp, bin_io, compare, hash, eq]

--- a/src/lib/transaction_snark_scan_state/inputs.ml
+++ b/src/lib/transaction_snark_scan_state/inputs.ml
@@ -50,8 +50,6 @@ module type S = sig
        and type proof := Proof.t
        and type sok_digest := Sok_message.Digest.t
 
-    include Binable.S with type t := t
-
     include Sexpable.S with type t := t
   end
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -84,7 +84,7 @@ end = struct
         module T = struct
           let version = 1
 
-          type t = Ledger_proof.t * Sok_message.Stable.V1.t
+          type t = Ledger_proof.Stable.V1.t * Sok_message.Stable.V1.t
           [@@deriving sexp, bin_io]
         end
 
@@ -104,7 +104,7 @@ end = struct
       module Registered_V1 = Registrar.Register (V1)
     end
 
-    include Stable.Latest
+    type t = Ledger_proof.t * Sok_message.t [@@deriving sexp]
   end
 
   module Available_job = struct
@@ -144,7 +144,8 @@ end = struct
   type job = Available_job.t [@@deriving sexp]
 
   type parallel_scan_completed_job =
-    Ledger_proof_with_sok_message.t Parallel_scan.State.Completed_job.t
+    Ledger_proof_with_sok_message.Stable.V1.t
+    Parallel_scan.State.Completed_job.t
   [@@deriving sexp, bin_io]
 
   module Stable = struct
@@ -155,7 +156,7 @@ end = struct
         type t =
           { (*Job_count: Keeping track of the number of jobs added to the tree. Every transaction added amounts to two jobs*)
             tree:
-              ( Ledger_proof_with_sok_message.t
+              ( Ledger_proof_with_sok_message.Stable.V1.t
               , Transaction_with_witness.t )
               Parallel_scan.State.t
           ; mutable job_count: int }
@@ -195,7 +196,7 @@ end = struct
   let hash t =
     let state_hash =
       Parallel_scan.State.hash t.tree
-        (Binable.to_string (module Ledger_proof_with_sok_message))
+        (Binable.to_string (module Ledger_proof_with_sok_message.Stable.V1))
         (Binable.to_string (module Transaction_with_witness))
     in
     Staged_ledger_aux_hash.of_bytes

--- a/src/lib/transition_frontier/inputs.ml
+++ b/src/lib/transition_frontier/inputs.ml
@@ -17,8 +17,6 @@ module type Inputs_intf = sig
        and type proof := Proof.t
        and type sok_digest := Sok_message.Digest.t
 
-    include Binable.S with type t := t
-
     include Sexpable.S with type t := t
   end
 

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -20,8 +20,17 @@ struct
   module Ledger_proof_statement = Transaction_snark.Statement
 
   module Ledger_proof = struct
-    type t = Ledger_proof_statement.t * Sok_message.Digest.Stable.V1.t
-    [@@deriving sexp, bin_io]
+    module Stable = struct
+      module V1 = struct
+        type t = Ledger_proof_statement.t * Sok_message.Digest.Stable.V1.t
+        [@@deriving sexp, bin_io]
+      end
+
+      module Latest = V1
+    end
+
+    (* TODO: remove bin_io, after fixing functors to accept this *)
+    type t = Stable.V1.t [@@deriving sexp, bin_io]
 
     let underlying_proof (_ : t) = Proof.dummy
 

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -415,7 +415,18 @@ module type Ledger_proof_intf = sig
 
   type sok_digest
 
-  type t [@@deriving sexp, bin_io]
+  (* bin_io omitted intentionally *)
+  type t [@@deriving sexp]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io]
+      end
+
+      module Latest = V1
+    end
+    with type V1.t = t
 
   val create : statement:statement -> sok_digest:sok_digest -> proof:proof -> t
 


### PR DESCRIPTION
Remove `bin_io` from `Debug` and `Prod` modules in `Ledger_proof`. Use versioned type for the module in places needing `bin_io`.

The TFC test stubs have a Ledger_proof.t` with `bin_io`, still, because some functors in those tests require it.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
