### PR TITLE
Finish versioning of Staged_ledger_aux in RPC types

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -5,11 +5,22 @@ open Coda_base
 open Pipe_lib
 open Network_peer
 
+(* assumption: the Rpcs functor is applied only once in the codebase, so that
+   any versions appearing in Inputs represent unique types
+
+   with that assumption, it's legitimate for the choice of versions to be made
+   inside the Rpcs functor, rather than at the locus of application
+*)
+
 module Rpcs (Inputs : sig
   module Staged_ledger_aux_hash :
     Protocols.Coda_pow.Staged_ledger_aux_hash_intf
 
-  module Staged_ledger_aux : Binable.S
+  module Staged_ledger_aux : sig
+    module Stable : sig
+      module V1 : Binable.S
+    end
+  end
 
   module Ledger_hash : Protocols.Coda_pow.Ledger_hash_intf
 
@@ -37,7 +48,7 @@ struct
         type query =
           Staged_ledger_hash.Stable.V1.t Envelope.Incoming.Stable.V1.t
 
-        type response = (Staged_ledger_aux.t * Ledger_hash.t) option
+        type response = (Staged_ledger_aux.Stable.V1.t * Ledger_hash.t) option
       end
 
       module Caller = T
@@ -59,7 +70,7 @@ struct
           Staged_ledger_hash.Stable.V1.t Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io]
 
-        type response = (Staged_ledger_aux.t * Ledger_hash.t) option
+        type response = (Staged_ledger_aux.Stable.V1.t * Ledger_hash.t) option
         [@@deriving bin_io]
 
         let version = 1
@@ -190,7 +201,7 @@ struct
           ( ( External_transition.t
             , State_body_hash.t list * External_transition.t )
             Proof_carrying_data.t
-          * Staged_ledger_aux.t
+          * Staged_ledger_aux.Stable.V1.t
           * Ledger_hash.t )
           option
       end
@@ -218,7 +229,7 @@ struct
           ( ( External_transition.t
             , State_body_hash.t list * External_transition.t )
             Proof_carrying_data.t
-          * Staged_ledger_aux.t
+          * Staged_ledger_aux.Stable.V1.t
           * Ledger_hash.t )
           option
         [@@deriving bin_io]
@@ -314,7 +325,15 @@ module type Inputs_intf = sig
   module Blockchain_state : Coda_base.Blockchain_state.S
 
   module Staged_ledger_aux : sig
-    type t [@@deriving bin_io]
+    type t
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving bin_io]
+        end
+      end
+      with type V1.t = t
 
     val hash : t -> Staged_ledger_aux_hash.t
   end
@@ -375,7 +394,7 @@ module Make (Inputs : Inputs_intf) = struct
   let create (config : Config.t)
       ~(get_staged_ledger_aux_at_hash :
             Staged_ledger_hash.t Envelope.Incoming.t
-         -> (Staged_ledger_aux.t * Ledger_hash.t) option Deferred.t)
+         -> (Staged_ledger_aux.Stable.V1.t * Ledger_hash.t) option Deferred.t)
       ~(answer_sync_ledger_query :
             (Ledger_hash.t * Ledger.Location.Addr.t Syncable_ledger.query)
             Envelope.Incoming.t

--- a/src/lib/parallel_scan/parallel_scan.mli
+++ b/src/lib/parallel_scan/parallel_scan.mli
@@ -69,7 +69,19 @@ module State : sig
   (** State of the parallel scan possibly containing base ['d] entities
    * and partially complete ['a option * 'a option] merges.
    *)
-  type ('a, 'd) t [@@deriving sexp, bin_io]
+
+  (* bin_io omitted intentionally *)
+  type ('a, 'd) t [@@deriving sexp]
+
+  module Stable : sig
+    module V1 :
+      sig
+        type ('a, 'd) t [@@deriving sexp, bin_io]
+      end
+      with type ('a, 'd) t = ('a, 'd) t
+
+    module Latest = V1
+  end
 
   val fold_chronological :
     ('a, 'd) t -> init:'acc -> f:('acc -> ('a, 'd) Job.t -> 'acc) -> 'acc

--- a/src/lib/parallel_scan/parallel_scan.mli
+++ b/src/lib/parallel_scan/parallel_scan.mli
@@ -73,15 +73,15 @@ module State : sig
   (* bin_io omitted intentionally *)
   type ('a, 'd) t [@@deriving sexp]
 
-  module Stable : sig
-    module V1 :
-      sig
+  module Stable :
+    sig
+      module V1 : sig
         type ('a, 'd) t [@@deriving sexp, bin_io]
       end
-      with type ('a, 'd) t = ('a, 'd) t
 
-    module Latest = V1
-  end
+      module Latest = V1
+    end
+    with type ('a, 'd) V1.t = ('a, 'd) t
 
   val fold_chronological :
     ('a, 'd) t -> init:'acc -> f:('acc -> ('a, 'd) Job.t -> 'acc) -> 'acc

--- a/src/lib/parallel_scan/state.ml
+++ b/src/lib/parallel_scan/state.ml
@@ -79,7 +79,19 @@ module Stable = struct
   module Latest = V1
 end
 
-include Stable.Latest
+(* bin_io omitted from deriving list intentionally *)
+type ('a, 'd) t = ('a, 'd) Stable.Latest.t =
+  { jobs: ('a, 'd) Job.t Ring_buffer.t
+  ; level_pointer: int Array.t
+  ; capacity: int
+  ; mutable acc: int * ('a * 'd list) option
+  ; mutable current_data_length: int
+  ; mutable base_none_pos: int option
+  ; mutable recent_tree_data: 'd list sexp_opaque
+  ; mutable other_trees_data: 'd list list sexp_opaque
+  ; stateful_work_order: int Queue.t
+  ; mutable curr_job_seq_no: int }
+[@@deriving sexp]
 
 module Hash = struct
   type t = Digestif.SHA256.t

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -117,17 +117,16 @@ end = struct
         let verify proof stmt ~message = verify_proof proof stmt ~message
       end)
 
-  type scan_state = Scan_state.t [@@deriving sexp, bin_io]
-
   type t =
     { scan_state:
-        scan_state
+        Scan_state.t
         (* Invariant: this is the ledger after having applied all the transactions in
      * the above state. *)
     ; ledger: Ledger.attached_mask sexp_opaque }
   [@@deriving sexp]
 
-  type serializable = scan_state * Ledger.serializable [@@deriving bin_io]
+  type serializable = Scan_state.Stable.V1.t * Ledger.serializable
+  [@@deriving bin_io]
 
   let serializable_of_t t = (t.scan_state, Ledger.serializable_of_t t.ledger)
 
@@ -188,7 +187,7 @@ end = struct
     let {Ledger_proof_statement.target; _} = Ledger_proof.statement proof in
     target
 
-  let verify_scan_state_after_apply ledger (scan_state : scan_state) =
+  let verify_scan_state_after_apply ledger (scan_state : Scan_state.t) =
     let error_prefix =
       "Error verifying the parallel scan state after applying the diff."
     in

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -185,7 +185,7 @@ end = struct
       let hash t =
         let state_hash =
           Parallel_scan.State.hash t.tree
-            (Binable.to_string (module Ledger_proof_with_sok_message))
+            (Binable.to_string (module Ledger_proof_with_sok_message.Stable.V1))
             (Binable.to_string (module Transaction_with_witness.Stable.V1))
         in
         Staged_ledger_aux_hash.of_bytes

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -151,6 +151,18 @@ end = struct
     Ledger_proof_with_sok_message.t Parallel_scan.State.Completed_job.t
   [@@deriving sexp, bin_io]
 
+  (*Work capacity represents max number of work(currently in the tree and the ones that would arise in the future when current jobs are done) in the tree. *)
+  let work_capacity () =
+    let open Constants in
+    (*+1 because of <, +1 to give enough time to adjust the counter after proof is emitted, +1 to due to delay in proof emitting*)
+    (*For Evan: Having C= 2x(txns/block * total-no-of-trees) essentially means all the trees can have full leaves without having to do any work. This doesn't work with the succinct representation and FIFO work order during when this specific edge case occurs*)
+    (*Edge case:When there is a single slot at the end of the tree before continuing at the begining of the tree (referring to the last level), the jobs on the right side of the tree are done along with the jobs on the left (because it wasn't added until then). The root node has to wait until the right sub-tree has completed before the next round begins. By the time the right sub-tree is completed, the left tree is also ready with the proof but has to wait until the root is emitted. This won't work with our succint datastructure impl and FIFO work order.*)
+    let work_delay_factor = max 2 work_delay_factor in
+    let nearest_log_2_txn = Int.ceil_log2 transaction_capacity_log_2 in
+    let nearest_log_2_incr = Int.ceil_log2 work_delay_factor in
+    3 + nearest_log_2_incr + nearest_log_2_txn
+    + Int.pow 2 (transaction_capacity_log_2 + work_delay_factor)
+
   module Stable = struct
     module V1 = struct
       module T = struct
@@ -177,6 +189,25 @@ end = struct
         in
         Staged_ledger_aux_hash.of_bytes
           ((state_hash :> string) ^ Int.to_string t.job_count)
+
+      let is_valid t =
+        let k = max Constants.work_delay_factor 2 in
+        Parallel_scan.parallelism ~state:t.tree
+        = Int.pow 2 (Constants.transaction_capacity_log_2 + k)
+        && t.job_count < work_capacity ()
+        && Parallel_scan.is_valid t.tree
+
+      include Binable.Of_binable
+                (T)
+                (struct
+                  type nonrec t = t
+
+                  let to_binable = Fn.id
+
+                  let of_binable t =
+                    assert (is_valid t) ;
+                    t
+                end)
     end
 
     module Latest = V1
@@ -199,26 +230,7 @@ end = struct
     ; mutable job_count: int }
   [@@deriving sexp]
 
-  let hash = Stable.Latest.hash
-
-  (*Work capacity represents max number of work(currently in the tree and the ones that would arise in the future when current jobs are done) in the tree. *)
-  let work_capacity () =
-    let open Constants in
-    (*+1 because of <, +1 to give enough time to adjust the counter after proof is emitted, +1 to due to delay in proof emitting*)
-    (*For Evan: Having C= 2x(txns/block * total-no-of-trees) essentially means all the trees can have full leaves without having to do any work. This doesn't work with the succinct representation and FIFO work order during when this specific edge case occurs*)
-    (*Edge case:When there is a single slot at the end of the tree before continuing at the begining of the tree (referring to the last level), the jobs on the right side of the tree are done along with the jobs on the left (because it wasn't added until then). The root node has to wait until the right sub-tree has completed before the next round begins. By the time the right sub-tree is completed, the left tree is also ready with the proof but has to wait until the root is emitted. This won't work with our succint datastructure impl and FIFO work order.*)
-    let work_delay_factor = max 2 work_delay_factor in
-    let nearest_log_2_txn = Int.ceil_log2 transaction_capacity_log_2 in
-    let nearest_log_2_incr = Int.ceil_log2 work_delay_factor in
-    3 + nearest_log_2_incr + nearest_log_2_txn
-    + Int.pow 2 (transaction_capacity_log_2 + work_delay_factor)
-
-  let is_valid t =
-    let k = max Constants.work_delay_factor 2 in
-    Parallel_scan.parallelism ~state:t.tree
-    = Int.pow 2 (Constants.transaction_capacity_log_2 + k)
-    && t.job_count < work_capacity ()
-    && Parallel_scan.is_valid t.tree
+  let hash, is_valid = Stable.Latest.(hash, is_valid)
 
   (**********Helpers*************)
 

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -600,7 +600,19 @@ module type Transaction_snark_scan_state_intf = sig
 
   type transaction
 
-  type t [@@deriving sexp, bin_io]
+  type staged_ledger_aux_hash
+
+  type t [@@deriving sexp]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io]
+
+        val hash : t -> staged_ledger_aux_hash
+      end
+    end
+    with type V1.t = t
 
   type ledger_proof
 
@@ -611,8 +623,6 @@ module type Transaction_snark_scan_state_intf = sig
   type transaction_with_info
 
   type frozen_ledger_hash
-
-  type staged_ledger_aux_hash
 
   module Transaction_with_witness : sig
     (* TODO: The statement is redundant here - it can be computed from the witness and the transaction *)
@@ -737,7 +747,17 @@ module type Staged_ledger_base_intf = sig
   type serializable [@@deriving bin_io]
 
   module Scan_state : sig
-    type t [@@deriving bin_io, sexp]
+    type t [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io]
+
+          val hash : t -> staged_ledger_aux_hash
+        end
+      end
+      with type V1.t = t
 
     module Job_view : sig
       type t [@@deriving sexp, to_yojson]


### PR DESCRIPTION
Within `Rpcs` functor, choose a version of `Staged_ledger_aux`. There's a comment to explain why that's justifiable.

Finish version-izing types used by that type.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
