### PR TITLE
Skip a command if just frontend files touched

### DIFF
--- a/scripts/skip_if_only_frontend.sh
+++ b/scripts/skip_if_only_frontend.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# aka if there exist things that don't start with `frontend/` then
+if git diff HEAD..$(git merge-base origin/master HEAD) --name-only | grep -E -q -v '^frontend'; then
+  exec "$@"
+fi
+


### PR DESCRIPTION
This will be hooked into the CI when the new system, #1838, lands. We
can expand this script in the future to skip other CI jobs in certain
scenarios.

I tested by making a branch off of an older commit than origin/master -- change just a frontend file, the command doesn't run. If I change something that includes another file, the command does end up running.