### PR TITLE
Use version of Ledger_hash in RPC

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -49,7 +49,7 @@ module Staged_ledger_hash = struct
 end
 
 module Ledger_hash = struct
-  include Ledger_hash.Stable.Latest
+  include Ledger_hash
 
   let of_digest = Ledger_hash.of_digest
 
@@ -63,7 +63,7 @@ module Ledger_hash = struct
 end
 
 module Frozen_ledger_hash = struct
-  include Frozen_ledger_hash.Stable.Latest
+  include Frozen_ledger_hash
 
   let to_bytes = Frozen_ledger_hash.to_bytes
 

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -70,7 +70,8 @@ struct
           Staged_ledger_hash.Stable.V1.t Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io]
 
-        type response = (Staged_ledger_aux.Stable.V1.t * Ledger_hash.t) option
+        type response =
+          (Staged_ledger_aux.Stable.V1.t * Ledger_hash.Stable.V1.t) option
         [@@deriving bin_io]
 
         let version = 1
@@ -117,10 +118,12 @@ struct
     module V1 = struct
       module T = struct
         type query =
-          (Ledger_hash.t * Sync_ledger.query) Envelope.Incoming.Stable.V1.t
+          (Ledger_hash.Stable.V1.t * Sync_ledger.query)
+          Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io, sexp]
 
-        type response = (Ledger_hash.t * Sync_ledger.answer) Or_error.t
+        type response =
+          (Ledger_hash.Stable.V1.t * Sync_ledger.answer) Or_error.t
         [@@deriving bin_io, sexp]
 
         let version = 1
@@ -202,7 +205,7 @@ struct
             , State_body_hash.t list * External_transition.t )
             Proof_carrying_data.t
           * Staged_ledger_aux.Stable.V1.t
-          * Ledger_hash.t )
+          * Ledger_hash.Stable.V1.t )
           option
       end
 
@@ -230,7 +233,7 @@ struct
             , State_body_hash.t list * External_transition.t )
             Proof_carrying_data.t
           * Staged_ledger_aux.Stable.V1.t
-          * Ledger_hash.t )
+          * Ledger_hash.Stable.V1.t )
           option
         [@@deriving bin_io]
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1520,12 +1520,17 @@ let%test_module "test" =
       end
 
       module Ledger_hash = struct
-        module T = struct
-          type t = int [@@deriving sexp, bin_io, compare, hash, eq]
+        module Stable = struct
+          module V1 = struct
+            type t = int [@@deriving sexp, bin_io, compare, hash, eq]
+          end
+
+          module Latest = V1
         end
 
-        include T
-        include Hashable.Make_binable (T)
+        type t = int [@@deriving sexp, compare, hash, eq]
+
+        include Hashable.Make_binable (Stable.Latest)
 
         let to_bytes : t -> string =
          fun _ -> failwith "to_bytes in ledger hash"
@@ -1544,8 +1549,8 @@ let%test_module "test" =
       module Ledger_proof_statement = struct
         module T = struct
           type t =
-            { source: Ledger_hash.t
-            ; target: Ledger_hash.t
+            { source: Ledger_hash.Stable.V1.t
+            ; target: Ledger_hash.Stable.V1.t
             ; supply_increase: Currency.Amount.t
             ; fee_excess: Fee.Signed.t
             ; proof_type: [`Base | `Merge] }

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -116,7 +116,15 @@ module type Time_intf = sig
 end
 
 module type Ledger_hash_intf = sig
-  type t [@@deriving bin_io, eq, sexp, compare]
+  type t [@@deriving eq, sexp, compare]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving eq, sexp, compare, bin_io]
+      end
+    end
+    with type V1.t = t
 
   val to_bytes : t -> string
 


### PR DESCRIPTION
`Ledger_hash` is another type that occurs in RPC types. Use specific version of that type in the RPC types.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
