### PR TITLE
Add versions for Sync_ledger answer and query

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -27,8 +27,8 @@ module type Inputs_intf = sig
      and type merkle_tree := Ledger.Db.t
      and type account := Account.t
      and type merkle_path := Ledger.path
-     and type query := Sync_ledger.query
-     and type answer := Sync_ledger.answer
+     and type query := Sync_ledger.Query.t
+     and type answer := Sync_ledger.Answer.t
 
   module Network :
     Network_intf
@@ -38,8 +38,8 @@ module type Inputs_intf = sig
      and type consensus_state := Consensus.Consensus_state.value
      and type state_body_hash := State_body_hash.t
      and type ledger_hash := Ledger_hash.t
-     and type sync_ledger_query := Sync_ledger.query
-     and type sync_ledger_answer := Sync_ledger.answer
+     and type sync_ledger_query := Sync_ledger.Query.t
+     and type sync_ledger_answer := Sync_ledger.Answer.t
      and type parallel_scan_state := Staged_ledger.Scan_state.t
 
   module Time : Time_intf
@@ -59,8 +59,8 @@ module type Inputs_intf = sig
      and type state_hash := State_hash.t
      and type external_transition := External_transition.t
      and type transition_frontier := Transition_frontier.t
-     and type syncable_ledger_query := Sync_ledger.query
-     and type syncable_ledger_answer := Sync_ledger.answer
+     and type syncable_ledger_query := Sync_ledger.Query.t
+     and type syncable_ledger_answer := Sync_ledger.Answer.t
 
   module Root_prover :
     Root_prover_intf

--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -1,4 +1,5 @@
 open Core_kernel
+open Module_version
 
 module Hash = struct
   include Ledger_hash
@@ -35,12 +36,66 @@ module Db = Syncable_ledger.Make (struct
   let subtree_height = 3
 end)
 
-type answer =
-  ( Ledger.Location.Addr.t
-  , Ledger_hash.t
-  , Account.Stable.V1.t )
-  Syncable_ledger.answer
-[@@deriving bin_io, sexp]
+module Answer = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        let version = 1
 
-type query = Ledger.Location.Addr.t Syncable_ledger.query
-[@@deriving bin_io, sexp]
+        type t =
+          ( Ledger.Location.Addr.t
+          , Ledger_hash.t
+          , Account.Stable.V1.t )
+          Syncable_ledger.answer
+        [@@deriving bin_io, sexp]
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "sync_ledger_answer"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
+  end
+
+  (* bin_io omitted from deriving list *)
+  type t = Stable.Latest.t [@@deriving sexp]
+end
+
+module Query = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        let version = 1
+
+        type t = Ledger.Location.Addr.t Syncable_ledger.query
+        [@@deriving bin_io, sexp]
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "sync_ledger_query"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
+  end
+
+  (* bin_io omitted from deriving list *)
+  type t = Stable.Latest.t [@@deriving sexp]
+end

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -299,8 +299,8 @@ module type Inputs_intf = sig
      and type transaction_pool_diff := Transaction_pool.pool_diff
      and type parallel_scan_state := Staged_ledger.Scan_state.t
      and type ledger_hash := Ledger_hash.t
-     and type sync_ledger_query := Coda_base.Sync_ledger.query
-     and type sync_ledger_answer := Coda_base.Sync_ledger.answer
+     and type sync_ledger_query := Coda_base.Sync_ledger.Query.t
+     and type sync_ledger_answer := Coda_base.Sync_ledger.Answer.t
      and type time := Time.t
      and type state_hash := Coda_base.State_hash.t
      and type state_body_hash := State_body_hash.t
@@ -368,8 +368,8 @@ module type Inputs_intf = sig
      and type state_hash := Coda_base.State_hash.t
      and type external_transition := External_transition.t
      and type transition_frontier := Transition_frontier.t
-     and type syncable_ledger_query := Coda_base.Sync_ledger.query
-     and type syncable_ledger_answer := Coda_base.Sync_ledger.answer
+     and type syncable_ledger_query := Coda_base.Sync_ledger.Query.t
+     and type syncable_ledger_answer := Coda_base.Sync_ledger.Answer.t
 end
 
 module Make (Inputs : Inputs_intf) = struct

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -97,9 +97,11 @@ struct
       module T = struct
         (* "master" types, do not change *)
         type query =
-          (Ledger_hash.t * Sync_ledger.query) Envelope.Incoming.Stable.V1.t
+          (Ledger_hash.t * Sync_ledger.Query.Stable.V1.t)
+          Envelope.Incoming.Stable.V1.t
 
-        type response = (Ledger_hash.t * Sync_ledger.answer) Or_error.t
+        type response =
+          (Ledger_hash.t * Sync_ledger.Answer.Stable.V1.t) Or_error.t
       end
 
       module Caller = T
@@ -118,12 +120,12 @@ struct
     module V1 = struct
       module T = struct
         type query =
-          (Ledger_hash.Stable.V1.t * Sync_ledger.query)
+          (Ledger_hash.Stable.V1.t * Sync_ledger.Query.Stable.V1.t)
           Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io, sexp]
 
         type response =
-          (Ledger_hash.Stable.V1.t * Sync_ledger.answer) Or_error.t
+          (Ledger_hash.Stable.V1.t * Sync_ledger.Answer.Stable.V1.t) Or_error.t
         [@@deriving bin_io, sexp]
 
         let version = 1
@@ -401,7 +403,7 @@ module Make (Inputs : Inputs_intf) = struct
       ~(answer_sync_ledger_query :
             (Ledger_hash.t * Ledger.Location.Addr.t Syncable_ledger.query)
             Envelope.Incoming.t
-         -> (Ledger_hash.t * Sync_ledger.answer) Deferred.Or_error.t)
+         -> (Ledger_hash.t * Sync_ledger.Answer.t) Deferred.Or_error.t)
       ~(transition_catchup :
             State_hash.t Envelope.Incoming.t
          -> External_transition.t Non_empty_list.t option Deferred.t)

--- a/src/lib/ledger_catchup/inputs.ml
+++ b/src/lib/ledger_catchup/inputs.ml
@@ -40,7 +40,7 @@ module type S = sig
      and type state_body_hash := State_body_hash.t
      and type ledger_hash := Ledger_hash.t
      and type sync_ledger_query := Ledger.Location.Addr.t Syncable_ledger.query
-     and type sync_ledger_answer := Sync_ledger.answer
+     and type sync_ledger_answer := Sync_ledger.Answer.t
      and type parallel_scan_state := Staged_ledger.Scan_state.t
 
   module Time : Time_intf

--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -35,8 +35,8 @@ module Make (Inputs : Inputs_intf) :
    and type state_hash := State_hash.t
    and type external_transition := Inputs.External_transition.t
    and type transition_frontier := Inputs.Transition_frontier.t
-   and type syncable_ledger_query := Sync_ledger.query
-   and type syncable_ledger_answer := Sync_ledger.answer = struct
+   and type syncable_ledger_query := Sync_ledger.Query.t
+   and type syncable_ledger_answer := Sync_ledger.Answer.t = struct
   open Inputs
 
   let get_breadcrumb_ledgers frontier =

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -13,8 +13,8 @@ module type Inputs_intf = sig
      and type state_hash := State_hash.t
      and type external_transition := External_transition.t
      and type transition_frontier := Transition_frontier.t
-     and type syncable_ledger_query := Sync_ledger.query
-     and type syncable_ledger_answer := Sync_ledger.answer
+     and type syncable_ledger_query := Sync_ledger.Query.t
+     and type syncable_ledger_answer := Sync_ledger.Answer.t
 
   module Transition_handler :
     Transition_handler_intf
@@ -35,8 +35,8 @@ module type Inputs_intf = sig
      and type consensus_state := Consensus.Consensus_state.value
      and type state_body_hash := State_body_hash.t
      and type ledger_hash := Ledger_hash.t
-     and type sync_ledger_query := Sync_ledger.query
-     and type sync_ledger_answer := Sync_ledger.answer
+     and type sync_ledger_query := Sync_ledger.Query.t
+     and type sync_ledger_answer := Sync_ledger.Answer.t
      and type parallel_scan_state := Staged_ledger.Scan_state.t
 
   module Catchup :

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -30,8 +30,8 @@ module type Inputs_intf = sig
      and type consensus_state := Consensus.Consensus_state.value
      and type state_body_hash := State_body_hash.t
      and type ledger_hash := Ledger_hash.t
-     and type sync_ledger_query := Sync_ledger.query
-     and type sync_ledger_answer := Sync_ledger.answer
+     and type sync_ledger_query := Sync_ledger.Query.t
+     and type sync_ledger_answer := Sync_ledger.Answer.t
      and type parallel_scan_state := Staged_ledger.Scan_state.t
 
   module Transition_frontier_controller :


### PR DESCRIPTION
Create versions for `Sync_ledger` answer and query types, use those in RPC types.

Still have to make sure that the types contained these versions are themselves versioned; but here's a bite-sized PR.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
