### PR TITLE
Removed exn from visualization code

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -483,10 +483,14 @@ let visualize_frontier =
        ~f:(fun port filename ->
          match%map dispatch Visualize_frontier.rpc filename port with
          | Ok (`Active ()) ->
-             printf !"Successfully wrote the visual at location %s." filename
+             printf
+               !"Successfully wrote the visualization of frontier at \
+                 location: %s."
+               filename
          | Ok `Bootstrapping ->
              printf
-               !"Could not visualize frontier becuase we are bootstrapping."
+               !"Could not visualize frontier since daemon is currently \
+                 bootstrapping"
          | Error e ->
              printf "Could not save file: %s\n" (Error.to_string_hum e) ))
 

--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -482,8 +482,11 @@ let visualize_frontier =
        Command.Param.(anon @@ ("output-filepath" %: string))
        ~f:(fun port filename ->
          match%map dispatch Visualize_frontier.rpc filename port with
-         | Ok () ->
+         | Ok (`Active ()) ->
              printf !"Successfully wrote the visual at location %s." filename
+         | Ok `Bootstrapping ->
+             printf
+               !"Could not visualize frontier becuase we are bootstrapping."
          | Error e ->
              printf "Could not save file: %s\n" (Error.to_string_hum e) ))
 

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1293,11 +1293,12 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
   let log_shutdown ~frontier_file ~log t =
     match visualize_frontier ~filename:frontier_file t with
     | `Active () ->
-        Logger.info log "Logging the transition_frontier at %s" frontier_file
+        Logger.info log
+          "Successfully wrote the visualization of frontier at location: %s"
+          frontier_file
     | `Bootstrapping ->
         Logger.info log
-          "Could not log transition_frontier since daemon is currently \
-           bootstrapping"
+          "Could not visualize frontier since daemon is currently bootstrapping"
 
   (* TODO: handle participation_status more appropriately than doing participate_exn *)
   let setup_local_server ?(client_whitelist = []) ?rest_server_port ~coda ~log

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -408,7 +408,7 @@ end
 module Visualize_frontier = struct
   type query = string [@@deriving bin_io]
 
-  type response = unit [@@deriving bin_io]
+  type response = [`Active of unit | `Bootstrapping] [@@deriving bin_io]
 
   let rpc : (query, response) Rpc.Rpc.t =
     Rpc.Rpc.create ~name:"Visualize_frontier" ~version:0 ~bin_query

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -454,9 +454,10 @@ struct
           let graph_with_node = add_vertex graph node in
           List.fold node.successor_hashes ~init:graph_with_node
             ~f:(fun acc_graph successor_state_hash ->
-              add_edge acc_graph node
-                ( State_hash.Table.find t.table successor_state_hash
-                |> Option.value_exn ) ) )
+              Option.value_map
+                (State_hash.Table.find t.table successor_state_hash)
+                ~default:acc_graph ~f:(fun child_node ->
+                  add_edge acc_graph node child_node ) ) )
   end
 
   let visualize ~filename t =


### PR DESCRIPTION
- Made it clearer to client when you are bootstrapping and when you are not

Visualizations should not fail randomly anymore because it should be impossible to throw an exception involving this code

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [X] Does this close issues? List them:

Closes #1842
Closes #1806
