### PR TITLE
Versions for syncable/sync_ledger query, answer types in RPC

### DIFF
--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -44,9 +44,9 @@ module Answer = struct
 
         type t =
           ( Ledger.Location.Addr.t
-          , Ledger_hash.t
+          , Ledger_hash.Stable.V1.t
           , Account.Stable.V1.t )
-          Syncable_ledger.answer
+          Syncable_ledger.Answer.Stable.V1.t
         [@@deriving bin_io, sexp]
       end
 
@@ -76,7 +76,8 @@ module Query = struct
       module T = struct
         let version = 1
 
-        type t = Ledger.Location.Addr.t Syncable_ledger.query
+        type t =
+          Ledger.Location.Addr.Stable.V1.t Syncable_ledger.Query.Stable.V1.t
         [@@deriving bin_io, sexp]
       end
 

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -97,11 +97,11 @@ struct
       module T = struct
         (* "master" types, do not change *)
         type query =
-          (Ledger_hash.t * Sync_ledger.Query.Stable.V1.t)
+          (Ledger_hash.Stable.V1.t * Sync_ledger.Query.Stable.V1.t)
           Envelope.Incoming.Stable.V1.t
 
         type response =
-          (Ledger_hash.t * Sync_ledger.Answer.Stable.V1.t) Or_error.t
+          (Ledger_hash.Stable.V1.t * Sync_ledger.Answer.Stable.V1.t) Or_error.t
       end
 
       module Caller = T
@@ -401,7 +401,7 @@ module Make (Inputs : Inputs_intf) = struct
             Staged_ledger_hash.t Envelope.Incoming.t
          -> (Staged_ledger_aux.Stable.V1.t * Ledger_hash.t) option Deferred.t)
       ~(answer_sync_ledger_query :
-            (Ledger_hash.t * Ledger.Location.Addr.t Syncable_ledger.query)
+            (Ledger_hash.t * Ledger.Location.Addr.t Syncable_ledger.Query.t)
             Envelope.Incoming.t
          -> (Ledger_hash.t * Sync_ledger.Answer.t) Deferred.Or_error.t)
       ~(transition_catchup :

--- a/src/lib/ledger_catchup/inputs.ml
+++ b/src/lib/ledger_catchup/inputs.ml
@@ -39,7 +39,8 @@ module type S = sig
      and type consensus_state := Consensus.Consensus_state.value
      and type state_body_hash := State_body_hash.t
      and type ledger_hash := Ledger_hash.t
-     and type sync_ledger_query := Ledger.Location.Addr.t Syncable_ledger.query
+     and type sync_ledger_query :=
+                Ledger.Location.Addr.t Syncable_ledger.Query.t
      and type sync_ledger_answer := Sync_ledger.Answer.t
      and type parallel_scan_state := Staged_ledger.Scan_state.t
 

--- a/src/lib/syncable_ledger/test.ml
+++ b/src/lib/syncable_ledger/test.ml
@@ -30,12 +30,12 @@ module type Input_intf = sig
      and type addr := Ledger.addr
      and type merkle_path := Ledger.path
      and type account := Ledger.account
-     and type query := Ledger.addr Syncable_ledger.query
+     and type query := Ledger.addr Syncable_ledger.Query.t
      and type answer :=
                 ( Ledger.addr
                 , Root_hash.t
                 , Ledger.account )
-                Syncable_ledger.answer
+                Syncable_ledger.Answer.t
 end
 
 module Make_test

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -476,7 +476,7 @@ struct
         ~f:(fun (ledger_hash, sync_ledger_query) ->
           Logger.info logger
             !"Processing ledger query : %{sexp:(Ledger.Addr.t \
-              Syncable_ledger.query)}"
+              Syncable_ledger.Query.t)}"
             sync_ledger_query ;
           let answer =
             Hashtbl.to_alist table
@@ -493,13 +493,13 @@ struct
           | None ->
               Logger.info logger
                 !"Could not find an answer for : %{sexp:(Ledger.Addr.t \
-                  Syncable_ledger.query)}"
+                  Syncable_ledger.Query.t)}"
                 sync_ledger_query ;
               Deferred.unit
           | Some answer ->
               Logger.info logger
                 !"Found an answer for : %{sexp:(Ledger.Addr.t \
-                  Syncable_ledger.query)}"
+                  Syncable_ledger.Query.t)}"
                 sync_ledger_query ;
               Pipe_lib.Linear_pipe.write response_writer answer )
       |> don't_wait_for


### PR DESCRIPTION
Added versions for `Sync_ledger` and `Syncable_ledger` query, answer types, used in the `Answer_sync_ledger_query` module in RPC.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
