### PR TITLE
Versioning of nonempty lists

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -152,7 +152,7 @@ struct
         (* "master" types, do not change *)
         type query = State_hash.t Envelope.Incoming.Stable.V1.t
 
-        type response = External_transition.t Non_empty_list.t option
+        type response = External_transition.t Non_empty_list.Stable.V1.t option
       end
 
       module Caller = T
@@ -173,7 +173,7 @@ struct
         type query = State_hash.t Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io, sexp]
 
-        type response = External_transition.t Non_empty_list.t option
+        type response = External_transition.t Non_empty_list.Stable.V1.t option
         [@@deriving bin_io, sexp]
 
         let version = 1

--- a/src/lib/non_empty_list/non_empty_list.ml
+++ b/src/lib/non_empty_list/non_empty_list.ml
@@ -1,7 +1,17 @@
 open Core_kernel
 
 (* A non-empty list is a tuple of the head and the rest (as a list) *)
-type 'a t = 'a * 'a list [@@deriving sexp, compare, eq, hash, bin_io]
+module Stable = struct
+  (* underlying type has a parameter, so don't register versions *)
+  module V1 = struct
+    type 'a t = 'a * 'a list [@@deriving sexp, compare, eq, hash, bin_io]
+  end
+
+  module Latest = V1
+end
+
+(* bin_io omitted intentionally *)
+type 'a t = 'a Stable.Latest.t [@@deriving sexp, compare, eq, hash]
 
 let init x xs = (x, xs)
 

--- a/src/lib/non_empty_list/non_empty_list.mli
+++ b/src/lib/non_empty_list/non_empty_list.mli
@@ -1,6 +1,15 @@
 (** A non-empty list that is safe by construction. *)
 
-type 'a t [@@deriving sexp, compare, eq, hash, bin_io]
+module Stable : sig
+  module V1 : sig
+    type 'a t [@@deriving sexp, compare, eq, hash, bin_io]
+  end
+
+  module Latest = V1
+end
+
+(* no bin_io on purpose *)
+type 'a t = 'a Stable.Latest.t [@@deriving sexp, compare, eq, hash]
 
 val init : 'a -> 'a list -> 'a t
 (** Create a non-empty list by proving you have a head element *)


### PR DESCRIPTION
Added versioning of nonempty lists, used in RPC types.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
