### PR TITLE
Make brew faster on frontend CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
                   command: cd frontend/website && npm run reformat && git diff --exit-code src
             - run:
                   name: Build website
-                  command: cd frontend/website && npm run build && brew install pandoc && node ./lib/js/src/Render.js
+                  command: cd frontend/website && npm run build && (yes | env HOMEBREW_NO_AUTO_UPDATE=1 brew install pandoc) && node ./lib/js/src/Render.js
 
     lint:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
                   command: cd frontend/website && npm run reformat && git diff --exit-code src
             - run:
                   name: Build website
-                  command: cd frontend/website && npm run build && (yes | env HOMEBREW_NO_AUTO_UPDATE=1 brew install pandoc) && node ./lib/js/src/Render.js
+                  command: cd frontend/website && npm run build && (env HOMEBREW_NO_AUTO_UPDATE=1 brew install pandoc) && node ./lib/js/src/Render.js
 
     lint:
         docker:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -30,7 +30,7 @@ jobs:
                   command: cd frontend/website && npm run reformat && git diff --exit-code src
             - run:
                   name: Build website
-                  command: cd frontend/website && npm run build && brew install pandoc && node ./lib/js/src/Render.js
+                  command: cd frontend/website && npm run build && (yes | env HOMEBREW_NO_AUTO_UPDATE=1 brew install pandoc) && node ./lib/js/src/Render.js
 
     lint:
         docker:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -30,7 +30,7 @@ jobs:
                   command: cd frontend/website && npm run reformat && git diff --exit-code src
             - run:
                   name: Build website
-                  command: cd frontend/website && npm run build && (yes | env HOMEBREW_NO_AUTO_UPDATE=1 brew install pandoc) && node ./lib/js/src/Render.js
+                  command: cd frontend/website && npm run build && (env HOMEBREW_NO_AUTO_UPDATE=1 brew install pandoc) && node ./lib/js/src/Render.js
 
     lint:
         docker:


### PR DESCRIPTION
Brew likes to burn a lot of cycles "autoupdating" every time we try to install things on circle. This change lets us skip that autoupdating.