### PR TITLE
Versioned State_hash in RPC types

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -150,7 +150,7 @@ struct
 
       module T = struct
         (* "master" types, do not change *)
-        type query = State_hash.t Envelope.Incoming.Stable.V1.t
+        type query = State_hash.Stable.V1.t Envelope.Incoming.Stable.V1.t
 
         type response = External_transition.t Non_empty_list.t option
       end
@@ -170,7 +170,7 @@ struct
 
     module V1 = struct
       module T = struct
-        type query = State_hash.t Envelope.Incoming.Stable.V1.t
+        type query = State_hash.Stable.V1.t Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io, sexp]
 
         type response = External_transition.t Non_empty_list.t option


### PR DESCRIPTION
Use versioned `State_hash` in RPC types

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
