### PR TITLE
Some cleanup of careers page

### DIFF
--- a/frontend/website/src/Careers.re
+++ b/frontend/website/src/Careers.re
@@ -1,5 +1,5 @@
-module CareerApplyItem = {
-  let component = ReasonReact.statelessComponent("Career");
+module ApplyItem = {
+  let component = ReasonReact.statelessComponent("Careers.ApplyItem");
   let make = (~filename, ~name, _) => {
     ...component,
     render: _self =>
@@ -12,6 +12,155 @@ module CareerApplyItem = {
       </li>,
   };
 };
+
+module HeadingItem = {
+  let component = ReasonReact.statelessComponent("Careers.HeadingItem");
+
+  let make = (~title, children) => {
+    ...component,
+    render: _self =>
+      <div>
+        <div className="dn db-ns">
+          <div className="flex justify-between mt45">
+            <h2
+              className="pr2 fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
+              {ReasonReact.string(title)}
+            </h2>
+            <p className="w-65 mt0 mb0 lh-copy"> ...children </p>
+          </div>
+        </div>
+        <div className="db dn-ns">
+          <div className="mt45">
+            <h2 className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
+              {ReasonReact.string(title)}
+            </h2>
+            <p className="mt3 mb0 ml15 lh-copy"> ...children </p>
+          </div>
+        </div>
+      </div>,
+  };
+};
+
+let benefits =
+  <>
+    <div className="flex justify-between ">
+      <div className="flex justify-end w-30">
+        <h3 className="fw6 f5 ph4 mt0 mb0">
+          {ReasonReact.string("Healthcare")}
+        </h3>
+      </div>
+      <ul className="mt0 mb0 ph0 w-70">
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string(
+             {js|We cover 100% of employee premiums for platinum healthcare plans with zero deductible, and 99% of vision and dental\u00A0premiums|js},
+           )}
+        </li>
+      </ul>
+    </div>
+    <div className="flex justify-between mt4">
+      <div className="flex justify-end w-30">
+        <h3 className="fw6 f5 ph4 mt0 mb0"> {ReasonReact.string("401k")} </h3>
+      </div>
+      <ul className="mt0 mb0 ph0 w-70">
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("401k contribution matching up to 3% of salary")}
+        </li>
+      </ul>
+    </div>
+    <div className="flex justify-between mt4">
+      <div className="flex justify-end w-30">
+        <h3 className="fw6 f5 ph4 mt0 mb0">
+          {ReasonReact.string("Education")}
+        </h3>
+      </div>
+      <ul className="mt0 mb0 ph0 w-70">
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string(
+             {js|$750 annual budget for conferences of your choice (we cover company-related\u00A0conferences)|js},
+           )}
+        </li>
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("Office library")}
+        </li>
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("Twice-a-week learning lunches")}
+        </li>
+      </ul>
+    </div>
+    <div className="flex justify-between mt4">
+      <div className="flex justify-end w-30">
+        <h3 className="fw6 f5 ph4 mt0 mb0">
+          {ReasonReact.string("Equipment")}
+        </h3>
+      </div>
+      <ul className="mt0 mb0 ph0 w-70">
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string(
+             {js|Top-of-the-line laptop, $500 monitor budget and $500 peripheral\u00A0budget|js},
+           )}
+        </li>
+      </ul>
+    </div>
+    <div className="flex justify-between mt4">
+      <div className="flex justify-end w-30">
+        <h3 className="fw6 f5 ph4 mt0 mb0">
+          {ReasonReact.string({js|Time\u00A0off|js})}
+        </h3>
+      </div>
+      <ul className="mt0 mb0 ph0 w-70">
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string(
+             {js|Unlimited vacation, with encouragement for employees to take off|js},
+           )}
+          <span className="i"> {ReasonReact.string(" at least ")} </span>
+          {ReasonReact.string({js|14 days\u00A0annually|js})}
+        </li>
+      </ul>
+    </div>
+    <div className="flex justify-between mt4">
+      <div className="flex justify-end w-30">
+        <h3 className="fw6 f5 ph4 mt0 mb0">
+          {ReasonReact.string("Meals")}
+        </h3>
+      </div>
+      <ul className="mt0 mb0 ph0 w-70">
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string(
+             "Healthy snacks and provided lunch twice a week",
+           )}
+        </li>
+      </ul>
+    </div>
+    <div className="flex justify-between mt4">
+      <div className="flex justify-end w-30">
+        <h3 className="fw6 f5 ph4 mt0 mb0">
+          {ReasonReact.string("Other")}
+        </h3>
+      </div>
+      <ul className="mt0 mb0 ph0 w-70">
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("Parental leave")}
+        </li>
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("Commuting benefits")}
+        </li>
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("Bike-friendly culture")}
+        </li>
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("Take up to 1 day of PTO per year to volunteer")}
+        </li>
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string(
+             "We match nonprofit donations up to $500 per year",
+           )}
+        </li>
+        <li className="lh-copy list mb0 mt0">
+          {ReasonReact.string("...and many others!")}
+        </li>
+      </ul>
+    </div>
+  </>;
 
 let str = ReasonReact.string;
 
@@ -35,7 +184,7 @@ let make = (~jobOpenings, _) => {
   render: _self => {
     let jobItems =
       Array.map(
-        ((filename, name)) => <CareerApplyItem filename name />,
+        ((filename, name)) => <ApplyItem filename name />,
         jobOpenings,
       );
 
@@ -43,7 +192,7 @@ let make = (~jobOpenings, _) => {
       <div className="mw960 pv3 center ph3 ibmplex oceanblack">
         <h1
           className="fadedblue aktivgroteskex careers-double-line-header ttu f5 fw5 tracked-more mb4">
-          {str("Work with us!")}
+          {ReasonReact.string("Work with us!")}
         </h1>
         <div>
           <div className="dn db-ns">
@@ -65,107 +214,33 @@ let make = (~jobOpenings, _) => {
         </div>
         <div className="mw800 center">
           <p className="lh-copy f3 ocean f2-ns tracked-tightly">
-            {str(
+            {ReasonReact.string(
                {js|We're using cryptography and cryptocurrency to build computing systems that put people back in control of their digital\u00A0lives.|js},
              )}
           </p>
           <div className="mt45">
             <hr className="mt45 ml0 mr0 mt0 mb0 b0 h2px bg-extradarksnow" />
             <div className="mt45">
-              <div>
-                <div className="dn db-ns">
-                  <div className="flex justify-between mt45">
-                    <h2
-                      className="pr2 fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                      {str("Open Source")}
-                    </h2>
-                    <p className="w-65 mt0 mb0 lh-copy">
-                      {str(
-                         {js|We passionately believe in the open-source philosophy, and make our software free for the entire world to\u00A0use.|js},
-                       )}
-                      <a
-                        href="/static/code.html"
-                        className="dodgerblue fw5 no-underline hover-link nowrap">
-                        {str({js|Take a look →|js})}
-                      </a>
-                    </p>
-                  </div>
-                </div>
-                <div className="db dn-ns">
-                  <div className="mt45">
-                    <h2
-                      className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                      {str("Open Source")}
-                    </h2>
-                    <p className="mt3 mb0 ml15 lh-copy">
-                      {str(
-                         {js|We passionately believe in the open-source philosophy, and make our software free for the entire world to\u00A0use.|js},
-                       )}
-                      <a
-                        href="/static/code.html"
-                        className="dodgerblue fw5 no-underline hover-link nowrap">
-                        {str({js|Take a look →|js})}
-                      </a>
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div>
-                <div className="dn db-ns">
-                  <div className="flex justify-between mt45">
-                    <h2
-                      className="pr2 fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                      {str("Collaboration")}
-                    </h2>
-                    <p className="w-65 mt0 mb0 lh-copy">
-                      {str(
-                         {js|The problems we face are novel and challenging and we take them on as a\u00A0team.|js},
-                       )}
-                    </p>
-                  </div>
-                </div>
-                <div className="db dn-ns">
-                  <div className="mt45">
-                    <h2
-                      className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                      {str("Collaboration")}
-                    </h2>
-                    <p className="mt3 mb0 ml15 lh-copy">
-                      {str(
-                         {js|The problems we face are novel and challenging and we take them on as a\u00A0team.|js},
-                       )}
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div>
-                <div className="dn db-ns">
-                  <div className="flex justify-between mt45">
-                    <h2
-                      className="pr2 fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                      {str("Inclusion")}
-                    </h2>
-                    <p className="w-65 mt0 mb0 lh-copy">
-                      {str(
-                         {js|We're working on technologies with the potential to reimagine social structures. We believe it's important to incorporate diverse perspectives from conception through\u00A0realization.|js},
-                       )}
-                    </p>
-                  </div>
-                </div>
-                <div className="db dn-ns">
-                  <div className="mt45">
-                    <h2
-                      className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                      {str("Inclusion")}
-                    </h2>
-                    <p className="mt3 mb0 ml15 lh-copy">
-                      {str(
-                         {js|We're working on technologies with the potential to reimagine social structures. We believe it's important to incorporate diverse perspectives from conception through\u00A0realization.|js},
-                       )}
-                    </p>
-                  </div>
-                </div>
-              </div>
+              <HeadingItem title="Open Source">
+                {ReasonReact.string(
+                   {js|We passionately believe in the open-source philosophy, and make our software free for the entire world to\u00A0use.|js},
+                 )}
+                <a
+                  href="/static/code.html"
+                  className="dodgerblue fw5 no-underline hover-link nowrap">
+                  {ReasonReact.string({js|Take a look →|js})}
+                </a>
+              </HeadingItem>
+              <HeadingItem title="Collaboration">
+                {ReasonReact.string(
+                   {js|The problems we face are novel and challenging and we take them on as a\u00A0team.|js},
+                 )}
+              </HeadingItem>
+              <HeadingItem title="Inclusion">
+                {ReasonReact.string(
+                   {js|We're working on technologies with the potential to reimagine social structures. We believe it's important to incorporate diverse perspectives from conception through\u00A0realization.|js},
+                 )}
+              </HeadingItem>
             </div>
           </div>
           <div>
@@ -175,266 +250,18 @@ let make = (~jobOpenings, _) => {
                 <div className="flex justify-between mt45">
                   <h2
                     className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                    {str("Benefits")}
+                    {ReasonReact.string("Benefits")}
                   </h2>
-                  <div className="w-70 mt3">
-                    <div className="flex justify-between ">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Healthcare")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|We cover 100% of employee premiums for platinum healthcare plans with zero deductible, and 99% of vision and dental\u00A0premiums|js},
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("401k")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "401k contribution matching up to 3% of salary",
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Education")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|$750 annual budget for conferences of your choice (we cover company-related\u00A0conferences)|js},
-                           )}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Office library")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Twice-a-week learning lunches")}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Equipment")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|Top-of-the-line laptop, $500 monitor budget and $500 peripheral\u00A0budget|js},
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str({js|Time\u00A0off|js})}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|Unlimited vacation, with encouragement for employees to take off|js},
-                           )}
-                          <span className="i"> {str(" at least ")} </span>
-                          {str({js|14 days\u00A0annually|js})}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Meals")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "Healthy snacks and provided lunch twice a week",
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Other")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Parental leave")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Commuting benefits")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Bike-friendly culture")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "Take up to 1 day of PTO per year to volunteer",
-                           )}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "We match nonprofit donations up to $500 per year",
-                           )}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("...and many others!")}
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
+                  <div className="w-70 mt3"> benefits </div>
                 </div>
               </div>
               <div className="db dn-ns">
                 <div className="mt45">
                   <h2
                     className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                    {str("Benefits")}
+                    {ReasonReact.string("Benefits")}
                   </h2>
-                  <div className="mt4 ml15 mt3">
-                    <div className="flex justify-between ">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Healthcare")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|We cover 100% of employee premiums for platinum healthcare plans with zero deductible, and 99% of vision and dental\u00A0premiums|js},
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("401k")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "401k contribution matching up to 3% of salary",
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Education")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|$750 annual budget for conferences of your choice (we cover company-related\u00A0conferences)|js},
-                           )}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Office library")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Twice-a-week learning lunches")}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Equipment")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|Top-of-the-line laptop, $500 monitor budget and $500 peripheral\u00A0budget|js},
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str({js|Time\u00A0off|js})}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             {js|Unlimited vacation, with encouragement for employees to take off|js},
-                           )}
-                          <span className="i"> {str(" at least ")} </span>
-                          {str({js|14 days\u00A0annually|js})}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Meals")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "Healthy snacks and provided lunch twice a week",
-                           )}
-                        </li>
-                      </ul>
-                    </div>
-                    <div className="flex justify-between mt4">
-                      <div className="flex justify-end w-30">
-                        <h3 className="fw6 f5 ph4 mt0 mb0">
-                          {str("Other")}
-                        </h3>
-                      </div>
-                      <ul className="mt0 mb0 ph0 w-70">
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Parental leave")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Commuting benefits")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("Bike-friendly culture")}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "Take up to 1 day of PTO per year to volunteer",
-                           )}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str(
-                             "We match nonprofit donations up to $500 per year",
-                           )}
-                        </li>
-                        <li className="lh-copy list mb0 mt0">
-                          {str("...and many others!")}
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
+                  <div className="mt4 ml15 mt3"> benefits </div>
                 </div>
               </div>
             </div>
@@ -447,7 +274,7 @@ let make = (~jobOpenings, _) => {
                   <div className="w-50">
                     <h2
                       className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                      {str("Apply")}
+                      {ReasonReact.string("Apply")}
                     </h2>
                   </div>
                   <div className="w-50">
@@ -459,7 +286,7 @@ let make = (~jobOpenings, _) => {
                 <div className="mt45">
                   <h2
                     className="fw5 mt0 mb0 ml15 f2 ocean f2-ns tracked-tightly">
-                    {str("Apply")}
+                    {ReasonReact.string("Apply")}
                   </h2>
                   <ul className="mt4 ml15 mb0 ph0"> ...jobItems </ul>
                 </div>

--- a/frontend/website/src/Page.re
+++ b/frontend/website/src/Page.re
@@ -1,6 +1,6 @@
 module Header = {
   let component = ReasonReact.statelessComponent("Header");
-  let make = (~extra, children) => {
+  let make = (~extra, _children) => {
     ...component,
     render: _self =>
       <head>
@@ -85,10 +85,30 @@ module Header = {
 };
 
 module Footer = {
-  let dot = ReasonReact.string({js| · |js});
+  module Link = {
+    let component = ReasonReact.statelessComponent("Page.Footer.Link");
+    let make = (~last=false, ~link, ~name, children) => {
+      ...component,
+      render: _self =>
+        <li className="mb2 dib">
+          <a
+            href=link
+            className="no-underline fw3 f6 silver hover-link"
+            name={"footer-" ++ name}
+            target="_blank">
+            ...children
+          </a>
+          {last ?
+             <span className="dn" /> :
+             <span className="f6 silver">
+               {ReasonReact.string({js| · |js})}
+             </span>}
+        </li>,
+    };
+  };
 
   let component = ReasonReact.statelessComponent("Footer");
-  let make = (~color="", children) => {
+  let make = (~color, _children) => {
     ...component,
     render: _self =>
       <div>
@@ -97,96 +117,33 @@ module Footer = {
             className="section-wrapper pv4 mw9 center bxs-bb ph6-l ph5-m ph4 mw9-l">
             <div className="flex justify-center tc mb4">
               <ul className="list ph0">
-                <li className="mb2 dib">
-                  <a
-                    href="mailto:contact@o1labs.org"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-mail"
-                    target="_blank">
-                    {ReasonReact.string("contact@o1labs.org")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="https://o1labs.org"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-o1www"
-                    target="_blank">
-                    {ReasonReact.string(" o1labs.org")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="https://twitter.com/codaprotocol"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-twitter"
-                    target="_blank">
-                    {ReasonReact.string(" Twitter")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="https://github.com/o1-labs"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-github"
-                    target="_blank">
-                    {ReasonReact.string(" GitHub")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="https://reddit.com/r/coda"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-reddit"
-                    target="_blank">
-                    {ReasonReact.string(" Reddit")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="https://t.me/codaprotocol"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-telegram"
-                    target="_blank">
-                    {ReasonReact.string(" Telegram")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="/tos.html"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-tos"
-                    target="_blank">
-                    {ReasonReact.string(" Terms of Service")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="/privacy.html"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-privacy"
-                    target="_blank">
-                    {ReasonReact.string(" Privacy Policy")}
-                  </a>
-                  <span className="f6 silver"> dot </span>
-                </li>
-                <li className="mb2 dib">
-                  <a
-                    href="/jobs.html"
-                    className="no-underline fw3 f6 silver hover-link"
-                    name="footer-hiring"
-                    target="_blank">
-                    {ReasonReact.string(" We're Hiring")}
-                  </a>
-                  <span className="dn" />
-                </li>
+                <Link link="mailto:contact@o1labs.org" name="mail">
+                  {ReasonReact.string("contact@o1labs.org")}
+                </Link>
+                <Link link="https://o1labs.org" name="o1www">
+                  {ReasonReact.string("o1labs.org")}
+                </Link>
+                <Link link="https://twitter.com/codaprotocol" name="twitter">
+                  {ReasonReact.string("Twitter.org")}
+                </Link>
+                <Link link="https://github.com/o1-labs" name="github">
+                  {ReasonReact.string("GitHub")}
+                </Link>
+                <Link link="https://reddit.com/r/coda" name="reddit">
+                  {ReasonReact.string("Reddit")}
+                </Link>
+                <Link link="https://t.me/codaprotocol" name="telegram">
+                  {ReasonReact.string("Telegram")}
+                </Link>
+                <Link link="/tos.html" name="tos">
+                  {ReasonReact.string("Terms of service")}
+                </Link>
+                <Link link="/privacy.html" name="privacy">
+                  {ReasonReact.string("Privacy Policy")}
+                </Link>
+                <Link link="/jobs.html" name="hiring" last=true>
+                  {ReasonReact.string("We're Hiring")}
+                </Link>
               </ul>
             </div>
           </section>
@@ -204,7 +161,7 @@ module Footer = {
 };
 
 let component = ReasonReact.statelessComponent("Page");
-let make = (~extraHeaders=ReasonReact.null, children) => {
+let make = (~extraHeaders=ReasonReact.null, ~footerColor="", children) => {
   ...component,
   render: _ =>
     <html>
@@ -212,7 +169,7 @@ let make = (~extraHeaders=ReasonReact.null, children) => {
       <body className="metropolis black bg-white">
         <Nav />
         <div className="wrapper"> ...children </div>
-        <Footer color="bg-snow" />
+        <Footer color=footerColor />
       </body>
     </html>,
 };

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -108,7 +108,7 @@ Router.(
           |> Array.map(((name, _content, html)) =>
                File(
                  name,
-                 <Page extraHeaders=BlogPost.extraHeaders>
+                 <Page extraHeaders=BlogPost.extraHeaders footerColor="bg-snow">
                    <BlogPost
                      name
                      title="A SNARKy Exponential Function"

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -108,7 +108,8 @@ Router.(
           |> Array.map(((name, _content, html)) =>
                File(
                  name,
-                 <Page extraHeaders=BlogPost.extraHeaders footerColor="bg-snow">
+                 <Page
+                   extraHeaders=BlogPost.extraHeaders footerColor="bg-snow">
                    <BlogPost
                      name
                      title="A SNARKy Exponential Function"


### PR DESCRIPTION
Removed some duplication to make it a little more manageable. The bulk of this change is just moving a section of layout to a variable so that it can be reused.

- move benefits to a reusable variable
- create component for Career "heading" and Page footer "link" items