### PR TITLE
Version External_transition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ kademlia:
 # Alias
 dht: kademlia
 
-build: git_hooks # reformat-diff
+build: git_hooks reformat-diff
 	$(info Starting Build)
 	ulimit -s 65532 && (ulimit -n 10240 || true) && cd src && $(WRAPSRC) env CODA_COMMIT_SHA1=$(GITLONGHASH) dune build --profile=$(DUNE_PROFILE)
 	$(info Build complete)

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ kademlia:
 # Alias
 dht: kademlia
 
-build: git_hooks reformat-diff
+build: git_hooks # reformat-diff
 	$(info Starting Build)
 	ulimit -s 65532 && (ulimit -n 10240 || true) && cd src && $(WRAPSRC) env CODA_COMMIT_SHA1=$(GITLONGHASH) dune build --profile=$(DUNE_PROFILE)
 	$(info Build complete)

--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -1,8 +1,9 @@
 open Core
+open Module_version
 
 module type Base_intf = sig
   (* TODO: delegate forget here *)
-  type t [@@deriving sexp, bin_io, compare, eq]
+  type t [@@deriving sexp, compare, eq]
 
   include Comparable.S with type t := t
 
@@ -31,6 +32,16 @@ module type S = sig
     with type protocol_state := Protocol_state.value
      and type protocol_state_proof := Proof.t
      and type staged_ledger_diff := Staged_ledger_diff.t
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io]
+      end
+
+      module Latest = V1
+    end
+    with type V1.t = t
 
   module Proof_verified :
     Base_intf
@@ -75,29 +86,52 @@ end)
   module Protocol_state = Protocol_state
   module Blockchain_state = Protocol_state.Blockchain_state
 
-  module T0 = struct
-    type t =
-      { protocol_state: Protocol_state.value
-      ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
-      ; staged_ledger_diff: Staged_ledger_diff.t }
-    [@@deriving sexp, fields, bin_io]
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        let version = 1
 
-    (* TODO: Important for bkase to review *)
-    let compare t1 t2 =
-      Protocol_state.compare t1.protocol_state t2.protocol_state
+        type t =
+          { protocol_state: Protocol_state.value
+          ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
+          ; staged_ledger_diff: Staged_ledger_diff.t }
+        [@@deriving sexp, fields, bin_io]
 
-    let equal t1 t2 =
-      Protocol_state.equal_value t1.protocol_state t2.protocol_state
+        (* TODO: Important for bkase to review *)
+        let compare t1 t2 =
+          Protocol_state.compare t1.protocol_state t2.protocol_state
+
+        let equal t1 t2 =
+          Protocol_state.equal_value t1.protocol_state t2.protocol_state
+      end
+
+      include T
+      include Comparable.Make (T)
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "external_transition"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
   end
 
-  module T = struct
-    include T0
-    include Comparable.Make (T0)
-  end
+  (* bin_io omitted *)
+  type t = Stable.Latest.t =
+    { protocol_state: Protocol_state.value
+    ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
+    ; staged_ledger_diff: Staged_ledger_diff.t }
+  [@@deriving sexp, fields]
 
-  include T
-  module Proof_verified = T
-  module Verified = T
+  include Comparable.Make (Stable.Latest)
+  module Proof_verified = Stable.Latest
+  module Verified = Stable.Latest
 
   let to_proof_verified x = `I_swear_this_is_safe_see_my_comment x
 

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -152,7 +152,8 @@ struct
         (* "master" types, do not change *)
         type query = State_hash.t Envelope.Incoming.Stable.V1.t
 
-        type response = External_transition.t Non_empty_list.Stable.V1.t option
+        type response =
+          External_transition.Stable.V1.t Non_empty_list.Stable.V1.t option
       end
 
       module Caller = T
@@ -173,7 +174,8 @@ struct
         type query = State_hash.t Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io, sexp]
 
-        type response = External_transition.t Non_empty_list.Stable.V1.t option
+        type response =
+          External_transition.Stable.V1.t Non_empty_list.Stable.V1.t option
         [@@deriving bin_io, sexp]
 
         let version = 1
@@ -203,7 +205,7 @@ struct
         [@@deriving sexp]
 
         type response =
-          ( ( External_transition.t
+          ( ( External_transition.Stable.V1.t
             , State_body_hash.t list * External_transition.t )
             Proof_carrying_data.t
           * Staged_ledger_aux.Stable.V1.t
@@ -231,8 +233,8 @@ struct
         [@@deriving bin_io, sexp]
 
         type response =
-          ( ( External_transition.t
-            , State_body_hash.t list * External_transition.t )
+          ( ( External_transition.Stable.V1.t
+            , State_body_hash.t list * External_transition.Stable.V1.t )
             Proof_carrying_data.t
           * Staged_ledger_aux.Stable.V1.t
           * Ledger_hash.Stable.V1.t )
@@ -265,9 +267,7 @@ module Message (Inputs : sig
     type t [@@deriving bin_io, sexp]
   end
 
-  module External_transition : sig
-    type t [@@deriving bin_io, sexp]
-  end
+  module External_transition : External_transition.S
 end) =
 struct
   open Inputs
@@ -276,7 +276,7 @@ struct
     module T = struct
       (* "master" types, do not change *)
       type content =
-        | New_state of External_transition.t
+        | New_state of External_transition.Stable.V1.t
         | Snark_pool_diff of Snark_pool_diff.t
         | Transaction_pool_diff of Transaction_pool_diff.t
       [@@deriving bin_io, sexp]

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -1055,7 +1055,16 @@ module type External_transition_intf = sig
 
   type staged_ledger_diff
 
-  type t [@@deriving sexp, bin_io]
+  module Stable : sig
+    module V1 : sig
+      type t [@@deriving sexp, bin_io]
+    end
+
+    module Latest = V1
+  end
+
+  (* bin_io intentionally omitted *)
+  type t = Stable.Latest.t [@@deriving sexp]
 
   val create :
        protocol_state:protocol_state
@@ -1064,7 +1073,7 @@ module type External_transition_intf = sig
     -> t
 
   module Verified : sig
-    type t [@@deriving sexp, bin_io]
+    type t [@@deriving sexp]
 
     val protocol_state : t -> protocol_state
 
@@ -1074,7 +1083,7 @@ module type External_transition_intf = sig
   end
 
   module Proof_verified : sig
-    type t [@@deriving sexp, bin_io]
+    type t [@@deriving sexp]
 
     val protocol_state : t -> protocol_state
 


### PR DESCRIPTION
Version `External_transition`, used in RPC types.

Still to do: version the functor inputs for that module, namely, `Staged_ledger_diff` and `Protocol_state`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
