### PR TITLE
 Added registered_mask visualization to cli and log_shutdown

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -473,26 +473,47 @@ let stop_tracing =
          | Ok () -> printf "Daemon stopped printing!"
          | Error e -> eprintf !"Error: %{sexp:Error.t}\n" e ))
 
-let visualize_frontier =
-  let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
-  let open Command.Param in
-  Command.async ~summary:"Produce a dot file of the transition_frontier"
-    (Cli_lib.Background_daemon.init
-       Command.Param.(anon @@ ("output-filepath" %: string))
-       ~f:(fun port filename ->
-         match%map dispatch Visualize_frontier.rpc filename port with
-         | Ok (`Active ()) ->
-             printf
-               !"Successfully wrote the visualization of frontier at \
-                 location: %s."
-               filename
-         | Ok `Bootstrapping ->
-             printf
-               !"Could not visualize frontier since daemon is currently \
-                 bootstrapping"
-         | Error e ->
-             printf "Could not save file: %s\n" (Error.to_string_hum e) ))
+module Visualization = struct
+  let create_command (type rpc_response) ~name ~f
+      (rpc : (string, rpc_response) Rpc.Rpc.t) =
+    let open Deferred.Let_syntax in
+    let open Command.Param in
+    Command.async
+      ~summary:(sprintf !"Produce a visualization of the %s" name)
+      (Cli_lib.Background_daemon.init
+         Command.Param.(anon @@ ("output-filepath" %: string))
+         ~f:(fun port filename ->
+           let%map message =
+             match%map dispatch rpc filename port with
+             | Ok response -> f filename response
+             | Error e ->
+                 sprintf "Could not save file: %s\n" (Error.to_string_hum e)
+           in
+           print_string message ))
+
+  module Frontier = struct
+    let name = "transition-frontier"
+
+    let command =
+      create_command ~name Daemon_rpcs.Visualization.Frontier.rpc
+        ~f:(fun filename -> function
+        | `Active () -> Visualization_message.success name filename
+        | `Bootstrapping -> Visualization_message.bootstrap name )
+  end
+
+  module Registered_masks = struct
+    let name = "registered-masks"
+
+    let command =
+      create_command ~name Daemon_rpcs.Visualization.Registered_masks.rpc
+        ~f:(fun filename () -> Visualization_message.success name filename )
+  end
+
+  let command_group =
+    Command.group ~summary:"Visualize data structures special to Coda"
+      [ (Frontier.name, Frontier.command)
+      ; (Registered_masks.name, Registered_masks.command) ]
+end
 
 let command =
   Command.group ~summary:"Lightweight client commands"
@@ -513,4 +534,4 @@ let command =
     ; ("start-tracing", start_tracing)
     ; ("stop-tracing", stop_tracing)
     ; ("snark-job-list", snark_job_list)
-    ; ("visualize-frontier", visualize_frontier) ]
+    ; ("visualizationr", Visualization.command_group) ]

--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -534,4 +534,4 @@ let command =
     ; ("start-tracing", start_tracing)
     ; ("stop-tracing", stop_tracing)
     ; ("snark-job-list", snark_job_list)
-    ; ("visualizationr", Visualization.command_group) ]
+    ; ("visualization", Visualization.command_group) ]

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -334,9 +334,7 @@ let daemon log =
               ~time_controller ?propose_keypair:Config0.propose_keypair ()
               ~banlist ~monitor)
        in
-       Run.handle_shutdown ~monitor
-         ~frontier_file:(conf_dir ^/ "frontier.dot")
-         ~log coda ;
+       Run.handle_shutdown ~monitor ~conf_dir ~log coda ;
        Async.Scheduler.within' ~monitor
        @@ fun () ->
        let%bind () = maybe_sleep 3. in

--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1290,15 +1290,21 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
 
   let clear_hist_status ~flag t = Perf_histograms.wipe () ; get_status ~flag t
 
-  let log_shutdown ~frontier_file ~log t =
+  let visualize_registered_masks = Coda_base.Ledger.Debug.visualize
+
+  let log_shutdown ~conf_dir ~log t =
+    let frontier_file = conf_dir ^/ "frontier.dot" in
+    let mask_file = conf_dir ^/ "registered_masks.dot" in
+    Logger.info log !"%s"
+      (Visualization_message.success "registered masks" frontier_file) ;
+    visualize_registered_masks ~filename:mask_file ;
     match visualize_frontier ~filename:frontier_file t with
     | `Active () ->
-        Logger.info log
-          "Successfully wrote the visualization of frontier at location: %s"
-          frontier_file
+        Logger.info log !"%s"
+          (Visualization_message.success "transition frontier" frontier_file)
     | `Bootstrapping ->
-        Logger.info log
-          "Could not visualize frontier since daemon is currently bootstrapping"
+        Logger.info log !"%s"
+          (Visualization_message.bootstrap "transition frontier")
 
   (* TODO: handle participation_status more appropriately than doing participate_exn *)
   let setup_local_server ?(client_whitelist = []) ?rest_server_port ~coda ~log
@@ -1366,8 +1372,11 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
             Coda_tracing.start Config_in.conf_dir )
       ; implement Daemon_rpcs.Stop_tracing.rpc (fun () () ->
             Coda_tracing.stop () ; Deferred.unit )
-      ; implement Daemon_rpcs.Visualize_frontier.rpc (fun () filename ->
-            return (visualize_frontier ~filename coda) ) ]
+      ; implement Daemon_rpcs.Visualization.Frontier.rpc (fun () filename ->
+            return (visualize_frontier ~filename coda) )
+      ; implement Daemon_rpcs.Visualization.Registered_masks.rpc
+          (fun () filename ->
+            return (Coda_base.Ledger.Debug.visualize ~filename) ) ]
     in
     let snark_worker_impls =
       [ implement Snark_worker.Rpcs.Get_work.rpc (fun () () ->
@@ -1494,13 +1503,13 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
           ~client_port
         |> ignore
 
-  let handle_shutdown ~monitor ~frontier_file ~log t =
+  let handle_shutdown ~monitor ~conf_dir ~log t =
     Monitor.detach_and_iter_errors monitor ~f:(fun exn ->
-        log_shutdown ~frontier_file ~log t ;
+        log_shutdown ~conf_dir ~log t ;
         raise exn ) ;
     Async_unix.Signal.(
       handle terminating ~f:(fun signal ->
-          log_shutdown ~frontier_file ~log t ;
+          log_shutdown ~conf_dir ~log t ;
           Logger.info log
             !"Coda process got interrupted by signal %{sexp:t}"
             signal ))

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -249,7 +249,6 @@ module T = struct
                 ; parent_log= log
                 ; trust_system } }
           in
-          let frontier_file = conf_dir ^/ "frontier.dot" in
           let monitor = Async.Monitor.create ~name:"coda" () in
           let with_monitor f input =
             Async.Scheduler.within' ~monitor (fun () -> f input)
@@ -267,7 +266,7 @@ module T = struct
                  ~snark_work_fee:(Currency.Fee.of_int 0)
                  ?propose_keypair:Config.propose_keypair () ~banlist ~monitor)
           in
-          Run.handle_shutdown ~monitor ~frontier_file ~log coda ;
+          Run.handle_shutdown ~monitor ~conf_dir ~log coda ;
           let%map () =
             with_monitor
               (fun () ->

--- a/src/app/cli/src/visualization_message.ml
+++ b/src/app/cli/src/visualization_message.ml
@@ -1,0 +1,11 @@
+open Core_kernel
+
+let success visualization_type filepath =
+  sprintf
+    !"Successfully wrote the visualization of the %s at location: %s."
+    visualization_type filepath
+
+let bootstrap visualization_type =
+  sprintf
+    !"Could not visualize %s since daemon is currently bootstrapping"
+    visualization_type

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -405,12 +405,24 @@ module Stop_tracing = struct
     Rpc.Rpc.create ~name:"Stop_tracing" ~version:0 ~bin_query ~bin_response
 end
 
-module Visualize_frontier = struct
-  type query = string [@@deriving bin_io]
+module Visualization = struct
+  module Frontier = struct
+    type query = string [@@deriving bin_io]
 
-  type response = [`Active of unit | `Bootstrapping] [@@deriving bin_io]
+    type response = [`Active of unit | `Bootstrapping] [@@deriving bin_io]
 
-  let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Visualize_frontier" ~version:0 ~bin_query
-      ~bin_response
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Visualize_frontier" ~version:0 ~bin_query
+        ~bin_response
+  end
+
+  module Registered_masks = struct
+    type query = string [@@deriving bin_io]
+
+    type response = unit [@@deriving bin_io]
+
+    let rpc : (query, response) Rpc.Rpc.t =
+      Rpc.Rpc.create ~name:"Visualize_registered_masks" ~version:0 ~bin_query
+        ~bin_response
+  end
 end


### PR DESCRIPTION
This will help with debugging the dangling masks errors we see

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

