### PR TITLE
Add pages for careers posts

### DIFF
--- a/frontend/website/jobs
+++ b/frontend/website/jobs
@@ -1,0 +1,1 @@
+../../src/app/website/jobs

--- a/frontend/website/src/CareerPost.re
+++ b/frontend/website/src/CareerPost.re
@@ -1,0 +1,43 @@
+let component = ReasonReact.statelessComponent("CareerPost");
+
+let make = (~path, _) => {
+  let (html, content) = Markdown.load(path);
+  let title = Markdown.Metadata.getRequiredValue("title", content, path);
+  let date = Markdown.Metadata.getRequiredValue("date", content, path);
+  {
+    ...component,
+    render: _self =>
+      <div className="bxs-cb bg-white">
+        <section
+          className="section-wrapper pv4 mw9 center bxs-bb ph6-l ph5-m ph4 mw9-l">
+          <div className="center mw7">
+            <div className="important-text">
+              <div>
+                <div className="dn db-ns">
+                  <h3
+                    className="dib mw6 m-none lh-copy f2 mb3 mb4-ns tc tl-ns mt0 mr0 ml0">
+                    {ReasonReact.string(title)}
+                  </h3>
+                </div>
+                <div className="db dn-ns">
+                  <div className="flex justify-center">
+                    <h3
+                      className="dib mw6 m-none lh-copy f2 mb3 mb4-ns tc tl-ns mt0 mr0 ml0">
+                      {ReasonReact.string(title)}
+                    </h3>
+                  </div>
+                </div>
+              </div>
+              <div className="lh-copy f4 fw3 silver tc tl-ns mt0 mr0 ml0">
+                <p
+                  className="mt0 mb0"
+                  dangerouslySetInnerHTML={"__html": html}
+                />
+              </div>
+            </div>
+          </div>
+        </section>
+        <BlogPost.MailingList />
+      </div>,
+  };
+};

--- a/frontend/website/src/Markdown.re
+++ b/frontend/website/src/Markdown.re
@@ -1,0 +1,38 @@
+module Metadata = {
+  let getValue = (key, content) => {
+    // Search inside of the area enclosed by `---` for
+    // a line that starts with `key:` and capture everything
+    // between the : and the end of the line.
+    let re =
+      Js.Re.fromStringWithFlags(
+        {|^---(?:.|\n)*^|} ++ key ++ {|:(.*)\n(?:.|\n)*^---|},
+        ~flags="m",
+      );
+    switch (Js.Re.exec(content, re)) {
+    | None => None
+    | Some(result) =>
+      let captures = Js.Re.captures(result);
+      let opt = Js.Nullable.toOption(captures[1]);
+      Belt.Option.map(opt, String.trim);
+    };
+  };
+
+  let getRequiredValue = (key, content, filename) =>
+    switch (getValue(key, content)) {
+    | None =>
+      failwith("Didn't provide " ++ key ++ " in " ++ filename ++ ".markdown")
+    | Some(s) => s
+    };
+};
+
+let load = path => {
+  let html =
+    Node.Child_process.execSync(
+      "pandoc " ++ path ++ " --mathjax",
+      Node.Child_process.option(),
+    );
+  let content = Node.Fs.readFileAsUtf8Sync(path);
+  (html, content);
+};
+
+let suffix = ".markdown";

--- a/frontend/website/src/Nav.re
+++ b/frontend/website/src/Nav.re
@@ -30,7 +30,7 @@ module Style = {
   let menuBtn =
     style([
       display(`none),
-      selector({j|":checked ~ .$options"|j}, [display(`block)]),
+      selector({j|:checked ~ .$options|j}, [display(`block)]),
     ]);
 
   let menuIcon =

--- a/frontend/website/src/Page.re
+++ b/frontend/website/src/Page.re
@@ -1,6 +1,6 @@
 module Header = {
   let component = ReasonReact.statelessComponent("Header");
-  let make = (~extra, _children) => {
+  let make = (~extra, ~filename, _children) => {
     ...component,
     render: _self =>
       <head>
@@ -39,11 +39,16 @@ module Header = {
           integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9"
           crossOrigin="anonymous"
         />
-        <link rel="stylesheet" type_="text/css" href="static/css/common.css" />
+        <link rel="stylesheet" type_="text/css" href={filename ++ ".css"} />
         <link
           rel="stylesheet"
           type_="text/css"
-          href="static/css/gallery.css"
+          href="/static/css/common.css"
+        />
+        <link
+          rel="stylesheet"
+          type_="text/css"
+          href="/static/css/gallery.css"
         />
         <link
           media="only screen and (min-device-width: 700px)"
@@ -161,11 +166,11 @@ module Footer = {
 };
 
 let component = ReasonReact.statelessComponent("Page");
-let make = (~extraHeaders=ReasonReact.null, ~footerColor="", children) => {
+let make = (~name, ~extraHeaders=ReasonReact.null, ~footerColor="", children) => {
   ...component,
   render: _ =>
     <html>
-      <Header extra=extraHeaders />
+      <Header extra=extraHeaders filename=name />
       <body className="metropolis black bg-white">
         <Nav>
           <a> {ReasonReact.string("Blog")} </a>

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -42,22 +42,13 @@ let writeStatic = (path, rootComponent) => {
   Node.Fs.writeFileAsUtf8Sync(path ++ ".css", rendered##css);
 };
 
-let load = path => {
-  Node.Child_process.execSync(
-    "pandoc " ++ path ++ " --mathjax",
-    Node.Child_process.option(),
-  );
-};
-
-let postSuffix = ".markdown";
 let posts =
   Node.Fs.readdirSync("posts")
-  |> Js.Array.filter(s => Js.String.endsWith(postSuffix, s))
+  |> Js.Array.filter(s => Js.String.endsWith(Markdown.suffix, s))
   |> Array.map(fileName => {
-       let length = String.length(fileName) - String.length(postSuffix);
+       let length = String.length(fileName) - String.length(Markdown.suffix);
        let name = String.sub(fileName, 0, length);
-       let content = Node.Fs.readFileAsUtf8Sync("posts/" ++ fileName);
-       let html = load("posts/" ++ fileName);
+       let (html, content) = Markdown.load("posts/" ++ fileName);
        (name, content, html);
      });
 
@@ -109,19 +100,36 @@ Router.(
                File(
                  name,
                  <Page
-                   extraHeaders=BlogPost.extraHeaders footerColor="bg-snow">
+                   name
+                   extraHeaders=BlogPost.extraHeaders
+                   footerColor="bg-snow">
                    <BlogPost name content html />
+                 </Page>,
+               )
+             ),
+        ),
+        Dir(
+          "jobs",
+          jobOpenings
+          |> Array.map(((name, _)) =>
+               File(
+                 name,
+                 <Page name footerColor="bg-snow">
+                   <CareerPost path={"jobs/" ++ name ++ ".markdown"} />
                  </Page>,
                )
              ),
         ),
         File(
           "jobs",
-          <Page extraHeaders=Careers.extraHeaders>
+          <Page name="jobs" extraHeaders=Careers.extraHeaders>
             <Careers jobOpenings />
           </Page>,
         ),
-        File("code", <Page extraHeaders=Code.extraHeaders> <Code /> </Page>),
+        File(
+          "code",
+          <Page name="code" extraHeaders=Code.extraHeaders> <Code /> </Page>,
+        ),
       |],
     ),
   )


### PR DESCRIPTION
- Add generation for job pages using the same list as is used for generating the list of jobs (impossible to have a dead link)
- Reorganize Markdown
- Fix menu selector and adds style to all pages

We might want to have `generateStatic` pass in the page name to Page later so that we don't need to duplicate it, but this seemed simpler for now.