### PR TITLE
Deprecate Logger.faulty_peer

### DIFF
--- a/src/lib/bootstrap_controller/dune
+++ b/src/lib/bootstrap_controller/dune
@@ -1,6 +1,7 @@
 (library
   (name bootstrap_controller)
   (public_name bootstrap_controller)
+  (flags :standard -warn-error -3)
   (preprocess (pps ppx_jane ppx_deriving.eq))
   (libraries
     core

--- a/src/lib/coda_networking/dune
+++ b/src/lib/coda_networking/dune
@@ -1,7 +1,7 @@
 (library
  (name coda_networking)
  (public_name coda_networking)
- (flags :standard -short-paths -warn-error -32-27-58)
+ (flags :standard -short-paths -warn-error -3-32-27-58)
  (inline_tests)
  (library_flags -linkall)
  (libraries core o1trace envelope async gossip_net coda_lib protocols

--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -1,5 +1,6 @@
 (library
   (name ledger_catchup)
   (public_name ledger_catchup)
+  (flags :standard -warn-error -3)
   (preprocess (pps ppx_jane) )
   (libraries async_kernel non_empty_list transition_frontier transition_handler consensus core_kernel protocols pipe_lib syncable_ledger merkle_address coda_base kademlia))

--- a/src/lib/logger/logger.ml
+++ b/src/lib/logger/logger.ml
@@ -158,4 +158,8 @@ let error ?loc ?attrs t fmt = log ~level:Error ?loc ?attrs t fmt
 
 let fatal ?loc ?attrs t fmt = log ~level:Fatal ?loc ?attrs t fmt
 
-let faulty_peer ?loc ?attrs t fmt = log ~level:Faulty_peer ?loc ?attrs t fmt
+let faulty_peer_without_punishment ?loc ?attrs t fmt =
+  log ~level:Faulty_peer ?loc ?attrs t fmt
+
+(* deprecated, use Trust_system.record instead *)
+let faulty_peer = faulty_peer_without_punishment

--- a/src/lib/logger/logger.mli
+++ b/src/lib/logger/logger.mli
@@ -51,7 +51,9 @@ val error : _ logger
 
 val fatal : _ logger
 
-val faulty_peer : _ logger
+val faulty_peer : _ logger [@@deprecated "use Trust_system.record"]
+
+val faulty_peer_without_punishment : _ logger
 
 val extend : t -> Attribute.t list -> t
 

--- a/src/lib/peer_trust/peer_trust.ml
+++ b/src/lib/peer_trust/peer_trust.ml
@@ -96,7 +96,7 @@ struct
     let%map () =
       match (simple_old.banned, simple_new.banned) with
       | Unbanned, Banned_until expiration ->
-          Logger.faulty_peer log'
+          Logger.faulty_peer_without_punishment log'
             !"Banning peer %{sexp:Peer_id.t} until %{sexp:Time.t} due to \
               action %{sexp:Action.t}."
             peer expiration action ;

--- a/src/lib/syncable_ledger/dune
+++ b/src/lib/syncable_ledger/dune
@@ -3,7 +3,7 @@
  (public_name syncable_ledger)
  (modules syncable_ledger)
  (library_flags -linkall)
- (flags :standard -short-paths -warn-error -32-34-58)
+ (flags :standard -short-paths -warn-error -3-32-34-58)
  (libraries core async async_extra pipe_lib merkle_ledger logger
    interruptible envelope)
  (preprocess

--- a/src/lib/transaction_pool/dune
+++ b/src/lib/transaction_pool/dune
@@ -1,7 +1,7 @@
 (library
  (name transaction_pool)
  (public_name transaction_pool)
- (flags :standard -short-paths -warn-error -27-58)
+ (flags :standard -short-paths -warn-error -3)
  (library_flags -linkall)
  (inline_tests)
  (libraries core async async_extra coda_base envelope protocols )

--- a/src/lib/transition_handler/dune
+++ b/src/lib/transition_handler/dune
@@ -1,5 +1,6 @@
 (library
   (name transition_handler)
   (public_name transition_handler)
+  (flags :standard -warn-error -3)
   (libraries perf_histograms core_kernel transition_frontier consensus protocols rose_tree pipe_lib otp_lib coda_base cache_lib)
   (preprocess (pps ppx_jane)))


### PR DESCRIPTION
I'll be fixing the warnings over the next while, then turning deprecation warnings back into errors when a given library is free of them.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: