### PR TITLE
SIMPLE:More context for bootstrap logging, extend wait on bootstrap test

### DIFF
--- a/src/app/cli/src/coda_bootstrap_test.ml
+++ b/src/app/cli/src/coda_bootstrap_test.ml
@@ -28,7 +28,7 @@ let main () =
     Coda_worker_testnet.Restarts.trigger_bootstrap testnet ~log ~node:1
       ~largest_account_keypair ~payment_receiver:0
   in
-  let%bind () = after (Time.Span.of_sec 60.) in
+  let%bind () = after (Time.Span.of_sec 180.) in
   let%map () = Coda_worker_testnet.Api.teardown testnet in
   Logger.info log "SUCCEEDED" ;
   ()

--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -331,6 +331,7 @@ end = struct
             ~consensus_local_state:
               (Transition_frontier.consensus_local_state frontier)
         in
+        Logger.info logger "Bootstrap state: complete." ;
         (new_frontier, Transition_cache.data transition_graph)
     | Error err ->
         (* TODO: punish *)

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -554,7 +554,8 @@ end = struct
           | Num_accounts (n, h) -> num_accounts t n h
         in
         if Valid.completely_fresh t.validity then (
-          Logger.trace t.log !"We are completely fresh, all done" ;
+          Logger.trace t.log
+            !"Snarked database sync'd. Completely fresh, all done" ;
           all_done t res )
         else res
     in

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -146,7 +146,7 @@ module Make (Inputs : Inputs_intf) :
       let bootstrap_controller_reader, bootstrap_controller_writer =
         Strict_pipe.create (Buffered (`Capacity 10, `Overflow Drop_head))
       in
-      Logger.info logger "Starting Bootstrapping phase" ;
+      Logger.info logger "Bootstrap state: starting." ;
       let root_state = get_root_state old_frontier in
       set_bootstrap_phase ~controller_type root_state
         bootstrap_controller_writer ;


### PR DESCRIPTION
Extends wait on bootstrap test from 60-180s
Adds minor context to some logging messages.