### PR TITLE
Start hero section on website

### DIFF
--- a/frontend/website/src/CodaNav.re
+++ b/frontend/website/src/CodaNav.re
@@ -9,7 +9,7 @@ module SimpleButton = {
         href=link
         className=Css.(
           merge([
-            Body.style,
+            Body.basic,
             style([textDecoration(`none), whiteSpace(`nowrap)]),
           ])
         )>

--- a/frontend/website/src/HeroSection.re
+++ b/frontend/website/src/HeroSection.re
@@ -1,31 +1,30 @@
-open Css;
-open Style;
-
 module Copy = {
   let component = ReasonReact.statelessComponent("HeroSection.Copy");
   let make = _ => {
     ...component,
     render: _self =>
-      <div className={style([width(`percent(50.0))])}>
+      <div className=Css.(style([width(`percent(50.0))]))>
         <h1
-          className={merge([
-            H1.hero,
-            style([
-              marginTop(`rem(1.0)),
-              media(MediaQuery.full, [marginTop(`rem(1.5))]),
-            ]),
-          ])}>
+          className=Css.(
+            merge([
+              Style.H1.hero,
+              style([
+                marginTop(`rem(1.0)),
+                media(Style.MediaQuery.full, [marginTop(`rem(1.5))]),
+              ]),
+            ])
+          )>
           {ReasonReact.string(
              "A cryptocurrency with a tiny, portable blockchain.",
            )}
         </h1>
-        <p className=Body.big>
+        <p className=Style.Body.big>
           <span>
             {ReasonReact.string(
                "Coda is the first cryptocurrency with a succinct blockchain. Out lightweight blockchain means ",
              )}
           </span>
-          <span className=Body.big_semibold>
+          <span className=Style.Body.big_semibold>
             {ReasonReact.string("anyone can use Coda directly")}
           </span>
           <span>
@@ -39,13 +38,15 @@ module Copy = {
 };
 
 module Graphic = {
-  module Placholder = {
+  module Placeholder = {
     let basic =
-      style([
-        width(`rem(16.0)),
-        height(`rem(29.0)),
-        backgroundColor(Colors.greyishBrown),
-      ]);
+      Css.(
+        style([
+          width(`rem(16.0)),
+          height(`rem(29.0)),
+          backgroundColor(Style.Colors.greyishBrown),
+        ])
+      );
   };
 
   module Info = {
@@ -56,32 +57,41 @@ module Graphic = {
       ...component,
       render: _ =>
         <div
-          className={style([
-            display(`flex),
-            flexDirection(`column),
-            justifyContent(`spaceBetween),
-            alignItems(`center),
-          ])}>
+          className=Css.(
+            style([
+              display(`flex),
+              flexDirection(`column),
+              justifyContent(`spaceBetween),
+              alignItems(`center),
+            ])
+          )>
           <div>
             <h3
-              className={merge([
-                H3.basic,
-                style([color(textColor), fontWeight(`medium)]),
-              ])}>
+              className=Css.(
+                merge([
+                  Style.H3.basic,
+                  style([color(textColor), fontWeight(`medium)]),
+                ])
+              )>
               {ReasonReact.string(name)}
             </h3>
             <h3
-              className={merge([
-                H3.basic,
-                style([
-                  color(textColor),
-                  fontWeight(sizeEmphasis ? `bold : `normal),
-                ]),
-              ])}>
+              className=Css.(
+                merge([
+                  Style.H3.basic,
+                  style([
+                    color(textColor),
+                    fontWeight(sizeEmphasis ? `bold : `normal),
+                  ]),
+                ])
+              )>
               {ReasonReact.string(size)}
             </h3>
           </div>
-          <h4 className={merge([H4.basic, style([marginTop(`rem(1.5))])])}>
+          <h4
+            className=Css.(
+              merge([Style.H4.basic, style([marginTop(`rem(1.5))])])
+            )>
             {ReasonReact.string(label)}
           </h4>
         </div>,
@@ -92,26 +102,31 @@ module Graphic = {
   let make = _ => {
     ...component,
     render: _self =>
-      <div className={style([width(`percent(50.0))])}>
-        <div className=Placholder.basic />
-        <div
-          className={style([display(`flex), justifyContent(`spaceBetween)])}>
-          <Info
-            sizeEmphasis=false
-            name="Coda"
-            size="22kB"
-            label="Fixed"
-            textColor=Colors.bluishGreen
-          />
-          <Info
-            sizeEmphasis=false
-            name="Other blockchains"
-            size="2TB+"
-            label="Increasing"
-            textColor=Colors.purpleBrown
-          />
+      Css.(
+        <div className={style([width(`percent(50.0))])}>
+          <div className=Placeholder.basic />
+          <div
+            className={style([
+              display(`flex),
+              justifyContent(`spaceBetween),
+            ])}>
+            <Info
+              sizeEmphasis=false
+              name="Coda"
+              size="22kB"
+              label="Fixed"
+              textColor=Style.Colors.bluishGreen
+            />
+            <Info
+              sizeEmphasis=true
+              name="Other blockchains"
+              size="2TB+"
+              label="Increasing"
+              textColor=Style.Colors.purpleBrown
+            />
+          </div>
         </div>
-      </div>,
+      ),
   };
 };
 
@@ -120,12 +135,15 @@ let make = _ => {
   ...component,
   render: _self =>
     <div
-      className={style([
-        display(`flex),
-        marginTop(`rem(1.5)),
-        media(MediaQuery.full, [marginTop(`rem(4.5))]),
-      ])}>
+      className=Css.(
+        style([
+          display(`flex),
+          marginTop(`rem(1.5)),
+          media(Style.MediaQuery.full, [marginTop(`rem(4.5))]),
+        ])
+      )>
       <Copy />
       <Graphic />
     </div>,
 };
+();

--- a/frontend/website/src/HeroSection.re
+++ b/frontend/website/src/HeroSection.re
@@ -1,0 +1,131 @@
+open Css;
+open Style;
+
+module Copy = {
+  let component = ReasonReact.statelessComponent("HeroSection.Copy");
+  let make = _ => {
+    ...component,
+    render: _self =>
+      <div className={style([width(`percent(50.0))])}>
+        <h1
+          className={merge([
+            H1.hero,
+            style([
+              marginTop(`rem(1.0)),
+              media(MediaQuery.full, [marginTop(`rem(1.5))]),
+            ]),
+          ])}>
+          {ReasonReact.string(
+             "A cryptocurrency with a tiny, portable blockchain.",
+           )}
+        </h1>
+        <p className=Body.big>
+          <span>
+            {ReasonReact.string(
+               "Coda is the first cryptocurrency with a succinct blockchain. Out lightweight blockchain means ",
+             )}
+          </span>
+          <span className=Body.big_semibold>
+            {ReasonReact.string("anyone can use Coda directly")}
+          </span>
+          <span>
+            {ReasonReact.string(
+               " from any device, in less data than a few tweets.",
+             )}
+          </span>
+        </p>
+      </div>,
+  };
+};
+
+module Graphic = {
+  module Placholder = {
+    let basic =
+      style([
+        width(`rem(16.0)),
+        height(`rem(29.0)),
+        backgroundColor(Colors.greyishBrown),
+      ]);
+  };
+
+  module Info = {
+    let component =
+      ReasonReact.statelessComponent("HeroSection.Graphic.Info");
+
+    let make = (~sizeEmphasis, ~name, ~size, ~label, ~textColor, _children) => {
+      ...component,
+      render: _ =>
+        <div
+          className={style([
+            display(`flex),
+            flexDirection(`column),
+            justifyContent(`spaceBetween),
+            alignItems(`center),
+          ])}>
+          <div>
+            <h3
+              className={merge([
+                H3.basic,
+                style([color(textColor), fontWeight(`medium)]),
+              ])}>
+              {ReasonReact.string(name)}
+            </h3>
+            <h3
+              className={merge([
+                H3.basic,
+                style([
+                  color(textColor),
+                  fontWeight(sizeEmphasis ? `bold : `normal),
+                ]),
+              ])}>
+              {ReasonReact.string(size)}
+            </h3>
+          </div>
+          <h4 className={merge([H4.basic, style([marginTop(`rem(1.5))])])}>
+            {ReasonReact.string(label)}
+          </h4>
+        </div>,
+    };
+  };
+
+  let component = ReasonReact.statelessComponent("HeroSection.Graphic");
+  let make = _ => {
+    ...component,
+    render: _self =>
+      <div className={style([width(`percent(50.0))])}>
+        <div className=Placholder.basic />
+        <div
+          className={style([display(`flex), justifyContent(`spaceBetween)])}>
+          <Info
+            sizeEmphasis=false
+            name="Coda"
+            size="22kB"
+            label="Fixed"
+            textColor=Colors.bluishGreen
+          />
+          <Info
+            sizeEmphasis=false
+            name="Other blockchains"
+            size="2TB+"
+            label="Increasing"
+            textColor=Colors.purpleBrown
+          />
+        </div>
+      </div>,
+  };
+};
+
+let component = ReasonReact.statelessComponent("HeroSection");
+let make = _ => {
+  ...component,
+  render: _self =>
+    <div
+      className={style([
+        display(`flex),
+        marginTop(`rem(1.5)),
+        media(MediaQuery.full, [marginTop(`rem(4.5))]),
+      ])}>
+      <Copy />
+      <Graphic />
+    </div>,
+};

--- a/frontend/website/src/Home.re
+++ b/frontend/website/src/Home.re
@@ -3,5 +3,5 @@ let extraHeaders = <link rel="stylesheet" type_="text/css" href="index.css" />;
 let component = ReasonReact.statelessComponent("Home");
 let make = _ => {
   ...component,
-  render: _self => <p> {ReasonReact.string("Home page")} </p>,
+  render: _self => <section> <HeroSection /> </section>,
 };

--- a/frontend/website/src/LegacyPage.re
+++ b/frontend/website/src/LegacyPage.re
@@ -160,11 +160,11 @@ module Footer = {
             target="_blank">
             ...children
           </a>
-          {last
-             ? <span className="dn" />
-             : <span className="f6 silver">
-                 {ReasonReact.string({js| · |js})}
-               </span>}
+          {last ?
+             <span className="dn" /> :
+             <span className="f6 silver">
+               {ReasonReact.string({js| · |js})}
+             </span>}
         </li>,
     };
   };

--- a/frontend/website/src/LegacyPage.re
+++ b/frontend/website/src/LegacyPage.re
@@ -75,6 +75,63 @@ module Header = {
         <script
           src="https://www.googletagmanager.com/gtag/js?id=UA-115553548-2"
         />
+        // HACK: Force ibm plex fonts on all the pages
+        <style
+          dangerouslySetInnerHTML={
+            "__html": {|
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: url("/static/font/IBMPlexSans-Regular-Latin1.woff2") format("woff2"),
+    url("/static/font/IBMPlexSans-Regular-Latin1.woff") format("woff");
+  unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2074, U+20AC, U+2122, U+2212, U+FB01-FB02;
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 500;
+  src: url("/static/font/IBMPlexSans-Medium-Latin1.woff2") format("woff2"),
+    url("/static/font/IBMPlexSans-Medium-Latin1.woff") format("woff");
+  unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2074, U+20AC, U+2122, U+2212, U+FB01-FB02;
+}
+
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 600;
+  src: url("/static/font/IBMPlexSans-SemiBold-Latin1.woff2") format("woff2"),
+    url("/static/font/IBMPlexSans-SemiBold-Latin1.woff") format("woff");
+  unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2074, U+20AC, U+2122, U+2212, U+FB01-FB02;
+}
+@font-face {
+  font-family: 'IBM Plex Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: url("/static/font/IBMPlexSans-Bold-Latin1.woff2") format("woff2"),
+    url("/static/font/IBMPlexSans-Bold-Latin1.woff") format("woff");
+  unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2074, U+20AC, U+2122, U+2212, U+FB01-FB02; }
+
+@font-face {
+  font-family: 'IBM Plex Mono';
+  font-style: normal;
+  font-weight: 600;
+  src: url("/static/font/IBMPlexMono-SemiBold-Latin1.woff2") format("woff2"),
+    url("/static/font/IBMPlexMono-SemiBold-Latin1.woff") format("woff");
+  unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2074, U+20AC, U+2122, U+2212, U+FB01-FB02; }
+
+@font-face {
+  font-family: 'IBM Plex Italic';
+  font-style: italic;
+  font-weight: 400;
+  src: url("/static/font/IBMPlexSans-Italic-Latin1.woff2") format("woff2"),
+    url("/static/font/IBMPlexSans-Italic-Latin1.woff") format("woff");
+  unicode-range: U+0000, U+000D, U+0020-007E, U+00A0-00A3, U+00A4-00FF, U+0131, U+0152-0153, U+02C6, U+02DA, U+02DC, U+2013-2014, U+2018-201A, U+201C-201E, U+2020-2022, U+2026, U+2030, U+2039-203A, U+2044, U+2074, U+20AC, U+2122, U+2212, U+FB01-FB02;
+}
+|},
+          }
+        />
         <RunScript>
           {|
   window.dataLayer = window.dataLayer || [];
@@ -103,11 +160,11 @@ module Footer = {
             target="_blank">
             ...children
           </a>
-          {last ?
-             <span className="dn" /> :
-             <span className="f6 silver">
-               {ReasonReact.string({js| · |js})}
-             </span>}
+          {last
+             ? <span className="dn" />
+             : <span className="f6 silver">
+                 {ReasonReact.string({js| · |js})}
+               </span>}
         </li>,
     };
   };

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -5,12 +5,20 @@ module Colors = {
   let hyperlinkHover = `hsl((201, 71, 70));
 
   let metallicBlue = `rgb((70, 99, 131));
+  let denimTwo = `rgb((61, 88, 120));
+  let darkGreyBlue = `rgb((61, 88, 120));
+  let greyishBrown = `rgb((74, 74, 74));
+
+  let bluishGreen = `rgb((22, 168, 85));
+  let purpleBrown = `rgb((100, 46, 48));
 };
 
 module Typeface = {
   open Css;
 
-  let ibmplexsans = fontFamily("IBMPlexSans, Helvetica, sans-serif");
+  let ibmplexsans =
+    fontFamily("IBM Plex Sans, Helvetica Neue, Arial, sans-serif");
+
   let aktivgrotesk = fontFamily("aktiv-grotesk-extended, sans-serif");
 };
 
@@ -39,8 +47,38 @@ module Link = {
     ]);
 };
 
+module H1 = {
+  open Css;
+
+  let hero =
+    style([
+      Typeface.ibmplexsans,
+      fontWeight(`light),
+      fontSize(`rem(2.25)),
+      letterSpacing(`rem(-0.02375)),
+      lineHeight(`rem(3.0)),
+      color(Colors.denimTwo),
+      media(
+        MediaQuery.full,
+        [
+          fontSize(`rem(3.0)),
+          letterSpacing(`rem(-0.03125)),
+          lineHeight(`rem(4.0)),
+        ],
+      ),
+    ]);
+};
+
 module H3 = {
   open Css;
+
+  let basic =
+    style([
+      Typeface.ibmplexsans,
+      fontSize(`rem(1.25)),
+      textAlign(`center),
+      lineHeight(`rem(1.5)),
+    ]);
 
   let wide = {
     let wing = [
@@ -70,14 +108,41 @@ module H3 = {
   };
 };
 
+module H4 = {
+  open Css;
+
+  let basic =
+    style([
+      Typeface.ibmplexsans,
+      textAlign(`center),
+      fontSize(`rem(1.0625)),
+      lineHeight(`rem(1.5)),
+      letterSpacing(`rem(0.25)),
+      opacity(50.0),
+      textTransform(`uppercase),
+      fontWeight(`normal),
+      color(Colors.greyishBrown),
+    ]);
+};
+
 module Body = {
   open Css;
 
-  let style =
+  let basic =
     style([
       Typeface.ibmplexsans,
       color(Colors.metallicBlue),
       fontSize(`rem(1.0)),
       lineHeight(`rem(1.5)),
     ]);
+
+  let big =
+    style([
+      Typeface.ibmplexsans,
+      color(Colors.darkGreyBlue),
+      fontSize(`rem(1.125)),
+      lineHeight(`rem(1.875)),
+    ]);
+
+  let big_semibold = merge([big, style([fontWeight(`semiBold)])]);
 };


### PR DESCRIPTION
The hero section on the website is starting to look sort of like what it should look like based on the spec. I fully fleshed out the color/font styling from zeplin, but did not do layout completely (if the graphics change we may want to change how this bit is laid out)

I also hacked IBM plex fonts in by copying some styles from the legacy site. It looks like we're missing some of the weights, so we'll have to add those and we should clean up my hack.

<img width="1156" alt="Screen Shot 2019-03-17 at 10 56 09 PM" src="https://user-images.githubusercontent.com/515445/54509800-03925b00-4908-11e9-85ee-f3e15b1a5344.png">
