### PR TITLE
Add privacy and tos pages

### DIFF
--- a/frontend/website/html/Privacy.html
+++ b/frontend/website/html/Privacy.html
@@ -1,0 +1,96 @@
+<p><strong>O(1) LABS OPERATING CORPORATION</strong></p>
+<p><strong>PRIVACY POLICY</strong></p>
+<p><strong>Last Updated: May 9th, 2018</strong></p>
+<p>This privacy policy ("<strong>Policy</strong>") describes how O(1) Labs Operating Corporation and its related
+  companies ("<strong>Company</strong>") collect, use and share personal information of consumer users of this website,
+  codaprotocol.com (the "<strong>Site</strong>"). This Policy also applies to any of our other websites that post this
+  Policy. This Policy does not apply to websites that post different statements.</p>
+<p><strong>WHAT WE COLLECT</strong></p>
+<p>We get information about you in a range of ways.</p>
+<blockquote>
+  <p><strong>Information You Give Us.</strong> We collect your email address as well as other information you directly
+    give us on our Site.</p>
+  <p><strong>Information We Get From Others.</strong> We may get information about you from other sources. We may add
+    this to information we get from this Site.</p>
+  <p><strong>Information Automatically Collected.</strong> We automatically log information about you and your computer.
+    For example, when visiting our Site, we log your computer operating system type, browser type, browser language, the
+    website you visited before browsing to our Site, pages you viewed, how long you spent on a page, access times and
+    information about your use of and actions on our Site.</p>
+  <p><strong>Cookies.</strong> We may log information using &quot;cookies.&quot; Cookies are small data files stored on
+    your hard drive by a website. We may use both session Cookies (which expire once you close your web browser) and
+    persistent Cookies (which stay on your computer until you delete them) to provide you with a more personal and
+    interactive experience on our Site. This type of information is collected to make the Site more useful to you and to
+    tailor the experience with us to meet your special interests and needs.</p>
+</blockquote>
+<p><strong>USE OF PERSONAL INFORMATION</strong></p>
+<p>We use your personal information as follows:</p>
+<ul>
+  <li>
+    <p>We use your personal information to operate, maintain, and improve our sites, products, and services.</p>
+  </li>
+  <li>
+    <p>We use your personal information to respond to comments and questions and provide customer service.</p>
+  </li>
+  <li>
+    <p>We use your personal information to send information including confirmations, invoices, technical notices,
+      updates, security alerts, and support and administrative messages.</p>
+  </li>
+  <li>
+    <p>We use your personal information to communicate about promotions, upcoming events, and other news about products
+      and services offered by us and our selected partners.</p>
+  </li>
+  <li>
+    <p>We use your personal information to provide and deliver products and services customers request.</p>
+  </li>
+</ul>
+<p><strong>SHARING OF PERSONAL INFORMATION</strong></p>
+<p>We may share personal information as follows:</p>
+<ul>
+  <li>
+    <p>We may share personal information with your consent. For example, you may let us share personal information with
+      others for their own marketing uses. Those uses will be subject to their privacy policies.</p>
+  </li>
+  <li>
+    <p>We may share personal information when we do a business deal, or negotiate a business deal, involving the sale or
+      transfer of all or a part of our business or assets. These deals can include any merger, financing, acquisition,
+      or bankruptcy transaction or proceeding.</p>
+  </li>
+  <li>
+    <p>We may share personal information for legal, protection, and safety purposes.</p>
+    <ul>
+      <li>
+        <p>We may share information to comply with laws.</p>
+      </li>
+      <li>
+        <p>We may share information to respond to lawful requests and legal processes.</p>
+      </li>
+      <li>
+        <p>We may share information to protect the rights and property of O(1) Labs Operating Corporation, our agents,
+          customers, and others. This includes enforcing our agreements, policies, and terms of use.</p>
+      </li>
+      <li>
+        <p>We may share information in an emergency. This includes protecting the safety of our employees and agents,
+          our customers, or any person.</p>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <p>We may share information with those who need it to do work for us.</p>
+  </li>
+</ul>
+<p>We may also share aggregated and/or anonymized data with others for their own uses.</p>
+<p><strong>INFORMATION CHOICES AND CHANGES</strong></p>
+<p>Our marketing emails tell you how to "opt-out." If you opt out, we may still send you non-marketing emails.
+  Non-marketing emails include emails about your accounts and our business dealings with you.</p>
+<p>You may send requests about personal information to our Contact Information below. You can request to change contact
+  choices, opt-out of our sharing with others, and update your personal information.</p>
+<p>You can typically remove and reject cookies from our Site with your browser settings. Many browsers are set to accept
+  cookies until you change your settings. If you remove or reject our cookies, it could affect how our Site works for
+  you.</p>
+<p><strong>CONTACT INFORMATION.</strong> We welcome your comments or questions about this privacy policy. You may also
+  contact us at our address:</p>
+<p>O(1) Labs Operating Corporation</p>
+<p>362 Pierce St Apt D</p>
+<p>San Francisco, California 94117</p>
+<p><strong>CHANGES TO THIS PRIVACY POLICY.</strong> We may change this privacy policy. If we make any changes, we will
+  change the Last Updated date above.</p>

--- a/frontend/website/html/TOS.html
+++ b/frontend/website/html/TOS.html
@@ -1,0 +1,493 @@
+<p><strong><span class="smallcaps">Website Terms of Use</span></strong></p>
+<p><strong><span class="smallcaps">Version 1.0</span></strong></p>
+<p><strong><span class="smallcaps">Last revised on: May 9th, 2018</span></strong></p>
+<p>The website located at codaprotocol.com (the "<strong>Site</strong>") is a copyrighted work belonging to O(1) Labs
+    Operating Corporation ("<strong>Company</strong>", "<strong>us</strong>", "<strong>our</strong>", and
+    "<strong>we</strong>"). Certain features of the Site may be subject to additional guidelines, terms, or rules, which
+    will be posted on the Site in connection with such features. All such additional terms, guidelines, and rules are
+    incorporated by reference into these Terms.</p>
+<p>These Terms of Use (these "<strong>Terms</strong>") set forth the legally binding terms and conditions that govern
+    your use of the Site. By accessing or using the Site, you are accepting these Terms (on behalf of yourself or the
+    entity that you represent), and you represent and warrant that you have the right, authority, and capacity to enter
+    into these Terms (on behalf of yourself or the entity that you represent). you may not access or use the Site or
+    accept the Terms if you are not at least 18 years old. If you do not agree with all of the provisions of these
+    Terms, do not access and/or use the Site.</p>
+<p>These terms require the use of arbitration (Section 10.2) on an individual basis to resolve disputes, rather than
+    jury trials or class actions, and also limit the remedies available to you in the event of a dispute.</p>
+<ol type="1">
+    <li>
+        <p><span id="_Ref228014867" class="anchor"></span><strong><span class="smallcaps">Accounts </span></strong></p>
+    </li>
+    <li>
+        <p><strong>Account Creation.</strong> In order to use certain features of the Site, you must register for an
+            account ("<strong>Account</strong>") and provide certain information about yourself as prompted by the
+            account registration form. You represent and warrant that: (a) all required registration information you
+            submit is truthful and accurate; (b) you will maintain the accuracy of such information. <span
+                id="_Ref208387834" class="anchor"></span>You may delete your Account at any time, for any reason, by
+            following the instructions on the Site. Company may suspend or terminate your Account in accordance with
+            Section 8.</p>
+    </li>
+    <li>
+        <p><strong>Account Responsibilities.</strong> You are responsible for maintaining the confidentiality of your
+            Account login information and are fully responsible for all activities that occur under your Account. You
+            agree to immediately notify Company of any unauthorized use, or suspected unauthorized use of your Account
+            or any other breach of security. Company cannot and will not be liable for any loss or damage arising from
+            your failure to comply with the above requirements.</p>
+    </li>
+    <li>
+        <p><strong><span class="smallcaps">Access to the Site </span></strong></p>
+    </li>
+    <li>
+        <p><span id="_Ref303914870" class="anchor"></span><strong>License.</strong> Subject to these Terms, Company
+            grants you a non-transferable, non-exclusive, revocable, limited license to use and access the Site solely
+            for your own personal, noncommercial use.</p>
+    </li>
+    <li>
+        <p><span id="_Ref228014206" class="anchor"><span id="_Ref228077206" class="anchor"></span></span><strong>Certain
+                Restrictions.</strong> The rights granted to you in these Terms are subject to the following
+            restrictions: (a) you shall not license, sell, rent, lease, transfer, assign, distribute, host, or otherwise
+            commercially exploit the Site, whether in whole or in part, or any content displayed on the Site; (b) you
+            shall not modify, make derivative works of, disassemble, reverse compile or reverse engineer any part of the
+            Site; (c) you shall not access the Site in order to build a similar or competitive website, product, or
+            service; and (d) except as expressly stated herein, no part of the Site may be copied, reproduced,
+            distributed, republished, downloaded, displayed, posted or transmitted in any form or by any means. Unless
+            otherwise indicated, any future release, update, or other addition to functionality of the Site shall be
+            subject to these Terms. All copyright and other proprietary notices on the Site (or on any content displayed
+            on the Site) must be retained on all copies thereof.</p>
+    </li>
+    <li>
+        <p><span id="_Ref228014207" class="anchor"></span><strong>Modification.</strong> Company reserves the right, at
+            any time, to modify, suspend, or discontinue the Site (in whole or in part) with or without notice to you.
+            You agree that Company will not be liable to you or to any third party for any modification, suspension, or
+            discontinuation of the Site or any part thereof.</p>
+    </li>
+    <li>
+        <p><span id="_Ref228077208" class="anchor"></span><strong>No Support or Maintenance.</strong> You acknowledge
+            and agree that Company will have no obligation to provide you with any support or maintenance in connection
+            with the Site.</p>
+    </li>
+    <li>
+        <p><span id="_Ref287369117" class="anchor"></span><strong>Ownership.</strong> Excluding any User Content that
+            you may provide (defined below), you acknowledge that all the intellectual property rights, including
+            copyrights, patents, trade marks, and trade secrets, in the Site and its content are owned by Company or
+            Company’s suppliers. Neither these Terms (nor your access to the Site) transfers to you or any third party
+            any rights, title or interest in or to such intellectual property rights, except for the limited access
+            rights expressly set forth in Section 2.1. Company and its suppliers reserve all rights not granted in these
+            Terms. There are no implied licenses granted under these Terms.</p>
+    </li>
+    <li>
+        <p><span id="_Ref228014211" class="anchor"><span id="_Ref287369132" class="anchor"><span id="_Ref143054392"
+                        class="anchor"></span></span></span><strong><span class="smallcaps">User Content</span></strong>
+        </p>
+    </li>
+    <li>
+        <p><span id="_Ref303914733" class="anchor"><span id="_Ref208388325" class="anchor"></span></span><strong>User
+                Content.</strong> "<strong>User Content</strong>" means any and all information and content that a user
+            submits to, or uses with, the Site (e.g., content in the user’s profile or postings). You are solely
+            responsible for your User Content. You assume all risks associated with use of your User Content, including
+            any reliance on its accuracy, completeness or usefulness by others, or any disclosure of your User Content
+            that personally identifies you or any third party. You hereby represent and warrant that your User Content
+            does not violate our Acceptable Use Policy (defined in Section 3.3). You may not represent or imply to
+            others that your User Content is in any way provided, sponsored or endorsed by Company. Because you alone
+            are responsible for your User Content, you may expose yourself to liability if, for example, your User
+            Content violates the Acceptable Use Policy. Company is not obligated to backup any User Content, and your
+            User Content may be deleted at any time without prior notice. You are solely responsible for creating and
+            maintaining your own backup copies of your User Content if you desire.</p>
+    </li>
+    <li>
+        <p><strong>License.</strong> You hereby grant (and you represent and warrant that you have the right to grant)
+            to Company an irrevocable, nonexclusive, royalty-free and fully paid, worldwide license to reproduce,
+            distribute, publicly display and perform, prepare derivative works of, incorporate into other works, and
+            otherwise use and exploit your User Content, and to grant sublicenses of the foregoing rights, solely for
+            the purposes of including your User Content in the Site. You hereby irrevocably waive (and agree to cause to
+            be waived) any claims and assertions of moral rights or attribution with respect to your User Content.</p>
+    </li>
+    <li>
+        <p><span id="_Ref228014212" class="anchor"><span id="_Ref303914981"
+                    class="anchor"></span></span><strong>Acceptable Use Policy.</strong> The following terms constitute
+            our "<strong>Acceptable Use Policy</strong>":</p>
+    </li>
+    <li>
+        <p>You agree not to use the Site to collect, upload, transmit, display, or distribute any User Content (i) that
+            violates any third-party right, including any copyright, trademark, patent, trade secret, moral right,
+            privacy right, right of publicity, or any other intellectual property or proprietary right; (ii) that is
+            unlawful, harassing, abusive, tortious, threatening, harmful, invasive of another’s privacy, vulgar,
+            defamatory, false, intentionally misleading, trade libelous, pornographic, obscene, patently offensive,
+            promotes racism, bigotry, hatred, or physical harm of any kind against any group or individual or is
+            otherwise objectionable; (iii) that is harmful to minors in any way; or (iv) that is in violation of any
+            law, regulation, or obligations or restrictions imposed by any third party.</p>
+    </li>
+    <li>
+        <p>In addition, you agree not to: (i) upload, transmit, or distribute to or through the Site any computer
+            viruses, worms, or any software intended to damage or alter a computer system or data; (ii) send through the
+            Site unsolicited or unauthorized advertising, promotional materials, junk mail, spam, chain letters, pyramid
+            schemes, or any other form of duplicative or unsolicited messages, whether commercial or otherwise; (iii)
+            use the Site to harvest, collect, gather or assemble information or data regarding other users, including
+            e-mail addresses, without their consent; (iv) interfere with, disrupt, or create an undue burden on servers
+            or networks connected to the Site, or violate the regulations, policies or procedures of such networks; (v)
+            attempt to gain unauthorized access to the Site (or to other computer systems or networks connected to or
+            used together with the Site), whether through password mining or any other means; (vi) harass or interfere
+            with any other user’s use and enjoyment of the Site; or (vi) use software or automated agents or scripts to
+            produce multiple accounts on the Site, or to generate automated searches, requests, or queries to (or to
+            strip, scrape, or mine data from) the Site (provided, however, that we conditionally grant to the operators
+            of public search engines revocable permission to use spiders to copy materials from the Site for the sole
+            purpose of and solely to the extent necessary for creating publicly available searchable indices of the
+            materials, but not caches or archives of such materials, subject to the parameters set forth in our
+            robots.txt file).</p>
+    </li>
+    <li>
+        <p><span id="_Ref228014214" class="anchor"></span><strong>Enforcement.</strong> We reserve the right (but have
+            no obligation) to review any User Content, and to investigate and/or take appropriate action against you in
+            our sole discretion if you violate the Acceptable Use Policy or any other provision of these Terms or
+            otherwise create liability for us or any other person<span id="_Ref143069811" class="anchor"></span>. Such
+            action may include removing or modifying your User Content, terminating your Account in accordance with
+            Section 8, and/or reporting you to law enforcement authorities.</p>
+    </li>
+    <li>
+        <p><strong>Feedback.</strong> If you provide Company with any feedback or suggestions regarding the Site
+            ("<strong>Feedback</strong>"), you hereby assign to Company all rights in such Feedback and agree that
+            Company shall have the right to use and fully exploit such Feedback and related information in any manner it
+            deems appropriate. Company will treat any Feedback you provide to Company as non-confidential and
+            non-proprietary. You agree that you will not submit to Company any information or ideas that you consider to
+            be confidential or proprietary.</p>
+    </li>
+    <li>
+        <p><span id="_Ref370458795" class="anchor"></span><strong><span
+                    class="smallcaps">Indemnification.</span></strong> You agree to indemnify and hold Company (and its
+            officers, employees, and agents) harmless, including costs and attorneys’ fees, from any claim or demand
+            made by any third party due to or arising out of (a) your use of the Site, (b) your violation of these
+            Terms, (c) your violation of applicable laws or regulations or (d) your User Content. Company reserves the
+            right, at your expense, to assume the exclusive defense and control of any matter for which you are required
+            to indemnify us, and you agree to cooperate with our defense of these claims. You agree not to settle any
+            matter without the prior written consent of Company. Company will use reasonable efforts to notify you of
+            any such claim, action or proceeding upon becoming aware of it.</p>
+    </li>
+    <li>
+        <p><strong><span class="smallcaps">Third-Party Links &amp; Ads; Other Users</span></strong></p>
+    </li>
+    <li>
+        <p><strong>Third-Party Links &amp; Ads.</strong> The Site may contain links to third-party websites and
+            services, and/or display advertisements for third parties (collectively, "<strong>Third-Party Links &amp;
+                Ads</strong>"). Such Third-Party Links &amp; Ads are not under the control of Company, and Company is
+            not responsible for any Third-Party Links &amp; Ads. Company provides access to these Third-Party Links
+            &amp; Ads only as a convenience to you, and does not review, approve, monitor, endorse, warrant, or make any
+            representations with respect to Third-Party Links &amp; Ads. You use all Third-Party Links &amp; Ads at your
+            own risk, and should apply a suitable level of caution and discretion in doing so. When you click on any of
+            the Third-Party Links &amp; Ads, the applicable third party’s terms and policies apply, including the third
+            party’s privacy and data gathering practices. You should make whatever investigation you feel necessary or
+            appropriate before proceeding with any transaction in connection with such Third-Party Links &amp; Ads.</p>
+    </li>
+    <li>
+        <p><strong>Other Users.</strong> Each Site user is solely responsible for any and all of its own User Content.
+            Because we do not control User Content, you acknowledge and agree that we are not responsible for any User
+            Content, whether provided by you or by others. We make no guarantees regarding the accuracy, currency,
+            suitability, or quality of any User Content. Your interactions with other Site users are solely between you
+            and such users. You agree that Company will not be responsible for any loss or damage incurred as the result
+            of any such interactions. If there is a dispute between you and any Site user, we are under no obligation to
+            become involved.</p>
+    </li>
+    <li>
+        <p><strong>Release.</strong> You hereby release and forever discharge the Company (and our officers, employees,
+            agents, successors, and assigns) from, and hereby waive and relinquish, each and every past, present and
+            future dispute, claim, controversy, demand, right, obligation, liability, action and cause of action of
+            every kind and nature (including personal injuries, death, and property damage), that has arisen or arises
+            directly or indirectly out of, or that relates directly or indirectly to, the Site (including any
+            interactions with, or act or omission of, other Site users or any Third-Party Links &amp; Ads). IF YOU ARE A
+            CALIFORNIA RESIDENT, YOU HEREBY WAIVE CALIFORNIA CIVIL CODE SECTION 1542 IN CONNECTION WITH THE FOREGOING,
+            WHICH STATES: “A GENERAL RELEASE DOES NOT EXTEND TO CLAIMS WHICH THE CREDITOR DOES NOT KNOW OR SUSPECT TO
+            EXIST IN HIS OR HER FAVOR AT THE TIME OF EXECUTING THE RELEASE, WHICH IF KNOWN BY HIM OR HER MUST HAVE
+            MATERIALLY AFFECTED HIS OR HER SETTLEMENT WITH THE DEBTOR.”</p>
+    </li>
+    <li>
+        <p><span id="_Ref143069835" class="anchor"></span><strong><span class="smallcaps">Disclaimers </span></strong>
+        </p>
+    </li>
+</ol>
+<p><span class="smallcaps">THE SITE IS PROVIDED ON AN "AS-IS" AND "AS AVAILABLE" BASIS, AND COMPANY (AND OUR SUPPLIERS)
+        EXPRESSLY DISCLAIM ANY AND ALL WARRANTIES AND CONDITIONS OF ANY KIND, WHETHER EXPRESS, IMPLIED, OR STATUTORY,
+        INCLUDING ALL WARRANTIES OR CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, QUIET
+        ENJOYMENT, ACCURACY, OR NON-INFRINGEMENT. WE (AND OUR SUPPLIERS) MAKE NO WARRANTY THAT THE SITE WILL MEET YOUR
+        REQUIREMENTS, WILL BE AVAILABLE ON AN UNINTERRUPTED, TIMELY, SECURE, OR ERROR-FREE BASIS, OR WILL BE ACCURATE,
+        RELIABLE, FREE OF VIRUSES OR OTHER HARMFUL CODE, COMPLETE, LEGAL, OR SAFE. IF APPLICABLE LAW REQUIRES ANY
+        WARRANTIES WITH RESPECT TO THE SITE, ALL SUCH WARRANTIES ARE LIMITED IN DURATION TO NINETY (90) DAYS FROM THE
+        DATE OF FIRST USE.</span></p>
+<p><span class="smallcaps">SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO THE ABOVE EXCLUSION
+        MAY NOT APPLY TO YOU. SOME JURISDICTIONS DO NOT ALLOW LIMITATIONS ON HOW LONG AN IMPLIED WARRANTY LASTS, SO THE
+        ABOVE LIMITATION MAY NOT APPLY TO YOU. </span></p>
+<ol start="24" type="1">
+    <li>
+        <p><span id="_Ref143069844" class="anchor"></span><strong><span class="smallcaps">Limitation on
+                    Liability</span></strong></p>
+        <p><span class="smallcaps">TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT SHALL COMPANY (OR OUR SUPPLIERS)
+                BE LIABLE TO YOU OR ANY THIRD PARTY FOR ANY LOST PROFITS, LOST DATA, COSTS OF PROCUREMENT OF SUBSTITUTE
+                PRODUCTS, OR ANY INDIRECT, CONSEQUENTIAL, EXEMPLARY, INCIDENTAL, SPECIAL OR PUNITIVE DAMAGES ARISING
+                FROM OR RELATING TO THESE TERMS OR YOUR USE OF, OR INABILITY TO USE, THE SITE, EVEN IF COMPANY HAS BEEN
+                ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. ACCESS TO, AND USE OF, THE SITE IS AT YOUR OWN DISCRETION
+                AND RISK, AND YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR DEVICE OR COMPUTER SYSTEM, OR LOSS
+                OF DATA RESULTING THEREFROM. </span></p>
+        <p><span class="smallcaps">TO THE MAXIMUM EXTENT PERMITTED BY LAW, NOTWITHSTANDING ANYTHING TO THE CONTRARY
+                CONTAINED HEREIN, OUR LIABILITY TO YOU FOR ANY DAMAGES ARISING FROM OR RELATED TO THIS AGREEMENT (FOR
+                ANY CAUSE WHATSOEVER AND REGARDLESS OF THE FORM OF THE ACTION), WILL AT ALL TIMES BE LIMITED TO A
+                MAXIMUM OF FIFTY US DOLLARS (U.S. $50). THE EXISTENCE OF MORE THAN ONE CLAIM WILL NOT ENLARGE THIS
+                LIMIT. YOU AGREE THAT OUR SUPPLIERS WILL HAVE NO LIABILITY OF ANY KIND ARISING FROM OR RELATING TO THIS
+                AGREEMENT.</span></p>
+        <p><span class="smallcaps">SOME JURISDICTIONS DO NOT ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY FOR
+                INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU. </span>
+        </p>
+    </li>
+    <li>
+        <p><span id="_Ref228013948" class="anchor"><span id="_Ref148765691" class="anchor"></span></span><strong><span
+                    class="smallcaps">Term and Termination.</span></strong> Subject to this Section, these Terms will
+            remain in full force and effect while you use the Site. We may suspend or terminate your rights to use the
+            Site (including your Account) at any time for any reason at our sole discretion, including for any use of
+            the Site in violation of these Terms. Upon termination of your rights under these Terms, your Account and
+            right to access and use the Site will terminate immediately. You understand that any termination of your
+            Account may involve deletion of your User Content associated with your Account from our live databases.
+            Company will not have any liability whatsoever to you for any termination of your rights under these Terms,
+            including for termination of your Account or deletion of your User Content. Even after your rights under
+            these Terms are terminated, the following provisions of these Terms will remain in effect: Sections 2.2
+            through 2.5, Section 3 and Sections 4 through 10.</p>
+    </li>
+    <li>
+        <p><span id="_Ref370458879" class="anchor"><span id="_Ref228014249" class="anchor"></span></span><strong><span
+                    class="smallcaps">Copyright Policy. </span></strong></p>
+        <p>Company respects the intellectual property of others and asks that users of our Site do the same. In
+            connection with our Site, we have adopted and implemented a policy respecting copyright law that provides
+            for the removal of any infringing materials and for the termination, in appropriate circumstances, of users
+            of our online Site who are repeat infringers of intellectual property rights, including copyrights. If you
+            believe that one of our users is, through the use of our Site, unlawfully infringing the copyright(s) in a
+            work, and wish to have the allegedly infringing material removed, the following information in the form of a
+            written notification (pursuant to 17 U.S.C. § 512(c)) must be provided to our designated Copyright Agent:
+        </p>
+    </li>
+</ol>
+<ol type="1">
+    <li>
+        <p>your physical or electronic signature;</p>
+    </li>
+    <li>
+        <p>identification of the copyrighted work(s) that you claim to have been infringed;</p>
+    </li>
+    <li>
+        <p>identification of the material on our services that you claim is infringing and that you request us to
+            remove;</p>
+    </li>
+    <li>
+        <p>sufficient information to permit us to locate such material;</p>
+    </li>
+    <li>
+        <p>your address, telephone number, and e-mail address;</p>
+    </li>
+    <li>
+        <p>a statement that you have a good faith belief that use of the objectionable material is not authorized by the
+            copyright owner, its agent, or under the law; and</p>
+    </li>
+    <li>
+        <p>a statement that the information in the notification is accurate, and under penalty of perjury, that you are
+            either the owner of the copyright that has allegedly been infringed or that you are authorized to act on
+            behalf of the copyright owner.</p>
+    </li>
+</ol>
+<p>Please note that, pursuant to 17 U.S.C. § 512(f), any misrepresentation of material fact (falsities) in a written
+    notification automatically subjects the complaining party to liability for any damages, costs and attorney’s fees
+    incurred by us in connection with the written notification and allegation of copyright infringement.</p>
+<ol start="27" type="1">
+    <li>
+        <p><span id="_Ref230002322" class="anchor"></span><strong><span class="smallcaps">General</span></strong></p>
+    </li>
+    <li>
+        <p><span id="_Ref228016583" class="anchor"></span><strong>Changes.</strong> These Terms are subject to
+            occasional revision, and if we make any substantial changes, we may notify you by sending you an e-mail to
+            the last e-mail address you provided to us (if any), and/or by prominently posting notice of the changes on
+            our Site. You are responsible for providing us with your most current e-mail address. In the event that the
+            last e-mail address that you have provided us is not valid, or for any reason is not capable of delivering
+            to you the notice described above, our dispatch of the e-mail containing such notice will nonetheless
+            constitute effective notice of the changes described in the notice. Any changes to these Terms will be
+            effective upon the earlier of thirty (30) calendar days following our dispatch of an e-mail notice to you
+            (if applicable) or thirty (30) calendar days following our posting of notice of the changes on our Site.
+            These changes will be effective immediately for new users of our Site. Continued use of our Site following
+            notice of such changes shall indicate your acknowledgement of such changes and agreement to be bound by the
+            terms and conditions of such changes.</p>
+    </li>
+    <li>
+        <p><span id="_Ref355871778" class="anchor"></span><strong>Dispute Resolution. <em>Please read this Arbitration
+                    Agreement carefully. It is part of your contract with Company and affects your rights. It contains
+                    procedures for MANDATORY BINDING ARBITRATION AND A CLASS ACTION WAIVER.</em></strong></p>
+    </li>
+    <li>
+        <p><em>Applicability of Arbitration Agreement.</em> All claims and disputes (excluding claims for injunctive or
+            other equitable relief as set forth below) in connection with the Terms or the use of any product or service
+            provided by the Company that cannot be resolved informally or in small claims court shall be resolved by
+            binding arbitration on an individual basis under the terms of this Arbitration Agreement. Unless otherwise
+            agreed to, all arbitration proceedings shall be held in English. This Arbitration Agreement applies to you
+            and the Company, and to any subsidiaries, affiliates, agents, employees, predecessors in interest,
+            successors, and assigns, as well as all authorized or unauthorized users or beneficiaries of services or
+            goods provided under the Terms.</p>
+    </li>
+    <li>
+        <p><em>Notice Requirement and Informal Dispute Resolution</em>. Before either party may seek arbitration, the
+            party must first send to the other party a written Notice of Dispute (<strong>“Notice”</strong>) describing
+            the nature and basis of the claim or dispute, and the requested relief. A Notice to the Company should be
+            sent to: 362 Pierce St Apt D, San Francisco, California 94117. After the Notice is received, you and the
+            Company may attempt to resolve the claim or dispute informally. If you and the Company do not resolve the
+            claim or dispute within thirty (30) days after the Notice is received, either party may begin an arbitration
+            proceeding. The amount of any settlement offer made by any party may not be disclosed to the arbitrator
+            until after the arbitrator has determined the amount of the award, if any, to which either party is
+            entitled.</p>
+    </li>
+    <li>
+        <p>Arbitration Rules. Arbitration shall be initiated through the American Arbitration Association
+            (<strong>"AAA"</strong>), an established alternative dispute resolution provider (<strong>"ADR
+                Provider"</strong>) that offers arbitration as set forth in this section. If AAA is not available to
+            arbitrate, the parties shall agree to select an alternative ADR Provider. The rules of the ADR Provider
+            shall govern all aspects of the arbitration, including but not limited to the method of initiating and/or
+            demanding arbitration, except to the extent such rules are in conflict with the Terms. The AAA Consumer
+            Arbitration Rules (<strong>"Arbitration Rules"</strong>) governing the arbitration are available online at
+            www.adr.org or by calling the AAA at 1-800-778-7879. The arbitration shall be conducted by a single, neutral
+            arbitrator. Any claims or disputes where the total amount of the award sought is less than Ten Thousand U.S.
+            Dollars (US $10,000.00) may be resolved through binding non-appearance-based arbitration, at the option of
+            the party seeking relief. For claims or disputes where the total amount of the award sought is Ten Thousand
+            U.S. Dollars (US $10,000.00) or more, the right to a hearing will be determined by the Arbitration Rules.
+            Any hearing will be held in a location within 100 miles of your residence, unless you reside outside of the
+            United States, and unless the parties agree otherwise. If you reside outside of the U.S., the arbitrator
+            shall give the parties reasonable notice of the date, time and place of any oral hearings. Any judgment on
+            the award rendered by the arbitrator may be entered in any court of competent jurisdiction. If the
+            arbitrator grants you an award that is greater than the last settlement offer that the Company made to you
+            prior to the initiation of arbitration, the Company will pay you the greater of the award or $2,500.00. Each
+            party shall bear its own costs (including attorney’s fees) and disbursements arising out of the arbitration
+            and shall pay an equal share of the fees and costs of the ADR Provider.</p>
+    </li>
+    <li>
+        <p><em>Additional Rules for Non-Appearance Based Arbitration</em>. If non-appearance based arbitration is
+            elected, the arbitration shall be conducted by telephone, online and/or based solely on written submissions;
+            the specific manner shall be chosen by the party initiating the arbitration. The arbitration shall not
+            involve any personal appearance by the parties or witnesses unless otherwise agreed by the parties.</p>
+    </li>
+    <li>
+        <p><em>Time Limits.</em> If you or the Company pursue arbitration, the arbitration action must be initiated
+            and/or demanded within the statute of limitations (i.e., the legal deadline for filing a claim) and within
+            any deadline imposed under the AAA Rules for the pertinent claim.</p>
+    </li>
+    <li>
+        <p><em>Authority of Arbitrator</em>. If arbitration is initiated, the arbitrator will decide the rights and
+            liabilities, if any, of you and the Company, and the dispute will not be consolidated with any other matters
+            or joined with any other cases or parties. The arbitrator shall have the authority to grant motions
+            dispositive of all or part of any claim. The arbitrator shall have the authority to award monetary damages,
+            and to grant any non-monetary remedy or relief available to an individual under applicable law, the AAA
+            Rules, and the Terms. The arbitrator shall issue a written award and statement of decision describing the
+            essential findings and conclusions on which the award is based, including the calculation of any damages
+            awarded. The arbitrator has the same authority to award relief on an individual basis that a judge in a
+            court of law would have. The award of the arbitrator is final and binding upon you and the Company.</p>
+    </li>
+    <li>
+        <p><em>Waiver of Jury Trial.</em> THE PARTIES HEREBY WAIVE THEIR CONSTITUTIONAL AND STATUTORY RIGHTS TO GO TO
+            COURT AND HAVE A TRIAL IN FRONT OF A JUDGE OR A JURY, instead electing that all claims and disputes shall be
+            resolved by arbitration under this Arbitration Agreement. Arbitration procedures are typically more limited,
+            more efficient and less costly than rules applicable in a court and are subject to very limited review by a
+            court. In the event any litigation should arise between you and the Company in any state or federal court in
+            a suit to vacate or enforce an arbitration award or otherwise, YOU AND THE COMPANY WAIVE ALL RIGHTS TO A
+            JURY TRIAL, instead electing that the dispute be resolved by a judge.</p>
+    </li>
+    <li>
+        <p><em>Waiver of Class or Consolidated Actions</em>. ALL CLAIMS AND DISPUTES WITHIN THE SCOPE OF THIS
+            ARBITRATION AGREEMENT MUST BE ARBITRATED OR LITIGATED ON AN INDIVIDUAL BASIS AND NOT ON A CLASS BASIS, AND
+            CLAIMS OF MORE THAN ONE CUSTOMER OR USER CANNOT BE ARBITRATED OR LITIGATED JOINTLY OR CONSOLIDATED WITH
+            THOSE OF ANY OTHER CUSTOMER OR USER.</p>
+    </li>
+    <li>
+        <p><em>Confidentiality</em>. All aspects of the arbitration proceeding, including but not limited to the award
+            of the arbitrator and compliance therewith, shall be strictly confidential. The parties agree to maintain
+            confidentiality unless otherwise required by law. This paragraph shall not prevent a party from submitting
+            to a court of law any information necessary to enforce this Agreement, to enforce an arbitration award, or
+            to seek injunctive or equitable relief.</p>
+    </li>
+    <li>
+        <p><em>Severability</em>. If any part or parts of this Arbitration Agreement are found under the law to be
+            invalid or unenforceable by a court of competent jurisdiction, then such specific part or parts shall be of
+            no force and effect and shall be severed and the remainder of the Agreement shall continue in full force and
+            effect.</p>
+    </li>
+    <li>
+        <p><em>Right to Waive.</em> Any or all of the rights and limitations set forth in this Arbitration Agreement may
+            be waived by the party against whom the claim is asserted. Such waiver shall not waive or affect any other
+            portion of this Arbitration Agreement.</p>
+    </li>
+    <li>
+        <p><em>Survival of Agreement</em>. This Arbitration Agreement will survive the termination of your relationship
+            with Company.</p>
+    </li>
+    <li>
+        <p><em>Small Claims Court.</em> Notwithstanding the foregoing, either you or the Company may bring an individual
+            action in small claims court.</p>
+    </li>
+    <li>
+        <p><em>Emergency Equitable Relief</em>. Notwithstanding the foregoing, either party may seek emergency equitable
+            relief before a state or federal court in order to maintain the status quo pending arbitration. A request
+            for interim measures shall not be deemed a waiver of any other rights or obligations under this Arbitration
+            Agreement.</p>
+    </li>
+    <li>
+        <p><em>Claims Not Subject to Arbitration.</em> Notwithstanding the foregoing, claims of defamation, violation of
+            the Computer Fraud and Abuse Act, and infringement or misappropriation of the other party’s patent,
+            copyright, trademark or trade secrets shall not be subject to this Arbitration Agreement.</p>
+    </li>
+    <li>
+        <p><em>Courts.</em> In any circumstances where the foregoing Arbitration Agreement permits the parties to
+            litigate in court, the parties hereby agree to submit to the personal jurisdiction of the courts located
+            within San Francisco County, California, for such purpose</p>
+    </li>
+    <li>
+        <p><strong>Export.</strong> The Site may be subject to U.S. export control laws and may be subject to export or
+            import regulations in other countries. You agree not to export, reexport, or transfer, directly or
+            indirectly, any U.S. technical data acquired from Company, or any products utilizing such data, in violation
+            of the United States export laws or regulations.</p>
+    </li>
+    <li>
+        <p><strong>Disclosures.</strong> Company is located at the address in Section 10.8. If you are a California
+            resident, you may report complaints to the Complaint Assistance Unit of the Division of Consumer Product of
+            the California Department of Consumer Affairs by contacting them in writing at 400 R Street, Sacramento, CA
+            95814, or by telephone at (800) 952-5210.</p>
+    </li>
+    <li>
+        <p><strong>Electronic Communications.</strong> The communications between you and Company use electronic means,
+            whether you use the Site or send us emails, or whether Company posts notices on the Site or communicates
+            with you via email. For contractual purposes, you (a) consent to receive communications from Company in an
+            electronic form; and (b) agree that all terms and conditions, agreements, notices, disclosures, and other
+            communications that Company provides to you electronically satisfy any legal requirement that such
+            communications would satisfy if it were be in a hardcopy writing. The foregoing does not affect your
+            non-waivable rights.</p>
+    </li>
+    <li>
+        <p><strong>Entire Terms.</strong> These Terms constitute the entire agreement between you and us regarding the
+            use of the Site. Our failure to exercise or enforce any right or provision of these Terms shall not operate
+            as a waiver of such right or provision. The section titles in these Terms are for convenience only and have
+            no legal or contractual effect. The word "including" means "including without limitation". If any provision
+            of these Terms is, for any reason, held to be invalid or unenforceable, the other provisions of these Terms
+            will be unimpaired and the invalid or unenforceable provision will be deemed modified so that it is valid
+            and enforceable to the maximum extent permitted by law. Your relationship to Company is that of an
+            independent contractor, and neither party is an agent or partner of the other. These Terms, and your rights
+            and obligations herein, may not be assigned, subcontracted, delegated, or otherwise transferred by you
+            without Company’s prior written consent, and any attempted assignment, subcontract, delegation, or transfer
+            in violation of the foregoing will be null and void. Company may freely assign these Terms. The terms and
+            conditions set forth in these Terms shall be binding upon assignees.</p>
+    </li>
+    <li>
+        <p><strong>Copyright/Trademark Information</strong>. Copyright © <span class="smallcaps">2018</span> O(1) Labs
+            Operating Corporation. All rights reserved. All trademarks, logos and service marks
+            ("<strong>Marks</strong>") displayed on the Site are our property or the property of other third parties.
+            You are not permitted to use these Marks without our prior written consent or the consent of such third
+            party which may own the Marks.</p>
+    </li>
+    <li>
+        <p><span id="_Ref370408017" class="anchor"></span><strong>Contact Information:</strong></p>
+    </li>
+</ol>
+<blockquote>
+    <p>Evan Shapiro</p>
+    <p>Address:</p>
+    <p>362 Pierce St Apt D</p>
+    <p>San Francisco, California 94117</p>
+    <p>Telephone: +1 (415) 985-7715</p>
+    <p>Email: contact@o1labs.org</p>
+</blockquote>
+<p><sup>* * *</sup></p>

--- a/frontend/website/src/RawHtml.re
+++ b/frontend/website/src/RawHtml.re
@@ -1,0 +1,14 @@
+let component = ReasonReact.statelessComponent("RawHtml");
+
+let make = (~path, _) => {
+  let html = Node.Fs.readFileAsUtf8Sync(path);
+  Css.(global("strong", [fontWeight(`num(800)), color(black)]));
+  {
+    ...component,
+    render: _self =>
+      <div
+        className="section-wrapper ibmplex blueblack lh-copy mw7-ns center f5 mt4 tl"
+        dangerouslySetInnerHTML={"__html": html}
+      />,
+  };
+};

--- a/frontend/website/src/RawHtml.re
+++ b/frontend/website/src/RawHtml.re
@@ -7,7 +7,17 @@ let make = (~path, _) => {
     ...component,
     render: _self =>
       <div
-        className="section-wrapper ibmplex blueblack lh-copy mw7-ns center f5 mt4 tl"
+        className=Css.(
+          style([
+            Style.Typeface.ibmplexsans,
+            color(Style.Colors.metallicBlue),
+            lineHeight(`em(1.5)),
+            maxWidth(`rem(48.0)),
+            marginLeft(`auto),
+            marginRight(`auto),
+            marginTop(`rem(2.0)),
+          ])
+        )
         dangerouslySetInnerHTML={"__html": html}
       />,
   };

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -146,6 +146,18 @@ Router.(
             <Blog posts />
           </Page>,
         ),
+        File(
+          "privacy",
+          <Page name="privacy">
+            <RawHtml path="html/Privacy.html" />
+          </Page>,
+        ),
+        File(
+          "tos",
+          <Page name="tos">
+            <RawHtml path="html/TOS.html" />
+          </Page>,
+        ),
       |],
     ),
   )

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -148,15 +148,11 @@ Router.(
         ),
         File(
           "privacy",
-          <Page name="privacy">
-            <RawHtml path="html/Privacy.html" />
-          </Page>,
+          <Page name="privacy"> <RawHtml path="html/Privacy.html" /> </Page>,
         ),
         File(
           "tos",
-          <Page name="tos">
-            <RawHtml path="html/TOS.html" />
-          </Page>,
+          <Page name="tos"> <RawHtml path="html/TOS.html" /> </Page>,
         ),
       |],
     ),


### PR DESCRIPTION
This adds the privacy and tos pages to the new site. They are slightly styled and include the header and footer, unlike the old ones. The html of the content is completely unchanged, it's just copied from the ml string into its own file and formatted.

![image](https://user-images.githubusercontent.com/2154522/54556618-7a663d00-4976-11e9-8228-1a67576fbe04.png)

![image](https://user-images.githubusercontent.com/2154522/54556624-7f2af100-4976-11e9-9bc1-9696ad579e8a.png)
