### PR TITLE
Versioning of Work

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -368,7 +368,6 @@ module Fee_transfer = Coda_base.Fee_transfer
 module Ledger_proof_statement = Transaction_snark.Statement
 module Transaction_snark_work =
   Staged_ledger.Make_completed_work
-    (Public_key.Compressed)
     (Ledger_proof.Stable.V1)
     (Ledger_proof_statement)
 

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -10,7 +10,15 @@ module Make (Proof : sig
 end) (Fee : sig
   type t [@@deriving bin_io, sexp]
 end) (Work : sig
-  type t [@@deriving sexp, bin_io]
+  type t [@@deriving sexp]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io]
+      end
+    end
+    with type V1.t = t
 end)
 (Transition_frontier : T)
 (Pool : Snark_pool.S
@@ -56,8 +64,7 @@ struct
       module T = struct
         let version = 1
 
-        (* TODO : version Work *)
-        type t = (Work.t, Priced_proof.Stable.V1.t) diff
+        type t = (Work.Stable.V1.t, Priced_proof.Stable.V1.t) diff
         [@@deriving bin_io, sexp]
       end
 

--- a/src/lib/snark_pool/snark_pool.ml
+++ b/src/lib/snark_pool/snark_pool.ml
@@ -12,9 +12,19 @@ module type Transition_frontier_intf = sig
 
   module Extensions : sig
     module Work : sig
-      type t [@@deriving sexp, bin_io]
+      type t [@@deriving sexp]
 
-      include Hashable.S_binable with type t := t
+      module Stable :
+        sig
+          module V1 : sig
+            type t [@@deriving sexp, bin_io]
+
+            include Hashable.S_binable with type t := t
+          end
+        end
+        with type V1.t = t
+
+      include Hashable.S with type t := t
     end
   end
 
@@ -59,9 +69,19 @@ end) (Fee : sig
 
   include Comparable.S with type t := t
 end) (Work : sig
-  type t [@@deriving sexp, bin_io]
+  type t [@@deriving sexp]
 
-  include Hashable.S_binable with type t := t
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io]
+
+        include Hashable.S_binable with type t := t
+      end
+    end
+    with type V1.t = t
+
+  include Hashable.S with type t := t
 end)
 (Transition_frontier : Transition_frontier_intf
                        with module Extensions.Work = Work) :
@@ -87,9 +107,10 @@ end)
     let fee (t : t) = t.fee
   end
 
+  (* TODO : Version this type *)
   type t =
-    { snark_table: Priced_proof.t Work.Table.t
-    ; mutable ref_table: int Work.Table.t option }
+    { snark_table: Priced_proof.t Work.Stable.V1.Table.t
+    ; mutable ref_table: int Work.Stable.V1.Table.t option }
   [@@deriving sexp, bin_io]
 
   (* shadow generated bin_io code so that ref table is always None when written *)
@@ -182,13 +203,29 @@ let%test_module "random set test" =
       let gen = Int.gen
     end
 
+    module Mock_work = struct
+      (* no bin_io except in Stable versions *)
+      module T = struct
+        type t = Int.t [@@deriving sexp, hash, compare]
+
+        let gen = Int.gen
+      end
+
+      include T
+      include Hashable.Make (T)
+
+      module Stable = struct
+        module V1 = Int
+      end
+    end
+
     module Mock_transition_frontier = struct
       type t = string
 
       let create () : t = ""
 
       module Extensions = struct
-        module Work = Int
+        module Work = Mock_work
       end
 
       let snark_pool_refcount_pipe _ =
@@ -198,7 +235,6 @@ let%test_module "random set test" =
         reader
     end
 
-    module Mock_work = Int
     module Mock_fee = Int
 
     module Mock_Priced_proof = struct

--- a/src/lib/snark_pool/snark_pool.mli
+++ b/src/lib/snark_pool/snark_pool.mli
@@ -11,9 +11,19 @@ module type Transition_frontier_intf = sig
 
   module Extensions : sig
     module Work : sig
-      type t [@@deriving sexp, bin_io]
+      type t [@@deriving sexp]
 
-      include Hashable.S_binable with type t := t
+      module Stable :
+        sig
+          module V1 : sig
+            type t [@@deriving sexp, bin_io]
+
+            include Hashable.S_binable with type t := t
+          end
+        end
+        with type V1.t = t
+
+      include Hashable.S with type t := t
     end
   end
 
@@ -58,9 +68,19 @@ end) (Fee : sig
 
   include Comparable.S with type t := t
 end) (Work : sig
-  type t [@@deriving sexp, bin_io]
+  type t [@@deriving sexp]
 
-  include Hashable.S_binable with type t := t
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io]
+
+        include Hashable.S_binable with type t := t
+      end
+    end
+    with type V1.t = t
+
+  include Hashable.S with type t := t
 end)
 (Transition_frontier : Transition_frontier_intf
                        with module Extensions.Work = Work) :

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1794,21 +1794,37 @@ let%test_module "test" =
         type public_key = Compressed_public_key.t
         [@@deriving sexp, bin_io, compare, yojson]
 
-        module T = struct
-          type t = {fee: fee; proofs: proof list; prover: public_key}
-          [@@deriving sexp, bin_io, compare, yojson]
-        end
-
-        include T
-
-        module Statement = struct
-          module T = struct
-            type t = statement list
-            [@@deriving sexp, bin_io, compare, hash, eq]
+        module Stable = struct
+          module V1 = struct
+            type t = {fee: fee; proofs: proof list; prover: public_key}
+            [@@deriving sexp, bin_io, compare, yojson]
           end
 
-          include T
-          include Hashable.Make_binable (T)
+          module Latest = V1
+        end
+
+        type t = Stable.Latest.t =
+          {fee: fee; proofs: proof list; prover: public_key}
+        [@@deriving sexp, compare]
+
+        module Statement = struct
+          module Stable = struct
+            module V1 = struct
+              module T = struct
+                type t = statement list
+                [@@deriving sexp, bin_io, compare, hash, eq]
+              end
+
+              include T
+              include Hashable.Make_binable (T)
+            end
+
+            module Latest = V1
+          end
+
+          type t = Stable.Latest.t [@@deriving sexp, compare, hash, eq]
+
+          include Hashable.Make (Stable.Latest)
 
           let gen =
             Quickcheck.Generator.list_with_length proofs_length
@@ -1818,7 +1834,11 @@ let%test_module "test" =
         type unchecked = t
 
         module Checked = struct
-          include T
+          module Stable = Stable
+
+          type t = Stable.Latest.t =
+            {fee: fee; proofs: proof list; prover: public_key}
+          [@@deriving sexp, compare]
 
           let create_unsafe = Fn.id
         end
@@ -1829,10 +1849,13 @@ let%test_module "test" =
       end
 
       module Staged_ledger_diff = struct
-        type completed_work = Transaction_snark_work.t
+        (* TODO : version *)
+        type completed_work = Transaction_snark_work.Stable.V1.t
         [@@deriving sexp, bin_io, compare, yojson]
 
-        type completed_work_checked = Transaction_snark_work.Checked.t
+        (* TODO : version *)
+        type completed_work_checked =
+          Transaction_snark_work.Checked.Stable.V1.t
         [@@deriving sexp, bin_io, compare, yojson]
 
         type user_command = User_command.t

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -68,14 +68,18 @@ end) :
 
   type ft = Inputs.Fee_transfer.single [@@deriving sexp, bin_io]
 
+  (* TODO: version *)
+
   type pre_diff_with_at_most_two_coinbase =
-    { completed_works: Transaction_snark_work.t list
+    { completed_works: Transaction_snark_work.Stable.V1.t list
     ; user_commands: User_command.t list
     ; coinbase: ft At_most_two.t }
   [@@deriving sexp, bin_io]
 
+  (* TODO: version *)
+
   type pre_diff_with_at_most_one_coinbase =
-    { completed_works: Transaction_snark_work.t list
+    { completed_works: Transaction_snark_work.Stable.V1.t list
     ; user_commands: User_command.t list
     ; coinbase: ft At_most_one.t }
   [@@deriving sexp, bin_io]

--- a/src/lib/staged_ledger/transaction_snark_work.ml
+++ b/src/lib/staged_ledger/transaction_snark_work.ml
@@ -2,29 +2,54 @@ open Core_kernel
 open Async_kernel
 open Protocols
 open Coda_pow
+open Signature_lib
+open Module_version
 
-module Make
-    (Compressed_public_key : Compressed_public_key_intf) (Ledger_proof : sig
-        type t [@@deriving sexp, bin_io]
-    end) (Ledger_proof_statement : sig
-      type t [@@deriving sexp, bin_io, hash, compare]
+module Make (Ledger_proof : sig
+  type t [@@deriving sexp, bin_io]
+end) (Ledger_proof_statement : sig
+  type t [@@deriving sexp, bin_io, hash, compare]
 
-      val gen : t Quickcheck.Generator.t
-    end) :
+  val gen : t Quickcheck.Generator.t
+end) :
   Coda_pow.Transaction_snark_work_intf
   with type proof := Ledger_proof.t
    and type statement := Ledger_proof_statement.t
-   and type public_key := Compressed_public_key.t = struct
+   and type public_key := Public_key.Compressed.t = struct
   let proofs_length = 2
 
   module Statement = struct
-    module T = struct
-      type t = Ledger_proof_statement.t list
-      [@@deriving bin_io, sexp, hash, compare]
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          let version = 1
+
+          (* TODO : version Ledger_proof_statement *)
+          type t = Ledger_proof_statement.t list
+          [@@deriving bin_io, sexp, hash, compare]
+        end
+
+        include T
+        include Registration.Make_latest_version (T)
+        include Hashable.Make_binable (T)
+      end
+
+      module Latest = V1
+
+      module Module_decl = struct
+        let name = "transaction_snark_work_statement"
+
+        type latest = Latest.t
+      end
+
+      module Registrar = Registration.Make (Module_decl)
+      module Registered_V1 = Registrar.Register (V1)
     end
 
-    include T
-    include Hashable.Make_binable (T)
+    (* bin_io omitted *)
+    type t = Stable.Latest.t [@@deriving sexp, hash, compare]
+
+    include Hashable.Make (Stable.Latest)
 
     let gen =
       Quickcheck.Generator.list_with_length proofs_length
@@ -32,11 +57,40 @@ module Make
   end
 
   module T = struct
-    type t =
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          let version = 1
+
+          type t =
+            { fee: Fee.Unsigned.t
+            ; proofs: Ledger_proof.t list
+            ; prover: Public_key.Compressed.Stable.V1.t }
+          [@@deriving sexp, bin_io]
+        end
+
+        include T
+        include Registration.Make_latest_version (T)
+      end
+
+      module Latest = V1
+
+      module Module_decl = struct
+        let name = "transaction_snark_work"
+
+        type latest = Latest.t
+      end
+
+      module Registrar = Registration.Make (Module_decl)
+      module Registered_V1 = Registrar.Register (V1)
+    end
+
+    (* bin_io omitted *)
+    type t = Stable.Latest.t =
       { fee: Fee.Unsigned.t
       ; proofs: Ledger_proof.t list
-      ; prover: Compressed_public_key.t }
-    [@@deriving sexp, bin_io]
+      ; prover: Public_key.Compressed.t }
+    [@@deriving sexp]
   end
 
   include T

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -60,8 +60,7 @@ struct
   end
 
   module Transaction_snark_work =
-    Staged_ledger.Make_completed_work (Public_key.Compressed) (Ledger_proof)
-      (Ledger_proof_statement)
+    Staged_ledger.Make_completed_work (Ledger_proof) (Ledger_proof_statement)
 
   module Staged_ledger_diff = Staged_ledger.Make_diff (struct
     module Fee_transfer = Fee_transfer
@@ -190,10 +189,12 @@ struct
         let {Keypair.public_key; _} = Keypair.create () in
         let prover = Public_key.compress public_key in
         Some
-          { Transaction_snark_work.Checked.fee= Fee.Unsigned.of_int 1
-          ; proofs=
-              List.map stmts ~f:(fun stmt -> (stmt, Sok_message.Digest.default))
-          ; prover }
+          Transaction_snark_work.Checked.
+            { fee= Fee.Unsigned.of_int 1
+            ; proofs=
+                List.map stmts ~f:(fun stmt ->
+                    (stmt, Sok_message.Digest.default) )
+            ; prover }
       in
       let staged_ledger_diff =
         Staged_ledger.create_diff parent_staged_ledger ~logger

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -246,9 +246,19 @@ module type Transition_frontier_intf = sig
 
   module Extensions : sig
     module Work : sig
-      type t [@@deriving sexp, bin_io]
+      type t [@@deriving sexp]
 
-      include Hashable.S_binable with type t := t
+      module Stable :
+        sig
+          module V1 : sig
+            type t [@@deriving sexp, bin_io]
+
+            include Hashable.S_binable with type t := t
+          end
+        end
+        with type V1.t = t
+
+      include Hashable.S with type t := t
     end
 
     module Snark_pool_refcount : sig


### PR DESCRIPTION
Versioning of `Work` parameter to `Snark_pool.Make` and `Snark_pool_diff.Make`.

Inlined `Public_key.Compressed` argument of `Staged_ledger.Make_completed_work`; same module was passed in real and test code.

More types flagged with TODOs for versioning.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
