### PR TITLE
Versioning for transaction_pool_diff

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -587,7 +587,7 @@ struct
     module Pool = Transaction_pool.Make (Staged_ledger) (Transition_frontier)
     include Network_pool.Make (Transition_frontier) (Pool) (Pool.Diff)
 
-    type pool_diff = Pool.Diff.t [@@deriving bin_io]
+    type pool_diff = Pool.Diff.t
 
     (* TODO *)
     let load ~logger ~disk_location:_ ~incoming_diffs ~frontier_broadcast_pipe

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -271,7 +271,15 @@ module Message (Inputs : sig
   end
 
   module Transaction_pool_diff : sig
-    type t [@@deriving bin_io, sexp]
+    type t [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving bin_io, sexp]
+        end
+      end
+      with type V1.t = t
   end
 
   module External_transition : External_transition.S
@@ -285,7 +293,7 @@ struct
       type content =
         | New_state of External_transition.Stable.V1.t
         | Snark_pool_diff of Snark_pool_diff.Stable.V1.t
-        | Transaction_pool_diff of Transaction_pool_diff.t
+        | Transaction_pool_diff of Transaction_pool_diff.Stable.V1.t
       [@@deriving bin_io, sexp]
 
       type msg = content Envelope.Incoming.Stable.V1.t [@@deriving sexp]
@@ -363,7 +371,15 @@ module type Inputs_intf = sig
   end
 
   module Transaction_pool_diff : sig
-    type t [@@deriving sexp, bin_io]
+    type t [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io]
+        end
+      end
+      with type V1.t = t
   end
 
   module Time : Protocols.Coda_pow.Time_intf

--- a/src/lib/transaction_pool/dune
+++ b/src/lib/transaction_pool/dune
@@ -4,7 +4,7 @@
  (flags :standard -short-paths -warn-error -3)
  (library_flags -linkall)
  (inline_tests)
- (libraries core async async_extra coda_base envelope protocols )
+ (libraries core async async_extra coda_base envelope protocols module_version)
  (preprocess
   (pps ppx_jane ppx_deriving.std bisect_ppx -- -conditional))
  (synopsis "Ledger fetcher fetches ledgers over the network"))


### PR DESCRIPTION
Versioning of `Transaction_pool.Diff`, which feeds into RPC types in `Coda_networking`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
