### PR TITLE
Version Proof_carrying_data

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -48,7 +48,8 @@ struct
         type query =
           Staged_ledger_hash.Stable.V1.t Envelope.Incoming.Stable.V1.t
 
-        type response = (Staged_ledger_aux.Stable.V1.t * Ledger_hash.t) option
+        type response =
+          (Staged_ledger_aux.Stable.V1.t * Ledger_hash.Stable.V1.t) option
       end
 
       module Caller = T
@@ -205,7 +206,7 @@ struct
         type response =
           ( ( External_transition.Stable.V1.t
             , State_body_hash.t list * External_transition.t )
-            Proof_carrying_data.t
+            Proof_carrying_data.Stable.V1.t
           * Staged_ledger_aux.Stable.V1.t
           * Ledger_hash.Stable.V1.t )
           option
@@ -234,7 +235,7 @@ struct
         type response =
           ( ( External_transition.Stable.V1.t
             , State_body_hash.t list * External_transition.Stable.V1.t )
-            Proof_carrying_data.t
+            Proof_carrying_data.Stable.V1.t
           * Staged_ledger_aux.Stable.V1.t
           * Ledger_hash.Stable.V1.t )
           option

--- a/src/lib/proof_carrying_data/proof_carrying_data.ml
+++ b/src/lib/proof_carrying_data/proof_carrying_data.ml
@@ -1,2 +1,14 @@
 (* A convenient data structure to bundle statements along with their proofs together *)
-type ('a, 'b) t = {data: 'a; proof: 'b} [@@deriving sexp, fields, bin_io]
+
+module Stable = struct
+  (* don't register versions, because of type parameters *)
+  module V1 = struct
+    type ('a, 'b) t = {data: 'a; proof: 'b} [@@deriving sexp, fields, bin_io]
+  end
+
+  module Latest = V1
+end
+
+(* bin_io omitted *)
+type ('a, 'b) t = ('a, 'b) Stable.Latest.t = {data: 'a; proof: 'b}
+[@@deriving sexp, fields]


### PR DESCRIPTION
Version `Proof_carrying_data`, plus mention a version for `Staged_ledger_diff` in a place where I forgot to.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
