### PR TITLE
Crash on Strict_pipe overflow

### DIFF
--- a/src/config/test_postake_five_even_snarkless.mlh
+++ b/src/config/test_postake_five_even_snarkless.mlh
@@ -4,6 +4,7 @@
 [%%import "config/scan_state/small.mlh"]
 [%%import "config/debug_level/some.mlh"]
 [%%import "config/proof_level/check.mlh"]
+[%%import "config/curve_size/small.mlh"]
 
 [%%define time_offsets false]
 [%%define fake_hash false]

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -160,7 +160,7 @@ module Make (Message : Message_intf) :
         let broadcast_reader, broadcast_writer = Linear_pipe.create () in
         let received_reader, received_writer =
           Strict_pipe.create ~name:"received gossip messages"
-            (Buffered (`Capacity 64, `Overflow Drop_head))
+            (Buffered (`Capacity 64, `Overflow Crash))
         in
         let t =
           { timeout= config.timeout

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -159,7 +159,8 @@ module Make (Message : Message_intf) :
         let peer_events = Membership.changes membership in
         let broadcast_reader, broadcast_writer = Linear_pipe.create () in
         let received_reader, received_writer =
-          Strict_pipe.create (Buffered (`Capacity 64, `Overflow Drop_head))
+          Strict_pipe.create ~name:"received gossip messages"
+            (Buffered (`Capacity 64, `Overflow Drop_head))
         in
         let t =
           { timeout= config.timeout

--- a/src/lib/otp_lib/capped_supervisor.ml
+++ b/src/lib/otp_lib/capped_supervisor.ml
@@ -7,7 +7,7 @@ type 'data t =
   { job_writer: ('data, crash buffered, unit) Writer.t
   ; f: 'data -> unit Deferred.t }
 
-let create ?(buffer_capacity = 10) ~job_capacity f =
+let create ?(buffer_capacity = 30) ~job_capacity f =
   let job_reader, job_writer =
     Strict_pipe.create (Buffered (`Capacity buffer_capacity, `Overflow Crash))
   in

--- a/src/lib/otp_lib/capped_supervisor.ml
+++ b/src/lib/otp_lib/capped_supervisor.ml
@@ -4,13 +4,12 @@ open Pipe_lib
 open Strict_pipe
 
 type 'data t =
-  { job_writer: ('data, drop_head buffered, unit) Writer.t
+  { job_writer: ('data, crash buffered, unit) Writer.t
   ; f: 'data -> unit Deferred.t }
 
 let create ?(buffer_capacity = 10) ~job_capacity f =
   let job_reader, job_writer =
-    Strict_pipe.create
-      (Buffered (`Capacity buffer_capacity, `Overflow Drop_head))
+    Strict_pipe.create (Buffered (`Capacity buffer_capacity, `Overflow Crash))
   in
   let active_jobs = ref 0 in
   let pending_jobs = ref [] in

--- a/src/lib/pipe_lib/dune
+++ b/src/lib/pipe_lib/dune
@@ -2,5 +2,5 @@
   (name pipe_lib)
   (inline_tests)
   (public_name pipe_lib)
-  (libraries core_kernel async o1trace)
+  (libraries core_kernel async o1trace logger)
   (preprocess (pps ppx_jane ppx_deriving.make)))

--- a/src/lib/pipe_lib/strict_pipe.ml
+++ b/src/lib/pipe_lib/strict_pipe.ml
@@ -1,9 +1,9 @@
 open Async_kernel
 open Core_kernel
 
-exception Overflow
+exception Overflow of string option
 
-exception Multiple_reads_attempted
+exception Multiple_reads_attempted of string option
 
 type crash = Overflow_behavior_crash
 
@@ -46,7 +46,7 @@ module Reader0 = struct
     {reader; has_reader; downstreams= []; name}
 
   let assert_not_read reader =
-    if reader.has_reader then raise Multiple_reads_attempted
+    if reader.has_reader then raise (Multiple_reads_attempted reader.name)
 
   let wrap_reader ?name reader =
     {reader; has_reader= false; downstreams= []; name}
@@ -181,7 +181,7 @@ module Writer = struct
       ('t, b buffered, unit) t -> 't -> b overflow_behavior -> unit =
    fun writer data overflow_behavior ->
     match overflow_behavior with
-    | Crash -> raise Overflow
+    | Crash -> raise (Overflow writer.name)
     | Drop_head ->
         let logger = Logger.create () in
         let my_name = Option.value writer.name ~default:"<unnamed>" in

--- a/src/lib/pipe_lib/strict_pipe.ml
+++ b/src/lib/pipe_lib/strict_pipe.ml
@@ -83,14 +83,18 @@ module Reader0 = struct
   let map reader ~f =
     assert_not_read reader ;
     reader.has_reader <- true ;
-    let strict_reader = wrap_reader (Pipe.map reader.reader ~f) in
+    let strict_reader =
+      wrap_reader ?name:reader.name (Pipe.map reader.reader ~f)
+    in
     reader.downstreams <- [strict_reader] ;
     strict_reader
 
   let filter_map reader ~f =
     assert_not_read reader ;
     reader.has_reader <- true ;
-    let strict_reader = wrap_reader (Pipe.filter_map reader.reader ~f) in
+    let strict_reader =
+      wrap_reader ?name:reader.name (Pipe.filter_map reader.reader ~f)
+    in
     reader.downstreams <- [strict_reader] ;
     strict_reader
 
@@ -149,7 +153,9 @@ module Reader0 = struct
       don't_wait_for
         (let%map () = Deferred.List.iter readers ~f:Pipe.closed in
          Pipe.close_read reader.reader) ;
-      let strict_readers = List.map readers ~f:wrap_reader in
+      let strict_readers =
+        List.map readers ~f:(wrap_reader ?name:reader.name)
+      in
       reader.downstreams <- downstreams_from_list strict_readers ;
       strict_readers
 

--- a/src/lib/pipe_lib/strict_pipe.mli
+++ b/src/lib/pipe_lib/strict_pipe.mli
@@ -31,7 +31,7 @@ module Reader : sig
 
   val to_linear_pipe : 't t -> 't Linear_pipe.Reader.t
 
-  val of_linear_pipe : 't Linear_pipe.Reader.t -> 't t
+  val of_linear_pipe : ?name:string -> 't Linear_pipe.Reader.t -> 't t
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
 
@@ -103,7 +103,8 @@ module Writer : sig
 end
 
 val create :
-     ('type_, 'write_return) type_
+  ?name:string
+  -> ('type_, 'write_return) type_
   -> 't Reader.t * ('t, 'type_, 'write_return) Writer.t
 
 val transfer :

--- a/src/lib/pipe_lib/strict_pipe.mli
+++ b/src/lib/pipe_lib/strict_pipe.mli
@@ -1,8 +1,8 @@
 open Async_kernel
 
-exception Overflow
+exception Overflow of string option
 
-exception Multiple_reads_attempted
+exception Multiple_reads_attempted of string option
 
 type crash = Overflow_behavior_crash
 
@@ -103,7 +103,7 @@ module Writer : sig
 end
 
 val create :
-  ?name:string
+     ?name:string
   -> ('type_, 'write_return) type_
   -> 't Reader.t * ('t, 'type_, 'write_return) Writer.t
 

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -68,7 +68,7 @@ module Make (Inputs : Inputs_intf) :
 
   let run ~logger ~network ~time_controller ~collected_transitions ~frontier
       ~network_transition_reader ~proposer_transition_reader ~clear_reader =
-    let valid_transition_pipe_capacity = 10 in
+    let valid_transition_pipe_capacity = 30 in
     let valid_transition_reader, valid_transition_writer =
       Strict_pipe.create ~name:"valid transitions"
         (Buffered (`Capacity valid_transition_pipe_capacity, `Overflow Crash))
@@ -82,7 +82,7 @@ module Make (Inputs : Inputs_intf) :
     in
     let processed_transition_reader, processed_transition_writer =
       Strict_pipe.create ~name:"processed transitions"
-        (Buffered (`Capacity 10, `Overflow Crash))
+        (Buffered (`Capacity 30, `Overflow Crash))
     in
     let catchup_job_reader, catchup_job_writer =
       Strict_pipe.create ~name:"catchup jobs" Synchronous

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -70,7 +70,7 @@ module Make (Inputs : Inputs_intf) :
       ~network_transition_reader ~proposer_transition_reader ~clear_reader =
     let valid_transition_pipe_capacity = 10 in
     let valid_transition_reader, valid_transition_writer =
-      Strict_pipe.create
+      Strict_pipe.create ~name:"valid transitions"
         (Buffered
            (`Capacity valid_transition_pipe_capacity, `Overflow Drop_head))
     in
@@ -78,21 +78,22 @@ module Make (Inputs : Inputs_intf) :
       valid_transition_pipe_capacity + List.length collected_transitions
     in
     let primary_transition_reader, primary_transition_writer =
-      Strict_pipe.create
+      Strict_pipe.create ~name:"primary transitions"
         (Buffered
            (`Capacity primary_transition_pipe_capacity, `Overflow Drop_head))
     in
     let processed_transition_reader, processed_transition_writer =
-      Strict_pipe.create (Buffered (`Capacity 10, `Overflow Drop_head))
+      Strict_pipe.create ~name:"processed transitions"
+        (Buffered (`Capacity 10, `Overflow Drop_head))
     in
     let catchup_job_reader, catchup_job_writer =
-      Strict_pipe.create Synchronous
+      Strict_pipe.create ~name:"catchup jobs" Synchronous
     in
     let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-      Strict_pipe.create Synchronous
+      Strict_pipe.create ~name:"catchup breadcrumbs" Synchronous
     in
     let proposer_transition_reader_copy, proposer_transition_writer_copy =
-      Strict_pipe.create Synchronous
+      Strict_pipe.create ~name:"proposer transition copy" Synchronous
     in
     Strict_pipe.transfer proposer_transition_reader
       proposer_transition_writer_copy ~f:Fn.id

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -71,20 +71,18 @@ module Make (Inputs : Inputs_intf) :
     let valid_transition_pipe_capacity = 10 in
     let valid_transition_reader, valid_transition_writer =
       Strict_pipe.create ~name:"valid transitions"
-        (Buffered
-           (`Capacity valid_transition_pipe_capacity, `Overflow Drop_head))
+        (Buffered (`Capacity valid_transition_pipe_capacity, `Overflow Crash))
     in
     let primary_transition_pipe_capacity =
       valid_transition_pipe_capacity + List.length collected_transitions
     in
     let primary_transition_reader, primary_transition_writer =
       Strict_pipe.create ~name:"primary transitions"
-        (Buffered
-           (`Capacity primary_transition_pipe_capacity, `Overflow Drop_head))
+        (Buffered (`Capacity primary_transition_pipe_capacity, `Overflow Crash))
     in
     let processed_transition_reader, processed_transition_writer =
       Strict_pipe.create ~name:"processed transitions"
-        (Buffered (`Capacity 10, `Overflow Drop_head))
+        (Buffered (`Capacity 10, `Overflow Crash))
     in
     let catchup_job_reader, catchup_job_writer =
       Strict_pipe.create ~name:"catchup jobs" Synchronous

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -586,6 +586,6 @@ struct
 
     let make_transition_pipe () =
       Pipe_lib.Strict_pipe.create
-        (Buffered (`Capacity 10, `Overflow Drop_head))
+        (Buffered (`Capacity 30, `Overflow Drop_head))
   end
 end

--- a/src/lib/transition_handler/validator.ml
+++ b/src/lib/transition_handler/validator.ml
@@ -65,7 +65,7 @@ module Make (Inputs : Inputs.With_unprocessed_transition_cache.S) :
          ( ( (External_transition.Verified.t, State_hash.t) With_hash.t
            , State_hash.t )
            Cached.t
-         , drop_head buffered
+         , crash buffered
          , unit )
          Writer.t) ~unprocessed_transition_cache =
     don't_wait_for

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -85,7 +85,7 @@ module Make (Inputs : Inputs_intf) :
     |> Unix_timestamp.of_int64
 
   let create_bufferred_pipe ?name () =
-    Strict_pipe.create ?name (Buffered (`Capacity 10, `Overflow Drop_head))
+    Strict_pipe.create ?name (Buffered (`Capacity 10, `Overflow Crash))
 
   let kill reader writer =
     Strict_pipe.Reader.clear reader ;
@@ -145,7 +145,7 @@ module Make (Inputs : Inputs_intf) :
       Strict_pipe.Writer.write clear_writer `Clear |> don't_wait_for ;
       let bootstrap_controller_reader, bootstrap_controller_writer =
         Strict_pipe.create ~name:"bootstrap controller"
-          (Buffered (`Capacity 10, `Overflow Drop_head))
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       Logger.info logger ~module_:__MODULE__ ~location:__LOC__
         "Bootstrap state: starting." ;

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -85,7 +85,7 @@ module Make (Inputs : Inputs_intf) :
     |> Unix_timestamp.of_int64
 
   let create_bufferred_pipe ?name () =
-    Strict_pipe.create ?name (Buffered (`Capacity 10, `Overflow Crash))
+    Strict_pipe.create ?name (Buffered (`Capacity 30, `Overflow Crash))
 
   let kill reader writer =
     Strict_pipe.Reader.clear reader ;

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -357,7 +357,7 @@ module type Transition_handler_validator_intf = sig
                                    With_hash.t
                                  , state_hash )
                                  Cached.t
-                               , Strict_pipe.drop_head Strict_pipe.buffered
+                               , Strict_pipe.crash Strict_pipe.buffered
                                , unit )
                                Strict_pipe.Writer.t
     -> unprocessed_transition_cache:unprocessed_transition_cache
@@ -428,7 +428,7 @@ module type Transition_handler_processor_intf = sig
     -> processed_transition_writer:( ( external_transition_verified
                                      , state_hash )
                                      With_hash.t
-                                   , Strict_pipe.drop_head Strict_pipe.buffered
+                                   , Strict_pipe.crash Strict_pipe.buffered
                                    , unit )
                                    Strict_pipe.Writer.t
     -> unprocessed_transition_cache:unprocessed_transition_cache
@@ -646,7 +646,7 @@ module type Initial_validator_intf = sig
     -> valid_transition_writer:( [ `Transition of external_transition_verified
                                                   Envelope.Incoming.t ]
                                  * [`Time_received of time]
-                               , Strict_pipe.drop_head Strict_pipe.buffered
+                               , Strict_pipe.crash Strict_pipe.buffered
                                , unit )
                                Strict_pipe.Writer.t
     -> unit


### PR DESCRIPTION
We think our system shouldn't be overflowing these pipes.

I also added a name field to strict pipes, so we can include that when there's a pipe error. I also added some logging to the `Drop_head` behavior so it won't go unnoticed.