### PR TITLE
Version cleanup for Peer

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -180,7 +180,7 @@ module type Main_intf = sig
           ; discovery_port: int (* UDP *)
           ; communication_port: int
           (* TCP *) }
-        [@@deriving bin_io, sexp, compare, hash]
+        [@@deriving sexp, compare, hash]
       end
 
       module Gossip_net : sig

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -44,7 +44,8 @@ end
 
 module T = struct
   module Peers = struct
-    type t = Network_peer.Peer.t List.t [@@deriving bin_io]
+    (* TODO: version *)
+    type t = Network_peer.Peer.Stable.V1.t List.t [@@deriving bin_io]
   end
 
   module State_hashes = struct

--- a/src/lib/envelope/envelope.ml
+++ b/src/lib/envelope/envelope.ml
@@ -8,7 +8,8 @@ module Sender = struct
       module T = struct
         let version = 1
 
-        type t = Local | Remote of Peer.t [@@deriving sexp, bin_io, yojson]
+        type t = Local | Remote of Peer.Stable.V1.t
+        [@@deriving sexp, bin_io, yojson]
       end
 
       include T

--- a/src/lib/network_peer/peer.ml
+++ b/src/lib/network_peer/peer.ml
@@ -63,7 +63,15 @@ module Stable = struct
   module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.Latest
+(* bin_io omitted *)
+type t = Stable.Latest.t =
+  { host: Unix.Inet_addr.Blocking_sexp.t
+  ; discovery_port: int
+  ; communication_port: int }
+[@@deriving compare, hash, sexp]
+
+let of_yojson, to_yojson = Stable.Latest.(of_yojson, to_yojson)
+
 include Hashable.Make (Stable.Latest)
 include Comparable.Make_binable (Stable.Latest)
 


### PR DESCRIPTION
Auditing versioning of RPC types, expect more cleanup PRs.

Removed `bin_io` for `Peer.t`. Use versioned `Peer` in `Envelope.Sender`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
