### PR TITLE
improve broadcast logging

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -500,7 +500,7 @@ struct
   module Sparse_ledger = Coda_base.Sparse_ledger
 
   module Transaction_snark_work_proof = struct
-    type t = Ledger_proof.Stable.V1.t list [@@deriving sexp, bin_io]
+    type t = Ledger_proof.Stable.V1.t list [@@deriving sexp, bin_io, yojson]
   end
 
   module Staged_ledger = struct
@@ -665,7 +665,7 @@ struct
     module Fee = struct
       module T = struct
         type t = {fee: Fee.Unsigned.t; prover: Public_key.Compressed.t}
-        [@@deriving bin_io, sexp]
+        [@@deriving bin_io, sexp, yojson]
 
         (* TODO: Compare in a better way than with public key, like in transaction pool *)
         let compare t1 t2 =

--- a/src/app/cli/src/ledger_proof.ml
+++ b/src/app/cli/src/ledger_proof.ml
@@ -21,7 +21,7 @@ module Prod :
       module T = struct
         let version = 1
 
-        type t = Transaction_snark.t [@@deriving bin_io, sexp]
+        type t = Transaction_snark.t [@@deriving bin_io, sexp, yojson]
       end
 
       include T
@@ -40,7 +40,7 @@ module Prod :
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  type t = Stable.Latest.t [@@deriving sexp]
+  type t = Stable.Latest.t [@@deriving sexp, yojson]
 
   type statement = Transaction_snark.Statement.t
 
@@ -76,7 +76,7 @@ module Debug :
         let version = 1
 
         type t = Transaction_snark.Statement.t * Sok_message.Digest.Stable.V1.t
-        [@@deriving sexp, bin_io]
+        [@@deriving sexp, bin_io, yojson]
       end
 
       include T
@@ -95,7 +95,7 @@ module Debug :
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  type t = Stable.Latest.t [@@deriving sexp]
+  type t = Stable.Latest.t [@@deriving sexp, yojson]
 
   type statement = Transaction_snark.Statement.t
 

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -15,6 +15,12 @@ module Stable = struct
     include T
     include Sexpable.Of_stringable (T)
 
+    let to_yojson t = `String (to_string t)
+
+    let of_yojson = function
+      | `String x -> Ok (of_string x)
+      | _ -> Error "expected `String"
+
     (* TODO: Figure out what the right thing to do is for conversion failures *)
     let ( { Bin_prot.Type_class.reader= bin_reader_t
           ; writer= bin_writer_t

--- a/src/lib/coda_base/proof.mli
+++ b/src/lib/coda_base/proof.mli
@@ -1,11 +1,11 @@
 open Snark_params
 
-type t = Tock.Proof.t [@@deriving bin_io, sexp]
+type t = Tock.Proof.t [@@deriving bin_io, sexp, yojson]
 
 val dummy : Tock.Proof.t
 
 module Stable : sig
   module V1 : sig
-    type nonrec t = t [@@deriving bin_io, sexp]
+    type nonrec t = t [@@deriving bin_io, sexp, yojson]
   end
 end

--- a/src/lib/coda_base/sok_message.ml
+++ b/src/lib/coda_base/sok_message.ml
@@ -10,7 +10,7 @@ module Stable = struct
       type t =
         { fee: Currency.Fee.Stable.V1.t
         ; prover: Public_key.Compressed.Stable.V1.t }
-      [@@deriving bin_io, sexp]
+      [@@deriving bin_io, sexp, yojson]
     end
 
     include T
@@ -32,7 +32,7 @@ end
 (* bin_io omitted intentionally *)
 type t = Stable.Latest.t =
   {fee: Currency.Fee.Stable.V1.t; prover: Public_key.Compressed.Stable.V1.t}
-[@@deriving sexp]
+[@@deriving sexp, yojson]
 
 let create ~fee ~prover = Stable.Latest.{fee; prover}
 
@@ -62,7 +62,7 @@ module Digest = struct
   end
 
   (* bin_io omitted intentionally *)
-  type t = Stable.Latest.t [@@deriving sexp, eq]
+  type t = Stable.Latest.t [@@deriving sexp, eq, yojson]
 
   module Checked = Stable.Latest.Checked
 

--- a/src/lib/coda_base/sok_message.mli
+++ b/src/lib/coda_base/sok_message.mli
@@ -9,7 +9,7 @@ module Stable : sig
   module V1 : sig
     type t =
       {fee: Currency.Fee.Stable.V1.t; prover: Public_key.Compressed.Stable.V1.t}
-    [@@deriving bin_io, sexp]
+    [@@deriving bin_io, sexp, yojson]
   end
 
   module Latest = V1
@@ -17,16 +17,16 @@ end
 
 type t = Stable.Latest.t =
   {fee: Currency.Fee.Stable.V1.t; prover: Public_key.Compressed.Stable.V1.t}
-[@@deriving sexp]
+[@@deriving sexp, yojson]
 
 val create : fee:Currency.Fee.t -> prover:Public_key.Compressed.t -> t
 
 module Digest : sig
-  type t [@@deriving sexp, eq]
+  type t [@@deriving sexp, eq, yojson]
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving sexp, bin_io, hash, compare, eq]
+      type nonrec t = t [@@deriving sexp, bin_io, hash, compare, eq, yojson]
     end
 
     module Latest = V1

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -260,24 +260,24 @@ end
 
 module Message (Inputs : sig
   module Snark_pool_diff : sig
-    type t [@@deriving sexp]
+    type t [@@deriving sexp, to_yojson]
 
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io, sexp]
+          type t [@@deriving bin_io, sexp, to_yojson]
         end
       end
       with type V1.t = t
   end
 
   module Transaction_pool_diff : sig
-    type t [@@deriving sexp]
+    type t [@@deriving sexp, to_yojson]
 
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io, sexp]
+          type t [@@deriving bin_io, sexp, to_yojson]
         end
       end
       with type V1.t = t
@@ -295,9 +295,10 @@ struct
         | New_state of External_transition.Stable.V1.t
         | Snark_pool_diff of Snark_pool_diff.Stable.V1.t
         | Transaction_pool_diff of Transaction_pool_diff.Stable.V1.t
-      [@@deriving bin_io, sexp]
+      [@@deriving bin_io, sexp, to_yojson]
 
-      type msg = content Envelope.Incoming.Stable.V1.t [@@deriving sexp]
+      type msg = content Envelope.Incoming.Stable.V1.t
+      [@@deriving sexp, to_yojson]
     end
 
     let name = "message"
@@ -330,6 +331,12 @@ struct
 
     include Register (T)
   end
+
+  let summary msg =
+    match Envelope.Incoming.data msg with
+    | New_state _ -> "new state"
+    | Snark_pool_diff _ -> "snark pool diff"
+    | Transaction_pool_diff _ -> "transaction pool diff"
 end
 
 module type Inputs_intf = sig
@@ -360,24 +367,24 @@ module type Inputs_intf = sig
   end
 
   module Snark_pool_diff : sig
-    type t [@@deriving sexp]
+    type t [@@deriving sexp, to_yojson]
 
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving sexp, bin_io]
+          type t [@@deriving sexp, bin_io, to_yojson]
         end
       end
       with type V1.t = t
   end
 
   module Transaction_pool_diff : sig
-    type t [@@deriving sexp]
+    type t [@@deriving sexp, to_yojson]
 
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving sexp, bin_io]
+          type t [@@deriving sexp, bin_io, to_yojson]
         end
       end
       with type V1.t = t
@@ -516,8 +523,9 @@ module Make (Inputs : Inputs_intf) = struct
   (* TODO: Have better pushback behavior *)
   let broadcast t x =
     Logger.trace t.logger ~module_:__MODULE__ ~location:__LOC__
-      !"Broadcasting %{sexp: Message.msg} over gossip net"
-      x ;
+      ~metadata:[("message", Message.msg_to_yojson x)]
+      !"Broadcasting %s over gossip net"
+      (Message.summary x) ;
     Linear_pipe.write_without_pushback (Gossip_net.broadcast t.gossip_net) x
 
   let broadcast_from_me t content = broadcast t (envelope_from_me t content)

--- a/src/lib/coda_networking/dune
+++ b/src/lib/coda_networking/dune
@@ -7,5 +7,5 @@
  (libraries core o1trace envelope async gossip_net coda_lib protocols
    async_extra coda_base unix_timestamp perf_histograms proof_carrying_data)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving.make bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Networking layer for coda"))

--- a/src/lib/envelope/envelope.ml
+++ b/src/lib/envelope/envelope.ml
@@ -37,14 +37,14 @@ module Incoming = struct
   module Stable = struct
     module V1 = struct
       type 'a t = {data: 'a; sender: Sender.Stable.V1.t}
-      [@@deriving sexp, bin_io]
+      [@@deriving sexp, bin_io, yojson]
     end
 
     module Latest = V1
   end
 
   (* bin_io intentionally omitted *)
-  type 'a t = 'a Stable.Latest.t [@@deriving sexp]
+  type 'a t = 'a Stable.Latest.t [@@deriving sexp, yojson]
 
   let sender t = t.Stable.Latest.sender
 

--- a/src/lib/envelope/envelope.mli
+++ b/src/lib/envelope/envelope.mli
@@ -18,13 +18,13 @@ module Incoming : sig
   module Stable : sig
     module V1 : sig
       type 'a t = {data: 'a; sender: Sender.Stable.V1.t}
-      [@@deriving sexp, bin_io]
+      [@@deriving sexp, bin_io, yojson]
     end
 
     module Latest = V1
   end
 
-  type 'a t = 'a Stable.Latest.t [@@deriving sexp]
+  type 'a t = 'a Stable.Latest.t [@@deriving sexp, yojson]
 
   val sender : 'a t -> Sender.t
 

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -5,7 +5,7 @@
  (library_flags -linkall)
  (libraries core async pipe_lib snark_pool)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_deriving.eq bisect_ppx ppx_deriving_yojson -- -conditional))
  (flags :standard -short-paths -warn-error -6-27-34-32-9-58)
  (synopsis
    "Network pool is an interface that processes incoming diffs and then broadcasts them"))

--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -101,10 +101,18 @@ end
 
 let%test_module "network pool test" =
   ( module struct
+    module Int = struct
+      include Int
+
+      let to_yojson x = `Int x
+
+      let of_yojson = function `Int x -> Ok x | _ -> Error "expected `Int"
+    end
+
     module Mock_proof = struct
       type input = Int.t
 
-      type t = Int.t [@@deriving sexp, bin_io]
+      type t = Int.t [@@deriving sexp, bin_io, yojson]
 
       let verify _ _ = return true
 
@@ -114,7 +122,7 @@ let%test_module "network pool test" =
     module Mock_work = struct
       (* no bin_io except in Stable versions *)
       module T = struct
-        type t = Int.t [@@deriving sexp, hash, compare]
+        type t = Int.t [@@deriving sexp, hash, compare, yojson]
 
         let gen = Int.gen
       end

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -3,19 +3,19 @@ open Async
 open Module_version
 
 type ('work, 'priced_proof) diff = Add_solved_work of 'work * 'priced_proof
-[@@deriving bin_io, sexp]
+[@@deriving bin_io, sexp, yojson]
 
 module Make (Proof : sig
-  type t [@@deriving bin_io]
+  type t [@@deriving bin_io, yojson]
 end) (Fee : sig
-  type t [@@deriving bin_io, sexp]
+  type t [@@deriving bin_io, sexp, yojson]
 end) (Work : sig
-  type t [@@deriving sexp]
+  type t [@@deriving sexp, yojson]
 
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io]
+        type t [@@deriving sexp, bin_io, yojson]
       end
     end
     with type V1.t = t
@@ -36,6 +36,30 @@ struct
           (* TODO : version Proof and Fee *)
           type t = {proof: Proof.t sexp_opaque; fee: Fee.t}
           [@@deriving bin_io, sexp]
+
+          let to_yojson {proof; fee} =
+            `Assoc
+              [("proof", Proof.to_yojson proof); ("fee", Fee.to_yojson fee)]
+
+          let of_yojson (json : Yojson.Safe.json) =
+            match json with
+            | `Assoc attrs ->
+                let open Result.Let_syntax in
+                let%bind proof_json, fee_json =
+                  Result.of_option ~error:"missing keys"
+                    (let open Option.Let_syntax in
+                    let%bind proof_json =
+                      List.Assoc.find attrs ~equal:String.equal "proof"
+                    in
+                    let%map fee_json =
+                      List.Assoc.find attrs ~equal:String.equal "fee"
+                    in
+                    (proof_json, fee_json))
+                in
+                let%bind proof_val = Proof.of_yojson proof_json in
+                let%map fee_val = Fee.of_yojson fee_json in
+                {proof= proof_val; fee= fee_val}
+            | _ -> Error "expected `Assoc"
         end
 
         include T
@@ -57,6 +81,10 @@ struct
     (* bin_io omitted *)
     type t = Stable.Latest.t = {proof: Proof.t sexp_opaque; fee: Fee.t}
     [@@deriving sexp]
+
+    let to_yojson = Stable.Latest.to_yojson
+
+    let of_yojson = Stable.Latest.of_yojson
   end
 
   module Stable = struct
@@ -65,7 +93,7 @@ struct
         let version = 1
 
         type t = (Work.Stable.V1.t, Priced_proof.Stable.V1.t) diff
-        [@@deriving bin_io, sexp]
+        [@@deriving bin_io, sexp, yojson]
       end
 
       include T
@@ -85,7 +113,7 @@ struct
   end
 
   (* bin_io omitted *)
-  type t = Stable.Latest.t [@@deriving sexp]
+  type t = Stable.Latest.t [@@deriving sexp, yojson]
 
   let summary = function
     | Add_solved_work (_, Priced_proof.({proof= _; fee})) ->

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1408,7 +1408,7 @@ let%test_module "test" =
       module Sok_message = struct
         module Stable = struct
           module V1 = struct
-            type t = unit [@@deriving bin_io, sexp]
+            type t = unit [@@deriving bin_io, sexp, yojson]
           end
 
           module Latest = V1
@@ -1416,7 +1416,7 @@ let%test_module "test" =
 
         module Digest = Unit
 
-        type t = Stable.Latest.t [@@deriving sexp]
+        type t = Stable.Latest.t [@@deriving sexp, yojson]
 
         let create ~fee:_ ~prover:_ = ()
       end
@@ -1646,7 +1646,7 @@ let%test_module "test" =
           module Latest = V1
         end
 
-        type t = Stable.Latest.t [@@deriving sexp]
+        type t = Stable.Latest.t [@@deriving sexp, yojson]
 
         type ledger_hash = Ledger_hash.t
 
@@ -1835,7 +1835,7 @@ let%test_module "test" =
             module V1 = struct
               module T = struct
                 type t = statement list
-                [@@deriving sexp, bin_io, compare, hash, eq]
+                [@@deriving sexp, bin_io, compare, hash, eq, yojson]
               end
 
               include T
@@ -1845,7 +1845,7 @@ let%test_module "test" =
             module Latest = V1
           end
 
-          type t = Stable.Latest.t [@@deriving sexp, compare, hash, eq]
+          type t = Stable.Latest.t [@@deriving sexp, compare, hash, eq, yojson]
 
           include Hashable.Make (Stable.Latest)
 

--- a/src/lib/staged_ledger/transaction_snark_work.ml
+++ b/src/lib/staged_ledger/transaction_snark_work.ml
@@ -8,7 +8,7 @@ open Module_version
 module Make (Ledger_proof : sig
   type t [@@deriving sexp, bin_io]
 end) (Ledger_proof_statement : sig
-  type t [@@deriving sexp, bin_io, hash, compare]
+  type t [@@deriving sexp, bin_io, hash, compare, yojson]
 
   val gen : t Quickcheck.Generator.t
 end) :
@@ -26,7 +26,7 @@ end) :
 
           (* TODO : version Ledger_proof_statement *)
           type t = Ledger_proof_statement.t list
-          [@@deriving bin_io, sexp, hash, compare]
+          [@@deriving bin_io, sexp, hash, compare, yojson]
         end
 
         include T
@@ -47,7 +47,7 @@ end) :
     end
 
     (* bin_io omitted *)
-    type t = Stable.Latest.t [@@deriving sexp, hash, compare]
+    type t = Stable.Latest.t [@@deriving sexp, hash, compare, yojson]
 
     include Hashable.Make (Stable.Latest)
 

--- a/src/lib/transaction_pool/dune
+++ b/src/lib/transaction_pool/dune
@@ -6,5 +6,5 @@
  (inline_tests)
  (libraries core async async_extra coda_base envelope protocols module_version)
  (preprocess
-  (pps ppx_jane ppx_deriving.std bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Ledger fetcher fetches ledgers over the network"))

--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -36,12 +36,12 @@ module type Transition_frontier_intf = sig
 end
 
 module type User_command_intf = sig
-  type t [@@deriving sexp]
+  type t [@@deriving sexp, yojson]
 
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io]
+        type t [@@deriving sexp, bin_io, yojson]
       end
     end
     with type V1.t = t
@@ -288,7 +288,8 @@ struct
         module T = struct
           let version = 1
 
-          type t = User_command.Stable.V1.t list [@@deriving bin_io, sexp]
+          type t = User_command.Stable.V1.t list
+          [@@deriving bin_io, sexp, yojson]
         end
 
         include T
@@ -308,7 +309,7 @@ struct
     end
 
     (* bin_io omitted *)
-    type t = Stable.Latest.t [@@deriving sexp]
+    type t = Stable.Latest.t [@@deriving sexp, yojson]
 
     let summary t =
       Printf.sprintf "Transaction diff of length %d" (List.length t)
@@ -425,6 +426,14 @@ let%test_module _ =
               : int Best_tip_diff_view.t )
         in
         ((pipe_r, ref ([], Int.Set.empty)), pipe_w)
+    end
+
+    module Int = struct
+      include Int
+
+      let to_yojson x = `Int x
+
+      let of_yojson = function `Int x -> Ok x | _ -> Error "expected `Int"
     end
 
     module Test =

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -6,5 +6,5 @@
  (inline_tests)
  (libraries core cache_dir cached snarky coda_base bignum)
  (preprocess
-  (pps ppx_snarky ppx_jane ppx_deriving.std bisect_ppx -- -conditional))
+  (pps ppx_snarky ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Transaction state transition snarking library"))

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -24,7 +24,7 @@ module Input = struct
 end
 
 module Proof_type = struct
-  type t = [`Merge | `Base] [@@deriving bin_io, sexp, hash, compare]
+  type t = [`Merge | `Base] [@@deriving bin_io, sexp, hash, compare, yojson]
 
   let is_base = function `Base -> true | `Merge -> false
 end
@@ -37,7 +37,7 @@ module Statement = struct
       ; supply_increase: Currency.Amount.Stable.V1.t
       ; fee_excess: Currency.Fee.Signed.Stable.V1.t
       ; proof_type: Proof_type.t }
-    [@@deriving sexp, bin_io, hash, compare, fields]
+    [@@deriving sexp, bin_io, hash, compare, fields, yojson]
 
     let option lab =
       Option.value_map ~default:(Or_error.error_string lab) ~f:(fun x -> Ok x)
@@ -80,7 +80,7 @@ type t =
   ; fee_excess: Amount.Signed.Stable.V1.t
   ; sok_digest: Sok_message.Digest.Stable.V1.t
   ; proof: Proof.Stable.V1.t }
-[@@deriving fields, sexp, bin_io]
+[@@deriving fields, sexp, bin_io, yojson]
 
 let statement
     { source

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -3,7 +3,7 @@ open Coda_base
 open Snark_params
 
 module Proof_type : sig
-  type t = [`Merge | `Base] [@@deriving bin_io, sexp]
+  type t = [`Merge | `Base] [@@deriving bin_io, sexp, yojson]
 end
 
 module Statement : sig
@@ -13,7 +13,7 @@ module Statement : sig
     ; supply_increase: Currency.Amount.Stable.V1.t
     ; fee_excess: Currency.Fee.Signed.Stable.V1.t
     ; proof_type: Proof_type.t }
-  [@@deriving sexp, bin_io, hash, compare, eq, fields]
+  [@@deriving sexp, bin_io, hash, compare, eq, fields, yojson]
 
   val gen : t Quickcheck.Generator.t
 
@@ -24,7 +24,7 @@ module Statement : sig
   include Comparable.S with type t := t
 end
 
-type t [@@deriving bin_io, sexp]
+type t [@@deriving bin_io, sexp, yojson]
 
 val create :
      source:Frozen_ledger_hash.t

--- a/src/lib/transition_frontier_controller_tests/dune
+++ b/src/lib/transition_frontier_controller_tests/dune
@@ -3,5 +3,5 @@
   (public_name transition_frontier_controller_tests)
   (inline_tests)
   (libraries core_kernel consensus protocols coda_base sync_handler transition_handler transition_frontier_controller bootstrap_controller genesis_ledger quickcheck_lib protocol_state_validator root_prover ledger_catchup)
-  (preprocess (pps ppx_jane ppx_deriving.eq)))
+  (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson)))
   

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -23,14 +23,14 @@ struct
     module Stable = struct
       module V1 = struct
         type t = Ledger_proof_statement.t * Sok_message.Digest.Stable.V1.t
-        [@@deriving sexp, bin_io]
+        [@@deriving sexp, bin_io, yojson]
       end
 
       module Latest = V1
     end
 
     (* TODO: remove bin_io, after fixing functors to accept this *)
-    type t = Stable.V1.t [@@deriving sexp, bin_io]
+    type t = Stable.V1.t [@@deriving sexp, bin_io, yojson]
 
     let underlying_proof (_ : t) = Proof.dummy
 

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -296,10 +296,10 @@ end
 
 module type Snark_pool_proof_intf = sig
   module Statement : sig
-    type t [@@deriving sexp, bin_io]
+    type t [@@deriving sexp, bin_io, yojson]
   end
 
-  type t [@@deriving sexp, bin_io]
+  type t [@@deriving sexp, bin_io, yojson]
 end
 
 module type User_command_intf = sig
@@ -426,12 +426,12 @@ module type Ledger_proof_intf = sig
   type sok_digest
 
   (* bin_io omitted intentionally *)
-  type t [@@deriving sexp]
+  type t [@@deriving sexp, yojson]
 
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io]
+        type t [@@deriving sexp, bin_io, yojson]
       end
 
       module Latest = V1
@@ -471,7 +471,7 @@ module type Transaction_snark_work_intf = sig
   type public_key
 
   module Statement : sig
-    type t = statement list
+    type t = statement list [@@deriving yojson]
 
     include Sexpable.S with type t := t
 
@@ -480,7 +480,7 @@ module type Transaction_snark_work_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t
+          type t [@@deriving yojson]
 
           include Sexpable.S with type t := t
 


### PR DESCRIPTION
this required some substantial yojsoning. I apologize that it is all in one commit, https://github.com/CodaProtocol/coda/compare/feature/broadcast-logging?expand=1#diff-08521bc469b5bcbc1e7c8528b8df6959R526 has the actually relevant change.