### PR TITLE
trivial: exit 1 if daemon not present

### DIFF
--- a/src/lib/cli_lib/background_daemon.ml
+++ b/src/lib/cli_lib/background_daemon.ml
@@ -21,7 +21,7 @@ let run ~f port arg =
         Print.printf !"Error: daemon not running. See `coda daemon`\n" ;
         go Abort
     | Run_client -> f port arg
-    | Abort -> Deferred.unit
+    | Abort -> exit 1
   in
   go Start
 


### PR DESCRIPTION
This will exit client with status code 1 when daemon not found. (helpful in automating tests that check for daemon's existence)

I tried calling exit directly from no_daemon, but I got this complaint about Abort. 
```
Error (warning 37): constructor Abort is never used to build values.
(However, this constructor appears in patterns.)
```

I tried removing Abort, but I got this complaint
```
Error (warning 8): this pattern-matching is not exhaustive.
Here is an example of a case that is not matched:
Abort
```

So as a compromise we keep the go abort and exit in abort.

Closes #1943
