### PR TITLE
TRIVIAL: workaround for dev build

### DIFF
--- a/src/lib/pipe_lib/dune
+++ b/src/lib/pipe_lib/dune
@@ -1,5 +1,6 @@
 (library
   (name pipe_lib)
+  (flags :standard -short-paths -safe-string -warn-error -9)
   (inline_tests)
   (public_name pipe_lib)
   (libraries core_kernel async o1trace logger)


### PR DESCRIPTION
dev build currently broken due to new 'name' in strict_pipes

```
File "lib/pipe_lib/strict_pipe.ml", line 42, characters 21-63:
Error (warning 9): the following labels are not bound in this record pattern:
name
Either bind these labels explicitly or add '; _' to the pattern.
File "lib/pipe_lib/strict_pipe.ml", line 184, characters 21-63:
Error (warning 9): the following labels are not bound in this record pattern:
name
Either bind these labels explicitly or add '; _' to the pattern.
File "lib/pipe_lib/strict_pipe.ml", line 210, characters 12-45:
Error (warning 9): the following labels are not bound in this record pattern:
name
Either bind these labels explicitly or add '; _' to the pattern.
File "lib/pipe_lib/strict_pipe.ml", line 225, characters 20-60:
Error (warning 9): the following labels are not bound in this record pattern:
name
```

This PR downgrades this error to a warn