### PR TITLE
Add -repeat argument to transaction-snark-profiler, tweak argument descriptions

### DIFF
--- a/src/app/cli/src/transaction_snark_profiler.ml
+++ b/src/app/cli/src/transaction_snark_profiler.ml
@@ -242,6 +242,6 @@ let command =
        |> Option.value ~default:`Two_from_same
      in
      let repeats = Option.value repeats ~default:1 in
-     if witness_only then witness num_transactions
-     else if check_only then dry num_transactions
-     else main num_transactions)
+     if witness_only then witness num_transactions repeats
+     else if check_only then dry num_transactions repeats
+     else main num_transactions repeats)

--- a/src/app/cli/src/transaction_snark_profiler.ml
+++ b/src/app/cli/src/transaction_snark_profiler.ml
@@ -181,7 +181,7 @@ let generate_base_snarks_witness sparse_ledger0
   in
   "Base constraint system satisfied"
 
-let run profiler num_transactions =
+let run profiler num_transactions repeats =
   let ledger, transitions = create_ledger_and_transactions num_transactions in
   let sparse_ledger =
     Coda_base.Sparse_ledger.of_ledger_subset_exn ledger
@@ -195,26 +195,31 @@ let run profiler num_transactions =
            | Coinbase {proposer; fee_transfer} ->
                proposer :: Option.to_list (Option.map fee_transfer ~f:fst) ))
   in
-  let message = profiler sparse_ledger transitions in
-  Core.printf !"%s\n%!" message ;
+  for i = 1 to repeats do
+    let message = profiler sparse_ledger transitions in
+    Core.printf !"[%i] %s\n%!" i message
+  done ;
   exit 0
 
-let main num_transactions () =
+let main num_transactions repeats () =
   Snarky.Libsnark.set_no_profiling false ;
   Test_util.with_randomness 123456789 (fun () ->
       let keys = Transaction_snark.Keys.create () in
       let module T = Transaction_snark.Make (struct
         let keys = keys
       end) in
-      run (profile (module T)) num_transactions )
+      run (profile (module T)) num_transactions repeats )
 
-let dry num_transactions () =
+let dry num_transactions repeats () =
   Test_util.with_randomness 123456789 (fun () ->
-      run check_base_snarks num_transactions )
+      run check_base_snarks num_transactions repeats )
 
-let witness num_transactions () =
+let witness num_transactions repeats () =
   Test_util.with_randomness 123456789 (fun () ->
-      run generate_base_snarks_witness num_transactions )
+      run
+        (generate_base_snarks_witness
+           Transaction_snark.generate_transaction_witness)
+        num_transactions repeats )
 
 let command =
   let open Command.Let_syntax in
@@ -222,7 +227,11 @@ let command =
     (let%map_open n =
        flag "k"
          ~doc:
-           "log_2(number of transactions to snark) or none for the mocked ones"
+           "count count = log_2(number of transactions to snark) or none for \
+            the mocked ones"
+         (optional int)
+     and repeats =
+       flag "repeat" ~doc:"count number of times to repeat the profile"
          (optional int)
      and check_only =
        flag "check-only"
@@ -235,6 +244,7 @@ let command =
        Option.map n ~f:(fun n -> `Count (Int.pow 2 n))
        |> Option.value ~default:`Two_from_same
      in
+     let repeats = Option.value repeats ~default:1 in
      if witness_only then witness num_transactions
      else if check_only then dry num_transactions
      else main num_transactions)

--- a/src/app/cli/src/transaction_snark_profiler.ml
+++ b/src/app/cli/src/transaction_snark_profiler.ml
@@ -216,7 +216,7 @@ let dry num_transactions repeats () =
 
 let witness num_transactions repeats () =
   Test_util.with_randomness 123456789 (fun () ->
-      run (generate_base_snarks_witness num_transactions repeats) )
+      run generate_base_snarks_witness num_transactions repeats )
 
 let command =
   let open Command.Let_syntax in

--- a/src/app/cli/src/transaction_snark_profiler.ml
+++ b/src/app/cli/src/transaction_snark_profiler.ml
@@ -216,10 +216,7 @@ let dry num_transactions repeats () =
 
 let witness num_transactions repeats () =
   Test_util.with_randomness 123456789 (fun () ->
-      run
-        (generate_base_snarks_witness
-           Transaction_snark.generate_transaction_witness)
-        num_transactions repeats )
+      run (generate_base_snarks_witness num_transactions repeats) )
 
 let command =
   let open Command.Let_syntax in


### PR DESCRIPTION
Description tweak means `coda.exe tra -help` now looks like this
```
  coda.exe transaction-snark-profiler

=== flags ===

  [-check-only]       Just check base snarks, don't keys or time anything
  [-k count]          count = log_2(number of transactions to snark) or none for
                      the mocked ones
  [-repeat count]     number of times to repeat the profile
  [-witness-only]     Just generate the witnesses for the base snarks
  [-help]             print this help text and exit
                      (alias: -?)
```

The `-repeat` argument is useful for profiling multiple runs of the snark profiler, e.g. for o1-labs/snarky#148.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
