### PR TITLE
Remove bin_io from Public_key and Public_key.Compressed

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -51,15 +51,7 @@ end
 module Ledger_hash = struct
   include Ledger_hash
 
-  let of_digest = Ledger_hash.of_digest
-
-  let merge = Ledger_hash.merge
-
-  let to_bytes = Ledger_hash.to_bytes
-
-  let of_digest = Ledger_hash.of_digest
-
-  let merge = Ledger_hash.merge
+  let of_digest, merge, to_bytes = Ledger_hash.(of_digest, merge, to_bytes)
 end
 
 module Frozen_ledger_hash = struct
@@ -668,8 +660,10 @@ struct
     module Proof = Transaction_snark_work_proof
 
     module Fee = struct
+      (* TODO : version Fee *)
       module T = struct
-        type t = {fee: Fee.Unsigned.t; prover: Public_key.Compressed.t}
+        type t =
+          {fee: Fee.Unsigned.t; prover: Public_key.Compressed.Stable.V1.t}
         [@@deriving bin_io, sexp, yojson]
 
         (* TODO: Compare in a better way than with public key, like in transaction pool *)
@@ -1088,10 +1082,17 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
            collision should not happen." ;
         Core.exit 1
 
+  module Receipt_chain_hash = struct
+    (* Receipt.Chain_hash does not have bin_io *)
+    include Receipt.Chain_hash.Stable.V1
+
+    let cons, empty = Receipt.Chain_hash.(cons, empty)
+  end
+
   module Payment_verifier =
     Receipt_chain_database_lib.Verifier.Make
       (User_command)
-      (Receipt.Chain_hash)
+      (Receipt_chain_hash)
 
   let verify_payment t log (addr : Public_key.Compressed.Stable.Latest.t)
       (verifying_txn : User_command.t) proof =

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -10,7 +10,9 @@ open Signature_lib
 open Pipe_lib
 
 module Snark_worker_config = struct
-  type t = {port: int; public_key: Public_key.Compressed.t} [@@deriving bin_io]
+  (* TODO : version *)
+  type t = {port: int; public_key: Public_key.Compressed.Stable.V1.t}
+  [@@deriving bin_io]
 end
 
 module Input = struct
@@ -35,7 +37,7 @@ open Input
 module Send_payment_input = struct
   type t =
     Private_key.t
-    * Public_key.Compressed.t
+    * Public_key.Compressed.Stable.V1.t
     * Currency.Amount.t
     * Currency.Fee.t
     * User_command_memo.t
@@ -57,8 +59,10 @@ module T = struct
   end
 
   module Prove_receipt = struct
+    (* TODO : version *)
     module Input = struct
-      type t = Receipt.Chain_hash.t * Receipt.Chain_hash.t [@@deriving bin_io]
+      type t = Receipt.Chain_hash.Stable.V1.t * Receipt.Chain_hash.Stable.V1.t
+      [@@deriving bin_io]
     end
 
     module Output = struct
@@ -174,11 +178,13 @@ module T = struct
         ()
 
     let get_balance =
-      C.create_rpc ~f:get_balance_impl ~bin_input:Public_key.Compressed.bin_t
+      C.create_rpc ~f:get_balance_impl
+        ~bin_input:Public_key.Compressed.Stable.V1.bin_t
         ~bin_output:Maybe_currency.bin_t ()
 
     let get_nonce =
-      C.create_rpc ~f:get_nonce_impl ~bin_input:Public_key.Compressed.bin_t
+      C.create_rpc ~f:get_nonce_impl
+        ~bin_input:Public_key.Compressed.Stable.V1.bin_t
         ~bin_output:[%bin_type_class: Coda_numbers.Account_nonce.t option] ()
 
     let prove_receipt =
@@ -187,11 +193,13 @@ module T = struct
 
     let send_payment =
       C.create_rpc ~f:send_payment_impl ~bin_input:Send_payment_input.bin_t
-        ~bin_output:[%bin_type_class: Receipt.Chain_hash.t Or_error.t] ()
+        ~bin_output:
+          [%bin_type_class: Receipt.Chain_hash.Stable.V1.t Or_error.t] ()
 
     let process_payment =
       C.create_rpc ~f:process_payment_impl ~bin_input:User_command.bin_t
-        ~bin_output:[%bin_type_class: Receipt.Chain_hash.t Or_error.t] ()
+        ~bin_output:
+          [%bin_type_class: Receipt.Chain_hash.Stable.V1.t Or_error.t] ()
 
     let strongest_ledgers =
       C.create_pipe ~f:strongest_ledgers_impl ~bin_input:Unit.bin_t

--- a/src/lib/coda_base/ancestor.ml
+++ b/src/lib/coda_base/ancestor.ml
@@ -7,7 +7,7 @@ module Input = struct
       module T = struct
         let version = 1
 
-        type t = {descendant: State_hash.t; generations: int}
+        type t = {descendant: State_hash.Stable.V1.t; generations: int}
         [@@deriving sexp, bin_io]
       end
 

--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -6,9 +6,10 @@ module Stable = struct
     module T = struct
       let version = 1
 
+      (* TODO : use version for Fee_transfer *)
       type t =
-        { proposer: Public_key.Compressed.t
-        ; amount: Currency.Amount.t
+        { proposer: Public_key.Compressed.Stable.V1.t
+        ; amount: Currency.Amount.Stable.V1.t
         ; fee_transfer: Fee_transfer.single option }
       [@@deriving sexp, bin_io, compare, eq]
     end

--- a/src/lib/coda_base/data_hash.mli
+++ b/src/lib/coda_base/data_hash.mli
@@ -5,10 +5,8 @@ open Tuple_lib
 open Fold_lib
 
 module type Basic = sig
-  (* TODO: Use stable for bin_io *)
-
   type t = private Pedersen.Digest.t
-  [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+  [@@deriving sexp, eq, compare, hash, yojson]
 
   val gen : t Quickcheck.Generator.t
 
@@ -46,7 +44,7 @@ module type Basic = sig
 
   include Bits_intf.S with type t := t
 
-  include Hashable_binable with type t := t
+  include Hashable with type t := t
 
   val fold : t -> bool Triple.t Fold.t
 end

--- a/src/lib/coda_base/fee_transfer.ml
+++ b/src/lib/coda_base/fee_transfer.ml
@@ -1,9 +1,11 @@
 open Core
 open Import
 
-type single = Public_key.Compressed.t * Currency.Fee.Stable.V1.t
+(* TODO : version *)
+type single = Public_key.Compressed.Stable.V1.t * Currency.Fee.Stable.V1.t
 [@@deriving bin_io, sexp, compare, eq, yojson]
 
+(* TODO : version *)
 type t = One of single | Two of single * single
 [@@deriving bin_io, sexp, compare, eq, yojson]
 

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -22,8 +22,9 @@ module Ledger_inner = struct
   end
 
   module Hash = struct
+    (* TODO : version *)
     module T = struct
-      type t = Ledger_hash.t
+      type t = Ledger_hash.Stable.V1.t
       [@@deriving bin_io, sexp, compare, hash, eq, yojson]
     end
 

--- a/src/lib/coda_base/payment_proof.ml
+++ b/src/lib/coda_base/payment_proof.ml
@@ -2,7 +2,9 @@ open Core_kernel
 open Receipt_chain_database_lib
 
 module T = struct
-  type t = (Receipt.Chain_hash.t, User_command.t) Payment_proof.t
+  (* TODO : version *)
+  type t =
+    (Receipt.Chain_hash.Stable.V1.t, User_command.Stable.V1.t) Payment_proof.t
   [@@deriving eq, sexp, bin_io, yojson]
 end
 

--- a/src/lib/coda_base/receipt_chain_database.ml
+++ b/src/lib/coda_base/receipt_chain_database.ml
@@ -3,9 +3,19 @@ open Receipt_chain_database_lib
 module Payment = User_command
 
 module Tree_node = struct
-  type t = (Receipt.Chain_hash.t, Payment.t) Tree_node.t [@@deriving bin_io]
+  (* TODO : version *)
+  type t = (Receipt.Chain_hash.Stable.V1.t, Payment.t) Tree_node.t
+  [@@deriving bin_io]
 end
 
 module Key_value_store =
-  Rocksdb.Serializable.Make (Receipt.Chain_hash) (Tree_node)
-include Database.Make (Payment) (Receipt.Chain_hash) (Key_value_store)
+  Rocksdb.Serializable.Make (Receipt.Chain_hash.Stable.V1) (Tree_node)
+
+module Receipt_chain_hash = struct
+  (* Receipt.Chain_hash.t is not bin_io *)
+  include Receipt.Chain_hash.Stable.V1
+
+  let empty, cons = Receipt.Chain_hash.(empty, cons)
+end
+
+include Database.Make (Payment) (Receipt_chain_hash) (Key_value_store)

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -2,14 +2,24 @@ open Core
 open Import
 open Snark_params.Tick
 
-include Sparse_ledger_lib.Sparse_ledger.Make
-          (Ledger_hash)
-          (Public_key.Compressed.Stable.V1)
-          (struct
-            include Account.Stable.Latest
+module Ledger_hash_binnable = struct
+  (* Ledger_hash.t not bin_io *)
+  include Ledger_hash.Stable.V1
 
-            let hash = Fn.compose Ledger_hash.of_digest Account.digest
-          end)
+  let merge = Ledger_hash.merge
+end
+
+module Account_binnable = struct
+  (* Account.t not bin_io *)
+  include Account.Stable.V1
+
+  let hash = Fn.compose Ledger_hash.of_digest Account.digest
+end
+
+include Sparse_ledger_lib.Sparse_ledger.Make
+          (Ledger_hash_binnable)
+          (Public_key.Compressed.Stable.V1)
+          (Account_binnable)
 
 let of_root (h : Ledger_hash.t) =
   of_hash ~depth:Ledger.depth (Ledger_hash.of_digest (h :> Pedersen.Digest.t))

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -2,14 +2,14 @@ open Core
 open Import
 open Snark_params.Tick
 
-module Ledger_hash_binnable = struct
+module Ledger_hash_binable = struct
   (* Ledger_hash.t not bin_io *)
   include Ledger_hash.Stable.V1
 
   let merge = Ledger_hash.merge
 end
 
-module Account_binnable = struct
+module Account_binable = struct
   (* Account.t not bin_io *)
   include Account.Stable.V1
 
@@ -17,9 +17,9 @@ module Account_binnable = struct
 end
 
 include Sparse_ledger_lib.Sparse_ledger.Make
-          (Ledger_hash_binnable)
+          (Ledger_hash_binable)
           (Public_key.Compressed.Stable.V1)
-          (Account_binnable)
+          (Account_binable)
 
 let of_root (h : Ledger_hash.t) =
   of_hash ~depth:Ledger.depth (Ledger_hash.of_digest (h :> Pedersen.Digest.t))

--- a/src/lib/coda_base/sparse_ledger.mli
+++ b/src/lib/coda_base/sparse_ledger.mli
@@ -2,7 +2,8 @@ open Core
 open Import
 open Snark_params.Tick
 
-type t [@@deriving bin_io, sexp]
+(* TODO : version *)
+type t [@@deriving sexp, bin_io]
 
 val merkle_root : t -> Ledger_hash.t
 

--- a/src/lib/coda_base/staged_ledger_hash.ml
+++ b/src/lib/coda_base/staged_ledger_hash.ml
@@ -34,7 +34,8 @@ module Aux_hash = struct
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  include Stable.Latest
+  (* bin_io omitted *)
+  type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash, yojson]
 
   let of_bytes = Fn.id
 
@@ -50,7 +51,8 @@ module Stable = struct
     module T = struct
       let version = 1
 
-      type t = {ledger_hash: Ledger_hash.Stable.V1.t; aux_hash: Aux_hash.t}
+      type t =
+        {ledger_hash: Ledger_hash.Stable.V1.t; aux_hash: Aux_hash.Stable.V1.t}
       [@@deriving bin_io, sexp, eq, compare, hash, yojson]
     end
 
@@ -71,7 +73,11 @@ module Stable = struct
   module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.Latest
+(* bin_io omitted *)
+type t = Stable.Latest.t = {ledger_hash: Ledger_hash.t; aux_hash: Aux_hash.t}
+[@@deriving sexp, eq, compare, hash, yojson]
+
+include Hashable.Make (Stable.Latest)
 
 let ledger_hash {ledger_hash; _} = ledger_hash
 

--- a/src/lib/coda_base/staged_ledger_hash.mli
+++ b/src/lib/coda_base/staged_ledger_hash.mli
@@ -3,9 +3,9 @@ open Fold_lib
 open Tuple_lib
 open Snark_params.Tick
 
-type t [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+type t [@@deriving sexp, eq, compare, hash, yojson]
 
-include Hashable_binable with type t := t
+include Hashable with type t := t
 
 type var
 

--- a/src/lib/coda_base/stake_delegation.ml
+++ b/src/lib/coda_base/stake_delegation.ml
@@ -1,14 +1,37 @@
 open Core_kernel
 open Signature_lib
+open Module_version
 
 module Stable = struct
   module V1 = struct
-    type t = Set_delegate of {new_delegate: Public_key.Compressed.t}
-    [@@deriving bin_io, eq, sexp, hash, yojson]
+    module T = struct
+      let version = 1
+
+      type t =
+        | Set_delegate of {new_delegate: Public_key.Compressed.Stable.V1.t}
+      [@@deriving bin_io, eq, sexp, hash, yojson]
+    end
+
+    include T
+    include Registration.Make_latest_version (T)
   end
+
+  module Latest = V1
+
+  module Module_decl = struct
+    let name = "stake_delegation"
+
+    type latest = Latest.t
+  end
+
+  module Registrar = Registration.Make (Module_decl)
+  module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.V1
+(* bin_io omitted *)
+type t = Stable.Latest.t =
+  | Set_delegate of {new_delegate: Public_key.Compressed.Stable.V1.t}
+[@@deriving eq, sexp, hash, yojson]
 
 let gen =
   Quickcheck.Generator.map Public_key.Compressed.gen ~f:(fun k ->

--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -2,7 +2,9 @@ open Core_kernel
 open Module_version
 
 module Hash = struct
-  include Ledger_hash
+  include Ledger_hash.Stable.V1
+
+  let merge = Ledger_hash.merge
 
   let hash_account = Fn.compose Ledger_hash.of_digest Account.digest
 

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -117,40 +117,49 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
     module UC = User_command
 
     module User_command = struct
+      (* TODO: version *)
       module Common = struct
         type t =
-          { user_command: User_command.t
-          ; previous_receipt_chain_hash: Receipt.Chain_hash.t }
+          { user_command: User_command.Stable.V1.t
+          ; previous_receipt_chain_hash: Receipt.Chain_hash.Stable.V1.t }
         [@@deriving sexp, bin_io]
       end
 
       module Body = struct
+        (* TODO: version *)
         type t =
-          | Payment of {previous_empty_accounts: Public_key.Compressed.t list}
-          | Stake_delegation of {previous_delegate: Public_key.Compressed.t}
+          | Payment of
+              { previous_empty_accounts: Public_key.Compressed.Stable.V1.t list
+              }
+          | Stake_delegation of
+              { previous_delegate: Public_key.Compressed.Stable.V1.t }
         [@@deriving sexp, bin_io]
       end
 
       type t = {common: Common.t; body: Body.t} [@@deriving sexp, bin_io]
     end
 
+    (* TODO : version *)
     type fee_transfer =
       { fee_transfer: Fee_transfer.t
-      ; previous_empty_accounts: Public_key.Compressed.t list }
+      ; previous_empty_accounts: Public_key.Compressed.Stable.V1.t list }
     [@@deriving sexp, bin_io]
 
+    (* TODO : version *)
     type coinbase =
       { coinbase: Coinbase.Stable.V1.t
-      ; previous_empty_accounts: Public_key.Compressed.t list }
+      ; previous_empty_accounts: Public_key.Compressed.Stable.V1.t list }
     [@@deriving sexp, bin_io]
 
+    (* TODO : version *)
     type varying =
       | User_command of User_command.t
       | Fee_transfer of fee_transfer
       | Coinbase of coinbase
     [@@deriving sexp, bin_io]
 
-    type t = {previous_hash: Ledger_hash.t; varying: varying}
+    (* TODO : version *)
+    type t = {previous_hash: Ledger_hash.Stable.V1.t; varying: varying}
     [@@deriving sexp, bin_io]
 
     let transaction : t -> Transaction.t Or_error.t =

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -19,7 +19,7 @@ module Stable = struct
         {payload: 'payload; sender: 'pk; signature: 'signature}
       [@@deriving bin_io, eq, sexp, hash, yojson]
 
-      type t = (Payload.Stable.V1.t, Public_key.t, Signature.t) t_
+      type t = (Payload.Stable.V1.t, Public_key.Stable.V1.t, Signature.t) t_
       [@@deriving bin_io, eq, sexp, hash, yojson]
 
       type with_seed = string * t [@@deriving hash]

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -234,7 +234,8 @@ struct
 
         type response =
           ( ( External_transition.Stable.V1.t
-            , State_body_hash.t list * External_transition.Stable.V1.t )
+            , State_body_hash.Stable.V1.t list
+              * External_transition.Stable.V1.t )
             Proof_carrying_data.Stable.V1.t
           * Staged_ledger_aux.Stable.V1.t
           * Ledger_hash.Stable.V1.t )

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -102,7 +102,7 @@ module Consensus_state = struct
         module T = struct
           let version = 1
 
-          type t = (Length.t, Public_key.Compressed.t) t_
+          type t = (Length.t, Public_key.Compressed.Stable.V1.t) t_
           [@@deriving bin_io, sexp, hash, compare, to_yojson]
         end
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -673,8 +673,13 @@ module Epoch_data = struct
     ; length: 'length }
   [@@deriving sexp, bin_io, eq, compare, hash, to_yojson]
 
+  (* TODO : version *)
   type value =
-    (Epoch_ledger.value, Epoch_seed.t, Coda_base.State_hash.t, Length.t) t
+    ( Epoch_ledger.value
+    , Epoch_seed.Stable.V1.t
+    , Coda_base.State_hash.Stable.V1.t
+    , Length.t )
+    t
   [@@deriving sexp, bin_io, eq, compare, hash, to_yojson]
 
   type var =
@@ -890,11 +895,12 @@ module Checkpoints = struct
       let to_yojson f t = List.to_yojson f (to_list t)
     end
 
+    (* TODO : version *)
     type t =
       { (* TODO: Make a nice way to force this to have bounded (or fixed) size for
          bin_io reasons *)
-        prefix: Coda_base.State_hash.t Q.t
-      ; tail: Hash.t }
+        prefix: Coda_base.State_hash.Stable.V1.t Q.t
+      ; tail: Hash.Stable.V1.t }
     [@@deriving sexp, bin_io, compare, hash, to_yojson]
 
     let equal t1 t2 = compare t1 t2 = 0

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -292,7 +292,8 @@ module Epoch_ledger = struct
   type ('ledger_hash, 'amount) t = {hash: 'ledger_hash; total_currency: 'amount}
   [@@deriving sexp, bin_io, eq, compare, hash, to_yojson]
 
-  type value = (Coda_base.Frozen_ledger_hash.t, Amount.t) t
+  (* TODO : version *)
+  type value = (Coda_base.Frozen_ledger_hash.Stable.V1.t, Amount.t) t
   [@@deriving sexp, bin_io, eq, compare, hash, to_yojson]
 
   type var = (Coda_base.Frozen_ledger_hash.var, Amount.var) t
@@ -848,7 +849,7 @@ module Global_slot = struct
       + (UInt32.to_int Constants.Epoch.size * Epoch.to_int epoch) )
 
   module Checked = struct
-    (* TODO: It's possible to share this hash computation with 
+    (* TODO: It's possible to share this hash computation with
        the hashing of the state. Might be worth doing. *)
     let create ~(epoch : Epoch.Unpacked.var) ~(slot : Epoch.Slot.Unpacked.var)
         =

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -237,7 +237,7 @@ module Types = struct
       ; user_commands_sent: int
       ; run_snark_worker: bool
       ; is_bootstrapping: bool
-      ; propose_pubkey: Public_key.t option
+      ; propose_pubkey: Public_key.Stable.Latest.t option
       ; histograms: Histograms.t option
       ; consensus_time_best_tip: string option
       ; consensus_time_now: string
@@ -270,7 +270,8 @@ end
 module Send_user_command = struct
   type query = User_command.Stable.Latest.t [@@deriving bin_io]
 
-  type response = Receipt.Chain_hash.t Or_error.t [@@deriving bin_io]
+  type response = Receipt.Chain_hash.Stable.Latest.t Or_error.t
+  [@@deriving bin_io]
 
   type error = unit [@@deriving bin_io]
 
@@ -294,7 +295,7 @@ end
 module Get_ledger = struct
   type query = Staged_ledger_hash.Stable.Latest.t [@@deriving bin_io]
 
-  type response = Account.Stable.V1.t list Or_error.t [@@deriving bin_io]
+  type response = Account.Stable.Latest.t list Or_error.t [@@deriving bin_io]
 
   type error = unit [@@deriving bin_io]
 
@@ -327,7 +328,8 @@ module Verify_proof = struct
 end
 
 module Prove_receipt = struct
-  type query = Receipt.Chain_hash.t * Public_key.Compressed.Stable.Latest.t
+  type query =
+    Receipt.Chain_hash.Stable.Latest.t * Public_key.Compressed.Stable.Latest.t
   [@@deriving bin_io]
 
   type response = Payment_proof.t Or_error.t [@@deriving bin_io]

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -1,7 +1,15 @@
 open Core
 
 module type Key = sig
-  type t [@@deriving sexp, bin_io]
+  type t [@@deriving sexp]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io]
+      end
+    end
+    with type V1.t = t
 
   val empty : t
 

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -4,13 +4,13 @@ open Tick
 open Tuple_lib
 open Fold_lib
 
-type t = Field.t * Field.t [@@deriving bin_io, sexp, hash]
+type t = Field.t * Field.t [@@deriving sexp, hash]
 
 include Codable.S with type t := t
 
 module Stable : sig
   module V1 : sig
-    type nonrec t = t [@@deriving bin_io, sexp, compare, eq, hash]
+    type nonrec t = t [@@deriving bin_io, sexp, compare, eq, hash, yojson]
   end
 
   module Latest = V1
@@ -29,7 +29,7 @@ val of_private_key_exn : Private_key.t -> t
 module Compressed : sig
   type ('field, 'boolean) t_ = {x: 'field; is_odd: 'boolean}
 
-  type t = (Field.t, bool) t_ [@@deriving bin_io, sexp, hash, yojson]
+  type t = (Field.t, bool) t_ [@@deriving sexp, hash, yojson]
 
   include Codable.S with type t := t
 
@@ -55,7 +55,7 @@ module Compressed : sig
 
   val var_of_t : t -> var
 
-  include Comparable.S_binable with type t := t
+  include Comparable.S with type t := t
 
   include Hashable.S_binable with type t := t
 

--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -18,11 +18,12 @@ module Spec = struct
 end
 
 module Result = struct
+  (* TODO : version *)
   type ('spec, 'single) t =
     { proofs: 'single list
     ; metrics: (Time.Span.t * [`Transition | `Merge]) list
     ; spec: 'spec
-    ; prover: Signature_lib.Public_key.Compressed.t }
+    ; prover: Signature_lib.Public_key.Compressed.Stable.V1.t }
   [@@deriving bin_io, fields]
 end
 

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -63,6 +63,7 @@ struct
 
   type t_tmp = (Hash.t, Key.t, Account.t) t [@@deriving bin_io, sexp]
 
+  (* TODO : version *)
   type t = t_tmp [@@deriving bin_io, sexp]
 
   let of_hash = of_hash

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1403,7 +1403,20 @@ let%test_module "test" =
           | _ -> Error "expected string"
       end
 
-      module Compressed_public_key = String
+      (* mirrors module structure of Public_key.Compressed *)
+      module Compressed_public_key = struct
+        type t = string [@@deriving sexp, compare, yojson]
+
+        module Stable = struct
+          module V1 = struct
+            type t = string [@@deriving sexp, bin_io, compare, eq, yojson]
+          end
+        end
+
+        let to_yojson, of_yojson = String.(to_yojson, of_yojson)
+
+        include Comparable.Make_binable (String)
+      end
 
       module Sok_message = struct
         module Stable = struct
@@ -1454,7 +1467,7 @@ let%test_module "test" =
       end
 
       module Fee_transfer = struct
-        type public_key = Compressed_public_key.t
+        type public_key = Compressed_public_key.Stable.V1.t
         [@@deriving sexp, bin_io, compare, eq, yojson]
 
         type fee = Fee.Unsigned.t
@@ -1814,7 +1827,7 @@ let%test_module "test" =
 
         type fee = Fee.Unsigned.t [@@deriving sexp, bin_io, compare, yojson]
 
-        type public_key = Compressed_public_key.t
+        type public_key = Compressed_public_key.Stable.V1.t
         [@@deriving sexp, bin_io, compare, yojson]
 
         module Stable = struct
@@ -1891,7 +1904,7 @@ let%test_module "test" =
           User_command.With_valid_signature.t
         [@@deriving sexp, bin_io, compare, yojson]
 
-        type public_key = Compressed_public_key.t
+        type public_key = Compressed_public_key.Stable.V1.t
         [@@deriving sexp, bin_io, compare, yojson]
 
         type staged_ledger_hash = Staged_ledger_hash.t

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -96,8 +96,8 @@ end) :
 
         type t =
           { diff: diff
-          ; prev_hash: Staged_ledger_hash.t
-          ; creator: Compressed_public_key.t }
+          ; prev_hash: Staged_ledger_hash.t (* TODO : version *)
+          ; creator: Compressed_public_key.Stable.V1.t }
         [@@deriving sexp, bin_io]
       end
 

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -62,11 +62,18 @@ struct
   module Transaction_snark_work =
     Staged_ledger.Make_completed_work (Ledger_proof) (Ledger_proof_statement)
 
+  module Staged_ledger_hash_binable = struct
+    include Staged_ledger_hash.Stable.V1
+
+    let of_aux_and_ledger_hash, aux_hash, ledger_hash =
+      Staged_ledger_hash.(of_aux_and_ledger_hash, aux_hash, ledger_hash)
+  end
+
   module Staged_ledger_diff = Staged_ledger.Make_diff (struct
     module Fee_transfer = Fee_transfer
     module Ledger_proof = Ledger_proof
     module Ledger_hash = Ledger_hash
-    module Staged_ledger_hash = Staged_ledger_hash
+    module Staged_ledger_hash = Staged_ledger_hash_binable
     module Staged_ledger_aux_hash = Staged_ledger_aux_hash
     module Compressed_public_key = Public_key.Compressed
     module User_command = User_command
@@ -108,7 +115,7 @@ struct
     module Ledger_proof = Ledger_proof
     module Ledger_proof_verifier = Ledger_proof_verifier
     module Staged_ledger_aux_hash = Staged_ledger_aux_hash
-    module Staged_ledger_hash = Coda_base.Staged_ledger_hash
+    module Staged_ledger_hash = Staged_ledger_hash_binable
     module Transaction_snark_work = Transaction_snark_work
     module Transaction_validator = Transaction_validator
     module Staged_ledger_diff = Staged_ledger_diff

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -130,7 +130,7 @@ module type Ledger_hash_intf = sig
 
   val to_bytes : t -> string
 
-  include Hashable.S_binable with type t := t
+  include Hashable.S with type t := t
 end
 
 module type Frozen_ledger_hash_intf = sig
@@ -325,7 +325,15 @@ module type Private_key_intf = sig
 end
 
 module type Compressed_public_key_intf = sig
-  type t [@@deriving sexp, bin_io, compare, yojson]
+  type t [@@deriving sexp, compare, yojson]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io, compare, yojson]
+      end
+    end
+    with type V1.t = t
 
   include Comparable.S with type t := t
 end


### PR DESCRIPTION
Removed `bin_io` for `Public_key` and its `Compressed` submodule, propagate that change.

Lots of types are marked with TODO to version them.

There are some unfortunate `include`s in modules to get `bin_io`, needed because of existing monkeypatching.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
