### PR TITLE
Bump generated keypairs and begin many_stakers

### DIFF
--- a/src/config/testnet_postake_many_proposers.mlh
+++ b/src/config/testnet_postake_many_proposers.mlh
@@ -1,0 +1,18 @@
+[%%import "config/ledger_depth/full.mlh"]
+[%%import "config/curve_size/small.mlh"]
+[%%import "config/coinbase/standard.mlh"]
+[%%import "config/consensus/postake_tiny.mlh"]
+[%%import "config/scan_state/small.mlh"]
+[%%import "config/debug_level/some.mlh"]
+[%%import "config/proof_level/full.mlh"]
+
+[%%define time_offsets false]
+[%%define cache_exceptions false]
+[%%define fake_hash false]
+
+[%%define genesis_ledger "testnet_postake_many_proposers"]
+[%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
+[%%define block_window_duration 30000]
+
+[%%define integration_tests false]
+[%%define force_updates false]

--- a/src/lib/coda_base/gen/gen.ml
+++ b/src/lib/coda_base/gen/gen.ml
@@ -27,7 +27,7 @@ let rec random_scalar () =
   else random_scalar ()
 
 let keypairs =
-  let n = 40 in
+  let n = 120 in
   List.init n ~f:(fun _ ->
       let pk = random_scalar () in
       Keypair.of_private_key_exn pk )

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -34,6 +34,11 @@ genesis_ledger = "testnet_postake"]
 
 include Testnet_postake_ledger
 
+[%%elif
+genesis_ledger = "testnet_postake_many_proposers"]
+
+include Testnet_postake_ledger_many_proposers
+
 [%%else]
 
 [%%error

--- a/src/lib/genesis_ledger/test_split_two_stakes_ledger.ml
+++ b/src/lib/genesis_ledger/test_split_two_stakes_ledger.ml
@@ -4,26 +4,9 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let balances =
-      [ 5_000_000
-      ; 5_000_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000 ]
-    in
+    let high_balances = List.init 2 ~f:(Fn.const 5_000_000) in
+    let low_balances = List.init 16 ~f:(Fn.const 1_000) in
+    let balances = high_balances @ low_balances in
     List.mapi balances ~f:(fun i b ->
         { balance= b
         ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)

--- a/src/lib/genesis_ledger/testnet_posig_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_posig_ledger.ml
@@ -4,26 +4,9 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let balances =
-      [ 10_000_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000 ]
-    in
+    let high_balances = List.init 1 ~f:(Fn.const 10_000_000) in
+    let low_balances = List.init 17 ~f:(Fn.const 1_000) in
+    let balances = high_balances @ low_balances in
     List.mapi balances ~f:(fun i b ->
         { balance= b
         ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -4,26 +4,9 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let balances =
-      [ 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000 ]
-    in
+    let high_balances = List.init 5 ~f:(Fn.const 5_000_000) in
+    let low_balances = List.init 13 ~f:(Fn.const 1_000) in
+    let balances = high_balances @ low_balances in
     List.mapi balances ~f:(fun i b ->
         { balance= b
         ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)

--- a/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
@@ -1,0 +1,46 @@
+open Functor.With_private
+open Core
+
+(* TODO: generate new keypairs before public testnet *)
+include Make (struct
+  let accounts =
+    let balances =
+      [ 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 5_000_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000
+      ; 1_000 ]
+    in
+    List.mapi balances ~f:(fun i b ->
+        { balance= b
+        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
+        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
+end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
@@ -4,41 +4,9 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let balances =
-      [ 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 5_000_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000 ]
-    in
+    let high_balances = List.init 20 ~f:(Fn.const 5_000_000) in
+    let low_balances = List.init 10 ~f:(Fn.const 1_000) in
+    let balances = high_balances @ low_balances in
     List.mapi balances ~f:(fun i b ->
         { balance= b
         ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)


### PR DESCRIPTION
- bumps generated keys up from 40 to 120
- creates a new postake genesis ledger option with 20 large balance accounts
