### PR TITLE
Versioning for Transaction_snark

### DIFF
--- a/src/app/cli/src/ledger_proof.ml
+++ b/src/app/cli/src/ledger_proof.ml
@@ -21,7 +21,8 @@ module Prod :
       module T = struct
         let version = 1
 
-        type t = Transaction_snark.t [@@deriving bin_io, sexp, yojson]
+        type t = Transaction_snark.Stable.V1.t
+        [@@deriving bin_io, sexp, yojson]
       end
 
       include T

--- a/src/app/cli/src/verifier.ml
+++ b/src/app/cli/src/verifier.ml
@@ -109,7 +109,8 @@ module Worker = struct
         { verify_blockchain= f (Blockchain.bin_t, Bool.bin_t, verify_blockchain)
         ; verify_transaction_snark=
             f
-              ( [%bin_type_class: Transaction_snark.t * Sok_message.Stable.V1.t]
+              ( [%bin_type_class:
+                  Transaction_snark.Stable.V1.t * Sok_message.Stable.V1.t]
               , Bool.bin_t
               , verify_transaction_snark ) }
 

--- a/src/lib/snark_worker_lib/prod.ml
+++ b/src/lib/snark_worker_lib/prod.ml
@@ -37,7 +37,7 @@ module Inputs = struct
     let worker_wait_time = 5.
   end
 
-  module Proof = Transaction_snark
+  module Proof = Transaction_snark.Stable.V1
   module Statement = Transaction_snark.Statement
 
   module Public_key = struct

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -106,8 +106,8 @@ module Stable = struct
 
       type t =
         { source: Frozen_ledger_hash.Stable.V1.t
-        ; target: Frozen_ledger_hash.Stable.V1.t (* TODO : version *)
-        ; proof_type: Proof_type.t
+        ; target: Frozen_ledger_hash.Stable.V1.t
+        ; proof_type: Proof_type.Stable.V1.t
         ; supply_increase: Amount.Stable.V1.t
         ; fee_excess: Amount.Signed.Stable.V1.t
         ; sok_digest: Sok_message.Digest.Stable.V1.t

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -24,7 +24,17 @@ module Statement : sig
   include Comparable.S with type t := t
 end
 
-type t [@@deriving bin_io, sexp, yojson]
+type t [@@deriving sexp, yojson]
+
+module Stable :
+  sig
+    module V1 : sig
+      type t [@@deriving bin_io, sexp, yojson]
+    end
+
+    module Latest = V1
+  end
+  with type V1.t = t
 
 val create :
      source:Frozen_ledger_hash.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -225,7 +225,7 @@ end = struct
 
   type t = Stable.Latest.t =
     { tree:
-        ( Ledger_proof_with_sok_message.t
+        ( Ledger_proof_with_sok_message.Stable.V1.t
         , Transaction_with_witness.Stable.V1.t )
         Parallel_scan.State.Stable.V1.t
     ; mutable job_count: int }


### PR DESCRIPTION
Audit of RPC type dependencies found another type that needs versioning.

As a result of this change, `Proof_type` will need to be versioned.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
