### PR TITLE
Better cryptoapps section

### DIFF
--- a/frontend/website/src/CryptoAppsSection.re
+++ b/frontend/website/src/CryptoAppsSection.re
@@ -29,7 +29,8 @@ module Code = {
 let swapQuery = "(min-width: 70rem)";
 
 module ImageCollage = {
-  let component = ReasonReact.statelessComponent("CryptoAppsSection");
+  let component =
+    ReasonReact.statelessComponent("CryptoAppsSection.ImageCollage");
   let make = (~className, _children) => {
     ...component,
     render: _self =>

--- a/frontend/website/src/CryptoAppsSection.re
+++ b/frontend/website/src/CryptoAppsSection.re
@@ -11,9 +11,10 @@ module Code = {
             @ [
               backgroundColor(Style.Colors.navy),
               color(Style.Colors.white),
-              Style.Typeface.ibmplexmono,
-              fontSize(`rem(0.75)),
-              borderRadius(`px(5)),
+              Style.Typeface.ibmplexsans,
+              fontSize(`rem(0.8125)),
+              borderRadius(`px(12)),
+              lineHeight(`rem(1.25)),
               // nudge so code background looks nicer
               marginRight(`rem(-0.25)),
               marginLeft(`rem(-0.25)),
@@ -25,10 +26,75 @@ module Code = {
   };
 };
 
+let swapQuery = "(min-width: 70rem)";
+
+module ImageCollage = {
+  let component = ReasonReact.statelessComponent("CryptoAppsSection");
+  let make = (~className, _children) => {
+    ...component,
+    render: _self =>
+      <div
+        className=Css.(
+          merge([
+            className,
+            style([
+              position(`relative),
+              top(`zero),
+              left(`zero),
+              media(swapQuery, [position(`static)]),
+            ]),
+          ])
+        )>
+        <Image
+          className=Css.(
+            style([
+              position(`relative),
+              top(`zero),
+              left(`zero),
+              right(`zero),
+              bottom(`zero),
+              margin(`auto),
+              maxWidth(`percent(100.0)),
+            ])
+          )
+          name="/static/img/map"
+        />
+        <Image
+          className=Css.(
+            style([
+              position(`absolute),
+              top(`zero),
+              left(`zero),
+              right(`zero),
+              bottom(`zero),
+              margin(`auto),
+              maxWidth(`percent(100.0)),
+            ])
+          )
+          name="/static/img/build-illustration"
+        />
+        <Image
+          className=Css.(
+            style([
+              position(`absolute),
+              top(`zero),
+              left(`zero),
+              right(`zero),
+              bottom(`zero),
+              margin(`auto),
+              maxWidth(`percent(100.0)),
+            ])
+          )
+          name="/static/img/coda"
+        />
+      </div>,
+  };
+};
+
 let component = ReasonReact.statelessComponent("CryptoAppsSection");
 let make = _ => {
   ...component,
-  render: _self =>
+  render: _self => {
     <div
       className=Css.(
         style([
@@ -36,37 +102,72 @@ let make = _ => {
           media(Style.MediaQuery.full, [marginTop(`rem(8.0))]),
         ])
       )>
-      <h1 className=Style.H1.hero>
+      <h1
+        className=Css.(merge([Style.H1.hero, style([textAlign(`center)])]))>
         {ReasonReact.string("Build global cryptocurrency apps with Coda")}
       </h1>
-      <div>
-        <p className=Style.Body.basic>
-          {ReasonReact.string(
-             "Empower your users with a direct secure connection to the Coda network.",
-           )}
-          <br />
-          <br />
-          {ReasonReact.string(
-             "Coda will be able to be embedded into any webpage or app with just a script tag and a couple lines of JavaScript.",
-           )}
-        </p>
-      </div>
-      <a
-        href=Links.mailingList
+      <div
         className=Css.(
-          merge([Style.Link.basic, style([marginTop(`rem(1.5))])])
+          style([position(`relative), top(`zero), left(`zero)])
         )>
-        {ReasonReact.string(
-           {j|Stay updated about developing with Coda\u00A0→|j},
-         )}
-      </a>
-      <Code
-        src={|<script src="https://codaprotocol.com/api.js"></script>
+        <ImageCollage
+          className=Css.(
+            style([display(`none), media(swapQuery, [display(`block)])])
+          )
+        />
+        <div
+          className=Css.(
+            style([
+              display(`flex),
+              flexWrap(`wrapReverse),
+              justifyContent(`spaceBetween),
+              alignItems(`center),
+              marginLeft(`auto),
+              marginRight(`auto),
+              marginBottom(`rem(4.0)),
+              maxWidth(`rem(78.0)),
+              // vertically/horiz center absolutely
+              media(
+                swapQuery,
+                [
+                  position(`absolute),
+                  top(`percent(50.0)),
+                  left(`percent(50.0)),
+                  transforms([
+                    `translateX(`percent(-50.0)),
+                    `translateY(`percent(-50.0)),
+                  ]),
+                  width(`percent(100.0)),
+                ],
+              ),
+            ])
+          )>
+          <Code
+            src={|<script src="https://codaprotocol.com/api.js"></script>
 <script>
   onClick(button)
      .then(() => Coda.requestWallet())
      .then((wallet) => Coda.sendTransaction(wallet, ...))
 </script>|}
-      />
-    </div>,
+          />
+          <SideText
+            paragraphs=[|
+              "Empower your users with a direct secure connection to the Coda network.",
+              "Coda will be able to be embedded into any webpage or app with just a script tag and a couple lines of JavaScript.",
+            |]
+            cta="Stay updated about developing with Coda"
+          />
+        </div>
+        <ImageCollage
+          className=Css.(
+            style([
+              display(`block),
+              marginBottom(`rem(4.0)),
+              media(swapQuery, [display(`none)]),
+            ])
+          )
+        />
+      </div>
+    </div>;
+  },
 };

--- a/frontend/website/src/Image.re
+++ b/frontend/website/src/Image.re
@@ -1,0 +1,13 @@
+let component = ReasonReact.statelessComponent("CryptoAppsSection");
+let make = (~className, ~name, _children) => {
+  ...component,
+  render: _self => {
+    <img
+      className
+      src={name ++ ".png"}
+      srcSet={
+        name ++ ".png 1x, " ++ name ++ "@2x.png 2x, " ++ name ++ "@3x.png 3x"
+      }
+    />;
+  },
+};

--- a/frontend/website/src/SideText.re
+++ b/frontend/website/src/SideText.re
@@ -1,0 +1,21 @@
+let component = ReasonReact.statelessComponent("SideText");
+let make = (~paragraphs, ~cta, _children) => {
+  ...component,
+  render: _self => {
+    let ps =
+      Belt.Array.map(paragraphs, p =>
+        <p className=Style.Body.basic key=p> {ReasonReact.string(p)} </p>
+      );
+
+    <div className=Css.(style([width(`rem(21.0))]))>
+      {ReasonReact.array(ps)}
+      <a
+        href=Links.mailingList
+        className=Css.(
+          merge([Style.Link.basic, style([marginTop(`rem(1.5))])])
+        )>
+        {ReasonReact.string(cta ++ {j|\u00A0→|j})}
+      </a>
+    </div>;
+  },
+};

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -77,7 +77,7 @@ module H1 = {
   let hero =
     style([
       Typeface.ibmplexsans,
-      fontWeight(`light),
+      fontWeight(`num(300)),
       fontSize(`rem(2.25)),
       letterSpacing(`rem(-0.02375)),
       lineHeight(`rem(3.0)),

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -77,7 +77,7 @@ module H1 = {
   let hero =
     style([
       Typeface.ibmplexsans,
-      fontWeight(`num(300)),
+      fontWeight(`light),
       fontSize(`rem(2.25)),
       letterSpacing(`rem(-0.02375)),
       lineHeight(`rem(3.0)),

--- a/frontend/website/src/Wrapped.re
+++ b/frontend/website/src/Wrapped.re
@@ -8,8 +8,13 @@ let make = children => {
           margin(`auto),
           media(
             Style.MediaQuery.full,
-            [maxWidth(`rem(84.0)), margin(`auto)],
+            [
+              maxWidth(`rem(84.0)),
+              margin(`auto),
+              ...Style.paddingX(`rem(3.0)),
+            ],
           ),
+          ...Style.paddingX(`rem(1.25)),
         ])
       )>
       ...children

--- a/frontend/website/static/img/build-illustration.png
+++ b/frontend/website/static/img/build-illustration.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3851cb3e0d09a7026d3d80f57d99c4ce77a998edd966bbef6fee9ebf2c0bc541
+size 40907

--- a/frontend/website/static/img/build-illustration@2x.png
+++ b/frontend/website/static/img/build-illustration@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f92794e00788b9dc0f6022189c58ed8926d995121168a1a37b3da6cafc27d73
+size 104461

--- a/frontend/website/static/img/build-illustration@3x.png
+++ b/frontend/website/static/img/build-illustration@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11f322289f70200577f1561bba05a93710b4d30641ee23ea349d04614c39a16a
+size 185353

--- a/frontend/website/static/img/coda.png
+++ b/frontend/website/static/img/coda.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d00b7258a0d11882b590104aeba97a61a2ffbeb5dd99d73c87585d210b02bc5c
+size 59878

--- a/frontend/website/static/img/coda@2x.png
+++ b/frontend/website/static/img/coda@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6f20bf38af42251d91b10fc98c89633b40ba497e986b8d0d20f65b46c51905c
+size 209540

--- a/frontend/website/static/img/coda@3x.png
+++ b/frontend/website/static/img/coda@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6609d20d9daf94296da60d1458b9d70eb5b9fe588c6b2e59ba9f33a69f62a32
+size 412251

--- a/frontend/website/static/img/map.png
+++ b/frontend/website/static/img/map.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11ab828d456a90cc147759d7057bf54291770acb69fbe41dfee1e4762a3cf926
+size 371412

--- a/frontend/website/static/img/map@2x.png
+++ b/frontend/website/static/img/map@2x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19d09bbf4d7387edad3866a8a04c383797bc8f01bfa230e91e8ab5233028a0a5
+size 514962

--- a/frontend/website/static/img/map@3x.png
+++ b/frontend/website/static/img/map@3x.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:851cea8568105d46a8fb5e7e0939eb9c52b926399b1b47760ca4b238a368d7e8
+size 705813


### PR DESCRIPTION
* `SideText` component can be reused on the next few sections.
* The PNG background images need to be re-centered when they're exported then it will look a bit better
* I didn't do the line from the code to the coda
* Flex-wrap makes it hard to center, will fix later

Not quite perfect, but much better than before:

## Full screen

<img width="1466" alt="Screen Shot 2019-03-20 at 4 19 52 PM" src="https://user-images.githubusercontent.com/515445/54725493-872c9180-4b2c-11e9-9361-e046949e9e8a.png">


## First breakpoint

<img width="1144" alt="Screen Shot 2019-03-20 at 4 20 18 PM" src="https://user-images.githubusercontent.com/515445/54725464-65cba580-4b2c-11e9-9dda-50c1a2e5e70e.png">

## Flex wrap

<img width="757" alt="Screen Shot 2019-03-20 at 4 20 32 PM" src="https://user-images.githubusercontent.com/515445/54725465-65cba580-4b2c-11e9-8e89-eab8dbdb2974.png">

## Mobile (large)

<img width="382" alt="Screen Shot 2019-03-20 at 4 20 57 PM" src="https://user-images.githubusercontent.com/515445/54725467-65cba580-4b2c-11e9-888f-508e8da4a847.png">
