### PR TITLE
Version Proof_type

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -261,7 +261,7 @@ end
 
 module Message (Inputs : sig
   module Snark_pool_diff : sig
-    type t [@@deriving sexp, to_yojson]
+    type t [@@deriving sexp]
 
     module Stable :
       sig
@@ -273,7 +273,7 @@ module Message (Inputs : sig
   end
 
   module Transaction_pool_diff : sig
-    type t [@@deriving sexp, to_yojson]
+    type t [@@deriving sexp]
 
     module Stable :
       sig

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -29,13 +29,13 @@ val of_private_key_exn : Private_key.t -> t
 module Compressed : sig
   type ('field, 'boolean) t_ = {x: 'field; is_odd: 'boolean}
 
-  type t = (Field.t, bool) t_ [@@deriving sexp, hash, yojson]
+  type t = (Field.t, bool) t_ [@@deriving sexp, hash]
 
   include Codable.S with type t := t
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving sexp, bin_io, eq, compare, hash, yojson]
+      type nonrec t = t [@@deriving sexp, bin_io, eq, compare, hash]
 
       include Codable.S with type t := t
     end

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -4,7 +4,7 @@
  (flags :standard -short-paths -warn-error -9-32-27-58)
  (library_flags -linkall)
  (inline_tests)
- (libraries core cache_dir cached snarky coda_base bignum)
+ (libraries core cache_dir cached snarky coda_base bignum module_version)
  (preprocess
   (pps ppx_snarky ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Transaction state transition snarking library"))

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -4,6 +4,7 @@ open Coda_base
 open Snark_params
 open Currency
 open Fold_lib
+open Module_version
 
 let state_hash_size_in_triples = Tick.Field.size_in_triples
 
@@ -24,7 +25,33 @@ module Input = struct
 end
 
 module Proof_type = struct
-  type t = [`Merge | `Base] [@@deriving bin_io, sexp, hash, compare, yojson]
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        let version = 1
+
+        type t = [`Merge | `Base]
+        [@@deriving bin_io, sexp, hash, compare, yojson]
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "transaction_snark_proof_type"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
+  end
+
+  (* bin_io omitted *)
+  type t = Stable.Latest.t [@@deriving sexp, hash, compare, yojson]
 
   let is_base = function `Base -> true | `Merge -> false
 end
@@ -36,7 +63,7 @@ module Statement = struct
       ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
       ; supply_increase: Currency.Amount.Stable.V1.t
       ; fee_excess: Currency.Fee.Signed.Stable.V1.t
-      ; proof_type: Proof_type.t }
+      ; proof_type: Proof_type.Stable.V1.t }
     [@@deriving sexp, bin_io, hash, compare, fields, yojson]
 
     let option lab =
@@ -75,7 +102,7 @@ end
 type t =
   { source: Frozen_ledger_hash.Stable.V1.t
   ; target: Frozen_ledger_hash.Stable.V1.t
-  ; proof_type: Proof_type.t
+  ; proof_type: Proof_type.Stable.V1.t
   ; supply_increase: Amount.Stable.V1.t
   ; fee_excess: Amount.Signed.Stable.V1.t
   ; sok_digest: Sok_message.Digest.Stable.V1.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -30,7 +30,7 @@ module Proof_type = struct
       module T = struct
         let version = 1
 
-        type t = [`Merge | `Base]
+        type t = [`Base | `Merge]
         [@@deriving bin_io, sexp, hash, compare, yojson]
       end
 

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -3,7 +3,15 @@ open Coda_base
 open Snark_params
 
 module Proof_type : sig
-  type t = [`Merge | `Base] [@@deriving bin_io, sexp, yojson]
+  module Stable : sig
+    module V1 : sig
+      type t = [`Base | `Merge] [@@deriving bin_io, sexp, yojson]
+    end
+
+    module Latest = V1
+  end
+
+  type t = Stable.Latest.t [@@deriving sexp, yojson]
 end
 
 module Statement : sig
@@ -12,8 +20,8 @@ module Statement : sig
     ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
     ; supply_increase: Currency.Amount.Stable.V1.t
     ; fee_excess: Currency.Fee.Signed.Stable.V1.t
-    ; proof_type: Proof_type.t }
-  [@@deriving sexp, bin_io, hash, compare, eq, fields, yojson]
+    ; proof_type: Proof_type.Stable.V1.t }
+  [@@deriving sexp, bin_io, hash, compare, fields, yojson]
 
   val gen : t Quickcheck.Generator.t
 

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -416,7 +416,7 @@ module type Ledger_proof_statement_intf = sig
     ; target: ledger_hash
     ; supply_increase: Currency.Amount.t
     ; fee_excess: Fee.Signed.t
-    ; proof_type: [`Merge | `Base] }
+    ; proof_type: [`Base | `Merge] }
   [@@deriving sexp, bin_io, compare]
 
   val merge : t -> t -> t Or_error.t

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -416,7 +416,7 @@ module type Ledger_proof_statement_intf = sig
     ; target: ledger_hash
     ; supply_increase: Currency.Amount.t
     ; fee_excess: Fee.Signed.t
-    ; proof_type: [`Base | `Merge] }
+    ; proof_type: [`Merge | `Base] }
   [@@deriving sexp, bin_io, compare]
 
   val merge : t -> t -> t Or_error.t


### PR DESCRIPTION
Version `Transaction_snark.Proof_type`. Probably that won't change, but adhering to convention.

Also removed some `yojson`, `eq` annotations that weren't being used.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
