### PR TITLE
Implemented deserialization of transition_frontier_persistence and transition_database API

### DIFF
--- a/src/lib/key_value_database/key_value_database.ml
+++ b/src/lib/key_value_database/key_value_database.ml
@@ -16,6 +16,11 @@ module type S = sig
   val set : t -> key:key -> data:value -> unit
 
   val remove : t -> key:key -> unit
+
+  val set_batch :
+    t -> ?remove_keys:key list -> update_pairs:(key * value) list -> unit
+
+  val to_alist : t -> (key * value) list
 end
 
 module type Mock_intf = sig
@@ -56,4 +61,10 @@ module Make_mock
   let random_key t =
     let keys = Key.Table.keys t in
     List.random_element keys
+
+  let set_batch t ?(remove_keys = []) ~update_pairs =
+    List.iter update_pairs ~f:(fun (key, data) -> set t ~key ~data) ;
+    List.iter remove_keys ~f:(fun key -> remove t ~key)
+
+  let to_alist = Key.Table.to_alist
 end

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -128,7 +128,7 @@ module Make (Inputs : Inputs_intf) :
       (loc, buf)
     in
     let locs_bufs = List.map locations_vs ~f:create_buf in
-    set_raw_batch mdb locs_bufs
+    set_raw_batch ~remove_keys:[] mdb locs_bufs
 
   let get_inner_hash_at_addr_exn mdb address =
     assert (Addr.depth address <= Depth.depth) ;
@@ -256,7 +256,7 @@ module Make (Inputs : Inputs_intf) :
       let last_location_key_value =
         (Account_location.last_location_key (), last_location)
       in
-      Account_location.set_batch mdb
+      Account_location.set_batch ~remove_keys:[] mdb
         ( Non_empty_list.cons last_location_key_value
             (Non_empty_list.map key_to_location_list ~f:(fun (key, location) ->
                  (Account_location.build_location key, location) ))

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -71,7 +71,11 @@ module type Key_value_database = sig
 
   val get_uuid : t -> Uuid.t
 
-  val set_batch : t -> key_data_pairs:(Bigstring.t * Bigstring.t) list -> unit
+  val set_batch :
+       t
+    -> ?remove_keys:Bigstring.t list
+    -> key_data_pairs:(Bigstring.t * Bigstring.t) list
+    -> unit
 
   val to_alist : t -> (Bigstring.t * Bigstring.t) list
   (* an association list, sorted by key *)

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -161,8 +161,10 @@ module In_memory_kvdb : Intf.Key_value_database = struct
 
   let set t ~key ~data = Bigstring_frozen.Table.set t.table ~key ~data
 
-  let set_batch tbl ~key_data_pairs =
-    List.iter key_data_pairs ~f:(fun (key, data) -> set tbl ~key ~data)
+  let set_batch t ?(remove_keys = []) ~key_data_pairs =
+    List.iter key_data_pairs ~f:(fun (key, data) -> set t ~key ~data) ;
+    List.iter remove_keys ~f:(fun key ->
+        Bigstring_frozen.Table.remove t.table key )
 
   let remove t ~key = Bigstring_frozen.Table.remove t.table key
 end

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -21,11 +21,14 @@ let set t ~(key : Bigstring.t) ~(data : Bigstring.t) : unit =
   Rocks.put ?key_pos:None ?key_len:None ?value_pos:None ?value_len:None
     ?opts:None t.db key data
 
-let set_batch t ~(key_data_pairs : (Bigstring.t * Bigstring.t) list) : unit =
+let set_batch t ?(remove_keys = [])
+    ~(key_data_pairs : (Bigstring.t * Bigstring.t) list) : unit =
   let batch = Rocks.WriteBatch.create () in
   (* write to batch *)
   List.iter key_data_pairs ~f:(fun (key, data) ->
       Rocks.WriteBatch.put batch key data ) ;
+  (* Delete any key pairs *)
+  List.iter remove_keys ~f:(fun key -> Rocks.WriteBatch.delete batch key) ;
   (* commit batch *)
   Rocks.write t.db batch
 

--- a/src/lib/rocksdb/serializable.ml
+++ b/src/lib/rocksdb/serializable.ml
@@ -21,6 +21,22 @@ struct
       ~key:(Binable.to_bigstring (module Key) key)
       ~data:(Binable.to_bigstring (module Value) data)
 
+  let set_batch t ?(remove_keys = []) ~update_pairs =
+    let key_data_pairs =
+      List.map update_pairs ~f:(fun (key, data) ->
+          ( Binable.to_bigstring (module Key) key
+          , Binable.to_bigstring (module Value) data ) )
+    in
+    let remove_keys =
+      List.map remove_keys ~f:(Binable.to_bigstring (module Key))
+    in
+    Database.set_batch t ~remove_keys ~key_data_pairs
+
   let remove t ~key =
     Database.remove t ~key:(Binable.to_bigstring (module Key) key)
+
+  let to_alist t =
+    List.map (Database.to_alist t) ~f:(fun (key, value) ->
+        ( Binable.of_bigstring (module Key) key
+        , Binable.of_bigstring (module Value) value ) )
 end

--- a/src/lib/transition_frontier_persistence/dune
+++ b/src/lib/transition_frontier_persistence/dune
@@ -1,0 +1,5 @@
+(library
+  (name transition_frontier_persistence)
+  (public_name transition_frontier_persistence)
+  (libraries coda_base core async rocksdb protocols signature_lib consensus storage transition_frontier)
+  (preprocess (pps ppx_jane ppx_deriving.eq)))

--- a/src/lib/transition_frontier_persistence/inputs.ml
+++ b/src/lib/transition_frontier_persistence/inputs.ml
@@ -1,0 +1,28 @@
+open Protocols.Coda_pow
+open Coda_base
+
+module type S = sig
+  include Transition_frontier.Inputs_intf
+
+  val max_length : int
+
+  module Transition_storage :
+    Key_value_database.S
+    with type key := State_hash.t
+     and type value := External_transition.Stable.Latest.t
+
+  module Root_storage : Storage.With_checksum_intf with type location := string
+
+  module Transition_frontier :
+    Transition_frontier_intf
+    with type state_hash := State_hash.t
+     and type external_transition_verified := External_transition.Verified.t
+     and type ledger_database := Ledger.Db.t
+     and type staged_ledger_diff := Staged_ledger_diff.t
+     and type staged_ledger := Staged_ledger.t
+     and type masked_ledger := Ledger.Mask.Attached.t
+     and type transaction_snark_scan_state := Staged_ledger.Scan_state.t
+     and type consensus_local_state := Consensus.Local_state.t
+     and type user_command := User_command.t
+     and module Extensions.Work = Transaction_snark_work.Statement
+end

--- a/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
@@ -1,0 +1,240 @@
+open Core
+open Coda_base
+open Async
+open Protocols
+
+module type S = sig
+  type external_transition_verified
+
+  type staged_ledger
+
+  type scan_state
+
+  type state_hash
+
+  type frontier
+
+  type root_snarked_ledger
+
+  type transition_storage
+
+  type root_storage
+
+  type frontier_diff
+
+  (* TODO: Diff_mutant will be a GADT that represents how it adds an
+     external_transition into it's frontier and how transitions are added and
+     removed when the root moves *)
+  type diff_mutant
+
+  type t
+
+  val set_transition : t -> state_hash -> external_transition_verified -> unit
+
+  val set_root : t -> state_hash -> scan_state -> unit Deferred.t
+
+  val remove_transitions : t -> state_hash list -> unit
+
+  val create :
+       logger:Logger.t
+    -> root_snarked_ledger:root_snarked_ledger
+    -> transition_storage:transition_storage
+    -> root_storage:root_storage
+    -> t
+
+  val deserialize :
+       t
+    -> consensus_local_state:Consensus.Local_state.t
+    -> frontier Deferred.Or_error.t
+
+  (* TODO: This will do all the writes *)
+  val handle_diff : t -> frontier_diff -> diff_mutant
+end
+
+module Make (Inputs : Inputs.S) : sig
+  open Inputs
+
+  include
+    S
+    with type external_transition_verified := External_transition.Verified.t
+     and type staged_ledger := Staged_ledger.t
+     and type scan_state := Staged_ledger.Scan_state.t
+     and type state_hash := State_hash.t
+     and type frontier := Transition_frontier.t
+     and type frontier_diff :=
+                External_transition.Verified.t
+                Coda_transition_frontier.Transition_frontier_diff.t
+     and type root_snarked_ledger := Ledger.Db.t
+     and type transition_storage := Transition_storage.t
+    (* TODO: Change type when Diff_mutant gets added *)
+     and type diff_mutant := unit
+end = struct
+  open Inputs
+
+  type root_storage =
+    { path: String.t
+    ; controller:
+        (State_hash.t * Staged_ledger.Scan_state.t) Root_storage.Controller.t
+    }
+
+  type t =
+    { transition_storage: Transition_storage.t
+    ; root_snarked_ledger: Ledger.Db.t
+    ; root_storage: root_storage
+    ; logger: Logger.t }
+
+  let create ~logger ~root_snarked_ledger ~transition_storage ~root_storage =
+    {transition_storage; root_snarked_ledger; root_storage; logger}
+
+  let set_transition {transition_storage; _} state_hash external_transition =
+    Transition_storage.set transition_storage ~key:state_hash
+      ~data:(External_transition.of_verified external_transition)
+
+  let set_root t state_hash scan_state =
+    Root_storage.store t.root_storage.controller t.root_storage.path
+      (state_hash, scan_state)
+
+  let to_verified transition =
+    (* We read a transition that was already verified before it was written to disk *)
+    let (`I_swear_this_is_safe_see_my_comment verified_transition) =
+      External_transition.to_verified transition
+    in
+    verified_transition
+
+  let read_transition {transition_storage; _} state_hash =
+    Option.map
+      (Transition_storage.get transition_storage ~key:state_hash)
+      ~f:to_verified
+
+  let remove_transitions {transition_storage; _} state_hashes =
+    Transition_storage.set_batch transition_storage ~remove_keys:state_hashes
+      ~update_pairs:[]
+
+  let lift_or_error deferred_x =
+    let%map x = deferred_x in
+    Or_error.return x
+
+  let parent_hash transition =
+    let open External_transition.Verified in
+    let protocol_state = protocol_state transition in
+    External_transition.Protocol_state.(previous_state_hash protocol_state)
+
+  let directly_add_breadcrumb ~logger transition_frontier transition_with_hash
+      parent =
+    let open Deferred.Or_error.Let_syntax in
+    let%bind child_breadcrumb =
+      Deferred.Result.map_error
+        (Transition_frontier.Breadcrumb.build ~logger ~parent
+           ~transition_with_hash) ~f:(function
+        | `Fatal_error exn ->
+            Error.createf !"Adding Breadcrumb Error: %s" (Exn.to_string exn)
+        | `Validation_error error ->
+            Error.createf "Validating Breadcrumb Error: %s"
+              (Error.to_string_hum error) )
+    in
+    let%map () =
+      Transition_frontier.add_breadcrumb_exn transition_frontier
+        child_breadcrumb
+      |> lift_or_error
+    in
+    child_breadcrumb
+
+  let rec add_breadcrumb ~logger ~in_memory_transition_storage
+      transition_frontier
+      ({With_hash.hash= _; data= external_transition} as transition_with_hash)
+      =
+    let open Deferred.Or_error.Let_syntax in
+    let parent_hash = parent_hash external_transition in
+    match Transition_frontier.find transition_frontier parent_hash with
+    | Some parent ->
+        directly_add_breadcrumb ~logger transition_frontier
+          transition_with_hash parent
+    | None ->
+        let%bind parent_external_transition =
+          match Hashtbl.find in_memory_transition_storage parent_hash with
+          | Some parent_external_transition ->
+              Deferred.Or_error.return parent_external_transition
+          | None ->
+              Deferred.Or_error.errorf
+                !"Parent transition %{sexp:State_hash.t} does not exist in \
+                  the transition storage"
+                parent_hash
+        in
+        let parent_external_transition_with_hash =
+          {With_hash.hash= parent_hash; data= parent_external_transition}
+        in
+        let%bind parent =
+          add_breadcrumb ~logger ~in_memory_transition_storage
+            transition_frontier parent_external_transition_with_hash
+        in
+        directly_add_breadcrumb ~logger transition_frontier
+          parent_external_transition_with_hash parent
+
+  let staged_ledger_hash transition =
+    let open External_transition.Verified in
+    let protocol_state = protocol_state transition in
+    Coda_base.Staged_ledger_hash.ledger_hash
+      External_transition.Protocol_state.(
+        Blockchain_state.staged_ledger_hash @@ blockchain_state protocol_state)
+
+  let deserialize
+      ({transition_storage; root_snarked_ledger; root_storage; logger} as t)
+      ~consensus_local_state =
+    let open Deferred.Or_error.Let_syntax in
+    let%bind state_hash, scan_state =
+      Deferred.Result.map_error
+        (Root_storage.load root_storage.controller root_storage.path)
+        ~f:(function
+        | `Checksum_no_match -> Error.of_string "Checksum did not match"
+        | `IO_error e -> Error.createf !"IO_error: %s" (Error.to_string_hum e)
+        | `No_exist ->
+            Error.createf !"File %s does not exist" root_storage.path )
+    in
+    let%bind root_transition =
+      Deferred.return
+        (let open Or_error.Let_syntax in
+        let%map verified_transition =
+          Result.of_option
+            (read_transition t state_hash)
+            ~error:
+              (Error.createf
+                 !"Could not find root transition %{sexp:State_hash.t}"
+                 state_hash)
+        in
+        {With_hash.data= verified_transition; hash= state_hash})
+    in
+    let%bind root_staged_ledger =
+      Staged_ledger.of_scan_state_and_snarked_ledger ~scan_state
+        ~snarked_ledger:(Ledger.of_database root_snarked_ledger)
+        ~expected_merkle_root:
+          (staged_ledger_hash @@ With_hash.data root_transition)
+    in
+    let%bind transition_frontier =
+      lift_or_error
+      @@ Transition_frontier.create ~logger ~consensus_local_state
+           ~root_transition ~root_snarked_ledger ~root_staged_ledger
+    in
+    let hashed_transitions =
+      List.map (Transition_storage.to_alist transition_storage)
+        ~f:(fun (hash, external_transition) ->
+          {With_hash.hash; data= to_verified external_transition} )
+    in
+    let in_memory_transition_storage = State_hash.Table.create () in
+    List.iter hashed_transitions ~f:(fun {With_hash.hash; data} ->
+        State_hash.Table.add_exn in_memory_transition_storage ~key:hash ~data
+    ) ;
+    let%map () =
+      Deferred.Or_error.List.iter hashed_transitions
+        ~f:(fun ({With_hash.hash= state_hash; data= _} as transition_with_hash)
+           ->
+          match Transition_frontier.find transition_frontier state_hash with
+          | Some _ -> Deferred.Or_error.return ()
+          | None ->
+              add_breadcrumb ~logger ~in_memory_transition_storage
+                transition_frontier transition_with_hash
+              |> Deferred.Or_error.ignore )
+    in
+    transition_frontier
+
+  let handle_diff = failwith "handle_diff: Need to Implement"
+end

--- a/src/transition_frontier_persistence.opam
+++ b/src/transition_frontier_persistence.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
- Created common functions to interact with the transition database
- Created deserialize function for the frontier
- Rocksdb.set_batch can now delete a list of keys

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

