### PR TITLE
Fix building with the dev profile

### DIFF
--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -181,7 +181,7 @@ module Key = struct
     module Latest = V1
   end
 
-  type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash]
+  type t = Stable.Latest.t [@@deriving sexp, compare, hash]
 
   let to_string = Signature_lib.Public_key.Compressed.to_base64
 


### PR DESCRIPTION
There are warnings turned on in the `dev` profile that aren't in the others, and CI doesn't build with the `dev` profile. I'll add a CI job for that in a separate PR.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
