### PR TITLE
Version Statement in Transaction_snark

### DIFF
--- a/src/app/cli/src/ledger_proof.ml
+++ b/src/app/cli/src/ledger_proof.ml
@@ -76,7 +76,9 @@ module Debug :
       module T = struct
         let version = 1
 
-        type t = Transaction_snark.Statement.t * Sok_message.Digest.Stable.V1.t
+        type t =
+          Transaction_snark.Statement.Stable.V1.t
+          * Sok_message.Digest.Stable.V1.t
         [@@deriving sexp, bin_io, yojson]
       end
 

--- a/src/lib/snark_worker_lib/debug.ml
+++ b/src/lib/snark_worker_lib/debug.ml
@@ -11,8 +11,10 @@ module Inputs = struct
   end
 
   module Proof = struct
+    (* TODO : version *)
     type t =
-      Transaction_snark.Statement.t * Coda_base.Sok_message.Digest.Stable.V1.t
+      Transaction_snark.Statement.Stable.V1.t
+      * Coda_base.Sok_message.Digest.Stable.V1.t
     [@@deriving bin_io, sexp]
   end
 

--- a/src/lib/snark_worker_lib/intf.ml
+++ b/src/lib/snark_worker_lib/intf.ml
@@ -18,7 +18,15 @@ module type Inputs_intf = sig
   end
 
   module Statement : sig
-    type t [@@deriving bin_io, sexp]
+    type t [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving bin_io, sexp]
+        end
+      end
+      with type V1.t = t
   end
 
   open Snark_work_lib

--- a/src/lib/snark_worker_lib/rpcs.ml
+++ b/src/lib/snark_worker_lib/rpcs.ml
@@ -9,7 +9,11 @@ module Make (Inputs : Intf.Inputs_intf) = struct
     type query = unit [@@deriving bin_io]
 
     type response =
-      (Statement.t, Transaction.t, Sparse_ledger.t, Proof.t) Work.Single.Spec.t
+      ( Statement.Stable.V1.t
+      , Transaction.t
+      , Sparse_ledger.t
+      , Proof.t )
+      Work.Single.Spec.t
       Work.Spec.t
       option
     [@@deriving bin_io]
@@ -20,7 +24,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
 
   module Submit_work = struct
     type query =
-      ( ( Statement.t
+      ( ( Statement.Stable.V1.t
         , Transaction.t
         , Sparse_ledger.t
         , Proof.t )

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1607,40 +1607,44 @@ let%test_module "test" =
       end
 
       module Ledger_proof_statement = struct
-        module T = struct
-          type t =
-            { source: Ledger_hash.Stable.V1.t
-            ; target: Ledger_hash.Stable.V1.t
-            ; supply_increase: Currency.Amount.t
-            ; fee_excess: Fee.Signed.t
-            ; proof_type: [`Base | `Merge] }
-          [@@deriving sexp, bin_io, compare, hash, yojson]
+        module Stable = struct
+          module V1 = struct
+            type t =
+              { source: Ledger_hash.Stable.V1.t
+              ; target: Ledger_hash.Stable.V1.t
+              ; supply_increase: Currency.Amount.t
+              ; fee_excess: Fee.Signed.t
+              ; proof_type: [`Base | `Merge] }
+            [@@deriving sexp, bin_io, compare, hash, yojson]
 
-          let merge s1 s2 =
-            let open Or_error.Let_syntax in
-            let%bind _ =
-              if s1.target = s2.source then Ok ()
-              else
-                Or_error.errorf
-                  !"Invalid merge: target: %s source %s"
-                  (Int.to_string s1.target) (Int.to_string s2.source)
-            in
-            let%map fee_excess =
-              Fee.Signed.add s1.fee_excess s2.fee_excess
-              |> option "Error adding fees"
-            and supply_increase =
-              Currency.Amount.add s1.supply_increase s2.supply_increase
-              |> option "Error adding supply increases"
-            in
-            { source= s1.source
-            ; target= s2.target
-            ; supply_increase
-            ; fee_excess
-            ; proof_type= `Merge }
+            let merge s1 s2 =
+              let open Or_error.Let_syntax in
+              let%bind _ =
+                if s1.target = s2.source then Ok ()
+                else
+                  Or_error.errorf
+                    !"Invalid merge: target: %s source %s"
+                    (Int.to_string s1.target) (Int.to_string s2.source)
+              in
+              let%map fee_excess =
+                Fee.Signed.add s1.fee_excess s2.fee_excess
+                |> option "Error adding fees"
+              and supply_increase =
+                Currency.Amount.add s1.supply_increase s2.supply_increase
+                |> option "Error adding supply increases"
+              in
+              { source= s1.source
+              ; target= s2.target
+              ; supply_increase
+              ; fee_excess
+              ; proof_type= `Merge }
+          end
+
+          module Latest = V1
         end
 
-        include T
-        include Comparable.Make (T)
+        include Stable.Latest
+        include Comparable.Make (Stable.Latest)
 
         let gen =
           let open Quickcheck.Generator.Let_syntax in

--- a/src/lib/staged_ledger/transaction_snark_work.ml
+++ b/src/lib/staged_ledger/transaction_snark_work.ml
@@ -8,7 +8,15 @@ open Module_version
 module Make (Ledger_proof : sig
   type t [@@deriving sexp, bin_io]
 end) (Ledger_proof_statement : sig
-  type t [@@deriving sexp, bin_io, hash, compare, yojson]
+  type t [@@deriving sexp, hash, compare]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving sexp, bin_io, hash, compare, yojson]
+      end
+    end
+    with type V1.t = t
 
   val gen : t Quickcheck.Generator.t
 end) :
@@ -24,8 +32,7 @@ end) :
         module T = struct
           let version = 1
 
-          (* TODO : version Ledger_proof_statement *)
-          type t = Ledger_proof_statement.t list
+          type t = Ledger_proof_statement.Stable.V1.t list
           [@@deriving bin_io, sexp, hash, compare, yojson]
         end
 

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -21,7 +21,23 @@ module Statement : sig
     ; supply_increase: Currency.Amount.Stable.V1.t
     ; fee_excess: Currency.Fee.Signed.Stable.V1.t
     ; proof_type: Proof_type.Stable.V1.t }
-  [@@deriving sexp, bin_io, hash, compare, fields, yojson]
+  [@@deriving sexp, hash, compare, yojson]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t =
+          { source: Coda_base.Frozen_ledger_hash.Stable.V1.t
+          ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
+          ; supply_increase: Currency.Amount.Stable.V1.t
+          ; fee_excess: Currency.Fee.Signed.Stable.V1.t
+          ; proof_type: Proof_type.Stable.V1.t }
+        [@@deriving sexp, bin_io, hash, compare, yojson]
+      end
+
+      module Latest = V1
+    end
+    with type V1.t = t
 
   val gen : t Quickcheck.Generator.t
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -52,9 +52,10 @@ end = struct
           let version = 1
 
           (* TODO: The statement is redundant here - it can be computed from the witness and the transaction *)
+          (* TODO : version all fields *)
           type t =
             { transaction_with_info: Ledger.Undo.t
-            ; statement: Ledger_proof_statement.t
+            ; statement: Ledger_proof_statement.Stable.V1.t
             ; witness: Inputs.Sparse_ledger.t }
           [@@deriving sexp, bin_io]
         end

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -22,7 +22,8 @@ struct
   module Ledger_proof = struct
     module Stable = struct
       module V1 = struct
-        type t = Ledger_proof_statement.t * Sok_message.Digest.Stable.V1.t
+        type t =
+          Ledger_proof_statement.Stable.V1.t * Sok_message.Digest.Stable.V1.t
         [@@deriving sexp, bin_io, yojson]
       end
 

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -417,7 +417,21 @@ module type Ledger_proof_statement_intf = sig
     ; supply_increase: Currency.Amount.t
     ; fee_excess: Fee.Signed.t
     ; proof_type: [`Base | `Merge] }
-  [@@deriving sexp, bin_io, compare]
+  [@@deriving sexp, compare]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t =
+          { source: ledger_hash
+          ; target: ledger_hash
+          ; supply_increase: Currency.Amount.t
+          ; fee_excess: Fee.Signed.t
+          ; proof_type: [`Base | `Merge] }
+        [@@deriving sexp, bin_io, compare]
+      end
+    end
+    with type V1.t = t
 
   val merge : t -> t -> t Or_error.t
 


### PR DESCRIPTION
Versioning of `Transaction_snark.Statement`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
