### PR TITLE
Version Ledger.Undo

### DIFF
--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -119,8 +119,17 @@ module Undo : sig
     | Coinbase of coinbase
   [@@deriving sexp, bin_io]
 
-  type t = {previous_hash: Ledger_hash.t; varying: varying}
-  [@@deriving sexp, bin_io]
+  type t = {previous_hash: Ledger_hash.t; varying: varying} [@@deriving sexp]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving bin_io, sexp]
+      end
+
+      module Latest = V1
+    end
+    with type V1.t = t
 
   val transaction : t -> Transaction.t Or_error.t
 end

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1699,7 +1699,15 @@ let%test_module "test" =
         type transaction = Transaction.t [@@deriving sexp, bin_io]
 
         module Undo = struct
-          type t = transaction [@@deriving sexp, bin_io]
+          type t = transaction [@@deriving sexp]
+
+          module Stable = struct
+            module V1 = struct
+              type t = transaction [@@deriving sexp, bin_io]
+            end
+
+            module Latest = V1
+          end
 
           module User_command = struct end
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -54,7 +54,7 @@ end = struct
           (* TODO: The statement is redundant here - it can be computed from the witness and the transaction *)
           (* TODO : version all fields *)
           type t =
-            { transaction_with_info: Ledger.Undo.t
+            { transaction_with_info: Ledger.Undo.Stable.V1.t
             ; statement: Ledger_proof_statement.Stable.V1.t
             ; witness: Inputs.Sparse_ledger.t }
           [@@deriving sexp, bin_io]

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -245,7 +245,17 @@ module type Ledger_intf = sig
      and type unattached_mask := unattached_mask
 
   module Undo : sig
-    type t [@@deriving sexp, bin_io]
+    type t [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io]
+        end
+
+        module Latest = V1
+      end
+      with type V1.t = t
 
     val transaction : t -> transaction Or_error.t
   end


### PR DESCRIPTION
Version the `Undo` module.

This change will require versioning of the types `varying`, `fee_transfer`, and `coinbase` which it depends on.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
