### PR TITLE
Version Fee_transfer

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -117,7 +117,7 @@ module type Init_intf = sig
      and type user_command := User_command.t
      and type user_command_with_valid_signature :=
                 User_command.With_valid_signature.t
-     and type fee_transfer_single := Fee_transfer.single
+     and type fee_transfer_single := Fee_transfer.Single.t
 
   module Make_work_selector : Work_selector_F
 
@@ -246,7 +246,7 @@ module type Main_intf = sig
                   User_command.With_valid_signature.t
        and type public_key := Public_key.Compressed.t
        and type staged_ledger_hash := Staged_ledger_hash.t
-       and type fee_transfer_single := Fee_transfer.single
+       and type fee_transfer_single := Fee_transfer.Single.t
 
     module Staged_ledger :
       Protocols.Coda_pow.Staged_ledger_intf

--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -10,7 +10,7 @@ module Stable = struct
       type t =
         { proposer: Public_key.Compressed.Stable.V1.t
         ; amount: Currency.Amount.Stable.V1.t
-        ; fee_transfer: Fee_transfer.single option }
+        ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
       [@@deriving sexp, bin_io, compare, eq]
     end
 
@@ -54,9 +54,9 @@ end
 
 (* DO NOT add bin_io to the deriving list *)
 type t = Stable.Latest.t =
-  { proposer: Public_key.Compressed.t
-  ; amount: Currency.Amount.t
-  ; fee_transfer: Fee_transfer.single option }
+  { proposer: Public_key.Compressed.Stable.V1.t
+  ; amount: Currency.Amount.Stable.V1.t
+  ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
 [@@deriving sexp, compare, eq]
 
 let is_valid = Stable.Latest.is_valid

--- a/src/lib/coda_base/coinbase.mli
+++ b/src/lib/coda_base/coinbase.mli
@@ -6,7 +6,7 @@ module Stable : sig
     type t = private
       { proposer: Public_key.Compressed.t
       ; amount: Currency.Amount.t
-      ; fee_transfer: Fee_transfer.single option }
+      ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
     [@@deriving sexp, bin_io, compare, eq]
   end
 
@@ -17,13 +17,13 @@ end
 type t = Stable.Latest.t = private
   { proposer: Public_key.Compressed.t
   ; amount: Currency.Amount.t
-  ; fee_transfer: Fee_transfer.single option }
+  ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
 [@@deriving sexp, compare, eq]
 
 val create :
      amount:Currency.Amount.t
   -> proposer:Public_key.Compressed.t
-  -> fee_transfer:Fee_transfer.single option
+  -> fee_transfer:Fee_transfer.Single.Stable.V1.t option
   -> t Or_error.t
 
 val supply_increase : t -> Currency.Amount.t Or_error.t

--- a/src/lib/coda_base/fee_transfer.ml
+++ b/src/lib/coda_base/fee_transfer.ml
@@ -1,13 +1,69 @@
 open Core
 open Import
+open Module_version
 
-(* TODO : version *)
-type single = Public_key.Compressed.Stable.V1.t * Currency.Fee.Stable.V1.t
-[@@deriving bin_io, sexp, compare, eq, yojson]
+module Single = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        let version = 1
 
-(* TODO : version *)
-type t = One of single | Two of single * single
-[@@deriving bin_io, sexp, compare, eq, yojson]
+        type t = Public_key.Compressed.Stable.V1.t * Currency.Fee.Stable.V1.t
+        [@@deriving bin_io, sexp, compare, eq, yojson]
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "fee_transfer_single"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
+  end
+
+  (* bin_io omitted *)
+  type t = Stable.Latest.t [@@deriving sexp, compare, eq, yojson]
+end
+
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      let version = 1
+
+      type t =
+        | One of Single.Stable.V1.t
+        | Two of Single.Stable.V1.t * Single.Stable.V1.t
+      [@@deriving bin_io, sexp, compare, eq, yojson]
+    end
+
+    include T
+    include Registration.Make_latest_version (T)
+  end
+
+  module Latest = V1
+
+  module Module_decl = struct
+    let name = "fee_transfer"
+
+    type latest = Latest.t
+  end
+
+  module Registrar = Registration.Make (Module_decl)
+  module Registered_V1 = Registrar.Register (V1)
+end
+
+(* bin_io omitted *)
+type t = Stable.Latest.t =
+  | One of Single.Stable.V1.t
+  | Two of Single.Stable.V1.t * Single.Stable.V1.t
+[@@deriving sexp, compare, eq, yojson]
 
 let to_list = function One x -> [x] | Two (x, y) -> [x; y]
 

--- a/src/lib/coda_base/fee_transfer.mli
+++ b/src/lib/coda_base/fee_transfer.mli
@@ -1,17 +1,40 @@
 open Core_kernel
 open Import
 
-type single = Public_key.Compressed.t * Currency.Fee.t
-[@@deriving bin_io, sexp, compare, eq, yojson]
+module Single : sig
+  module Stable : sig
+    module V1 : sig
+      type t = Public_key.Compressed.t * Currency.Fee.t
+      [@@deriving bin_io, sexp, compare, eq, yojson]
+    end
 
-type t = One of single | Two of single * single
-[@@deriving bin_io, sexp, compare, eq, yojson]
+    module Latest = V1
+  end
 
-val to_list : t -> single list
+  type t = Stable.Latest.t [@@deriving sexp, compare, eq, yojson]
+end
 
-val of_single : single -> t
+module Stable : sig
+  module V1 : sig
+    type t =
+      | One of Single.Stable.V1.t
+      | Two of Single.Stable.V1.t * Single.Stable.V1.t
+    [@@deriving bin_io, sexp, compare, eq, yojson]
+  end
 
-val of_single_list : single list -> t list
+  module Latest = V1
+end
+
+type t = Stable.Latest.t =
+  | One of Single.Stable.V1.t
+  | Two of Single.Stable.V1.t * Single.Stable.V1.t
+[@@deriving sexp, compare, eq, yojson]
+
+val to_list : t -> Single.t list
+
+val of_single : Single.t -> t
+
+val of_single_list : Single.t list -> t list
 
 val fee_excess : t -> Currency.Fee.Signed.t Or_error.t
 

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -103,19 +103,33 @@ module Undo : sig
     type t = {common: Common.t; body: Body.t} [@@deriving sexp, bin_io]
   end
 
-  type fee_transfer =
-    { fee_transfer: Fee_transfer.t
-    ; previous_empty_accounts: Public_key.Compressed.t list }
-  [@@deriving sexp, bin_io]
+  module Fee_transfer_undo : sig
+    type t =
+      { fee_transfer: Fee_transfer.Stable.V1.t
+      ; previous_empty_accounts: Public_key.Compressed.t list }
+    [@@deriving sexp]
 
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io]
+        end
+
+        module Latest = V1
+      end
+      with type V1.t = t
+  end
+
+  (* TODO : version *)
   type coinbase =
     { coinbase: Coinbase.t
     ; previous_empty_accounts: Public_key.Compressed.t list }
   [@@deriving sexp, bin_io]
 
+  (* TODO : version *)
   type varying =
     | User_command of User_command.t
-    | Fee_transfer of fee_transfer
+    | Fee_transfer of Fee_transfer_undo.t
     | Coinbase of coinbase
   [@@deriving sexp, bin_io]
 

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -117,7 +117,7 @@ let apply_user_command_exn t ({sender; payload; signature= _} : User_command.t)
               (Balance.add_amount receiver_account.balance amount) }
 
 let apply_fee_transfer_exn =
-  let apply_single t ((pk, fee) : Fee_transfer.single) =
+  let apply_single t ((pk, fee) : Fee_transfer.Single.t) =
     let index = find_index_exn t pk in
     let account = get_or_initialize_exn pk t index in
     let open Currency in

--- a/src/lib/coda_base/transaction.ml
+++ b/src/lib/coda_base/transaction.ml
@@ -1,10 +1,12 @@
 open Core
 
-type fee_transfer = Fee_transfer.t [@@deriving bin_io, sexp]
+(* TODO : version *)
+type fee_transfer = Fee_transfer.Stable.V1.t [@@deriving bin_io, sexp]
 
+(* TODO : version *)
 type t =
   | User_command of User_command.With_valid_signature.t
-  | Fee_transfer of Fee_transfer.t
+  | Fee_transfer of Fee_transfer.Stable.V1.t
   | Coinbase of Coinbase.Stable.V1.t
 [@@deriving bin_io, sexp]
 

--- a/src/lib/staged_ledger/inputs.ml
+++ b/src/lib/staged_ledger/inputs.ml
@@ -15,7 +15,7 @@ module type S = sig
   module Coinbase :
     Coda_pow.Coinbase_intf
     with type public_key := Compressed_public_key.t
-     and type fee_transfer := Fee_transfer.single
+     and type fee_transfer := Fee_transfer.Single.t
 
   module Transaction :
     Coda_pow.Transaction_intf
@@ -81,7 +81,7 @@ module type S = sig
                 User_command.With_valid_signature.t
      and type public_key := Compressed_public_key.t
      and type staged_ledger_hash := Staged_ledger_hash.t
-     and type fee_transfer_single := Fee_transfer.single
+     and type fee_transfer_single := Fee_transfer.Single.t
 
   module Account : sig
     type t

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -39,7 +39,7 @@ end) :
    and type public_key := Inputs.Compressed_public_key.t
    and type completed_work := Inputs.Transaction_snark_work.t
    and type completed_work_checked := Inputs.Transaction_snark_work.Checked.t
-   and type fee_transfer_single := Inputs.Fee_transfer.single = struct
+   and type fee_transfer_single := Inputs.Fee_transfer.Single.t = struct
   open Inputs
 
   module At_most_two = struct
@@ -66,7 +66,9 @@ end) :
       | _ -> Or_error.error_string "Error incrementing coinbase parts"
   end
 
-  type ft = Inputs.Fee_transfer.single [@@deriving sexp, bin_io]
+  (* TODO: version *)
+
+  type ft = Inputs.Fee_transfer.Single.Stable.V1.t [@@deriving sexp, bin_io]
 
   (* TODO: version *)
 

--- a/src/lib/transaction_snark_scan_state/inputs.ml
+++ b/src/lib/transaction_snark_scan_state/inputs.ml
@@ -15,7 +15,7 @@ module type S = sig
   module Coinbase :
     Coda_pow.Coinbase_intf
     with type public_key := Compressed_public_key.t
-     and type fee_transfer := Fee_transfer.single
+     and type fee_transfer := Fee_transfer.Single.t
 
   module Transaction :
     Coda_pow.Transaction_intf

--- a/src/lib/transition_frontier/inputs.ml
+++ b/src/lib/transition_frontier/inputs.ml
@@ -35,7 +35,7 @@ module type Inputs_intf = sig
      and type public_key := Public_key.Compressed.t
      and type completed_work := Transaction_snark_work.t
      and type completed_work_checked := Transaction_snark_work.Checked.t
-     and type fee_transfer_single := Fee_transfer.single
+     and type fee_transfer_single := Fee_transfer.Single.t
 
   module External_transition :
     External_transition.S


### PR DESCRIPTION
Versioning of `Fee_transfer`, its `Single` submodule, and the `Fee_transfer_undo` submodule of `Undo`.

The type `fee_transfer` inside `Undo`, when versioned, has the name `Fee_transfer_undo` to avoid confusion with the existing module `Fee_transfer`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
