### PR TITLE
Version Coinbase in Undo

### DIFF
--- a/src/lib/coda_base/coinbase.mli
+++ b/src/lib/coda_base/coinbase.mli
@@ -4,8 +4,8 @@ open Import
 module Stable : sig
   module V1 : sig
     type t = private
-      { proposer: Public_key.Compressed.t
-      ; amount: Currency.Amount.t
+      { proposer: Public_key.Compressed.Stable.V1.t
+      ; amount: Currency.Amount.Stable.V1.t
       ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
     [@@deriving sexp, bin_io, compare, eq]
   end
@@ -15,8 +15,8 @@ end
 
 (* bin_io intentionally omitted in deriving list *)
 type t = Stable.Latest.t = private
-  { proposer: Public_key.Compressed.t
-  ; amount: Currency.Amount.t
+  { proposer: Public_key.Compressed.Stable.V1.t
+  ; amount: Currency.Amount.Stable.V1.t
   ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
 [@@deriving sexp, compare, eq]
 

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -120,17 +120,28 @@ module Undo : sig
       with type V1.t = t
   end
 
-  (* TODO : version *)
-  type coinbase =
-    { coinbase: Coinbase.t
-    ; previous_empty_accounts: Public_key.Compressed.t list }
-  [@@deriving sexp, bin_io]
+  module Coinbase_undo : sig
+    type t =
+      { coinbase: Coinbase.Stable.V1.t
+      ; previous_empty_accounts: Public_key.Compressed.Stable.V1.t list }
+    [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io]
+        end
+
+        module Latest = V1
+      end
+      with type V1.t = t
+  end
 
   (* TODO : version *)
   type varying =
     | User_command of User_command.t
     | Fee_transfer of Fee_transfer_undo.t
-    | Coinbase of coinbase
+    | Coinbase of Coinbase_undo.t
   [@@deriving sexp, bin_io]
 
   type t = {previous_hash: Ledger_hash.t; varying: varying} [@@deriving sexp]


### PR DESCRIPTION
Version `Coinbase_undo` that occurs in `Undo`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
