### PR TITLE
Make svgs inlineable

### DIFF
--- a/frontend/website/src/SustainableSection.re
+++ b/frontend/website/src/SustainableSection.re
@@ -62,12 +62,14 @@ let make = _children => {
           <Svg
             link="/static/img/chart-blockchain-size.svg"
             dims=(23.125, 17.3125)
+            inline=true
           />
         </div>
         <div className=Css.(style([marginBottom(`rem(2.375))]))>
           <Svg
             link="/static/img/chart-blockchain-energy.svg"
             dims=(23.9375, 18.1875)
+            inline=true
           />
         </div>
         <div className=Css.(style([marginBottom(`rem(2.375))]))>

--- a/frontend/website/src/Svg.re
+++ b/frontend/website/src/Svg.re
@@ -10,20 +10,32 @@ module Size = {
 };
 
 let component = ReasonReact.statelessComponent("Svg");
-let make = (~link, ~dims, _children) => {
+let make = (~link, ~dims, ~inline=false, _children) => {
   ...component,
   render: _self =>
-    <svg
-      className=Css.(
-        style([
-          width(`rem(Size.remX(dims))),
-          height(`rem(Size.remY(dims))),
-        ])
-      )>
-      <image
-        xlinkHref=link
-        width={Js.Int.toString(Size.pixelsX(dims))}
-        height={Js.Int.toString(Size.pixelsY(dims))}
-      />
-    </svg>,
+    if (inline) {
+      // Load the CSS inline so that we can get the fonts from the main page.
+      let content =
+        Node.Fs.readFileAsUtf8Sync(
+          String.sub(link, 1, String.length(link) - 1),
+        );
+      <div dangerouslySetInnerHTML={"__html": content} />;
+    } else {
+      <svg
+        version="1.1"
+        baseProfile="full"
+        xmlns="http://www.w3.org/2000/svg"
+        className=Css.(
+          style([
+            width(`rem(Size.remX(dims))),
+            height(`rem(Size.remY(dims))),
+          ])
+        )>
+        <image
+          xlinkHref=link
+          width={Js.Int.toString(Size.pixelsX(dims))}
+          height={Js.Int.toString(Size.pixelsY(dims))}
+        />
+      </svg>;
+    },
 };


### PR DESCRIPTION
Fonts weren't showing up correctly on the svgs with text and inlining the svg fixed it, but we don't want to blow up our html size.