### PR TITLE
Version varying type in Undo

### DIFF
--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -137,14 +137,27 @@ module Undo : sig
       with type V1.t = t
   end
 
-  (* TODO : version *)
-  type varying =
-    | User_command of User_command.t
-    | Fee_transfer of Fee_transfer_undo.t
-    | Coinbase of Coinbase_undo.t
-  [@@deriving sexp, bin_io]
+  module Varying : sig
+    type t =
+      | User_command of User_command.t
+      | Fee_transfer of Fee_transfer_undo.Stable.V1.t
+      | Coinbase of Coinbase_undo.Stable.V1.t
+    [@@deriving sexp]
 
-  type t = {previous_hash: Ledger_hash.t; varying: varying} [@@deriving sexp]
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io]
+        end
+
+        module Latest = V1
+      end
+      with type V1.t = t
+  end
+
+  type t =
+    {previous_hash: Ledger_hash.Stable.V1.t; varying: Varying.Stable.V1.t}
+  [@@deriving sexp]
 
   module Stable :
     sig


### PR DESCRIPTION
Version the `varying` type in `Undo`.

Still need to version `User_command`, which the new module `Varying` contains.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
