### PR TITLE
Fix RFC number in module version file

### DIFF
--- a/src/lib/module_version/registration.ml
+++ b/src/lib/module_version/registration.ml
@@ -1,6 +1,6 @@
 (* registration.ml -- register module versions *)
 
-(* see RFC 0014 for design discussion; see tests below for usage
+(* see RFC 0015 for design discussion; see tests below for usage
  *)
 
 open Core_kernel


### PR DESCRIPTION
Use correct RFC number in comment.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

