### PR TITLE
Remove bin_io from Nat.t

### DIFF
--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -190,7 +190,8 @@ module T = struct
     let get_nonce =
       C.create_rpc ~f:get_nonce_impl
         ~bin_input:Public_key.Compressed.Stable.V1.bin_t
-        ~bin_output:[%bin_type_class: Coda_numbers.Account_nonce.t option] ()
+        ~bin_output:
+          [%bin_type_class: Coda_numbers.Account_nonce.Stable.V1.t option] ()
 
     let prove_receipt =
       C.create_rpc ~f:prove_receipt_impl ~bin_input:Prove_receipt.Input.bin_t

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -14,7 +14,8 @@ module Common = struct
         type ('fee, 'nonce, 'memo) t_ = {fee: 'fee; nonce: 'nonce; memo: 'memo}
         [@@deriving bin_io, eq, sexp, hash, yojson]
 
-        type t = (Currency.Fee.Stable.V1.t, Account_nonce.t, Memo.t) t_
+        type t =
+          (Currency.Fee.Stable.V1.t, Account_nonce.Stable.V1.t, Memo.t) t_
         [@@deriving bin_io, eq, sexp, hash, yojson]
       end
 

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -13,6 +13,7 @@ module Common = struct
     module V1 = struct
       module T = struct
         let version = 1
+
         type t =
           (Currency.Fee.Stable.V1.t, Account_nonce.Stable.V1.t, Memo.t) t_
         [@@deriving bin_io, eq, sexp, hash, yojson]

--- a/src/lib/coda_numbers/nat.ml
+++ b/src/lib/coda_numbers/nat.ml
@@ -5,7 +5,7 @@ open Tuple_lib
 open Module_version
 
 module type S = sig
-  type t [@@deriving bin_io, sexp, compare, hash, yojson]
+  type t [@@deriving sexp, compare, hash, yojson]
 
   include Comparable.S with type t := t
 
@@ -104,7 +104,8 @@ struct
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  include Stable.Latest
+  type t = Stable.Latest.t [@@deriving sexp, compare, hash, yojson]
+
   include Comparable.Make (Stable.Latest)
 
   include (N : module type of N with type t := t)

--- a/src/lib/coda_numbers/nat.mli
+++ b/src/lib/coda_numbers/nat.mli
@@ -4,7 +4,7 @@ open Fold_lib
 open Tuple_lib
 
 module type S = sig
-  type t [@@deriving bin_io, sexp, compare, hash, yojson]
+  type t [@@deriving sexp, compare, hash, yojson]
 
   include Comparable.S with type t := t
 

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -102,7 +102,7 @@ module Consensus_state = struct
         module T = struct
           let version = 1
 
-          type t = (Length.t, Public_key.Compressed.Stable.V1.t) t_
+          type t = (Length.Stable.V1.t, Public_key.Compressed.Stable.V1.t) t_
           [@@deriving bin_io, sexp, hash, compare, to_yojson]
         end
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -678,7 +678,7 @@ module Epoch_data = struct
     ( Epoch_ledger.value
     , Epoch_seed.Stable.V1.t
     , Coda_base.State_hash.Stable.V1.t
-    , Length.t )
+    , Length.Stable.V1.t )
     t
   [@@deriving sexp, bin_io, eq, compare, hash, to_yojson]
 
@@ -805,7 +805,8 @@ module Consensus_transition_data = struct
   type ('epoch, 'slot) t = {epoch: 'epoch; slot: 'slot}
   [@@deriving sexp, bin_io, compare]
 
-  type value = (Epoch.t, Epoch.Slot.t) t [@@deriving sexp, bin_io, compare]
+  type value = (Epoch.Stable.V1.t, Epoch.Slot.Stable.V1.t) t
+  [@@deriving sexp, bin_io, compare]
 
   type var = (Epoch.Unpacked.var, Epoch.Slot.Unpacked.var) t
 
@@ -1021,11 +1022,11 @@ module Consensus_state = struct
           let version = 1
 
           type t =
-            ( Length.t
+            ( Length.Stable.V1.t
             , Vrf.Output.t
             , Amount.t
-            , Epoch.t
-            , Epoch.Slot.t
+            , Epoch.Stable.V1.t
+            , Epoch.Slot.Stable.V1.t
             , Epoch_data.value
             , bool
             , Checkpoints.t )


### PR DESCRIPTION
Removed `bin_io` from `Nat.t` (which has aliases `Account_nonce.t`, `Length.t`, ....).

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
