### PR TITLE
More website mobilization

### DIFF
--- a/frontend/website/src/GetInvolvedSection.re
+++ b/frontend/website/src/GetInvolvedSection.re
@@ -364,9 +364,21 @@ let make = _ => {
             alignItems(`center),
           ])
         )>
-        <SocialLink link="#" name="Twitter" svg=SocialLink.Svg.twitter />
-        <SocialLink link="#" name="Discord" svg=SocialLink.Svg.discord />
-        <SocialLink link="#" name="Telegram" svg=SocialLink.Svg.telegram />
+        <SocialLink
+          link="https://twitter.com/codaprotocol"
+          name="Twitter"
+          svg=SocialLink.Svg.twitter
+        />
+        <SocialLink
+          link="https://discord.gg/wz7zQyc"
+          name="Discord"
+          svg=SocialLink.Svg.discord
+        />
+        <SocialLink
+          link="https://t.me/codaprotocol"
+          name="Telegram"
+          svg=SocialLink.Svg.telegram
+        />
       </div>
       <KnowledgeBase />
     </div>,

--- a/frontend/website/src/GetInvolvedSection.re
+++ b/frontend/website/src/GetInvolvedSection.re
@@ -3,7 +3,8 @@ module Link = {
   let make = (~message, _) => {
     ...component,
     render: _ => {
-      <a className=Style.Link.basic>
+      <a
+        className=Css.(merge([Style.Link.basic, style([cursor(`pointer)])]))>
         {ReasonReact.string(message ++ {js|\u00A0→|js})}
       </a>;
     },
@@ -14,31 +15,64 @@ module KnowledgeBase = {
   module SubSection = {
     let component =
       ReasonReact.statelessComponent("GetInvolved.KnowledgeBase.SubSection");
-    let make = (~title, ~content, _) => {
+    let make = (~className="", ~title, ~content, _) => {
       ...component,
       render: _ => {
         let items =
           Belt.Array.map(content, ((copy, link)) =>
             <li className={Css.style([Css.color(Style.Colors.hyperlink)])}>
-              <a href=link className=Style.Link.basic>
+              <a
+                href=link
+                className=Css.(
+                  merge([Style.Link.basic, style([cursor(`pointer)])])
+                )>
                 {ReasonReact.string(copy)}
               </a>
             </li>
           );
 
-        <div>
+        <div className>
           <h5
             className=Css.(
               merge([
                 Style.H5.basic,
-                style([marginLeft(`rem(3.)), marginRight(`rem(1.5))]),
+                style([
+                  marginLeft(`zero),
+                  marginRight(`zero),
+                  marginTop(`zero),
+                  marginBottom(`rem(0.75)),
+                  media(
+                    Style.MediaQuery.notMobile,
+                    [
+                      marginTop(`rem(1.5)),
+                      marginLeft(`rem(3.)),
+                      marginRight(`rem(1.5)),
+                    ],
+                  ),
+                ]),
               ])
             )>
             {ReasonReact.string(title)}
           </h5>
           <ul
             className=Css.(
-              style([marginLeft(`rem(1.5)), marginRight(`rem(1.5))])
+              style([
+                marginLeft(`zero),
+                marginRight(`zero),
+                paddingBottom(`zero),
+                marginBottom(`zero),
+                unsafe("padding-inline-start", "0.0rem"),
+                listStyle(`none, `inside, `none),
+                media(
+                  Style.MediaQuery.notMobile,
+                  [
+                    unsafe("padding-inline-start", "40px"), // browser default
+                    marginLeft(`rem(1.5)),
+                    marginRight(`rem(1.5)),
+                    listStyle(`disc, `outside, `none),
+                  ],
+                ),
+              ])
             )>
             ...items
           </ul>
@@ -58,9 +92,17 @@ module KnowledgeBase = {
             Style.Typeface.ibmplexserif,
             border(`px(1), `solid, Style.Colors.hyperlinkAlpha(0.3)),
             borderRadius(`px(18)),
-            paddingBottom(`rem(3.)),
-            marginLeft(`rem(3.)),
-            marginRight(`rem(3.)),
+            paddingBottom(`rem(1.)),
+            marginLeft(`zero),
+            marginRight(`zero),
+            media(
+              Style.MediaQuery.notMobile,
+              [
+                paddingBottom(`rem(3.)),
+                marginLeft(`rem(3.)),
+                marginRight(`rem(3.)),
+              ],
+            ),
           ])
         )>
         <legend>
@@ -90,6 +132,7 @@ module KnowledgeBase = {
             ])
           )>
           <SubSection
+            className=Css.(style([marginBottom(`rem(2.0))]))
             title="Articles"
             content=[|
               ("Fast Accumulation on Streams", "#"),
@@ -226,20 +269,32 @@ module SocialLink = {
   };
 
   let component = ReasonReact.statelessComponent("GetInvolved.SocialLink");
-  let make = (~name, ~svg, _children) => {
+  let make = (~link, ~name, ~svg, _children) => {
     ...component,
     render: _ => {
-      <div
+      <a
+        href=link
         className=Css.(
           style([
+            cursor(`pointer),
             display(`flex),
+            textDecoration(`none),
             justifyContent(`center),
             alignItems(`center),
+            hover([color(Style.Colors.hyperlinkHover)]),
           ])
         )>
         <div className=Css.(style([margin(`rem(1.))]))> svg </div>
-        <h3 className=Style.H3.wide> {ReasonReact.string(name)} </h3>
-      </div>;
+        <h3
+          className=Css.(
+            merge([
+              Style.H3.wide,
+              style([hover([color(Style.Colors.hyperlinkHover)])]),
+            ])
+          )>
+          {ReasonReact.string(name)}
+        </h3>
+      </a>;
     },
   };
 };
@@ -268,13 +323,28 @@ let make = _ => {
         )>
         <p
           className=Css.(
-            merge([Style.Body.basic, style([maxWidth(`rem(22.5))])])
+            merge([
+              Style.Body.basic,
+              style([
+                maxWidth(`rem(22.5)),
+                media(
+                  Style.MediaQuery.full,
+                  [marginRight(`rem(3.75)), marginLeft(`rem(3.75))],
+                ),
+              ]),
+            ])
           )>
           {ReasonReact.string(
              "Help us build a more accessible, sustainable cryptocurrency. Join our community on discord, and follow our progress on twitter.",
            )}
         </p>
-        <ul className=Css.(style([listStyle(`none, `inside, `none)]))>
+        <ul
+          className=Css.(
+            style([
+              listStyle(`none, `inside, `none),
+              unsafe("padding-inline-start", "0"),
+            ])
+          )>
           <li> <Link message="Stay updated about developing with Coda" /> </li>
           <li>
             <Link message="Notify me about participating in consensus" />
@@ -294,9 +364,9 @@ let make = _ => {
             alignItems(`center),
           ])
         )>
-        <SocialLink name="Twitter" svg=SocialLink.Svg.twitter />
-        <SocialLink name="Discord" svg=SocialLink.Svg.discord />
-        <SocialLink name="Telegram" svg=SocialLink.Svg.telegram />
+        <SocialLink link="#" name="Twitter" svg=SocialLink.Svg.twitter />
+        <SocialLink link="#" name="Discord" svg=SocialLink.Svg.discord />
+        <SocialLink link="#" name="Telegram" svg=SocialLink.Svg.telegram />
       </div>
       <KnowledgeBase />
     </div>,

--- a/frontend/website/src/InclusiveSection.re
+++ b/frontend/website/src/InclusiveSection.re
@@ -60,15 +60,14 @@ module Legend = {
   };
 
   let component = ReasonReact.statelessComponent("InclusiveSection.Legend");
-  let make = _ => {
+  let make = (~className, _children) => {
     ...component,
     render: _self => {
       <div
         className=Css.(
-          style([
-            display(`flex),
-            justifyContent(`center),
-            alignItems(`center),
+          merge([
+            className,
+            style([justifyContent(`center), alignItems(`center)]),
           ])
         )>
         <div
@@ -77,7 +76,8 @@ module Legend = {
               display(`flex),
               marginTop(`zero),
               marginBottom(`zero),
-              marginRight(`rem(2.25)),
+              marginRight(`zero),
+              media(Style.MediaQuery.notMobile, [marginRight(`rem(2.25))]),
             ])
           )>
           <Square
@@ -134,13 +134,19 @@ module Figure = {
   };
 };
 
+let legendQuery = "(min-width: 66.8125rem)";
+
 let component = ReasonReact.statelessComponent("InclusiveSection");
 let make = _ => {
   ...component,
   render: _self =>
     <div className=Css.(style([marginTop(`rem(2.5))]))>
       <Title fontColor=Style.Colors.denimTwo text="Inclusive consensus" />
-      <Legend />
+      <Legend
+        className=Css.(
+          style([display(`none), media(legendQuery, [display(`flex)])])
+        )
+      />
       <div
         className=Css.(
           style([
@@ -162,13 +168,27 @@ let make = _ => {
           caption="Other Blockchains"
           captionColor=Style.Colors.navy
         />
-        <SideText
-          paragraphs=[|
-            "Simple, fair consensus. Participation is proportional to how much stake you have in the protocol with no lockups, no forced delegation, and low bandwidth requirements.",
-            "With just a small stake, you'll be able to participate directly in consensus and earn Coda.",
-          |]
-          cta="Stay updated about participating in consensus"
-        />
+        <div>
+          <div
+            className=Css.(style([display(`flex), justifyContent(`center)]))>
+            <SideText
+              paragraphs=[|
+                "Simple, fair consensus. Participation is proportional to how much stake you have in the protocol with no lockups, no forced delegation, and low bandwidth requirements.",
+                "With just a small stake, you'll be able to participate directly in consensus and earn Coda.",
+              |]
+              cta="Stay updated about participating in consensus"
+            />
+          </div>
+          <Legend
+            className=Css.(
+              style([
+                display(`flex),
+                marginTop(`rem(2.0)),
+                media(legendQuery, [display(`none)]),
+              ])
+            )
+          />
+        </div>
       </div>
     </div>,
 };

--- a/frontend/website/src/Nav.re
+++ b/frontend/website/src/Nav.re
@@ -85,10 +85,7 @@ module NavStyle = {
 };
 
 module Logo = {
-  let svg =
-    <svg className=Css.(style([width(`rem(7.125)), height(`rem(1.25))]))>
-      <image xlinkHref="/static/img/new-logo.svg" width="114" height="20" />
-    </svg>;
+  let svg = <Svg link="/static/img/new-logo.svg" dims=(7.125, 1.25) />;
 };
 
 let component = ReasonReact.statelessComponent("Nav");

--- a/frontend/website/src/Page.re
+++ b/frontend/website/src/Page.re
@@ -108,7 +108,12 @@ let make =
     ) => {
   ...component,
   render: _ =>
-    <html>
+    <html
+      className=Css.(
+        style([
+          media(Style.MediaQuery.iphoneSEorSmaller, [fontSize(`px(13))]),
+        ])
+      )>
       <Head filename=name extra=extraHeaders />
       <body>
         {if (Grid.enabled) {

--- a/frontend/website/src/SideText.re
+++ b/frontend/website/src/SideText.re
@@ -22,7 +22,13 @@ let make = (~paragraphs, ~cta, _children) => {
         </p>
       );
 
-    <div className=Css.(style([width(`rem(21.0))]))>
+    <div
+      className=Css.(
+        style([
+          width(`rem(20.625)),
+          media(Style.MediaQuery.notSmallMobile, [width(`rem(21.0))]),
+        ])
+      )>
       {ReasonReact.array(ps)}
       <a
         href=Links.mailingList

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -111,6 +111,8 @@ module MediaQuery = {
   let full = "(min-width: 48rem)";
   let notMobile = "(min-width: 32rem)";
   let notSmallMobile = "(min-width: 25rem)";
+  // to adjust root font size
+  let iphoneSEorSmaller = "(max-width: 24rem)";
 };
 
 /** sets both paddingLeft and paddingRight, as one should */

--- a/frontend/website/src/SustainableSection.re
+++ b/frontend/website/src/SustainableSection.re
@@ -62,7 +62,11 @@ let make = _children => {
         )>
         <div
           className=Css.(
-            style([marginBottom(`rem(2.375)), userSelect(`none)])
+            style([
+              marginBottom(`rem(2.375)),
+              userSelect(`none),
+              maxWidth(`rem(23.875)),
+            ])
           )>
           <Svg
             link="/static/img/chart-blockchain-size.svg"
@@ -72,7 +76,11 @@ let make = _children => {
         </div>
         <div
           className=Css.(
-            style([marginBottom(`rem(2.375)), userSelect(`none)])
+            style([
+              marginBottom(`rem(2.375)),
+              userSelect(`none),
+              maxWidth(`rem(23.125)),
+            ])
           )>
           <Svg
             link="/static/img/chart-blockchain-energy.svg"

--- a/frontend/website/src/Svg.re
+++ b/frontend/website/src/Svg.re
@@ -36,8 +36,8 @@ let make = (~link, ~dims, ~inline=false, ~className="", _children) => {
         )>
         <image
           xlinkHref=link
-          width={Js.Int.toString(Size.pixelsX(dims))}
-          height={Js.Int.toString(Size.pixelsY(dims))}
+          width={Js.Float.toString(Size.remX(dims)) ++ "rem"}
+          height={Js.Float.toString(Size.remY(dims)) ++ "rem"}
         />
       </svg>;
     },

--- a/frontend/website/static/img/chart-blockchain-energy.svg
+++ b/frontend/website/static/img/chart-blockchain-energy.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cb1db2de44840e7279ab4bd0b8f6967ede0afe3df1f241c52d7e07327f4ca771
-size 1888
+oid sha256:6d719ae06e1173a83eb7e7118369c58fe3a9c847189b6f5ce58a0fbe7b09ed91
+size 1876

--- a/frontend/website/static/img/chart-blockchain-size.svg
+++ b/frontend/website/static/img/chart-blockchain-size.svg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9eb3f3c8cd6bed0c0962c1e68608652b31b9fe7f868f1451801fb5988860a439
-size 2336
+oid sha256:196c4f9fbe99dd5b84266cbf3a26b39dcc8b74c2a40746ba1932cde8eca4ddb0
+size 2324


### PR DESCRIPTION
The website looks pretty good on mobile now (including iphone SE 320px width).

* Set root font size to be smaller for iphoneSE sized devices to rescale layout (thank god we used rems)
* SVGs can take rem widths as their width and height (and they need to, to look good at 320)
* Inclusive consensus does the display none hack :( , legend just needed to be in two different spots in the DOM
* Sustainable section SVGs are changed to use width100% in the SVG files and the wrapping div has a maxWidth so they'll look good as we scale down to mobile
* GetInvolved section knowledgebase on mobile is more to spec + I added hover states to the social links


## Improved knowledgebase on mobile

<img width="391" alt="Screen Shot 2019-03-24 at 4 10 55 PM" src="https://user-images.githubusercontent.com/515445/54887903-2915ec00-4e55-11e9-94bb-fc7c300459b8.png">

## I didn't break full btw

<img width="1099" alt="Screen Shot 2019-03-24 at 4 11 06 PM" src="https://user-images.githubusercontent.com/515445/54887904-2915ec00-4e55-11e9-9993-6b4d10d987cb.png">

## 320 width before

<img width="344" alt="Screen Shot 2019-03-24 at 4 21 46 PM" src="https://user-images.githubusercontent.com/515445/54887915-40ed7000-4e55-11e9-8e0d-dc1cd4a6c866.png">

## 320 width after

<img width="344" alt="Screen Shot 2019-03-24 at 4 21 16 PM" src="https://user-images.githubusercontent.com/515445/54887914-40ed7000-4e55-11e9-8bfc-e14c617dce01.png">

## Inclusive consensus

<img width="435" alt="Screen Shot 2019-03-24 at 4 44 00 PM" src="https://user-images.githubusercontent.com/515445/54887925-5cf11180-4e55-11e9-8c2a-3f4210c61ea3.png">

## Sustainable scalability

<img width="435" alt="Screen Shot 2019-03-24 at 4 49 17 PM" src="https://user-images.githubusercontent.com/515445/54887930-61b5c580-4e55-11e9-908c-3001306d4c3b.png">

