### PR TITLE
Signup whitespace shift and various improvements

### DIFF
--- a/frontend/website/src/CodaNav.re
+++ b/frontend/website/src/CodaNav.re
@@ -40,7 +40,7 @@ module SignupButton = {
           merge([
             H4.wide,
             style(
-              paddingX(`rem(1.0))
+              paddingX(`rem(0.75))
               @ paddingY(`rem(0.75))
               @ [
                 width(`rem(6.25)),
@@ -58,10 +58,9 @@ module SignupButton = {
                 // when the screen is small enough to show a menu
                 media(
                   Nav.NavStyle.MediaQuery.menuMax,
-                  [
+                  paddingX(`zero)
+                  @ [
                     height(`auto),
-                    paddingLeft(`rem(0.)),
-                    paddingRight(`zero),
                     borderWidth(`zero),
                     Typeface.ibmplexsans,
                     color(Colors.metallicBlue),
@@ -81,7 +80,12 @@ module SignupButton = {
             ),
           ])
         )>
-        {ReasonReact.string(name)}
+        <span
+          className=Css.(
+            style([marginLeft(`rem(0.25)), marginRight(`rem(0.0625))])
+          )>
+          {ReasonReact.string(name)}
+        </span>
       </a>;
     },
   };

--- a/frontend/website/src/CryptoAppsSection.re
+++ b/frontend/website/src/CryptoAppsSection.re
@@ -5,26 +5,52 @@ module Code = {
   let make = (~src, _children) => {
     ...component,
     render: _self =>
-      <pre
+      <div
         className=Css.(
-          style(
-            Style.paddingX(`rem(1.0))
-            @ Style.paddingY(`rem(1.0))
-            @ [
-              backgroundColor(Style.Colors.navy),
-              color(Style.Colors.white),
-              Style.Typeface.ibmplexsans,
-              fontSize(`rem(0.8125)),
-              borderRadius(`px(12)),
-              lineHeight(`rem(1.25)),
-              // nudge so code background looks nicer
-              marginRight(`rem(0.25)),
-              marginLeft(`rem(0.25)),
-            ],
-          )
+          style([
+            display(`block),
+            position(`relative),
+            media(Style.MediaQuery.veryLarge, [width(`percent(40.0))]),
+            before([
+              contentRule(""),
+              display(`none),
+              media(
+                Style.MediaQuery.veryLarge,
+                [
+                  display(`block),
+                  position(`absolute),
+                  top(`percent(50.0)),
+                  left(`percent(11.4)), // determined experimentally
+                  width(`percent(100.0)),
+                  height(`rem(0.125)),
+                  backgroundColor(Style.Colors.navy),
+                ],
+              ),
+            ]),
+          ])
         )>
-        {ReasonReact.string(src)}
-      </pre>,
+        <pre
+          className=Css.(
+            style(
+              Style.paddingX(`rem(1.0))
+              @ Style.paddingY(`rem(1.0))
+              @ [
+                backgroundColor(Style.Colors.navy),
+                color(Style.Colors.white),
+                Style.Typeface.ibmplexsans,
+                fontSize(`rem(0.8125)),
+                borderRadius(`px(12)),
+                lineHeight(`rem(1.25)),
+                // nudge so code background looks nicer
+                marginRight(`rem(0.25)),
+                marginLeft(`rem(0.25)),
+                media(Style.MediaQuery.notMobile, [width(`rem(23.0))]),
+              ],
+            )
+          )>
+          {ReasonReact.string(src)}
+        </pre>
+      </div>,
   };
 };
 

--- a/frontend/website/src/HeroSection.re
+++ b/frontend/website/src/HeroSection.re
@@ -42,6 +42,7 @@ module Copy = {
                 Style.Body.big,
                 style([
                   marginTop(`rem(1.75)),
+                  maxWidth(`rem(28.0)),
                   // align with the grid
                   media(
                     Style.MediaQuery.full,

--- a/frontend/website/src/HeroSection.re
+++ b/frontend/website/src/HeroSection.re
@@ -131,10 +131,10 @@ module Graphic = {
               {ReasonReact.string(size)}
             </h3>
           </div>
-          <h4
+          <h5
             className=Css.(
               merge([
-                Style.H4.basic,
+                Style.H5.basic,
                 style([
                   marginTop(`rem(1.125)),
                   marginBottom(`rem(0.375)),
@@ -142,7 +142,7 @@ module Graphic = {
               ])
             )>
             {ReasonReact.string(label)}
-          </h4>
+          </h5>
         </div>,
     };
   };
@@ -177,7 +177,7 @@ module Graphic = {
               name="Other blockchains"
               size="2TB+"
               label="Increasing"
-              textColor=Style.Colors.purpleBrown>
+              textColor=Style.Colors.rosebud>
               Big.svg
             </Info>
           </div>

--- a/frontend/website/src/InclusiveSection.re
+++ b/frontend/website/src/InclusiveSection.re
@@ -89,7 +89,7 @@ module Legend = {
           <h5
             className=Css.(
               merge([
-                Style.H5.basic,
+                Style.H5.tight,
                 style([
                   width(`rem(8.0)),
                   marginTop(`zero),

--- a/frontend/website/src/Page.re
+++ b/frontend/website/src/Page.re
@@ -111,6 +111,7 @@ let make =
     <html
       className=Css.(
         style([
+          media(Style.MediaQuery.iphoneXorSmaller, [fontSize(`px(15))]),
           media(Style.MediaQuery.iphoneSEorSmaller, [fontSize(`px(13))]),
         ])
       )>

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -12,7 +12,6 @@ module Colors = {
   let greyishBrown = `rgb((74, 74, 74));
 
   let bluishGreen = `rgb((22, 168, 85));
-  let purpleBrown = `rgb((100, 46, 48));
   let offWhite = `rgb((243, 243, 243));
   let grey = `rgb((129, 146, 168));
 
@@ -33,6 +32,8 @@ module Colors = {
 
   let teal = `rgb((71, 130, 160));
   let tealAlpha = a => `rgba((71, 130, 160, a));
+
+  let rosebud = `rgb((163, 83, 111));
 };
 
 module Typeface = {
@@ -241,16 +242,19 @@ module H4 = {
 module H5 = {
   open Css;
 
-  let basic =
+  let init =
     style([
       Typeface.ibmplexsans,
       fontSize(`rem(0.9345)),
-      lineHeight(`rem(1.5)),
       letterSpacing(`rem(0.125)),
       fontWeight(`normal),
       color(Colors.slateAlpha(0.5)),
       textTransform(`uppercase),
     ]);
+
+  let basic = merge([init, style([lineHeight(`rem(1.5))])]);
+
+  let tight = merge([init, style([lineHeight(`rem(1.25))])]);
 };
 
 module Body = {

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -112,8 +112,9 @@ module MediaQuery = {
   let full = "(min-width: 48rem)";
   let notMobile = "(min-width: 32rem)";
   let notSmallMobile = "(min-width: 25rem)";
-  // to adjust root font size
-  let iphoneSEorSmaller = "(max-width: 24rem)";
+  // to adjust root font size (therefore pixels)
+  let iphoneSEorSmaller = "(max-width: 374px)";
+  let iphoneXorSmaller = "(max-width: 384px)";
 };
 
 /** sets both paddingLeft and paddingRight, as one should */


### PR DESCRIPTION
  * Too much whitespace after signup button p
  * Hero `<p>` too wide
  * Red is too dark on other-blockchains
  * Font on fixed/increasing is too dark
  * Line from coda code to coda icon
  * Plus it doesn't look bad on 375 width anymore

<img width="1308" alt="Screen Shot 2019-03-25 at 2 38 53 PM" src="https://user-images.githubusercontent.com/515445/54957046-dbf65080-4f0e-11e9-879e-ff60265dd2c7.png">
