### PR TITLE
renamed strongest_ledgers to verified_transitions

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -339,7 +339,7 @@ module type Main_intf = sig
 
   val peers : t -> Network_peer.Peer.t list
 
-  val strongest_ledgers :
+  val verified_transitions :
        t
     -> (Inputs.External_transition.Verified.t, State_hash.t) With_hash.t
        Strict_pipe.Reader.t

--- a/src/app/cli/src/coda_process.ml
+++ b/src/app/cli/src/coda_process.ml
@@ -85,10 +85,10 @@ let prove_receipt_exn (conn, proc, _) proving_receipt resulting_receipt =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.prove_receipt
     ~arg:(proving_receipt, resulting_receipt)
 
-let strongest_ledgers_exn (conn, proc, _) =
+let verified_transitions_exn (conn, proc, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn
-      ~f:Coda_worker.functions.strongest_ledgers ~arg:()
+      ~f:Coda_worker.functions.verified_transitions ~arg:()
   in
   Linear_pipe.wrap_reader r
 

--- a/src/app/cli/src/coda_worker_testnet.ml
+++ b/src/app/cli/src/coda_worker_testnet.ml
@@ -305,7 +305,7 @@ let events workers start_reader =
   let event_r, event_w = Linear_pipe.create () in
   let root_r, root_w = Linear_pipe.create () in
   let connect_worker i worker =
-    let%bind transitions = Coda_process.strongest_ledgers_exn worker in
+    let%bind transitions = Coda_process.verified_transitions_exn worker in
     let%bind roots = Coda_process.root_diff_exn worker in
     Linear_pipe.transfer transitions event_w ~f:(fun t -> `Transition (i, t))
     |> don't_wait_for ;

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -98,7 +98,7 @@ let run_test () : unit Deferred.t =
       Main.start coda ;
       don't_wait_for
         (Strict_pipe.Reader.iter_without_pushback
-           (Main.strongest_ledgers coda)
+           (Main.verified_transitions coda)
            ~f:ignore) ;
       let wait_until_cond ~(f : t -> bool) ~(timeout : Float.t) =
         let rec go () =

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -384,7 +384,7 @@ module Make (Inputs : Inputs_intf) = struct
     ; transaction_pool: Transaction_pool.t
     ; snark_pool: Snark_pool.t
     ; transition_frontier: Transition_frontier.t option Broadcast_pipe.Reader.t
-    ; strongest_ledgers:
+    ; verified_transitions:
         (External_transition.Verified.t, Protocol_state_hash.t) With_hash.t
         Strict_pipe.Reader.t
     ; proposer_transition_writer:
@@ -502,7 +502,7 @@ module Make (Inputs : Inputs_intf) = struct
     let%bind sl = best_staged_ledger_opt t in
     Staged_ledger.current_ledger_proof sl
 
-  let strongest_ledgers t = t.strongest_ledgers
+  let verified_transitions t = t.verified_transitions
 
   let root_diff t =
     let root_diff_reader, root_diff_writer =
@@ -744,7 +744,7 @@ module Make (Inputs : Inputs_intf) = struct
               ; time_controller= config.time_controller
               ; external_transitions_writer=
                   Strict_pipe.Writer.to_linear_pipe external_transitions_writer
-              ; strongest_ledgers= valid_transitions_for_api
+              ; verified_transitions= valid_transitions_for_api
               ; logger= config.logger
               ; seen_jobs= Work_selector.State.init
               ; staged_ledger_transition_backup_capacity=


### PR DESCRIPTION
it's not used for much (driving some testnet event loops) but the name is now accurate.