### PR TITLE
gossip_net: bump up timeout

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -301,7 +301,7 @@ let daemon logger =
          { M.Inputs.Net.Config.logger
          ; time_controller
          ; gossip_net_params=
-             { timeout= Time.Span.of_sec 1.
+             { timeout= Time.Span.of_sec 3.
              ; logger
              ; target_peer_count= 8
              ; conf_dir

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -326,7 +326,7 @@ module T = struct
             { Main.Inputs.Net.Config.logger
             ; time_controller
             ; gossip_net_params=
-                { Main.Inputs.Net.Gossip_net.Config.timeout= Time.Span.of_sec 1.
+                { Main.Inputs.Net.Gossip_net.Config.timeout= Time.Span.of_sec 3.
                 ; target_peer_count= 8
                 ; conf_dir
                 ; initial_peers= peers

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -71,7 +71,7 @@ let run_test () : unit Deferred.t =
         { Inputs.Net.Config.logger
         ; time_controller
         ; gossip_net_params=
-            { Inputs.Net.Gossip_net.Config.timeout= Time.Span.of_sec 1.
+            { Inputs.Net.Gossip_net.Config.timeout= Time.Span.of_sec 3.
             ; logger
             ; target_peer_count= 8
             ; initial_peers= []


### PR DESCRIPTION
For some reason, in the 5 proposer test with payments, I was seeing transaction diff broadcast timeouts to one particular node. I tripled the timeout and it went away. Looking at the trace, the node was not blocked for an entire second ever, but it seems like there might be some latency problem somewhere in the gossip net control flow.