### PR TITLE
disable macos while circle is down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,53 +63,53 @@ jobs:
                   name: Update branch protection rule from test configuration
                   command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status
 
-    build-macos:
-        macos:
-            xcode: "10.1.0"
-        working_directory: /Users/distiller/coda
-        environment:
-            HOMEBREW_LOGS: /Users/distiller/homebrew.log
-            OPAMYES: 1
-        steps:
-            - run:
-                name: Make /nix paths
-                command: |
-                    sudo mkdir /nix
-                    sudo chown distiller /nix
-            - checkout
-            - restore_cache:
-                  keys:
-                      - homebrew-v1-{{ checksum "scripts/macos-setup.sh" }}
-                      - homebrew-v1-
-            - restore_cache:
-                  keys:
-                      - opam-v3-{{ checksum "src/opam.export" }}
-                      - opam-v3-
-            - run: git submodule sync && git submodule update --init --recursive
-            - run:
-                  name: Download Deps -- make macos-setup-download
-                  command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
-            - run:
-                  name: Compile Deps -- make macos-setup-compile
-                  command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
-            - save_cache:
-                  key: homebrew-v1-{{ checksum "scripts/macos-setup.sh" }}
-                  paths:
-                      - "/usr/local/Homebrew"
-                      - "/Users/distiller/Library/Caches/Homebrew"
-            - save_cache:
-                  key: opam-v3-{{ checksum "src/opam.export" }}
-                  paths:
-                      - "/Users/distiller/.opam"
-            - run:
-                  name: Build OCaml
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
-            - run:
-                  name: Record Constraint System Digests
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'src/_build/default/app/cli/src/coda.exe client constraint-system-digests | tee /tmp/constraint-system-digests.log'
-            - run:
-                  name: Run all tests (on master)
-                  command: echo "FIXME Tests not yet working on mac"
+    #build-macos:
+    #    macos:
+    #        xcode: "10.1.0"
+    #    working_directory: /Users/distiller/coda
+    #    environment:
+    #        HOMEBREW_LOGS: /Users/distiller/homebrew.log
+    #        OPAMYES: 1
+    #    steps:
+    #        - run:
+    #            name: Make /nix paths
+    #            command: |
+    #                sudo mkdir /nix
+    #                sudo chown distiller /nix
+    #        - checkout
+    #        - restore_cache:
+    #              keys:
+    #                  - homebrew-v1-{{ checksum "scripts/macos-setup.sh" }}
+    #                  - homebrew-v1-
+    #        - restore_cache:
+    #              keys:
+    #                  - opam-v3-{{ checksum "src/opam.export" }}
+    #                  - opam-v3-
+    #        - run: git submodule sync && git submodule update --init --recursive
+    #        - run:
+    #              name: Download Deps -- make macos-setup-download
+    #              command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
+    #        - run:
+    #              name: Compile Deps -- make macos-setup-compile
+    #              command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
+    #        - save_cache:
+    #              key: homebrew-v1-{{ checksum "scripts/macos-setup.sh" }}
+    #              paths:
+    #                  - "/usr/local/Homebrew"
+    #                  - "/Users/distiller/Library/Caches/Homebrew"
+    #        - save_cache:
+    #              key: opam-v3-{{ checksum "src/opam.export" }}
+    #              paths:
+    #                  - "/Users/distiller/.opam"
+    #        - run:
+    #              name: Build OCaml
+    #              command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
+    #        - run:
+    #              name: Record Constraint System Digests
+    #              command: ./scripts/skip_if_only_frontend.sh bash -c 'src/_build/default/app/cli/src/coda.exe client constraint-system-digests | tee /tmp/constraint-system-digests.log'
+    #        - run:
+    #              name: Run all tests (on master)
+    #              command: echo "FIXME Tests not yet working on mac"
     build-artifacts--testnet_postake:
         resource_class: large
         docker:
@@ -352,7 +352,6 @@ workflows:
                   branches:
                     only: master
             - tracetool
-            - build-macos
             - build-wallet
             - build-artifacts--testnet_postake
             - build-artifacts--testnet_postake_snarkless_fake_hash

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -63,53 +63,53 @@ jobs:
                   name: Update branch protection rule from test configuration
                   command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status
 
-    build-macos:
-        macos:
-            xcode: "10.1.0"
-        working_directory: /Users/distiller/coda
-        environment:
-            HOMEBREW_LOGS: /Users/distiller/homebrew.log
-            OPAMYES: 1
-        steps:
-            - run:
-                name: Make /nix paths
-                command: |
-                    sudo mkdir /nix
-                    sudo chown distiller /nix
-            - checkout
-            - restore_cache:
-                  keys:
-                      - homebrew-v1-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
-                      - homebrew-v1-
-            - restore_cache:
-                  keys:
-                      - opam-v3-{{'{{'}} checksum "src/opam.export" {{'}}'}}
-                      - opam-v3-
-            - run: git submodule sync && git submodule update --init --recursive
-            - run:
-                  name: Download Deps -- make macos-setup-download
-                  command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
-            - run:
-                  name: Compile Deps -- make macos-setup-compile
-                  command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
-            - save_cache:
-                  key: homebrew-v1-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
-                  paths:
-                      - "/usr/local/Homebrew"
-                      - "/Users/distiller/Library/Caches/Homebrew"
-            - save_cache:
-                  key: opam-v3-{{'{{'}} checksum "src/opam.export" {{'}}'}}
-                  paths:
-                      - "/Users/distiller/.opam"
-            - run:
-                  name: Build OCaml
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
-            - run:
-                  name: Record Constraint System Digests
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'src/_build/default/app/cli/src/coda.exe client constraint-system-digests | tee /tmp/constraint-system-digests.log'
-            - run:
-                  name: Run all tests (on master)
-                  command: echo "FIXME Tests not yet working on mac"
+    #build-macos:
+    #    macos:
+    #        xcode: "10.1.0"
+    #    working_directory: /Users/distiller/coda
+    #    environment:
+    #        HOMEBREW_LOGS: /Users/distiller/homebrew.log
+    #        OPAMYES: 1
+    #    steps:
+    #        - run:
+    #            name: Make /nix paths
+    #            command: |
+    #                sudo mkdir /nix
+    #                sudo chown distiller /nix
+    #        - checkout
+    #        - restore_cache:
+    #              keys:
+    #                  - homebrew-v1-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
+    #                  - homebrew-v1-
+    #        - restore_cache:
+    #              keys:
+    #                  - opam-v3-{{'{{'}} checksum "src/opam.export" {{'}}'}}
+    #                  - opam-v3-
+    #        - run: git submodule sync && git submodule update --init --recursive
+    #        - run:
+    #              name: Download Deps -- make macos-setup-download
+    #              command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
+    #        - run:
+    #              name: Compile Deps -- make macos-setup-compile
+    #              command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
+    #        - save_cache:
+    #              key: homebrew-v1-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
+    #              paths:
+    #                  - "/usr/local/Homebrew"
+    #                  - "/Users/distiller/Library/Caches/Homebrew"
+    #        - save_cache:
+    #              key: opam-v3-{{'{{'}} checksum "src/opam.export" {{'}}'}}
+    #              paths:
+    #                  - "/Users/distiller/.opam"
+    #        - run:
+    #              name: Build OCaml
+    #              command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
+    #        - run:
+    #              name: Record Constraint System Digests
+    #              command: ./scripts/skip_if_only_frontend.sh bash -c 'src/_build/default/app/cli/src/coda.exe client constraint-system-digests | tee /tmp/constraint-system-digests.log'
+    #        - run:
+    #              name: Run all tests (on master)
+    #              command: echo "FIXME Tests not yet working on mac"
 
     {%- for profile in build_artifact_profiles %}
     build-artifacts--{{profile}}:
@@ -190,7 +190,6 @@ workflows:
                   branches:
                     only: master
             - tracetool
-            - build-macos
             - build-wallet
             {%- for profile in build_artifact_profiles %}
             - build-artifacts--{{profile}}


### PR DESCRIPTION
[CircleCI currently has degraded performance](https://status.circleci.com/incidents/9jg85s3m1th8) and we're seeing our mac builds sit in the queue forever. Since they are currently failing anyway, let's just ignore them for now.