### PR TITLE
proof_level=check should complain if check fails

### DIFF
--- a/src/app/cli/src/prover.ml
+++ b/src/app/cli/src/prover.ml
@@ -136,13 +136,15 @@ module Worker_state = struct
                      (Consensus_mechanism.Prover_state.handler
                         state_for_handler)
                  in
-                 let _ =
+                 match
                    Tick.Groth16.check
                      (main @@ Tick.Field.Var.constant next_state_top_hash)
                      prover_state
-                 in
-                 { Blockchain.state= next_state
-                 ; proof= Precomputed_values.base_proof }
+                 with
+                 | Ok () ->
+                     { Blockchain.state= next_state
+                     ; proof= Precomputed_values.base_proof }
+                 | Error e -> Error.raise e
 
                let verify state proof = true
              end

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -549,6 +549,8 @@ end = struct
 
     let%test_module "currency_test" =
       ( module struct
+        let check c () = Or_error.is_ok (check c ())
+
         let expect_failure err c = if check c () then failwith err
 
         let expect_success err c = if not (check c ()) then failwith err

--- a/src/lib/snark_params/snark_util.ml
+++ b/src/lib/snark_params/snark_util.ml
@@ -158,6 +158,8 @@ module Make (Impl : Snarky.Snark_intf.S) = struct
           test ()
         done
 
+      let check x () = Or_error.is_ok (check x ())
+
       let%test_unit "boolean_assert_lte" =
         assert (
           check


### PR DESCRIPTION
:scream: forgot to push my snarky change that threw an exception instead of using a bool. this makes proof_level=check useful.