### PR TITLE
Improve fonts and firefox knowledgebase centering

### DIFF
--- a/frontend/website/src/GetInvolvedSection.re
+++ b/frontend/website/src/GetInvolvedSection.re
@@ -110,24 +110,28 @@ module KnowledgeBase = {
             ),
           ])
         )>
-        <legend>
-          <h4
-            className=Css.(
-              style([
-                letterSpacing(`rem(0.1875)),
-                border(`px(1), `solid, Style.Colors.midnight),
-                paddingLeft(`rem(1.0)),
-                paddingRight(`rem(1.0)),
-                paddingTop(`rem(0.5)),
-                paddingBottom(`rem(0.5)),
-                textTransform(`uppercase),
-                fontWeight(`medium),
-                color(Style.Colors.midnight),
-              ])
-            )>
-            {ReasonReact.string("Knowledge base")}
-          </h4>
-        </legend>
+        {ReactDOMRe.createElement(
+           "legend",
+           ~props=ReactDOMRe.objToDOMProps({"align": "center"}),
+           [|
+             <h4
+               className=Css.(
+                 style([
+                   letterSpacing(`rem(0.1875)),
+                   border(`px(1), `solid, Style.Colors.midnight),
+                   paddingLeft(`rem(1.0)),
+                   paddingRight(`rem(1.0)),
+                   paddingTop(`rem(0.5)),
+                   paddingBottom(`rem(0.5)),
+                   textTransform(`uppercase),
+                   fontWeight(`medium),
+                   color(Style.Colors.midnight),
+                 ])
+               )>
+               {ReasonReact.string("Knowledge base")}
+             </h4>,
+           |],
+         )}
         <div
           className=Css.(
             style([

--- a/frontend/website/src/Head.re
+++ b/frontend/website/src/Head.re
@@ -19,6 +19,11 @@ let make = (~extra, ~filename, _children) => {
   ...component,
   render: _self =>
     <head>
+      {ReactDOMRe.createElement(
+         "meta",
+         ~props=ReactDOMRe.objToDOMProps({"charSet": "utf-8"}),
+         [||],
+       )}
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta
         property="og:image"

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -37,7 +37,7 @@ let writeStatic = (path, rootComponent) => {
     extractCritical(ReactDOMServerRe.renderToStaticMarkup(rootComponent));
   Node.Fs.writeFileAsUtf8Sync(
     path ++ ".html",
-    "<!doctype html><meta charset=\"utf-8\" />\n" ++ rendered##html,
+    "<!doctype html>\n" ++ rendered##html,
   );
   Node.Fs.writeFileAsUtf8Sync(path ++ ".css", rendered##css);
 };

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -43,26 +43,24 @@ module Typeface = {
   open Css;
   let weights = [
     // The weights are intentionally shifted thinner one unit
-    (`thin, "Thin", "Thin"),
-    (`extraLight, "ExtraLight", "Thin"),
-    (`light, "Light", "ExtraLight"),
-    (`normal, "Regular", "Light"),
-    (`medium, "Medium", "Regular"),
-    (`semiBold, "SemiBold", "Medium"),
-    (`bold, "Bold", "SemiBold"),
-    (`extraBold, "ExtraBold", "Bold"),
+    (`thin, "Thin"),
+    (`extraLight, "Thin"),
+    (`light, "ExtraLight"),
+    (`normal, "Light"),
+    (`medium, "Regular"),
+    (`semiBold, "Medium"),
+    (`bold, "SemiBold"),
+    (`extraBold, "Bold"),
   ];
 
   // TODO: add format("woff") and unicode ranges
   let () =
     List.iter(
-      ((weight, localName, name)) =>
+      ((weight, name)) =>
         ignore @@
         fontFace(
           ~fontFamily="IBM Plex Sans",
           ~src=[
-            localUrl("IBM Plex Sans " ++ localName),
-            localUrl("IBMPlexSans-" ++ localName),
             url("/static/font/IBMPlexSans-" ++ name ++ "-Latin1.woff2"),
             url("/static/font/IBMPlexSans-" ++ name ++ "-Latin1.woff"),
           ],
@@ -77,8 +75,6 @@ module Typeface = {
     fontFace(
       ~fontFamily="IBM Plex Mono",
       ~src=[
-        localUrl("IBM Plex Mono SemiBold"),
-        localUrl("IBMPlexMono-SemiBold"),
         url("/static/font/IBMPlexMono-Medium-Latin1.woff2"),
         url("/static/font/IBMPlexMono-Medium-Latin1.woff"),
       ],
@@ -90,8 +86,6 @@ module Typeface = {
     fontFace(
       ~fontFamily="IBM Plex Mono",
       ~src=[
-        localUrl("IBM Plex Mono Bold"),
-        localUrl("IBMPlexMono-Bold"),
         url("/static/font/IBMPlexMono-SemiBold-Latin1.woff2"),
         url("/static/font/IBMPlexMono-SemiBold-Latin1.woff"),
       ],
@@ -105,8 +99,6 @@ module Typeface = {
       fontFace(
         ~fontFamily="IBM Plex Serif",
         ~src=[
-          localUrl("IBM Plex Serif Medium"),
-          localUrl("IBMPlexSerif-Medium"),
           url("/static/font/IBMPlexSerif-Medium-Latin1.woff2"),
           url("/static/font/IBMPlexSerif-Medium-Latin1.woff"),
         ],

--- a/frontend/website/static/font/IBMPlexMono-Medium-Latin1.woff
+++ b/frontend/website/static/font/IBMPlexMono-Medium-Latin1.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b9b91dae7549e044797f7c029beb5c00cec131c56a4a8604d4ffac0940dc769e
+size 18320

--- a/frontend/website/static/font/IBMPlexMono-Medium-Latin1.woff2
+++ b/frontend/website/static/font/IBMPlexMono-Medium-Latin1.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cde1fc437aa530319ffbf813a040e956733e74dcc69e516f0ac302e06049be1f
+size 13808


### PR DESCRIPTION
`<legend align=center>` isn't a supported property in reasonreact but is required for the fieldset legend to be centered in firefox, so we have to use `createElement`.
- Removed local font loading for now
- Actually push the IBM plex mono fonts