### PR TITLE
Improve style for GetInvolved, fix alt copy

### DIFF
--- a/frontend/website/src/GetInvolvedSection.re
+++ b/frontend/website/src/GetInvolvedSection.re
@@ -27,7 +27,7 @@ module KnowledgeBase = {
                   color(Style.Colors.hyperlink),
                   listStyle(`none, `inside, `none),
                   before([
-                    unsafe("content", {js|"•"|js}),
+                    unsafe("content", {js|"*"|js}),
                     color(Style.Colors.hyperlink),
                     marginRight(`rem(1.)),
                     display(`inlineBlock),
@@ -51,6 +51,7 @@ module KnowledgeBase = {
                 Style.H5.basic,
                 style([
                   marginLeft(`zero),
+                  color(Style.Colors.slate),
                   marginRight(`zero),
                   marginTop(`zero),
                   marginBottom(`rem(0.75)),
@@ -71,10 +72,6 @@ module KnowledgeBase = {
                 paddingLeft(`zero),
                 paddingRight(`zero),
                 marginBottom(`zero),
-                media(
-                  Style.MediaQuery.notMobile,
-                  [marginRight(`rem(1.5))],
-                ),
               ])
             )>
             ...items
@@ -96,28 +93,44 @@ module KnowledgeBase = {
             display(`block),
             border(`px(1), `solid, Style.Colors.hyperlinkAlpha(0.3)),
             borderRadius(`px(18)),
-            paddingBottom(`rem(1.)),
             maxWidth(`rem(58.625)),
             marginLeft(`auto),
             marginRight(`auto),
             paddingTop(`rem(1.0)),
+            paddingBottom(`rem(1.)),
             unsafe("min-width", "min-content"),
-            media(Style.MediaQuery.notMobile, [paddingBottom(`rem(3.))]),
+            media(Style.MediaQuery.notMobile, [paddingBottom(`rem(2.))]),
           ])
         )>
         {ReactDOMRe.createElement(
            "legend",
-           ~props=ReactDOMRe.objToDOMProps({"align": "center"}),
+           ~props=
+             ReactDOMRe.objToDOMProps({
+               "align": "center",
+               "className":
+                 Css.(
+                   style([
+                     textAlign(`center),
+                     marginTop(`zero),
+                     marginBottom(`zero),
+                     media(
+                       Style.MediaQuery.notMobile,
+                       [marginTop(`rem(-1.)), marginBottom(`rem(-1.))],
+                     ),
+                   ])
+                 ),
+             }),
            [|
              <h4
                className=Css.(
                  style([
+                   textAlign(`center),
                    letterSpacing(`rem(0.1875)),
                    border(`px(1), `solid, Style.Colors.saville),
-                   paddingLeft(`rem(1.0)),
-                   paddingRight(`rem(1.0)),
-                   paddingTop(`rem(0.5)),
-                   paddingBottom(`rem(0.5)),
+                   paddingLeft(`rem(1.25)),
+                   paddingRight(`rem(1.25)),
+                   paddingTop(`rem(0.25)),
+                   paddingBottom(`rem(0.25)),
                    textTransform(`uppercase),
                    fontWeight(`medium),
                    color(Style.Colors.midnight),
@@ -131,15 +144,17 @@ module KnowledgeBase = {
           className=Css.(
             style([
               display(`flex),
-              justifyContent(`center),
+              justifyContent(`spaceAround),
               flexWrap(`wrap),
               textAlign(`left),
+              paddingLeft(`rem(1.0)),
+              paddingRight(`rem(1.0)),
             ])
           )>
           <SubSection
-            className=Css.(style([marginBottom(`rem(2.0))]))
             title="Articles"
             content=[|
+              ("Read the Coda Whitepaper", "#"),
               ("Fast Accumulation on Streams", "#"),
               ("Coindesk: This Blockchain Tosses Blocks", "#"),
               ("TokenDaily: Deep Dive with O(1) on Coda Protocol", "#"),
@@ -314,7 +329,7 @@ let component = ReasonReact.statelessComponent("GetInvolved");
 let make = _ => {
   ...component,
   render: _self =>
-    <div>
+    <div className=Css.(style([marginBottom(`rem(13.0))]))>
       <h1
         className=Css.(
           merge([
@@ -375,14 +390,14 @@ let make = _ => {
           style([
             media(
               Style.MediaQuery.notMobile,
-              [marginTop(`rem(2.0)), marginBottom(`rem(3.))],
+              [marginTop(`rem(2.0)), marginBottom(`rem(2.4))],
             ),
             display(`flex),
             flexWrap(`wrap),
             justifyContent(`spaceAround),
             alignItems(`center),
-            marginBottom(`rem(1.)),
-            maxWidth(`rem(58.625)),
+            marginBottom(`rem(1.25)),
+            maxWidth(`rem(63.)),
             marginLeft(`auto),
             marginRight(`auto),
           ])

--- a/frontend/website/src/GetInvolvedSection.re
+++ b/frontend/website/src/GetInvolvedSection.re
@@ -93,21 +93,16 @@ module KnowledgeBase = {
           style([
             textAlign(`center),
             Style.Typeface.ibmplexserif,
+            display(`block),
             border(`px(1), `solid, Style.Colors.hyperlinkAlpha(0.3)),
             borderRadius(`px(18)),
             paddingBottom(`rem(1.)),
-            marginLeft(`zero),
-            marginRight(`zero),
+            maxWidth(`rem(58.625)),
+            marginLeft(`auto),
+            marginRight(`auto),
             paddingTop(`rem(1.0)),
             unsafe("min-width", "min-content"),
-            media(
-              Style.MediaQuery.notMobile,
-              [
-                paddingBottom(`rem(3.)),
-                marginLeft(`rem(3.)),
-                marginRight(`rem(3.)),
-              ],
-            ),
+            media(Style.MediaQuery.notMobile, [paddingBottom(`rem(3.))]),
           ])
         )>
         {ReactDOMRe.createElement(
@@ -166,6 +161,12 @@ module KnowledgeBase = {
 };
 
 module SocialLink = {
+  let fillStyle =
+    ReactDOMRe.Style.unsafeAddProp(
+      ReactDOMRe.Style.make(),
+      "fill",
+      "var(--svg-color-social)",
+    );
   module Svg = {
     let twitter =
       <svg
@@ -184,7 +185,7 @@ module SocialLink = {
           <g
             id="coda_homepage"
             transform="translate(-418.000000, -3293.000000)"
-            fill="#7693BE">
+            style=fillStyle>
             <g id="Community" transform="translate(418.000000, 3032.000000)">
               <g id="Twitter" transform="translate(0.000000, 261.000000)">
                 <path
@@ -226,7 +227,7 @@ module SocialLink = {
                   <path
                     d="M19.944064,16.423984 C19.032064,16.423984 18.312064,17.223984 18.312064,18.199984 C18.312064,19.175984 19.047904,19.975984 19.944064,19.975984 C20.855904,19.975984 21.575904,19.175984 21.575904,18.199984 C21.575904,17.223984 20.855904,16.423984 19.944064,16.423984 M14.104064,16.423984 C13.192064,16.423984 12.472064,17.223984 12.472064,18.199984 C12.472064,19.175984 13.207904,19.975984 14.104064,19.975984 C15.016064,19.975984 15.736064,19.175984 15.736064,18.199984 C15.752064,17.223984 15.016064,16.423984 14.104064,16.423984"
                     id="Eyes"
-                    fill="#7693BE"
+                    style=fillStyle
                   />
                   <g id="Bubble">
                     <mask id="mask-2" fill="white">
@@ -236,7 +237,7 @@ module SocialLink = {
                     <path
                       d="M22.517792,24.813924 C22.517792,24.813924 21.8181691,23.996924 21.235312,23.274924 C23.7806491,22.571924 24.7520777,21.013924 24.7520777,21.013924 C23.955312,21.526924 23.197792,21.888114 22.517792,22.134924 C21.5463634,22.533924 20.6135977,22.799924 19.7006491,22.951924 C17.835312,23.293924 16.125792,23.198924 14.6686491,22.933114 C13.5610263,22.723924 12.6092206,22.419924 11.8124549,22.116114 C11.365792,21.944924 10.8800777,21.736114 10.3943634,21.469924 C10.3360777,21.431924 10.277792,21.413114 10.2195063,21.374924 C10.1806491,21.356114 10.1610263,21.336924 10.141792,21.318114 C9.79207771,21.128114 9.597792,20.994924 9.597792,20.994924 C9.597792,20.994924 10.5303634,22.514924 12.997792,23.236924 C12.4149349,23.958924 11.6960777,24.813924 11.6960777,24.813924 C7.40236343,24.681114 5.77036343,21.926114 5.77036343,21.926114 C5.77036343,15.808114 8.56807771,10.848924 8.56807771,10.848924 C11.365792,8.796924 14.0275063,8.853924 14.0275063,8.853924 L14.221792,9.081924 C10.7246491,10.069924 9.11207771,11.570924 9.11207771,11.570924 C9.11207771,11.570924 9.53950629,11.343114 10.2581691,11.019924 C12.3372206,10.126924 13.9886491,9.879924 14.6686491,9.823114 C14.7852206,9.803924 14.8823634,9.784924 14.9989349,9.784924 C16.1838834,9.633114 17.5246491,9.594924 18.9235063,9.746924 C20.7692206,9.955924 22.7507406,10.488114 24.7715063,11.570924 C24.7715063,11.570924 23.2364549,10.145924 19.9335977,9.158114 L20.205792,8.853924 C20.205792,8.853924 22.8675063,8.796924 25.6650263,10.848924 C25.6650263,10.848924 28.4629349,15.808114 28.4629349,21.926114 C28.4629349,21.926114 26.8115063,24.681114 22.517792,24.813924 M30.0172206,-7.6e-05 L3.98293486,-7.6e-05 C1.78750629,-7.6e-05 7.77142857e-05,1.748114 7.77142857e-05,3.913924 L7.77142857e-05,29.601924 C7.77142857e-05,31.768114 1.78750629,33.516114 3.98293486,33.516114 L26.0149349,33.516114 L24.9850263,30.001114 L27.4720777,32.261924 L29.8229349,34.389924 L34.0000777,37.999924 L34.0000777,3.913924 C34.0000777,1.748114 32.2124549,-7.6e-05 30.0172206,-7.6e-05"
                       id="Fill-3"
-                      fill="#7693BE"
+                      style=fillStyle
                       mask="url(#mask-2)"
                     />
                   </g>
@@ -264,7 +265,7 @@ module SocialLink = {
           <g
             id="coda_homepage"
             transform="translate(-1074.000000, -3292.000000)"
-            fill="#7693BE">
+            style=fillStyle>
             <g id="Community" transform="translate(418.000000, 3032.000000)">
               <g id="Telegram" transform="translate(656.000000, 260.000000)">
                 <path
@@ -291,19 +292,17 @@ module SocialLink = {
             textDecoration(`none),
             justifyContent(`center),
             alignItems(`center),
-            hover([color(Style.Colors.hyperlinkHover)]),
+            color(Style.Colors.fadedBlue),
+            // Original color of svg
+            unsafe("--svg-color-social", "#7693BE"),
+            hover([
+              color(Style.Colors.hyperlink),
+              unsafe("--svg-color-social", Style.Colors.hyperlinkString),
+            ]),
           ])
         )>
-        <div className=Css.(style([margin(`rem(1.))]))> svg </div>
-        <h3
-          className=Css.(
-            merge([
-              Style.H3.wide,
-              style([hover([color(Style.Colors.hyperlinkHover)])]),
-            ])
-          )>
-          {ReasonReact.string(name)}
-        </h3>
+        <div className=Css.(style([marginRight(`rem(1.))]))> svg </div>
+        <h3 className=Style.H3.wideNoColor> {ReasonReact.string(name)} </h3>
       </a>;
     },
   };
@@ -327,7 +326,7 @@ let make = _ => {
             ]),
           ])
         )>
-        {ReasonReact.string("Get Involved")}
+        {ReasonReact.string("Get involved")}
       </h1>
       <div
         className=Css.(
@@ -383,6 +382,9 @@ let make = _ => {
             justifyContent(`spaceAround),
             alignItems(`center),
             marginBottom(`rem(1.)),
+            maxWidth(`rem(58.625)),
+            marginLeft(`auto),
+            marginRight(`auto),
           ])
         )>
         <SocialLink

--- a/frontend/website/src/InclusiveSection.re
+++ b/frontend/website/src/InclusiveSection.re
@@ -193,7 +193,7 @@ let make = _ => {
           link="/static/img/coda-figure.svg"
           dims=(15.125, 15.125)
           caption="Coda"
-          alt="Figure showing everyone participating in consensus, including all individual users of Coda."
+          alt="Figure showing everyone participating in consensus, including individual users of Coda."
           captionColor=Style.Colors.clover
         />
         <Figure

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -3,8 +3,9 @@ module Colors = {
   let white = Css.white;
   let whiteAlpha = a => `rgba((255, 255, 255, a));
   let hyperlink = `hsl((201, 71, 52));
+  let hyperlinkString = "hsl(201, 71%, 52%)";
   let hyperlinkAlpha = a => `hsla((201, 71, 52, a));
-  let hyperlinkHover = `hsl((201, 71, 70));
+  let hyperlinkHover = `hsl((201, 71, 40));
 
   let metallicBlue = `rgb((70, 99, 131));
   let denimTwo = `rgb((61, 88, 120));
@@ -187,11 +188,10 @@ module H3 = {
       lineHeight(`rem(1.5)),
     ]);
 
-  let wide =
+  let wideNoColor =
     style([
       whiteSpace(`nowrap),
       fontSize(`rem(1.0)),
-      color(Colors.fadedBlue),
       letterSpacing(`em(0.25)),
       Typeface.aktivgrotesk,
       fontWeight(`medium),
@@ -199,6 +199,8 @@ module H3 = {
       textAlign(`center),
       textTransform(`uppercase),
     ]);
+
+  let wide = merge([wideNoColor, style([color(Colors.fadedBlue)])]);
 
   let wings = {
     let wing = [

--- a/frontend/website/src/SustainableSection.re
+++ b/frontend/website/src/SustainableSection.re
@@ -38,7 +38,7 @@ let make = _children => {
               ]),
             ])
           )>
-          {ReasonReact.string("Sustainable Scalability")}
+          {ReasonReact.string("Sustainable scalability")}
           <div
             className=Css.(
               style([
@@ -108,8 +108,8 @@ let make = _children => {
             link="/static/img/chart-blockchain-energy.svg"
             dims=(23.9375, 18.1875)
             alt="Line graph comparing the energy usage of Coda to other blockchains. \
-            Over time, the energy requirements for other blockchains to process a single \
-            transaction will go up, whereas the Coda network will remain constant."
+            Over time, the energy requirements for proof of work blockchains to process \
+            a single transaction will go up, whereas the Coda network will remain constant."
           />
         </div>
         <div className=Css.(style([marginBottom(`rem(2.375))]))>


### PR DESCRIPTION
- Made the svgs change color (see rightmost social link) when hovering. This uses css variables cause I couldn't think of a better way.
- Fixed the hyperlinkHover color as suggested in discord.
- Added a max width to the knowledge base and social links to match zeplin
![image](https://user-images.githubusercontent.com/2154522/55122345-d38f4880-50bb-11e9-87a7-44ab3cbd8636.png)
