### PR TITLE
Un-regress bulti-by-o1 overflow hide

### DIFF
--- a/frontend/website/src/Home.re
+++ b/frontend/website/src/Home.re
@@ -12,7 +12,7 @@ let make = _ => {
           media(Style.MediaQuery.full, [marginTop(`rem(-0.25))]),
         ])
       )>
-      <Wrapped>
+      <Wrapped overflowHidden=true>
         <HeroSection />
         <CryptoAppsSection />
         <InclusiveSection />

--- a/frontend/website/src/Wrapped.re
+++ b/frontend/website/src/Wrapped.re
@@ -1,22 +1,24 @@
 let component = ReasonReact.statelessComponent("Page.Wrapped");
-let make = children => {
+let make = (~overflowHidden=false, children) => {
   ...component,
   render: _ => {
     <div
       className=Css.(
-        style([
-          margin(`auto),
-          overflow(`hidden),
-          media(
-            Style.MediaQuery.full,
-            [
-              maxWidth(`rem(84.0)),
-              margin(`auto),
-              ...Style.paddingX(`rem(3.0)),
-            ],
-          ),
-          ...Style.paddingX(`rem(1.25)),
-        ])
+        style(
+          (overflowHidden ? [overflow(`hidden)] : [])
+          @ [
+            margin(`auto),
+            media(
+              Style.MediaQuery.full,
+              [
+                maxWidth(`rem(84.0)),
+                margin(`auto),
+                ...Style.paddingX(`rem(3.0)),
+              ],
+            ),
+            ...Style.paddingX(`rem(1.25)),
+          ],
+        )
       )>
       ...children
     </div>;


### PR DESCRIPTION
Fix annoying cut of built-by-o1 (that I caused)

<img width="551" alt="Screen Shot 2019-03-27 at 6 15 11 PM" src="https://user-images.githubusercontent.com/515445/55122447-4ac4dc80-50bc-11e9-8804-44340ef54580.png">
