### PR TITLE
Hero better

### DIFF
--- a/frontend/website/src/Head.re
+++ b/frontend/website/src/Head.re
@@ -27,7 +27,7 @@ let make = (~extra, ~filename, _children) => {
       <meta name="viewport" content="width=device-width, initial-scale=1" />
       <meta
         property="og:image"
-        content="https://codaprotocol.com/static/img/compare-outlined-png.png"
+        content="https://codaprotocol.com/static/img/coda_facebook_OG.jpg"
       />
       <meta property="og:updated_time" content="1526001445" />
       <meta property="og:type" content="website" />
@@ -35,11 +35,11 @@ let make = (~extra, ~filename, _children) => {
       <meta property="og:title" content="Coda Cryptocurrency Protocol" />
       <meta
         property="og:description"
-        content="That means that no matter how many transactions are performed, verifying the blockchain remains inexpensive and accessible to everyone."
+        content="Coda is the first cryptocurrency with a succinct blockchain. Our lightweight blockchain means anyone can use Coda directly from any device, in less data than a few tweets."
       />
       <meta
         name="description"
-        content="That means that no matter how many transactions are performed, verifying the blockchain remains inexpensive and accessible to everyone."
+        content="Coda is the first cryptocurrency with a succinct blockchain. Our lightweight blockchain means anyone can use Coda directly from any device, in less data than a few tweets."
       />
       extra
       <title> {ReasonReact.string("Coda Cryptocurrency Protocol")} </title>

--- a/frontend/website/src/HeroSection.re
+++ b/frontend/website/src/HeroSection.re
@@ -14,7 +14,7 @@ module Copy = {
             minWidth(`rem(17.5)),
             media(
               Style.MediaQuery.full,
-              [width(`percent(50.0)), minWidth(`rem(24.0))],
+              [width(`percent(60.0)), minWidth(`rem(24.0))],
             ),
             media("(min-width: 30rem)", [minWidth(`rem(24.0))]),
           ])
@@ -49,7 +49,7 @@ module Copy = {
                   // align with the grid
                   media(
                     Style.MediaQuery.full,
-                    [marginTop(`rem(1.75)), marginBottom(`rem(11.875))],
+                    [marginTop(`rem(1.75)), marginBottom(`rem(4.0))],
                   ),
                 ]),
               ])
@@ -167,7 +167,7 @@ module Graphic = {
         <div
           className={style([
             width(`percent(100.0)),
-            media(Style.MediaQuery.full, [maxWidth(`rem(22.625))]),
+            maxWidth(`rem(20.0)),
           ])}>
           <div
             className={style([
@@ -216,6 +216,7 @@ let make = _ => {
           display(`flex),
           justifyContent(`spaceAround),
           flexWrap(`wrap),
+          maxWidth(`rem(69.0)),
           media(Style.MediaQuery.full, [flexWrap(`nowrap)]),
         ])
       )>

--- a/frontend/website/src/Nav.re
+++ b/frontend/website/src/Nav.re
@@ -7,8 +7,8 @@ module NavStyle = {
   module MediaQuery = {
     let menu = "(min-width: 62rem)";
     let menuMax = "(max-width: 61.9375rem)";
-    let statusLift = mainPage =>
-      mainPage ? "(min-width: 38rem)" : "(min-width: 0rem)";
+    let statusLift = keepAnnouncementBar =>
+      keepAnnouncementBar ? "(min-width: 38rem)" : "(min-width: 0rem)";
   };
   let bottomNudge = Css.marginBottom(`rem(2.0));
   let bottomNudgeOffset = offset => Css.marginBottom(`rem(2.0 -. offset));
@@ -164,7 +164,7 @@ module DropdownMenu = {
 
 module NavWrapper = {
   let component = ReasonReact.statelessComponent("Nav");
-  let make = (~mainPage, children) => {
+  let make = (~keepAnnouncementBar, children) => {
     ...component,
     render: _self => {
       let items =
@@ -219,7 +219,7 @@ module NavWrapper = {
             alignItems(`flexEnd),
             flexWrap(`wrap),
             media(
-              NavStyle.MediaQuery.statusLift(mainPage),
+              NavStyle.MediaQuery.statusLift(keepAnnouncementBar),
               [flexWrap(`nowrap), alignItems(`center)],
             ),
           ])
@@ -233,7 +233,7 @@ module NavWrapper = {
               width(`percent(50.0)),
               marginTop(`zero),
               media(
-                NavStyle.MediaQuery.statusLift(mainPage),
+                NavStyle.MediaQuery.statusLift(keepAnnouncementBar),
                 [
                   width(`auto),
                   marginRight(`rem(0.75)),
@@ -253,11 +253,11 @@ module NavWrapper = {
               width(`percent(100.0)),
               NavStyle.bottomNudge,
               media(
-                NavStyle.MediaQuery.statusLift(mainPage),
+                NavStyle.MediaQuery.statusLift(keepAnnouncementBar),
                 [order(2), width(`auto), marginLeft(`zero)],
               ),
               media(NavStyle.MediaQuery.menu, [width(`percent(40.0))]),
-              ...mainPage ? [] : [display(`none)],
+              ...keepAnnouncementBar ? [] : [display(`none)],
             ])
           )>
           <div
@@ -265,7 +265,7 @@ module NavWrapper = {
               style([
                 width(`rem(21.25)),
                 media(
-                  NavStyle.MediaQuery.statusLift(mainPage),
+                  NavStyle.MediaQuery.statusLift(keepAnnouncementBar),
                   [width(`rem(21.25)), margin(`auto)],
                 ),
               ])
@@ -281,15 +281,10 @@ module NavWrapper = {
               order(2),
               NavStyle.bottomNudgeOffset(0.5),
               media(
-                NavStyle.MediaQuery.statusLift(mainPage),
+                NavStyle.MediaQuery.statusLift(keepAnnouncementBar),
                 [order(3), width(`auto), NavStyle.bottomNudge],
               ),
-              media(
-                NavStyle.MediaQuery.menu,
-                [
-                  mainPage ? width(`percent(50.0)) : width(`percent(70.0)),
-                ],
-              ),
+              media(NavStyle.MediaQuery.menu, [width(`percent(50.0))]),
             ])
           )>
           <DropdownMenu> ...items </DropdownMenu>
@@ -411,7 +406,7 @@ let component = ReasonReact.statelessComponent("CodaNav");
 let make = (~page, _children) => {
   ...component,
   render: _self => {
-    <NavWrapper mainPage={page == `Home}>
+    <NavWrapper keepAnnouncementBar={page == `Home || page == `Blog}>
       <SimpleButton name="Blog" link="/blog.html" activePage={page == `Blog} />
       <SimpleButton
         name="Testnet"

--- a/frontend/website/static/img/coda_facebook_OG.jpg
+++ b/frontend/website/static/img/coda_facebook_OG.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:139d413dcb74c0b80c0814b39a984afa764a026afe9b769bf1552904627a7d8d
+size 543042


### PR DESCRIPTION
* Og updated (we won't be able to confirm image because it's required to be a full url not a relative one)
* Hero section looks closer to the spec + fixed max-width graphic when it overflows

<img width="1892" alt="Screen Shot 2019-03-28 at 8 31 44 PM" src="https://user-images.githubusercontent.com/515445/55207903-5803c900-5199-11e9-89f5-af981a8e4ac1.png">
<img width="799" alt="Screen Shot 2019-03-28 at 8 35 08 PM" src="https://user-images.githubusercontent.com/515445/55207904-589c5f80-5199-11e9-8784-4e3ce2a23b83.png">
<img width="799" alt="Screen Shot 2019-03-28 at 8 35 14 PM" src="https://user-images.githubusercontent.com/515445/55207906-589c5f80-5199-11e9-838a-b09c3829eae4.png">


* keepAnnouncement bar on blog too
* Make menu be in the same space on the other pages

<img width="1892" alt="Screen Shot 2019-03-28 at 8 31 51 PM" src="https://user-images.githubusercontent.com/515445/55207894-4d493400-5199-11e9-84ad-7c2c99e7a203.png">
 