### PR TITLE
Fix announcement shift firefox

### DIFF
--- a/frontend/website/src/AnnouncementBar.re
+++ b/frontend/website/src/AnnouncementBar.re
@@ -35,8 +35,25 @@ module Icon = {
 let component = ReasonReact.statelessComponent("AnnouncementBar");
 let make = _ => {
   ...component,
-  render: _self =>
+  render: _self => {
+    // HACK: On firefox (and only firefox) the text seems to not be centered in the announcementbar
+    //  This way we can write CSS that only targets firefox
+    Css.(
+      global(
+        "@-moz-document url-prefix()",
+        [
+          unsafe(
+            "#announcementbar--viewdemo, #announcementbar--testnetlive { margin-bottom",
+            "-0.125rem; }",
+          ),
+          unsafe("#announcementbar--anchor { padding-top", "0.5625rem; }"),
+          unsafe("#announcementbar--anchor { padding-bottom", "0.5625rem; }"),
+        ],
+      )
+    );
+
     <a
+      id="announcementbar--anchor"
       href="/testnet.html"
       className=Css.(
         style(
@@ -58,13 +75,14 @@ let make = _ => {
       <div className=Css.(style([display(`flex), alignItems(`center)]))>
         Icon.svg
         <p
+          id="announcementbar--testnetlive"
           className=Css.(
             merge([
               Style.Body.basic,
               style([
                 marginLeft(`rem(1.25)),
+                marginBottom(`zero),
                 marginTop(`px(0)),
-                marginBottom(`px(0)),
               ]),
             ])
           )>
@@ -72,17 +90,19 @@ let make = _ => {
         </p>
       </div>
       <p
+        id="announcementbar--viewdemo"
         className=Css.(
           merge([
             Style.Link.No_hover.basic,
             style([
               marginTop(`px(0)),
-              marginBottom(`px(0)),
+              marginBottom(`zero),
               marginLeft(`rem(1.5)),
             ]),
           ])
         )>
         {ReasonReact.string({j|View the demo\u00A0→|j})}
       </p>
-    </a>,
+    </a>;
+  },
 };


### PR DESCRIPTION
Fix announcement shifting on firefox

## Chrome

<img width="351" alt="Screen Shot 2019-03-29 at 11 23 28 AM" src="https://user-images.githubusercontent.com/515445/55254463-22042a80-5215-11e9-9c39-1bacbfb7d157.png">


## Firefox

<img width="351" alt="Screen Shot 2019-03-29 at 11 27 27 AM" src="https://user-images.githubusercontent.com/515445/55254639-ace52500-5215-11e9-84ee-a2548fa61a03.png">

