### PR TITLE
Use deriver for version ppx

### DIFF
--- a/src/lib/ppx_coda/dune
+++ b/src/lib/ppx_coda/dune
@@ -1,7 +1,7 @@
 (library
     (name ppx_coda)
     (public_name ppx_coda)
-    (kind ppx_rewriter)
-    (libraries ppxlib core_kernel)
-    (preprocess (pps ppxlib.metaquot))
-)
+    (kind ppx_deriver)
+    (libraries compiler-libs.common ppxlib ppx_deriving.api core_kernel)
+    (preprocess (pps ppxlib.metaquot)))
+

--- a/src/lib/ppx_coda/tests/Makefile
+++ b/src/lib/ppx_coda/tests/Makefile
@@ -1,5 +1,14 @@
 # Makefile for ppx_coda tests
 
+# useful for negative tests, so we know the failure is the failure
+# we expect
+
+ifdef VERBOSE
+REDIRECT=
+else
+REDIRECT= > /dev/null 2>&1
+endif
+
 .PHONY: positive-tests negative-tests
 
 all : positive-tests negative-tests
@@ -7,46 +16,49 @@ all : positive-tests negative-tests
 positive-tests : unexpired.ml
 # expiration
 	@ echo -n "Unexpired, should succeed..."
-	@ dune build unexpired.cma > /dev/null 2>&1
+	@ dune build unexpired.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Unexpired in module, should succeed..."
-	@ dune build unexpired_in_module.cma > /dev/null 2>&1
+	@ dune build unexpired_in_module.cma ${REDIRECT}
 	@ echo "OK"
 # versioning
 	@ echo -n "Versioned type, should succeed..."
-	@ dune build versioned_good.cma > /dev/null 2>&1
+	@ dune build versioned_good.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Versioned, wrapped type, should succeed..."
-	@ dune build versioned_good_wrapped.cma > /dev/null 2>&1
+	@ dune build versioned_good_wrapped.cma ${REDIRECT}
 	@ echo "OK"
 
 negative-tests :
 # expiration
 	@ echo -n "Expired, should fail..."
-	@ ! dune build expired.cma > /dev/null 2>&1
+	@ ! dune build expired.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Expired in module, should fail..."
-	@ ! dune build expiry_in_module.cma > /dev/null 2>&1
+	@ ! dune build expiry_in_module.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Invalid date, should fail..."
-	@ ! dune build expiry_invalid_date.cma > /dev/null 2>&1
+	@ ! dune build expiry_invalid_date.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Invalid format, should fail..."
-	@ ! dune build expiry_invalid_format.cma > /dev/null 2>&1
+	@ ! dune build expiry_invalid_format.cma ${REDIRECT}
 	@ echo "OK"
 # versioning
 	@ echo -n "Versioned type in module with invalid name, should fail..."
-	@ ! dune build versioned_bad_module_name.cma > /dev/null 2>&1
+	@ ! dune build versioned_bad_module_name.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Versioned type has wrong name, should fail..."
-	@ ! dune build versioned_bad_type_name.cma > /dev/null 2>&1
+	@ ! dune build versioned_bad_type_name.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Versioned type, bad module structure, should fail..."
-	@ ! dune build versioned_bad_module_structure.cma > /dev/null 2>&1
+	@ ! dune build versioned_bad_module_structure.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned type, bad wrapped module structure, should fail..."
+	@ ! dune build versioned_bad_wrapped_module_structure.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Versioned type with bad option, should fail..."
-	@ ! dune build versioned_bad_option.cma > /dev/null 2>&1
+	@ ! dune build versioned_bad_option.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Versioned type with bad version name, should fail..."
-	@ ! dune build versioned_bad_version_name.cma > /dev/null 2>&1
+	@ ! dune build versioned_bad_version_name.cma ${REDIRECT}
 	@ echo "OK"

--- a/src/lib/ppx_coda/tests/dune
+++ b/src/lib/ppx_coda/tests/dune
@@ -1,9 +1,12 @@
+;;; each library below has an identical preprocess clause, because of this
+;;; dune bug: https://github.com/ocaml/dune/issues/1946
+
 ;;; should succeed
 
 ;; expiration
 (library
   (name unexpired)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (modules unexpired))
 
 (library
@@ -14,12 +17,14 @@
 ;; versioning
 (library
   (name versioned_good)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
   (modules versioned_good))
 
 (library
   (name versioned_good_wrapped)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
   (modules versioned_good_wrapped))
 
 ;;; should fail
@@ -27,46 +32,52 @@
 ;; expiration
 (library
   (name expired)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (modules expired))
 
 (library
   (name expiry_in_module)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (modules expiry_in_module))
 
 (library
   (name expiry_invalid_date)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (modules expiry_invalid_date))
 
 (library
   (name expiry_invalid_format)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (modules expiry_invalid_format))
 
 ;; versioning
 (library
  (name versioned_bad_module_structure)
- (preprocess (pps ppx_coda))
+ (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
  (modules versioned_bad_module_structure))
 
 (library
+ (name versioned_bad_wrapped_module_structure)
+ (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+ (modules versioned_bad_wrapped_module_structure))
+
+(library
  (name versioned_bad_module_name)
- (preprocess (pps ppx_coda))
+ (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
  (modules versioned_bad_module_name))
 
 (library
  (name versioned_bad_version_name)
- (preprocess (pps ppx_coda))
+ (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
  (modules versioned_bad_version_name))
 
 (library
   (name versioned_bad_type_name)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (modules versioned_bad_type_name))
 
 (library
   (name versioned_bad_option)
-  (preprocess (pps ppx_coda))
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
   (modules versioned_bad_option))

--- a/src/lib/ppx_coda/tests/versioned_bad_module_structure.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_module_structure.ml
@@ -3,7 +3,7 @@ module Foo = struct
     module Stable = struct
       module V1 = struct
         (* type t must be in module T *)
-        type t [@@deriving version]
+        type t [@@deriving version, blah]
       end
     end
   end

--- a/src/lib/ppx_coda/tests/versioned_bad_option.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_option.ml
@@ -1,11 +1,14 @@
+open Core_kernel
+
 module Foo = struct
   module Bar = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          (* "version" with invalid option *)
-          type t [@@deriving yojson, bin_io, version {unwrapped}]
+          type t = int [@@deriving yojson, bin_io, version {unwrapped}]
         end
+
+        include T
       end
     end
   end

--- a/src/lib/ppx_coda/tests/versioned_bad_wrapped_module_structure.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_wrapped_module_structure.ml
@@ -1,8 +1,8 @@
 module Foo = struct
-  module Wrapped = struct
+  module Unwrapped = struct
     module Stable = struct
       module V1 = struct
-        type t = string [@@deriving version {wrapped}]
+        type t [@@deriving version {wrapped}]
       end
     end
   end

--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -1,9 +1,11 @@
+open Core_kernel
+
 module Foo = struct
   module Bar = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          type t [@@deriving yojson, bin_io, version]
+          type t = int [@@deriving yojson, bin_io, version]
         end
 
         include T

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -1,6 +1,6 @@
 (* versioned.ml -- static enforcement of versioned types via ppx
 
-   1) check that versioned type always in Stable.Vn.T module hierarchy
+   1) check that versioned type always in valid module hierarchy
    2) versioned types depend only on other versioned types or OCaml built-in types
 
   to use, add coda_ppx to the dune pps list, and annotate a type declaration with
@@ -29,162 +29,103 @@ open Ppxlib
 
 type version_info = {versioned: bool; wrapped: bool}
 
-(* {wrapped} *)
-let is_wrapped_option args =
-  match args with
-  | [ ( Nolabel
-      , { pexp_desc=
-            Pexp_record
-              ( [ ( {txt= Lident "wrapped"; _}
-                  , {pexp_desc= Pexp_ident {txt= Lident "wrapped"; _}; _} ) ]
-              , None ); _ } ) ] ->
-      true
-  | _ -> false
+let deriver = "version"
 
-let item_versioned_info_opt item : version_info option =
-  let is_version_id id =
-    match id.txt with Lident s -> String.equal s "version" | _ -> false
-  in
-  match item with
-  | Pexp_ident id ->
-      if is_version_id id then Some {versioned= true; wrapped= false} else None
-  | Pexp_apply ({pexp_desc= Pexp_ident id; _}, args) ->
-      if is_version_id id then
-        if is_wrapped_option args then Some {versioned= true; wrapped= true}
-        else
-          (* build location from entire args list *)
-          let _, {pexp_loc= loc1; _} = List.hd_exn args in
-          let _, {pexp_loc= loc2; _} = List.hd_exn (List.rev args) in
-          let loc =
-            {loc_start= loc1.loc_start; loc_end= loc2.loc_end; loc_ghost= true}
-          in
-          Location.raise_errorf ~loc
-            "Invalid option(s) to \"version\", can only be \"wrapped\""
-      else None
-  | _ -> None
-
-let payload_version_info_opt payload : version_info option =
-  match payload with
-  | PStr structure ->
-      List.find_map structure ~f:(fun str ->
-          match str.pstr_desc with
-          | Pstr_eval (expr, _) -> (
-            (* "version" can appear as:
-                - an indvidual identifier
-                - an application, or
-                - in a tuple, as an identifier or application
-            *)
-            match expr.pexp_desc with
-            | Pexp_ident _ | Pexp_apply _ ->
-                item_versioned_info_opt expr.pexp_desc
-            | Pexp_tuple exprs ->
-                List.find_map exprs ~f:(fun expr ->
-                    item_versioned_info_opt expr.pexp_desc )
-            | _ -> None )
-          | _ -> None )
-  | _ -> None
-
-let attribute_version_info_opt ((name, payload) : attribute) :
-    version_info option =
-  if String.equal name.txt "deriving" then payload_version_info_opt payload
-  else None
-
-let get_attributes_version_info_opt (attrs : attribute list) :
-    version_info option =
-  List.find_map attrs ~f:attribute_version_info_opt
-
-let get_type_version_info_opt type_decl : version_info option =
-  get_attributes_version_info_opt type_decl.ptype_attributes
-
-let validate_module_version module_version =
-  let version_name = module_version.txt in
-  let version_name_loc = module_version.loc in
-  let len = String.length version_name in
-  if not (Char.equal version_name.[0] 'V' && len > 1) then
-    Location.raise_errorf ~loc:version_name_loc
+let validate_module_version module_version loc =
+  let len = String.length module_version in
+  if not (Char.equal module_version.[0] 'V' && len > 1) then
+    Location.raise_errorf ~loc
       "Versioning module containing versioned type must be named Vn, for some \
        number n"
   else
-    let numeric_part = String.sub version_name ~pos:1 ~len:(len - 1) in
+    let numeric_part = String.sub module_version ~pos:1 ~len:(len - 1) in
     String.iter numeric_part ~f:(fun c ->
         if not (Char.is_digit c) then
-          Location.raise_errorf ~loc:version_name_loc
+          Location.raise_errorf ~loc
             "Versioning module name must be Vn, for some number n, got: \"%s\""
-            version_name ) ;
+            module_version ) ;
     (* invariant: 0th char is digit *)
     if Int.equal (Char.get_digit_exn numeric_part.[0]) 0 then
-      Location.raise_errorf ~loc:version_name_loc
-        "Versioning module name must be Vn, for a number n, but n cannot \
+      Location.raise_errorf ~loc
+        "Versioning module name must be Vn, for a number n, which cannot \
          begin with 0, got: \"%s\""
-        version_name
+        module_version
 
 let validate_unwrapped_type_decl inner3_modules type_decl =
   match inner3_modules with
-  | [{txt= "T"; _}; module_version; {txt= "Stable"; _}] ->
-      validate_module_version module_version
+  | ["T"; module_version; "Stable"] ->
+      validate_module_version module_version type_decl.ptype_loc
   | _ ->
       Location.raise_errorf ~loc:type_decl.ptype_loc
-        "Versioned type must be contained in module structure Stable.Vn.T, \
-         for some number n"
+        "Versioned type must be contained in module path Stable.Vn.T, for \
+         some number n"
 
 let validate_wrapped_type_decl inner3_modules type_decl =
   match inner3_modules with
-  | [module_version; {txt= "Stable"; _}; {txt= "Wrapped"; _}] ->
-      validate_module_version module_version
+  | [module_version; "Stable"; "Wrapped"] ->
+      validate_module_version module_version type_decl.ptype_loc
   | _ ->
       Location.raise_errorf ~loc:type_decl.ptype_loc
-        "Wrapped versioned type must be contained in module structure \
+        "Wrapped versioned type must be contained in module path \
          Wrapped.Stable.Vn, for some number n"
 
 (* check that a versioned type occurs in valid module hierarchy and is named "t"
  *)
-let validate_type_decl inner3_modules type_decl =
-  match get_type_version_info_opt type_decl with
-  | None
-  (* should not happen *)
-   |Some {versioned= false; _} ->
-      ()
-  | Some {versioned= true; wrapped} ->
-      if not (String.equal type_decl.ptype_name.txt "t") then
-        Location.raise_errorf ~loc:type_decl.ptype_loc
-          "Versioned type must be named \"t\", got: \"%s\""
-          type_decl.ptype_name.txt ;
-      if not (List.is_empty type_decl.ptype_params) then
-        Location.raise_errorf ~loc:type_decl.ptype_loc
-          "Versioned type must not have type parameters" ;
-      if wrapped then validate_wrapped_type_decl inner3_modules type_decl
-      else validate_unwrapped_type_decl inner3_modules type_decl
+let validate_type_decl inner3_modules wrapped type_decl =
+  if not (String.equal type_decl.ptype_name.txt "t") then
+    Location.raise_errorf ~loc:type_decl.ptype_name.loc
+      "Versioned type must be named \"t\", got: \"%s\""
+      type_decl.ptype_name.txt ;
+  if not (List.is_empty type_decl.ptype_params) then
+    Location.raise_errorf ~loc:type_decl.ptype_loc
+      "Versioned type must not have type parameters" ;
+  if wrapped then validate_wrapped_type_decl inner3_modules type_decl
+  else validate_unwrapped_type_decl inner3_modules type_decl
 
-(* syntax check only *)
-let versioned_syntactic_check =
-  object (self)
-    inherit [string loc list] Ast_traverse.fold as super
+let generate_contained_type_decls _type_decl =
+  (* TODO *)
+  []
 
-    (* module_path is list of module names traversed, from innermost to outer *)
-    method! structure_item ({pstr_desc; _} as str) module_path =
-      match pstr_desc with
-      (* for modules, current name is cons'ed to acc *)
-      | Pstr_module {pmb_name; pmb_expr; _} -> (
-        match pmb_expr.pmod_desc with
-        | Pmod_structure structure ->
-            let new_module_path = pmb_name :: module_path in
-            List.iter structure ~f:(fun si ->
-                ignore (self#structure_item si new_module_path) ) ;
-            (* we've left the structure, so we're in the same module hierarchy we started with *)
-            module_path
-        | _ -> module_path )
-      | Pstr_type (_rec_decl, type_decls) ->
-          (* if versioned, check syntactic placement of type, add code *)
-          let inner3_modules = List.take module_path 3 in
-          List.iter type_decls ~f:(validate_type_decl inner3_modules) ;
-          module_path
-      | _ -> super#structure_item str module_path
-  end
+let generate_versioned_decls type_decl wrapped =
+  let module E = Ppxlib.Ast_builder.Make (struct
+    let loc = type_decl.ptype_loc
+  end) in
+  let open E in
+  let versioned_current = [%stri let __versioned__ = true] in
+  if wrapped then [versioned_current]
+  else versioned_current :: generate_contained_type_decls type_decl
 
-let check_versioned_module structure =
-  ignore (versioned_syntactic_check#structure structure []) ;
-  structure
+let generate_val_decls_for_type_decl ~options ~path type_decls =
+  let type_decl1 = List.hd_exn type_decls in
+  let type_decl2 = List.hd_exn (List.rev type_decls) in
+  ( if not (Int.equal (List.length type_decls) 1) then
+    let loc =
+      { loc_start= type_decl1.ptype_loc.loc_start
+      ; loc_end= type_decl2.ptype_loc.loc_end
+      ; loc_ghost= true }
+    in
+    Ppx_deriving.raise_errorf ~loc
+      "Versioned type must be just one type \"t\", not a sequence of types" ) ;
+  let wrapped =
+    match options with
+    | [] -> false
+    | [("wrapped", {pexp_desc= Pexp_ident {txt= Lident "wrapped"; _}; _})] ->
+        true
+    | _ ->
+        let exprs = List.map options ~f:snd in
+        let {pexp_loc= loc1; _} = List.hd_exn exprs in
+        let {pexp_loc= loc2; _} = List.hd_exn (List.rev exprs) in
+        let loc =
+          {loc_start= loc1.loc_start; loc_end= loc2.loc_end; loc_ghost= true}
+        in
+        Ppx_deriving.raise_errorf ~loc
+          "Invalid option(s) to \"version\", can only be \"wrapped\""
+  in
+  let inner3_modules = List.take (List.rev path) 3 in
+  validate_type_decl inner3_modules wrapped type_decl1 ;
+  generate_versioned_decls type_decl1 wrapped
 
 let () =
-  Driver.register_transformation "versioned_module"
-    ~impl:check_versioned_module
+  Ppx_deriving.(
+    register
+      (create deriver ~type_decl_str:generate_val_decls_for_type_decl ()))


### PR DESCRIPTION
Instead of using the `Driver` in `Ppxlib`, use `Ppx_deriving`. A deriver gets passed a module path and options, and is invoked only when the particular `deriving` flag is used. That makes a lot of code we had unnecessary.

Small loss:i f a module version name is wrong, like `Vx` instead of `V1`, we don't have the location to highlight in Merlin.

I discovered a dune bug others had reported, mentioned in the `dune` for the tests.  Added a `VERBOSE` flag to the Makefile, allowing confirmation that expected test failures fail for the expected reason.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
