### PR TITLE
Generate declarations for contained versioned types

### DIFF
--- a/src/lib/ppx_coda/tests/Makefile
+++ b/src/lib/ppx_coda/tests/Makefile
@@ -28,6 +28,9 @@ positive-tests : unexpired.ml
 	@ echo -n "Versioned, wrapped type, should succeed..."
 	@ dune build versioned_good_wrapped.cma ${REDIRECT}
 	@ echo "OK"
+	@ echo -n "Versioned types with contained types, should succeed..."
+	@ dune build versioned_good_contained_types.cma ${REDIRECT}
+	@ echo "OK"
 
 negative-tests :
 # expiration
@@ -61,4 +64,7 @@ negative-tests :
 	@ echo "OK"
 	@ echo -n "Versioned type with bad version name, should fail..."
 	@ ! dune build versioned_bad_version_name.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned types with bad contained types, should fail..."
+	@ ! dune build versioned_bad_contained_types.cma ${REDIRECT}
 	@ echo "OK"

--- a/src/lib/ppx_coda/tests/dune
+++ b/src/lib/ppx_coda/tests/dune
@@ -27,6 +27,12 @@
   (libraries core_kernel)
   (modules versioned_good_wrapped))
 
+(library
+  (name versioned_good_contained_types)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
+  (modules versioned_good_contained_types))
+
 ;;; should fail
 
 ;; expiration
@@ -81,3 +87,10 @@
   (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (libraries core_kernel)
   (modules versioned_bad_option))
+
+(library
+  (name versioned_bad_contained_types)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
+  (modules versioned_bad_contained_types))
+

--- a/src/lib/ppx_coda/tests/versioned_bad_contained_types.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_contained_types.ml
@@ -1,0 +1,53 @@
+open Core_kernel
+
+module Foo = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        (* can't version arrow type *)
+        type t = int -> string [@@deriving version]
+      end
+
+      include T
+    end
+  end
+end
+
+module Bar = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = Foo.Stable.V1.t [@@deriving version]
+      end
+
+      include T
+    end
+  end
+end
+
+module Quux = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        (* tuple of versioned types *)
+        type t = Foo.Stable.V1.t * Bar.Stable.V1.t [@@deriving version]
+      end
+
+      include T
+    end
+  end
+end
+
+module Bazz = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        (* record of versioned types *)
+        type t = {one: Foo.Stable.V1.t; two: Bar.Stable.V1.t}
+        [@@deriving version]
+      end
+
+      include T
+    end
+  end
+end

--- a/src/lib/ppx_coda/tests/versioned_bad_module_structure.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_module_structure.ml
@@ -3,7 +3,7 @@ module Foo = struct
     module Stable = struct
       module V1 = struct
         (* type t must be in module T *)
-        type t [@@deriving version, blah]
+        type t [@@deriving version]
       end
     end
   end

--- a/src/lib/ppx_coda/tests/versioned_good_contained_types.ml
+++ b/src/lib/ppx_coda/tests/versioned_good_contained_types.ml
@@ -1,0 +1,53 @@
+open Core_kernel
+
+module Foo = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = int [@@deriving yojson, bin_io, version]
+      end
+
+      include T
+    end
+  end
+end
+
+module Bar = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = Foo.Stable.V1.t [@@deriving yojson, bin_io, version]
+      end
+
+      include T
+    end
+  end
+end
+
+module Quux = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        (* tuple of versioned types *)
+        type t = Foo.Stable.V1.t * Bar.Stable.V1.t
+        [@@deriving yojson, bin_io, version]
+      end
+
+      include T
+    end
+  end
+end
+
+module Bazz = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        (* record of versioned types *)
+        type t = {one: Foo.Stable.V1.t; two: Bar.Stable.V1.t}
+        [@@deriving yojson, bin_io, version]
+      end
+
+      include T
+    end
+  end
+end


### PR DESCRIPTION
For types contained in versioned types, generate let-bindings for their `__versioned__` values. For example, if a versioned type is declared with:
```
  let t = Foo.Bar.t [@@deriving version]
```
we generate let-bindings
```
let __versioned__ = true
let _ = Foo.Bar.__versioned__
```
Therefore, a type can be versioned only if the types it depends on are versioned (unless those dependencies are wrapped types).

I added good and bad tests for this behavior, and also inspected the preprocessor output to verify these let-bindings are present.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
