### PR TITLE
Generate val declarations for versioned types in module signatures

### DIFF
--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -13,3 +13,7 @@ module Foo = struct
     end
   end
 end
+
+module type Some_intf = sig
+  type t = Quux | Zzz [@@deriving bin_io, version]
+end


### PR DESCRIPTION
For a module signature like:
```
sig
  type t [@@deriving version]
end
```
we generate
```
  val version : int
  val __versioned__ : bool
```
to add to the signature.

There's not much checking to do here. Added such a signature to the "good" test case, and verified these declarations appear in the code after preprocessing.

There's another piece that needs to be added to the ppx: the case where the versioned type `t` instantiates a type with parameters.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
