### PR TITLE
Require versioning of types with parameters used by versioned types

### DIFF
--- a/src/lib/ppx_coda/tests/Makefile
+++ b/src/lib/ppx_coda/tests/Makefile
@@ -31,6 +31,9 @@ positive-tests : unexpired.ml
 	@ echo -n "Versioned types with contained types, should succeed..."
 	@ dune build versioned_good_contained_types.cma ${REDIRECT}
 	@ echo "OK"
+	@ echo -n "Versioned types with type parameters, should succeed..."
+	@ dune build versioned_good_type_parameters.cma ${REDIRECT}
+	@ echo "OK"
 
 negative-tests :
 # expiration
@@ -67,4 +70,7 @@ negative-tests :
 	@ echo "OK"
 	@ echo -n "Versioned types with bad contained types, should fail..."
 	@ ! dune build versioned_bad_contained_types.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned types with unversioned type with type parameters, should fail..."
+	@ ! dune build versioned_bad_type_parameters.cma ${REDIRECT}
 	@ echo "OK"

--- a/src/lib/ppx_coda/tests/dune
+++ b/src/lib/ppx_coda/tests/dune
@@ -33,6 +33,12 @@
   (libraries core_kernel)
   (modules versioned_good_contained_types))
 
+(library
+  (name versioned_good_type_parameters)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
+  (modules versioned_good_type_parameters))
+
 ;;; should fail
 
 ;; expiration
@@ -94,3 +100,8 @@
   (libraries core_kernel)
   (modules versioned_bad_contained_types))
 
+(library
+  (name versioned_bad_type_parameters)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
+  (modules versioned_bad_type_parameters))

--- a/src/lib/ppx_coda/tests/versioned_bad_type_parameters.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_type_parameters.ml
@@ -1,0 +1,29 @@
+open Core_kernel
+
+module Poly = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        (* missing version in deriving list *)
+        type ('a, 'b) t = Poly of 'a * 'b [@@deriving bin_io, yojson]
+      end
+
+      include T
+    end
+  end
+end
+
+module Foo = struct
+  module Bar = struct
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          type t = (string, int) Poly.Stable.V1.t
+          [@@deriving yojson, bin_io, version]
+        end
+
+        include T
+      end
+    end
+  end
+end

--- a/src/lib/ppx_coda/tests/versioned_good_type_parameters.ml
+++ b/src/lib/ppx_coda/tests/versioned_good_type_parameters.ml
@@ -1,0 +1,29 @@
+open Core_kernel
+
+module Poly = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type ('a, 'b) t = Poly of 'a * 'b
+        [@@deriving bin_io, yojson, version]
+      end
+
+      include T
+    end
+  end
+end
+
+module Foo = struct
+  module Bar = struct
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          type t = (string, int) Poly.Stable.V1.t
+          [@@deriving yojson, bin_io, version]
+        end
+
+        include T
+      end
+    end
+  end
+end


### PR DESCRIPTION
Versioned types may depend on types with parameters. Since the latter may change, we require that they be versioned, too. We can't use the versioning registration machinery for them, because we don't know how to serialize them without knowing the instantiations of their type parameters. Aside from that, such types can be treated as versioned like other types.

Removed redundant checking for the name "t" introduced in #2088.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
