### PR TITLE
Version some types using ppx

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -712,7 +712,7 @@ struct
           let%map x = Bignum_bigint.(gen_incl zero (Field.size - one))
           and is_odd = Bool.gen in
           let x = Bigint.(to_field (of_bignum_bigint x)) in
-          {Public_key.Compressed.x; is_odd}
+          {Public_key.Compressed.Poly.Stable.Latest.x; is_odd}
         in
         Quickcheck.Generator.map2 Fee.Unsigned.gen pk ~f:(fun fee prover ->
             {fee; prover} )

--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -6,12 +6,11 @@ module Stable = struct
     module T = struct
       let version = 1
 
-      (* TODO : use version for Fee_transfer *)
       type t =
         { proposer: Public_key.Compressed.Stable.V1.t
         ; amount: Currency.Amount.Stable.V1.t
         ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
-      [@@deriving sexp, bin_io, compare, eq]
+      [@@deriving sexp, bin_io, compare, eq, version]
     end
 
     include T

--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -4,8 +4,6 @@ open Import
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
       type t =
         { proposer: Public_key.Compressed.Stable.V1.t
         ; amount: Currency.Amount.Stable.V1.t

--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -81,9 +81,9 @@ struct
       module T = struct
         let version = 1
 
-        (* TODO : will this type be versioned? *)
+        (* TODO : version Pedersen.Digest *)
         type t = Pedersen.Digest.t
-        [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+        [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
       end
 
       include T

--- a/src/lib/coda_base/dune
+++ b/src/lib/coda_base/dune
@@ -42,7 +42,7 @@
     coda_compile_config)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_snarky ppx_deriving.eq ppx_deriving.enum ppx_deriving.ord
+  (pps ppx_snarky ppx_coda ppx_deriving.eq ppx_deriving.enum ppx_deriving.ord
     ppx_base ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test
     bisect_ppx -- -conditional))
  (synopsis "Snarks and friends necessary for keypair generation"))

--- a/src/lib/coda_base/fee_transfer.ml
+++ b/src/lib/coda_base/fee_transfer.ml
@@ -6,8 +6,6 @@ module Single = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t = Public_key.Compressed.Stable.V1.t * Currency.Fee.Stable.V1.t
         [@@deriving bin_io, sexp, compare, eq, yojson, version]
       end
@@ -35,12 +33,10 @@ end
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
       type t =
         | One of Single.Stable.V1.t
         | Two of Single.Stable.V1.t * Single.Stable.V1.t
-      [@@deriving bin_io, sexp, compare, eq, yojson]
+      [@@deriving bin_io, sexp, compare, eq, yojson, version]
     end
 
     include T

--- a/src/lib/coda_base/fee_transfer.ml
+++ b/src/lib/coda_base/fee_transfer.ml
@@ -9,7 +9,7 @@ module Single = struct
         let version = 1
 
         type t = Public_key.Compressed.Stable.V1.t * Currency.Fee.Stable.V1.t
-        [@@deriving bin_io, sexp, compare, eq, yojson]
+        [@@deriving bin_io, sexp, compare, eq, yojson, version]
       end
 
       include T

--- a/src/lib/coda_base/fee_transfer.mli
+++ b/src/lib/coda_base/fee_transfer.mli
@@ -4,8 +4,8 @@ open Import
 module Single : sig
   module Stable : sig
     module V1 : sig
-      type t = Public_key.Compressed.t * Currency.Fee.t
-      [@@deriving bin_io, sexp, compare, eq, yojson]
+      type t = Public_key.Compressed.Stable.V1.t * Currency.Fee.Stable.V1.t
+      [@@deriving bin_io, sexp, compare, eq, yojson, version]
     end
 
     module Latest = V1

--- a/src/lib/coda_base/payment_payload.ml
+++ b/src/lib/coda_base/payment_payload.ml
@@ -81,7 +81,8 @@ let%test_unit "to_bits" =
   with_randomness 123456789 (fun () ->
       let input =
         { receiver=
-            {Public_key.Compressed.x= Field.random (); is_odd= Random.bool ()}
+            { Public_key.Compressed.Poly.Stable.Latest.x= Field.random ()
+            ; is_odd= Random.bool () }
         ; amount= Amount.of_int (Random.int Int.max_value) }
       in
       Test_util.test_to_triples typ fold var_to_triples input )

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -23,7 +23,8 @@ module type Basic = sig
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, sexp, compare, eq, hash, yojson]
+      type nonrec t = t
+      [@@deriving bin_io, sexp, compare, eq, hash, yojson, version]
     end
 
     module Latest = V1
@@ -215,9 +216,7 @@ end = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
-        type t = Unsigned.t [@@deriving bin_io, sexp, compare, hash]
+        type t = Unsigned.t [@@deriving bin_io, sexp, compare, hash, version]
 
         let of_int = Unsigned.of_int
 

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -19,7 +19,8 @@ module type Basic = sig
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, sexp, compare, eq, hash, yojson]
+      type nonrec t = t
+      [@@deriving bin_io, sexp, compare, eq, hash, yojson, version]
     end
 
     module Latest = V1

--- a/src/lib/currency/dune
+++ b/src/lib/currency/dune
@@ -7,6 +7,6 @@
  (libraries core fold_lib tuple_lib snark_bits sgn snark_params
    unsigned_extended test_util codable module_version)
  (preprocess
-  (pps ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx --
+  (pps ppx_jane ppx_coda ppx_deriving.std ppx_deriving_yojson bisect_ppx --
     -conditional))
  (synopsis "Currency types"))

--- a/src/lib/non_zero_curve_point/dune
+++ b/src/lib/non_zero_curve_point/dune
@@ -5,4 +5,4 @@
  (library_flags -linkall)
  (libraries core_kernel snark_params fold_lib base64 codable module_version)
  (preprocess
-  (pps ppx_snarky ppx_jane ppx_deriving.eq)))
+  (pps ppx_snarky ppx_coda ppx_jane ppx_deriving.eq)))

--- a/src/lib/signature_lib/dune
+++ b/src/lib/signature_lib/dune
@@ -6,5 +6,5 @@
  (libraries snarky base64 snark_params core non_zero_curve_point yojson)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_snarky ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (pps ppx_snarky ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
  (synopsis "Schnorr signatures using the tick and tock curves"))

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -10,7 +10,8 @@ include Codable.S with type t := t
 
 module Stable : sig
   module V1 : sig
-    type nonrec t = t [@@deriving bin_io, sexp, compare, eq, hash, yojson]
+    type nonrec t = t
+    [@@deriving bin_io, sexp, compare, eq, hash, yojson, version]
   end
 
   module Latest = V1
@@ -27,15 +28,23 @@ val var_of_t : t -> var
 val of_private_key_exn : Private_key.t -> t
 
 module Compressed : sig
-  type ('field, 'boolean) t_ = {x: 'field; is_odd: 'boolean}
+  module Poly : sig
+    module Stable : sig
+      module V1 : sig
+        type ('field, 'boolean) t = {x: 'field; is_odd: 'boolean}
+      end
 
-  type t = (Field.t, bool) t_ [@@deriving sexp, hash]
+      module Latest = V1
+    end
+  end
+
+  type t = (Field.t, bool) Poly.Stable.Latest.t [@@deriving sexp, hash]
 
   include Codable.S with type t := t
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving sexp, bin_io, eq, compare, hash]
+      type nonrec t = t [@@deriving sexp, bin_io, eq, compare, hash, version]
 
       include Codable.S with type t := t
     end
@@ -49,7 +58,7 @@ module Compressed : sig
 
   val length_in_triples : int
 
-  type var = (Field.Var.t, Boolean.var) t_
+  type var = (Field.Var.t, Boolean.var) Poly.Stable.Latest.t
 
   val typ : (var, t) Typ.t
 

--- a/src/lib/snark_params/pedersen.ml
+++ b/src/lib/snark_params/pedersen.ml
@@ -19,6 +19,9 @@ module type S = sig
   module Digest : sig
     type t [@@deriving bin_io, sexp, eq, hash, compare, yojson]
 
+    (* TODO : really version *)
+    val __versioned__ : bool
+
     val size_in_bits : int
 
     val fold : t -> bool Triple.t Fold.t
@@ -79,6 +82,9 @@ struct
 
   module Digest = struct
     type t = Field.t [@@deriving sexp, bin_io, compare, hash, eq]
+
+    (* TODO : really version *)
+    let __versioned__ = true
 
     let size_in_bits = Field.size_in_bits
 

--- a/src/lib/snark_params/pedersen.mli
+++ b/src/lib/snark_params/pedersen.mli
@@ -17,6 +17,9 @@ module type S = sig
   module Digest : sig
     type t [@@deriving bin_io, sexp, eq, hash, compare, yojson]
 
+    (* TODO: assert versioned, for now *)
+    val __versioned__ : bool
+
     val size_in_bits : int
 
     val fold : t -> bool Triple.t Fold.t

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -357,6 +357,11 @@ module Tick = struct
     module Bits = Bits.Make_field (Tick0.Field) (Tick0.Bigint)
 
     let size_in_triples = (size_in_bits + 2) / 3
+
+    (* for now, assert this type, derived from snarky, is versioned; can we 
+       prevent it changing?
+     *)
+    let __versioned__ = true
   end
 
   module Fq = Snarky_field_extensions.Field_extensions.F (Tick0)

--- a/src/lib/unsigned_extended/dune
+++ b/src/lib/unsigned_extended/dune
@@ -6,5 +6,5 @@
  (inline_tests)
  (libraries core integers snark_params)
  (preprocess
-  (pps ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_coda ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Unsigned integer functions"))

--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -4,7 +4,7 @@ open Snark_params
 type uint64 = Unsigned.uint64
 
 module type S = sig
-  type t [@@deriving bin_io, sexp, hash, compare, eq, yojson]
+  type t [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
 
   val length_in_bits : int
 
@@ -107,6 +107,11 @@ module Extend
 
   include T
   include Hashable.Make (T)
+
+  (* TODO : actually version this type *)
+  let version = 1
+
+  let __versioned__ = true
 
   include Bin_prot.Utils.Make_binable (struct
     module Binable = Signed

--- a/src/lib/unsigned_extended/unsigned_extended.mli
+++ b/src/lib/unsigned_extended/unsigned_extended.mli
@@ -3,7 +3,7 @@ open Core_kernel
 type uint64 = Unsigned.uint64
 
 module type S = sig
-  type t [@@deriving bin_io, sexp, hash, compare, eq, yojson]
+  type t [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
 
   val length_in_bits : int
 


### PR DESCRIPTION
Added `deriving version` for `Coinbase.Stable.V1.t`, which required versioning of the types it depends on. This helps show the viability of the version ppx.

For `Non_zero_curve_point`, the type `t_`, which takes type parameters, is now wrapped in `Poly.Stable.V1` and renamed `t`, to conform to the versioning ppx's requirements.

For three of the contained types, `Pedersen.Digest.t`, `Tick.Field.t`, and `Unsigned_extended.t`, the types are not actually versioned. Instead, by hand we write `let __versioned__ = true`, which allows the requirements of the ppx to be fulfilled. I'm not yet sure how to version these, but the strategy here allows versioning of the types that depend on them. It will be easy to find these harder cases via `grep`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
