### PR TITLE
Deriving version for envelopes

### DIFF
--- a/src/lib/envelope/dune
+++ b/src/lib/envelope/dune
@@ -2,4 +2,4 @@
   (name envelope)
   (public_name envelope)
   (libraries core_kernel network_peer)
-  (preprocess (pps ppx_jane ppx_deriving_yojson)))
+  (preprocess (pps ppx_jane ppx_coda ppx_deriving_yojson)))

--- a/src/lib/envelope/envelope.ml
+++ b/src/lib/envelope/envelope.ml
@@ -6,10 +6,8 @@ module Sender = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t = Local | Remote of Peer.Stable.V1.t
-        [@@deriving sexp, bin_io, yojson]
+        [@@deriving sexp, bin_io, yojson, version]
       end
 
       include T
@@ -36,8 +34,12 @@ end
 module Incoming = struct
   module Stable = struct
     module V1 = struct
-      type 'a t = {data: 'a; sender: Sender.Stable.V1.t}
-      [@@deriving sexp, bin_io, yojson]
+      module T = struct
+        type 'a t = {data: 'a; sender: Sender.Stable.V1.t}
+        [@@deriving sexp, bin_io, yojson, version]
+      end
+
+      include T
     end
 
     module Latest = V1

--- a/src/lib/envelope/envelope.mli
+++ b/src/lib/envelope/envelope.mli
@@ -4,7 +4,8 @@ open Network_peer
 module Sender : sig
   module Stable : sig
     module V1 : sig
-      type t = Local | Remote of Peer.t [@@deriving sexp, bin_io, yojson]
+      type t = Local | Remote of Peer.t
+      [@@deriving sexp, bin_io, yojson, version]
     end
 
     module Latest = V1
@@ -18,7 +19,7 @@ module Incoming : sig
   module Stable : sig
     module V1 : sig
       type 'a t = {data: 'a; sender: Sender.Stable.V1.t}
-      [@@deriving sexp, bin_io, yojson]
+      [@@deriving sexp, bin_io, yojson, version]
     end
 
     module Latest = V1

--- a/src/lib/network_peer/peer.ml
+++ b/src/lib/network_peer/peer.ml
@@ -18,6 +18,11 @@ module Stable = struct
         (* TCP *) }
       [@@deriving bin_io, compare, hash, sexp]
 
+      (* TODO : the port int's don't need versioning; the host type should be wrapped
+         for now, we assert the type is versioned
+       *)
+      let __versioned__ = true
+
       let to_yojson {host; discovery_port; communication_port} =
         `Assoc
           [ ("host", `String (Unix.Inet_addr.to_string host))


### PR DESCRIPTION
Add `deriving version` for `Envelope.Stable.V1.t` and `Envelope.Sender.Stable.V1.t`.

That required asserting that `Peer.Stable.V1.t` is versioned, but it depends on a Jane St library. There's a comment about that.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
