### PR TITLE
Allow sexp_opaque type constructor

### DIFF
--- a/src/lib/ppx_coda/tests/versioned_good_type_constructors.ml
+++ b/src/lib/ppx_coda/tests/versioned_good_type_constructors.ml
@@ -3,7 +3,7 @@ open Core_kernel
 module Stable = struct
   module V1 = struct
     module T = struct
-      type t = int [@@deriving yojson, bin_io, version]
+      type t = int [@@deriving yojson, bin_io, version, sexp]
     end
 
     include T
@@ -23,7 +23,7 @@ module Foo = struct
 
       module V2 = struct
         module T = struct
-          type t = Stable.V1.t option [@@deriving yojson, bin_io, version]
+          type t = Stable.V1.t list [@@deriving yojson, bin_io, version]
         end
 
         include T
@@ -31,7 +31,16 @@ module Foo = struct
 
       module V3 = struct
         module T = struct
-          type t = Stable.V1.t option [@@deriving yojson, bin_io, version]
+          type t = Stable.V1.t ref [@@deriving yojson, bin_io, version]
+        end
+
+        include T
+      end
+
+      module V4 = struct
+        module T = struct
+          type t = Stable.V1.t option sexp_opaque
+          [@@deriving sexp, bin_io, version]
         end
 
         include T

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -109,6 +109,8 @@ let ocaml_builtin_types = ["int"; "float"; "char"; "string"; "bool"; "unit"]
 
 let ocaml_builtin_type_constructors = ["list"; "option"; "ref"]
 
+let jane_street_type_constructors = ["sexp_opaque"]
+
 let rec generate_core_type_version_decls core_type =
   match core_type.ptyp_desc with
   | Ptyp_constr ({txt; _}, core_types) -> (
@@ -120,7 +122,9 @@ let rec generate_core_type_version_decls core_type =
           && List.mem ocaml_builtin_types id ~equal:String.equal
         then (* no versioning to worry about *)
           []
-        else if List.mem ocaml_builtin_type_constructors id ~equal:String.equal
+        else if
+          List.mem ocaml_builtin_type_constructors id ~equal:String.equal
+          || List.mem jane_street_type_constructors id ~equal:String.equal
         then
           match core_types with
           | [_] -> generate_version_lets_for_core_types core_types


### PR DESCRIPTION
Allow Jane Street `sexp_opaque` as a type constructor for versioning.

Added test to check this case (and fixed tests for other type constructors).

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
