### PR TITLE
O(1) section redesign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ jobs:
                   name: Lint wallet
                   command: cd frontend/wallet && npm run reformat && git diff --exit-code src
             - run:
-                  name: Decrypt PragmataPro font
-                  command: cd frontend/wallet && npm run decrypt-ci
-            - run:
                   name: Build wallet
                   command: cd frontend/wallet && npm run build
             - run: cd frontend/website && npm install
+            - run:
+                  name: Decrypt PragmataPro font
+                  command: cd frontend/wallet && npm run decrypt-ci
             - run:
                   name: Lint website
                   command: cd frontend/website && npm run reformat && git diff --exit-code src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             - run: cd frontend/website && npm install
             - run:
                   name: Decrypt PragmataPro font
-                  command: cd frontend/wallet && npm run decrypt-ci
+                  command: cd frontend/website && npm run decrypt-ci
             - run:
                   name: Lint website
                   command: cd frontend/website && npm run reformat && git diff --exit-code src

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
                   name: Lint wallet
                   command: cd frontend/wallet && npm run reformat && git diff --exit-code src
             - run:
+                  name: Decrypt PragmataPro font
+                  command: cd frontend/wallet && npm run decrypt-ci
+            - run:
                   name: Build wallet
                   command: cd frontend/wallet && npm run build
             - run: cd frontend/website && npm install

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -22,12 +22,12 @@ jobs:
                   name: Lint wallet
                   command: cd frontend/wallet && npm run reformat && git diff --exit-code src
             - run:
-                  name: Decrypt PragmataPro font
-                  command: cd frontend/wallet && npm run decrypt-ci
-            - run:
                   name: Build wallet
                   command: cd frontend/wallet && npm run build
             - run: cd frontend/website && npm install
+            - run:
+                  name: Decrypt PragmataPro font
+                  command: cd frontend/wallet && npm run decrypt-ci
             - run:
                   name: Lint website
                   command: cd frontend/website && npm run reformat && git diff --exit-code src

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -27,7 +27,7 @@ jobs:
             - run: cd frontend/website && npm install
             - run:
                   name: Decrypt PragmataPro font
-                  command: cd frontend/wallet && npm run decrypt-ci
+                  command: cd frontend/website && npm run decrypt-ci
             - run:
                   name: Lint website
                   command: cd frontend/website && npm run reformat && git diff --exit-code src

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -22,6 +22,9 @@ jobs:
                   name: Lint wallet
                   command: cd frontend/wallet && npm run reformat && git diff --exit-code src
             - run:
+                  name: Decrypt PragmataPro font
+                  command: cd frontend/wallet && npm run decrypt-ci
+            - run:
                   name: Build wallet
                   command: cd frontend/wallet && npm run build
             - run: cd frontend/website && npm install

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,13 @@
 # Ignore vendored code when calculating repo code %s
 # libsnark is lots of c++
 src/lib/snarky/src/camlsnark_c/libsnark-caml/* linguist-vendored
+# PragmataPro requires a license and costs $$, let's protect it with password
+# protected zip file
+frontend/website/static/font/PragmataPro.zip filter=lfs diff=lfs merge=lfs -text
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
 *.svg filter=lfs diff=lfs merge=lfs -text
 *.woff filter=lfs diff=lfs merge=lfs -text
 *.woff2 filter=lfs diff=lfs merge=lfs -text
 frontend/website/static/*.bc.js filter=lfs diff=lfs merge=lfs -text
+

--- a/frontend/website/.gitignore
+++ b/frontend/website/.gitignore
@@ -6,3 +6,5 @@ node_modules
 /lib
 /bundle
 /site
+Essential-PragmataPro-Bold.woff2
+Essential-PragmataPro-Regular.woff2

--- a/frontend/website/package.json
+++ b/frontend/website/package.json
@@ -13,8 +13,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "deploy-ci": "firebase deploy --project coda-staging-84430 --token \"$FIREBASE_TOKEN\"",
     "deploy-cdn": "npm run build && node lib/js/src/Render.js prod && aws s3 sync . s3://website-codaprotocol/",
-    "decrypt": "cd ./static/font && unzip PragamataPro.zip",
-    "decrypt-ci": "cd ./static/font && unzip -P \"$PRAGMATA_ZIP_PASSWORD\" PragamataPro.zip"
+    "decrypt": "cd static/font && unzip PragmataPro.zip",
+    "decrypt-ci": "cd static/font && unzip -P \"$PRAGMATA_ZIP_PASSWORD\" PragmataPro.zip"
   },
   "dependencies": {
     "bs-css": "8.0.2",

--- a/frontend/website/package.json
+++ b/frontend/website/package.json
@@ -12,7 +12,9 @@
     "link-static": "ln -s $(pwd)/../../src/app/website/static site/static",
     "test": "echo \"Error: no test specified\" && exit 1",
     "deploy-ci": "firebase deploy --project coda-staging-84430 --token \"$FIREBASE_TOKEN\"",
-    "deploy-cdn": "npm run build && node lib/js/src/Render.js prod && aws s3 sync . s3://website-codaprotocol/"
+    "deploy-cdn": "npm run build && node lib/js/src/Render.js prod && aws s3 sync . s3://website-codaprotocol/",
+    "decrypt": "cd ./static/font && unzip PragamataPro.zip",
+    "decrypt-ci": "cd ./static/font && unzip -P \"$PRAGMATA_ZIP_PASSWORD\" PragamataPro.zip"
   },
   "dependencies": {
     "bs-css": "8.0.2",

--- a/frontend/website/src/Home.re
+++ b/frontend/website/src/Home.re
@@ -20,7 +20,7 @@ let make = (~posts, _children) => {
       <div
         className=Css.(
           style([
-            backgroundColor(Style.Colors.gandalf),
+            backgroundColor(Style.Colors.navyBlue),
             marginTop(`rem(13.)),
           ])
         )>

--- a/frontend/website/src/InvestorsSection.re
+++ b/frontend/website/src/InvestorsSection.re
@@ -2,51 +2,35 @@ let twoColumnMedia = "(min-width: 34rem)";
 
 module Investor = {
   let component = ReasonReact.statelessComponent("Investors.Investor");
-  let make = (~name, ~suffix, _) => {
-    let firstName = Js.String.split(" ", name)[0];
-    let suffixStr =
-      switch (suffix) {
-      | `Png => "png"
-      | `Jpg => "jpg"
-      };
-    let imageSrc =
-      Links.Cdn.url(
-        "/static/img/investors/"
-        ++ String.lowercase(firstName)
-        ++ "."
-        ++ suffixStr,
-      );
-    {
-      ...component,
-      render: _self =>
-        <div
-          className=Css.(
-            style([
-              display(`flex),
-              flexDirection(`row),
-              alignItems(`center),
-              media(twoColumnMedia, [marginLeft(`rem(3.))]),
-            ])
-          )>
-          // Note: change this alt text if we ever hide the investor name
+  let make = (~name, _) => {
+    ...component,
+    render: _self =>
+      <div
+        className=Css.(
+          style([
+            display(`flex),
+            alignItems(`center),
+            backgroundColor(Style.Colors.greyish),
+            height(`rem(1.75)),
+            marginRight(`rem(0.75)),
+            marginBottom(`rem(0.625)),
+          ])
+        )>
+        // Note: change this alt text if we ever hide the investor name
 
-            <img
-              src=imageSrc
-              className=TeamSection.iconStyle
-              alt=""
-              ariaHidden=true
-            />
-            <h4
-              className=Css.(
-                merge([
-                  Style.Body.basic,
-                  style([color(Style.Colors.slate)]),
-                ])
-              )>
-              {ReasonReact.string(name)}
-            </h4>
-          </div>,
-    };
+          <h4
+            className=Css.(
+              merge([
+                Style.H3.Technical.title,
+                style([
+                  marginTop(`rem(0.0625)),
+                  ...Style.paddingX(`rem(0.1875)),
+                ]),
+              ])
+            )>
+            {ReasonReact.string(name)}
+          </h4>
+        </div>,
   };
 };
 
@@ -55,46 +39,37 @@ let make = _children => {
   ...component,
   render: _self =>
     <div>
-      <h3 className=Style.H3.wings> {ReasonReact.string("Investors")} </h3>
+      <h3 className=Style.H3.Technical.boxed>
+        {ReasonReact.string("O(1) Investors")}
+      </h3>
       <div
         className=Css.(
           style([
-            maxWidth(`rem(64.)),
-            display(`grid),
-            gridGap(`rem(1.)),
+            maxWidth(`rem(78.)),
+            display(`flex),
+            flexWrap(`wrap),
             marginTop(`rem(3.)),
             marginLeft(`auto),
             marginRight(`auto),
             justifyContent(`center),
-            gridTemplateColumns([`fr(1.), `fr(1.)]),
-            media(
-              twoColumnMedia,
-              [
-                // bs-css doesn't allow fr in minmax: https://github.com/SentiaAnalytics/bs-css/pull/124
-                unsafe(
-                  "grid-template-columns",
-                  "repeat(auto-fit, minmax(15rem, 1fr))",
-                ),
-              ],
-            ),
           ])
         )>
-        <Investor name="Metastable" suffix=`Png />
-        <Investor name="Polychain Capital" suffix=`Jpg />
-        <Investor name="ScifiVC" suffix=`Png />
-        <Investor name="Dekrypt Capital" suffix=`Png />
-        <Investor name="Electric Capital" suffix=`Png />
-        <Investor name="Curious Endeavors" suffix=`Jpg />
-        <Investor name="Kindred Ventures" suffix=`Png />
-        <Investor name="Caffeinated Capital" suffix=`Png />
-        <Investor name="Naval Ravikant" suffix=`Png />
-        <Investor name="Elad Gil" suffix=`Jpg />
-        <Investor name="Linda Xie" suffix=`Jpg />
-        <Investor name="Fred Ehrsam" suffix=`Jpg />
-        <Investor name="Jack Herrick" suffix=`Jpg />
-        <Investor name="Nima Capital" suffix=`Png />
-        <Investor name="Charlie Noyes" suffix=`Png />
-        <Investor name="O Group" suffix=`Png />
+        <Investor name="Metastable" />
+        <Investor name="Polychain Capital" />
+        <Investor name="ScifiVC" />
+        <Investor name="Dekrypt Capital" />
+        <Investor name="Electric Capital" />
+        <Investor name="Curious Endeavors" />
+        <Investor name="Kindred Ventures" />
+        <Investor name="Caffeinated Capital" />
+        <Investor name="Naval Ravikant" />
+        <Investor name="Elad Gil" />
+        <Investor name="Linda Xie" />
+        <Investor name="Fred Ehrsam" />
+        <Investor name="Jack Herrick" />
+        <Investor name="Nima Capital" />
+        <Investor name="Charlie Noyes" />
+        <Investor name="O Group" />
       </div>
     </div>,
 };

--- a/frontend/website/src/Page.re
+++ b/frontend/website/src/Page.re
@@ -97,6 +97,15 @@ module Footer = {
               </Link>
             </ul>
           </div>
+          <p
+            className=Css.(
+              merge([
+                Style.Body.small,
+                style([textAlign(`center), color(Style.Colors.saville)]),
+              ])
+            )>
+            {ReasonReact.string({j|© 2019 O(1) Labs Corporation|j})}
+          </p>
         </section>
       </footer>,
   };

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -142,7 +142,7 @@ Router.(
         Css_file("fonts", Style.Typeface.Loader.load()),
         File(
           "index",
-          <Page page=`Home name="index" footerColor=Style.Colors.gandalf>
+          <Page page=`Home name="index" footerColor=Style.Colors.navyBlue>
             <Home
               posts={List.map(
                 ((name, html, metadata)) =>

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -33,6 +33,8 @@ module Colors = {
   let slateAlpha = a => `hsla((209, 20, 40, a));
 
   let navy = `rgb((0, 49, 90));
+  let navyBlue = `rgb((0, 23, 74));
+  let greyish = `rgb((170, 170, 170));
   let saville = `hsl((212, 33, 35));
   // For use with box-shadow so we can't use opacity
   let greenShadow = `rgba((136, 191, 163, 0.64));
@@ -41,6 +43,7 @@ module Colors = {
   let lightClover = `rgba((118, 205, 135, 0.12));
 
   let teal = `rgb((71, 130, 160));
+  let tealBlue = `rgb((0, 170, 170));
   let tealAlpha = a => `rgba((71, 130, 160, a));
 
   let rosebud = `rgb((163, 83, 111));
@@ -125,6 +128,18 @@ module Typeface = {
         "\n",
         [
           genFontFace(
+            ~fontFamily="PragmataPro",
+            ~src=["/static/font/Essential-PragmataPro-Regular.woff2"],
+            ~fontWeight=`normal,
+            (),
+          ),
+          genFontFace(
+            ~fontFamily="PragmataPro",
+            ~src=["/static/font/Essential-PragmataPro-Bold.woff2"],
+            ~fontWeight=`bold,
+            (),
+          ),
+          genFontFace(
             ~fontFamily="IBM Plex Serif",
             ~src=[
               "/static/font/IBMPlexSerif-Medium-Latin1.woff2",
@@ -179,6 +194,8 @@ module Typeface = {
   let aktivgrotesk = fontFamily("aktiv-grotesk-extended, sans-serif");
 
   let rubik = fontFamily("Rubik, sans-serif");
+
+  let pragmataPro = fontFamily("PragmataPro, monospace");
 };
 
 module MediaQuery = {
@@ -256,6 +273,21 @@ module H2 = {
     ]);
 };
 
+module Technical = {
+  open Css;
+  // TODO: Replace with equals signs
+  let border = f => style([f(`px(6), `solid, Colors.greyish)]);
+
+  let basic =
+    style([
+      Typeface.pragmataPro,
+      fontWeight(`normal),
+      color(Css.white),
+      fontSize(`rem(0.9375)),
+      textTransform(`uppercase),
+    ]);
+};
+
 module H3 = {
   open Css;
 
@@ -299,6 +331,35 @@ module H3 = {
         after([marginLeft(`rem(2.0)), ...wing]),
       ]),
     ]);
+  };
+
+  module Technical = {
+    let basic =
+      style([
+        Typeface.pragmataPro,
+        fontSize(`rem(0.9375)),
+        fontWeight(`bold),
+        letterSpacing(`px(1)),
+        textTransform(`uppercase),
+      ]);
+
+    let title = merge([basic, style([color(Css.black)])]);
+
+    let boxed =
+      merge([
+        basic,
+        Technical.border(Css.border),
+        style([
+          color(Colors.white),
+          lineHeight(`rem(1.5)),
+          display(`flex),
+          justifyContent(`center),
+          alignItems(`center),
+          width(`rem(9.0625)),
+          height(`rem(3.)),
+          margin(`auto),
+        ]),
+      ]);
   };
 };
 
@@ -352,6 +413,17 @@ module H5 = {
 module Body = {
   open Css;
 
+  module Technical = {
+    let basic =
+      style([
+        Typeface.pragmataPro,
+        color(Css.white),
+        fontSize(`rem(1.)),
+        lineHeight(`rem(1.25)),
+        letterSpacing(`rem(0.00625)),
+      ]);
+  };
+
   let basic =
     style([
       Typeface.ibmplexsans,
@@ -372,6 +444,14 @@ module Body = {
     ]);
 
   let big_semibold = merge([big, style([fontWeight(`semiBold)])]);
+
+  let small =
+    style([
+      Typeface.ibmplexsans,
+      fontSize(`rem(0.8125)),
+      opacity(0.5),
+      lineHeight(`rem(1.25)),
+    ]);
 };
 
 // Match Tachyons setting pretty much everything to border-box

--- a/frontend/website/src/TeamSection.re
+++ b/frontend/website/src/TeamSection.re
@@ -1,20 +1,3 @@
-let iconStyle =
-  Css.(
-    style([
-      width(`rem(2.5)),
-      height(`rem(2.5)),
-      borderRadius(`percent(100.)),
-      marginRight(`rem(1.)),
-      boxShadow(
-        ~x=`zero,
-        ~y=`zero,
-        ~blur=`px(4),
-        ~spread=`zero,
-        Style.Colors.greenShadow,
-      ),
-    ])
-  );
-
 module Member = {
   let component = ReasonReact.statelessComponent("Team.Member");
   let make = (~name, ~title, ~description, _children) => {
@@ -26,34 +9,54 @@ module Member = {
       render: _self =>
         <div
           className=Css.(
-            style([
-              display(`flex),
-              flexDirection(`column),
-              width(`rem(20.5)),
-              minWidth(`rem(20.5)),
-              flexGrow(1.),
-              maxWidth(`rem(23.75)),
-              backgroundColor(Style.Colors.veryLightGrey),
-              borderRadius(`px(10)),
-              border(`px(1), `solid, Style.Colors.hyperlinkAlpha(0.2)),
-              padding(`rem(1.5)),
-              marginTop(`rem(1.5625)),
-              marginBottom(`rem(1.5625)),
-              marginLeft(`zero),
-              marginRight(`zero),
-              media(
-                Style.MediaQuery.notMobile,
-                [
-                  minHeight(`rem(27.5)),
-                  marginLeft(`rem(1.5625)),
-                  marginRight(`rem(1.5625)),
-                ],
-              ),
+            merge([
+              Style.Technical.border(Css.border),
+              style([
+                display(`flex),
+                flexDirection(`column),
+                width(`rem(20.5)),
+                minWidth(`rem(20.5)),
+                flexGrow(1.),
+                maxWidth(`rem(23.75)),
+                marginTop(`rem(1.5625)),
+                marginBottom(`rem(1.5625)),
+                marginLeft(`zero),
+                marginRight(`zero),
+                media(
+                  Style.MediaQuery.notMobile,
+                  [
+                    minHeight(`rem(27.5)),
+                    marginLeft(`rem(1.5625)),
+                    marginRight(`rem(1.5625)),
+                  ],
+                ),
+              ]),
             ])
           )>
-          <div className=Css.(style([display(`flex), flexDirection(`row)]))>
+          <div
+            className=Css.(
+              merge([
+                Style.Technical.border(Css.borderBottom),
+                style([
+                  display(`flex),
+                  flexDirection(`row),
+                  alignItems(`center),
+                ]),
+              ])
+            )>
             <img
-              className=iconStyle
+              className=Css.(
+                style([
+                  width(`rem(5.5)),
+                  height(`rem(5.5)),
+                  unsafe("-webkit-filter", "grayscale(1)"),
+                  unsafe("filter", "grayscale(1)"),
+                  marginLeft(`rem(0.875)),
+                  marginTop(`rem(0.625)),
+                  marginBottom(`rem(0.625)),
+                  ...Style.paddingX(`rem(1.)),
+                ])
+              )
               src=imageSrc
               alt={j|Portrait photo of $name.|j}
             />
@@ -68,33 +71,55 @@ module Member = {
               )>
               <div
                 className=Css.(
-                  merge([Style.H3.wide, style([letterSpacing(`em(0.2))])])
+                  style([
+                    display(`flex),
+                    justifyContent(`center),
+                    alignItems(`center),
+                    backgroundColor(Style.Colors.tealBlue),
+                    height(`rem(1.75)),
+                  ])
                 )>
-                {ReasonReact.string(name)}
+                <h3
+                  className=Css.(
+                    merge([
+                      Style.H3.Technical.title,
+                      style([
+                        marginTop(`rem(0.0625)),
+                        ...Style.paddingX(`rem(0.1875)),
+                      ]),
+                    ])
+                  )>
+                  {ReasonReact.string(name)}
+                </h3>
               </div>
-              <div
+              <h5
                 className=Css.(
                   merge([
-                    Style.H5.basic,
-                    style([textAlign(`left), whiteSpace(`nowrap)]),
+                    Style.Technical.basic,
+                    style([
+                      textAlign(`left),
+                      whiteSpace(`nowrap),
+                      marginTop(`rem(0.125)),
+                    ]),
                   ])
                 )>
                 {ReasonReact.string(title)}
-              </div>
+              </h5>
             </div>
           </div>
-          <div
+          <p
             className=Css.(
               merge([
                 style([
-                  color(Style.Colors.saville),
-                  marginTop(`rem(1.875)),
+                  marginLeft(`rem(1.875)),
+                  marginRight(`rem(2.)),
+                  ...Style.paddingY(`rem(0.5)),
                 ]),
-                Style.Body.basic,
+                Style.Body.Technical.basic,
               ])
             )>
             {ReasonReact.string(description)}
-          </div>
+          </p>
         </div>,
     };
   };
@@ -128,7 +153,12 @@ let make = _children => {
             marginRight(`auto),
             marginBottom(`rem(3.0)),
             maxWidth(`rem(27.125)),
-            backgroundColor(Style.Colors.navy),
+            backgroundColor(Style.Colors.navyBlue),
+            // TODO: How do you use the boxShadow in bs-css
+            unsafe(
+              "box-shadow",
+              "0 2px 50px 0 rgba(0, 0, 0, 0.2), 0 7px 8px 0 rgba(0, 0, 0, 0.5)",
+            ),
             textAlign(`center),
             whiteSpace(`nowrap),
           ])
@@ -147,7 +177,9 @@ let make = _children => {
           {ReasonReact.string(" O(1) Labs")}
         </span>
       </div>
-      <h3 className=Style.H3.wings> {ReasonReact.string("Team")} </h3>
+      <h3 className=Style.H3.Technical.boxed>
+        {ReasonReact.string("Team")}
+      </h3>
       <div
         className=Css.(
           style([
@@ -347,7 +379,9 @@ let make = _children => {
        well-being of the user."
         />
       </div>
-      <h3 className=Style.H3.wings> {ReasonReact.string("Advisors")} </h3>
+      <h3 className=Style.H3.Technical.boxed>
+        {ReasonReact.string("Advisors")}
+      </h3>
       <div
         className=Css.(
           style([
@@ -358,6 +392,25 @@ let make = _children => {
             justifyContent(`center),
           ])
         )>
+        <Member
+          name="Jill Carlson"
+          title=advisor
+          description="Jill has worked with the IMF and is an advisor to cryptocurrency and blockchain-based ventures. \
+        Previously, Jill ran strategy at blockchain start up Chain, where she managed \
+        initiatives with Nasdaq and State Street. Jill has conducted academic research \
+        on cryptocurrency at the University of Oxford, where she focused on the economic \
+        and political implications of bitcoin. Jill began her career as a credit trader at Goldman Sachs. \
+        She holds a MSc from Magdalen College, Oxford, and an AB from Harvard, where she studied Classics."
+        />
+        <Member
+          name="Paul Davison"
+          title=advisor
+          description="Paul Davison is the CEO of CoinList - the leading platform for high \
+       quality, compliant token sales and airdrops. Prior to CoinList, Paul \
+       was the Founder/CEO of Highlight (acquired by Pinterest), an EIR at \
+       Benchmark Capital, and a VP at Metaweb (acquired by Google). He holds \
+       a BS from Stanford University and an MBA from Stanford Business School."
+        />
         <Member
           name="Joseph Bonneau"
           title=advisor
@@ -391,23 +444,9 @@ let make = _children => {
        light clients, confidential smart contracts and proofs of solvency."
         />
         <Member
-          name="Jill Carlson"
+          name="Amit Sahai"
           title=advisor
-          description="Jill has worked with the IMF and is an advisor to cryptocurrency and blockchain-based ventures. \
-        Previously, Jill ran strategy at blockchain start up Chain, where she managed \
-        initiatives with Nasdaq and State Street. Jill has conducted academic research \
-        on cryptocurrency at the University of Oxford, where she focused on the economic \
-        and political implications of bitcoin. Jill began her career as a credit trader at Goldman Sachs. \
-        She holds a MSc from Magdalen College, Oxford, and an AB from Harvard, where she studied Classics."
-        />
-        <Member
-          name="Paul Davison"
-          title=advisor
-          description="Paul Davison is the CEO of CoinList - the leading platform for high \
-       quality, compliant token sales and airdrops. Prior to CoinList, Paul \
-       was the Founder/CEO of Highlight (acquired by Pinterest), an EIR at \
-       Benchmark Capital, and a VP at Metaweb (acquired by Google). He holds \
-       a BS from Stanford University and an MBA from Stanford Business School."
+          description="Amit Sahai is a Professor of Computer Science at UCLA, Fellow of the ACM, and Fellow of the IACR. His research interests are in security, cryptography, and theoretical computer science. He is the co-inventor of Attribute-Based Encryption, Functional Encryption, Indistinguishability Obfuscation, author of over 100 technical research papers, and invited speaker at institutions such as MIT, Stanford, and Berkeley. He has also received honors from the Alfred P. Sloan Foundation, Okawa Foundation, Xerox Foundation, Google Research, the BSF, and the ACM. He earned his PhD in Computer Science from MIT and served on the faculty at Princeton before joining UCLA in 2004."
         />
       </div>
     </>,

--- a/frontend/website/static/font/PragmataPro.zip
+++ b/frontend/website/static/font/PragmataPro.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b6e35e38f8fda0ef4f83fad6c6b58e2dee7cf87adcfedca452813ca41c72d0a
+size 79058

--- a/frontend/website/static/img/investors/caffeinated.png
+++ b/frontend/website/static/img/investors/caffeinated.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:239a1239ea5cf4008a06a8d23baad20035fb3771a883ff29a595f3758f3b2868
-size 6971

--- a/frontend/website/static/img/investors/charlie.png
+++ b/frontend/website/static/img/investors/charlie.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4e3c2bd3018bea810c8b641254ce988e079d26a11a219708525b51d72e7ec10d
-size 20827

--- a/frontend/website/static/img/investors/curious.jpg
+++ b/frontend/website/static/img/investors/curious.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed01b854d176335ebd6fa5a1ce3e93a5d634c30598bfe0355c59ac3fe63640b2
-size 2694

--- a/frontend/website/static/img/investors/dekrypt.png
+++ b/frontend/website/static/img/investors/dekrypt.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0b2bf1a0138bd95b309f27362190e69ed22adb263a830084973207c1eada5ab
-size 9579

--- a/frontend/website/static/img/investors/elad.jpg
+++ b/frontend/website/static/img/investors/elad.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c2ff183d1e0a9618d37e63b886e92b2eed9c3386def17a53e233a8af9c3c8d71
-size 4400

--- a/frontend/website/static/img/investors/electric.png
+++ b/frontend/website/static/img/investors/electric.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ab84accdb7dfa1867dde5135f51b761bbc93785670e107760e47a6c9ba00fa7a
-size 7978

--- a/frontend/website/static/img/investors/fred.jpg
+++ b/frontend/website/static/img/investors/fred.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd20ae93aa6196feb01ea2884a0da04a753a5ee9c9c3688ce718885443b7a788
-size 7930

--- a/frontend/website/static/img/investors/jack.jpg
+++ b/frontend/website/static/img/investors/jack.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b00a18121a1d14290f7b56caf04c4b98861b8022da0918bc39650138182e080
-size 9178

--- a/frontend/website/static/img/investors/kindred.png
+++ b/frontend/website/static/img/investors/kindred.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87b2f2e358e5ee93385d1538daae719b0257e707d756775efe169d33d952f5c0
-size 4989

--- a/frontend/website/static/img/investors/linda.jpg
+++ b/frontend/website/static/img/investors/linda.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:45094d810977c67b1ddc25fd4c18dcef6cc71fe2c9605ccf0b93b10f0ad3a578
-size 4528

--- a/frontend/website/static/img/investors/metastable.png
+++ b/frontend/website/static/img/investors/metastable.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5517fe9a7ae9ad57cf18c48eb64abdc1ee369b2411ba62ce7c7cf8b1945c215a
-size 5236

--- a/frontend/website/static/img/investors/naval.png
+++ b/frontend/website/static/img/investors/naval.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1498f02c59ad570eb5fc9bd4bc01cd3d8a6c6258053cae831103284e4074eea4
-size 23916

--- a/frontend/website/static/img/investors/nima.png
+++ b/frontend/website/static/img/investors/nima.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:567e71705416b7f77905e936900c82c8c88d7fe1207886aa13e798402ac0dadf
-size 7150

--- a/frontend/website/static/img/investors/o.png
+++ b/frontend/website/static/img/investors/o.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f0016d05eaf8a070662e81ad42e74ae79e788ff201aaeef9196e788380a744d1
-size 3146

--- a/frontend/website/static/img/investors/polychain.jpg
+++ b/frontend/website/static/img/investors/polychain.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d09ac3acb6f7ac7eff50fcf2400a489de42ba18f73992a6660468a67d03cd1a
-size 2650

--- a/frontend/website/static/img/investors/scifivc.png
+++ b/frontend/website/static/img/investors/scifivc.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:545e8f800bce3816fba469934fed26d2dbc8a7c0dbc2c7ed5ff87cf640c2765a
-size 4548

--- a/frontend/website/static/img/sahai.jpg
+++ b/frontend/website/static/img/sahai.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce7a5fcda3976d0c3a76871e248d2b71bc50a29c5c2b785a5fbfa1d494c9aa8b
+size 32154


### PR DESCRIPTION
Section is re-done in the new technical style. Not done are the
equal-sign borders (just a placeholder for now). Looks good on my
iPhone.

The fonts are encrypted inside a zip file to mitigate the
potential pirating of these fonts, ask @bkase for the password if
you have creds to see the font files. Decrypt by running
`npm run decrypt`.

<img width="1468" alt="Screen Shot 2019-04-03 at 1 03 32 AM" src="https://user-images.githubusercontent.com/515445/55462772-5d538000-55ac-11e9-8579-1754877fa898.png">
<img width="1468" alt="Screen Shot 2019-04-03 at 1 03 40 AM" src="https://user-images.githubusercontent.com/515445/55462774-5d538000-55ac-11e9-96eb-6ee85d4cd8cf.png">

![mobile-o1-0](https://user-images.githubusercontent.com/515445/55462850-925fd280-55ac-11e9-82c6-78da81288602.png)
![mobile-o1-1](https://user-images.githubusercontent.com/515445/55462851-925fd280-55ac-11e9-831f-a86057dd6e05.png)
