### PR TITLE
Version ppx for more RPC types in Coda_networking

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -465,9 +465,7 @@ struct
 
       include (
         Currency.Amount.Signed.Stable.Latest :
-          module type of Currency.Amount.Signed.Stable.Latest
-          with type t := t
-           and type ('a, 'b) t_ := ('a, 'b) t_ )
+          module type of Currency.Amount.Signed.Stable.Latest with type t := t )
     end
   end
 

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -225,7 +225,8 @@ module T = struct
           [%bin_type_class: Receipt.Chain_hash.Stable.V1.t Or_error.t] ()
 
     let process_payment =
-      C.create_rpc ~f:process_payment_impl ~bin_input:User_command.bin_t
+      C.create_rpc ~f:process_payment_impl
+        ~bin_input:User_command.Stable.Latest.bin_t
         ~bin_output:
           [%bin_type_class: Receipt.Chain_hash.Stable.V1.t Or_error.t] ()
 
@@ -237,8 +238,8 @@ module T = struct
       C.create_pipe ~f:root_diff_impl ~bin_input:Unit.bin_t
         ~bin_output:
           [%bin_type_class:
-            User_command.t Protocols.Coda_transition_frontier.Root_diff_view.t]
-        ()
+            User_command.Stable.Latest.t
+            Protocols.Coda_transition_frontier.Root_diff_view.t] ()
 
     let dump_tf =
       C.create_rpc ~f:dump_tf_impl ~bin_input:Unit.bin_t

--- a/src/app/cli/src/ledger_proof.ml
+++ b/src/app/cli/src/ledger_proof.ml
@@ -19,10 +19,8 @@ module Prod :
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t = Transaction_snark.Stable.V1.t
-        [@@deriving bin_io, sexp, yojson]
+        [@@deriving bin_io, sexp, yojson, version]
       end
 
       include T
@@ -81,7 +79,7 @@ module Debug :
         type t =
           Transaction_snark.Statement.Stable.V1.t
           * Sok_message.Digest.Stable.V1.t
-        [@@deriving sexp, bin_io, yojson]
+        [@@deriving sexp, bin_io, yojson, version]
       end
 
       include T

--- a/src/lib/coda_base/coinbase.mli
+++ b/src/lib/coda_base/coinbase.mli
@@ -7,7 +7,7 @@ module Stable : sig
       { proposer: Public_key.Compressed.Stable.V1.t
       ; amount: Currency.Amount.Stable.V1.t
       ; fee_transfer: Fee_transfer.Single.Stable.V1.t option }
-    [@@deriving sexp, bin_io, compare, eq]
+    [@@deriving sexp, bin_io, compare, eq, version]
   end
 
   module Latest = V1

--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -80,8 +80,6 @@ struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         (* TODO : version Pedersen.Digest *)
         type t = Pedersen.Digest.t
         [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]

--- a/src/lib/coda_base/fee_transfer.mli
+++ b/src/lib/coda_base/fee_transfer.mli
@@ -19,7 +19,7 @@ module Stable : sig
     type t =
       | One of Single.Stable.V1.t
       | Two of Single.Stable.V1.t * Single.Stable.V1.t
-    [@@deriving bin_io, sexp, compare, eq, yojson]
+    [@@deriving bin_io, sexp, compare, eq, yojson, version]
   end
 
   module Latest = V1

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -97,7 +97,7 @@ module Undo : sig
       module Stable :
         sig
           module V1 : sig
-            type t [@@deriving bin_io, sexp]
+            type t [@@deriving bin_io, sexp, version]
           end
 
           module Latest = V1
@@ -193,7 +193,7 @@ module Undo : sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving bin_io, sexp]
+        type t [@@deriving bin_io, sexp, version]
       end
 
       module Latest = V1

--- a/src/lib/coda_base/payment_payload.ml
+++ b/src/lib/coda_base/payment_payload.ml
@@ -6,16 +6,29 @@ open Module_version
 module Amount = Currency.Amount
 module Fee = Currency.Fee
 
+module Poly = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type ('pk, 'amount) t = {receiver: 'pk; amount: 'amount}
+        [@@deriving bin_io, eq, sexp, hash, yojson, compare, version]
+      end
+
+      include T
+    end
+
+    module Latest = V1
+  end
+end
+
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
-      type ('pk, 'amount) t_ = {receiver: 'pk; amount: 'amount}
-      [@@deriving bin_io, eq, sexp, hash, compare, yojson]
-
-      type t = (Public_key.Compressed.Stable.V1.t, Amount.Stable.V1.t) t_
-      [@@deriving bin_io, eq, sexp, hash, compare, yojson]
+      type t =
+        ( Public_key.Compressed.Stable.V1.t
+        , Amount.Stable.V1.t )
+        Poly.Stable.V1.t
+      [@@deriving bin_io, eq, sexp, hash, compare, yojson, version]
     end
 
     include T
@@ -34,33 +47,40 @@ module Stable = struct
   module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.Latest
+(* bin_io, version omitted *)
+type t = Stable.Latest.t [@@deriving eq, sexp, hash, yojson]
 
-let dummy = {receiver= Public_key.Compressed.empty; amount= Amount.zero}
+let dummy =
+  Poly.Stable.Latest.
+    {receiver= Public_key.Compressed.empty; amount= Amount.zero}
 
-type var = (Public_key.Compressed.var, Amount.var) t_
+type var = (Public_key.Compressed.var, Amount.var) Poly.Stable.Latest.t
 
 let typ : (var, t) Typ.t =
   let spec =
     let open Data_spec in
     [Public_key.Compressed.typ; Amount.typ]
   in
-  let of_hlist : 'a 'b. (unit, 'a -> 'b -> unit) H_list.t -> ('a, 'b) t_ =
+  let of_hlist
+        : 'a 'b.    (unit, 'a -> 'b -> unit) H_list.t
+          -> ('a, 'b) Poly.Stable.Latest.t =
     let open H_list in
     fun [receiver; amount] -> {receiver; amount}
   in
-  let to_hlist {receiver; amount} = H_list.[receiver; amount] in
+  let to_hlist Poly.Stable.Latest.({receiver; amount}) =
+    H_list.[receiver; amount]
+  in
   Typ.of_hlistable spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
     ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
 
-let fold {receiver; amount} =
+let fold Poly.Stable.Latest.({receiver; amount}) =
   let open Fold in
   Public_key.Compressed.fold receiver +> Amount.fold amount
 
 (* TODO: This could be a bit more efficient by packing across triples,
    but I think the added confusion-possibility
    is not worth it. *)
-let%snarkydef var_to_triples {receiver; amount} =
+let%snarkydef var_to_triples Poly.Stable.Latest.({receiver; amount}) =
   let%map receiver = Public_key.Compressed.var_to_triples receiver in
   let amount = Amount.var_to_triples amount in
   receiver @ amount
@@ -74,16 +94,17 @@ let gen ~max_amount =
   let open Quickcheck.Generator.Let_syntax in
   let%map receiver = Public_key.Compressed.gen
   and amount = Amount.gen_incl Amount.zero max_amount in
-  {receiver; amount}
+  Poly.Stable.Latest.{receiver; amount}
 
 let%test_unit "to_bits" =
   let open Test_util in
   with_randomness 123456789 (fun () ->
       let input =
-        { receiver=
-            { Public_key.Compressed.Poly.Stable.Latest.x= Field.random ()
-            ; is_odd= Random.bool () }
-        ; amount= Amount.of_int (Random.int Int.max_value) }
+        Poly.Stable.Latest.
+          { receiver=
+              { Public_key.Compressed.Poly.Stable.Latest.x= Field.random ()
+              ; is_odd= Random.bool () }
+          ; amount= Amount.of_int (Random.int Int.max_value) }
       in
       Test_util.test_to_triples typ fold var_to_triples input )
 

--- a/src/lib/coda_base/payment_payload.mli
+++ b/src/lib/coda_base/payment_payload.mli
@@ -4,29 +4,37 @@ open Tuple_lib
 open Snark_params.Tick
 open Import
 
-type ('pk, 'amount) t_ = {receiver: 'pk; amount: 'amount}
-[@@deriving bin_io, eq, sexp, hash, yojson]
+module Poly : sig
+  module Stable : sig
+    module V1 : sig
+      type nonrec ('pk, 'amount) t = {receiver: 'pk; amount: 'amount}
+      [@@deriving bin_io, eq, sexp, hash, yojson, version]
+    end
 
-type t = (Public_key.Compressed.t, Currency.Amount.t) t_
-[@@deriving bin_io, eq, sexp, hash, yojson]
+    module Latest = V1
+  end
+end
+
+module Stable : sig
+  module V1 : sig
+    type t =
+      ( Public_key.Compressed.Stable.V1.t
+      , Currency.Amount.Stable.V1.t )
+      Poly.Stable.V1.t
+    [@@deriving bin_io, eq, sexp, hash, yojson, version]
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t [@@deriving eq, sexp, hash, yojson]
 
 val dummy : t
 
 val gen : max_amount:Currency.Amount.t -> t Quickcheck.Generator.t
 
-module Stable : sig
-  module V1 : sig
-    type nonrec ('pk, 'amount) t_ = ('pk, 'amount) t_ =
-      {receiver: 'pk; amount: 'amount}
-    [@@deriving bin_io, eq, sexp, hash, yojson]
-
-    type t =
-      (Public_key.Compressed.Stable.V1.t, Currency.Amount.Stable.V1.t) t_
-    [@@deriving bin_io, eq, sexp, hash, yojson]
-  end
-end
-
-type var = (Public_key.Compressed.var, Currency.Amount.var) t_
+type var =
+  (Public_key.Compressed.var, Currency.Amount.var) Poly.Stable.Latest.t
 
 val length_in_triples : int
 

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -5,7 +5,7 @@ module Stable = struct
   module V1 = struct
     (* TODO: This should be stable. *)
     module T = struct
-      type t = Tock.Proof.t
+      type t = Tock.Proof.t [@@deriving version]
 
       let to_string = Tock_backend.Proof.to_string
 
@@ -33,8 +33,14 @@ module Stable = struct
     let {Bin_prot.Type_class.write= bin_write_t; size= bin_size_t} =
       bin_writer_t
   end
+
+  module Latest = V1
 end
+
+type t = Stable.Latest.t
 
 let dummy = Tock.Proof.dummy
 
-include Stable.V1
+include Sexpable.Of_stringable (Stable.Latest)
+
+let to_yojson, of_yojson = Stable.Latest.(to_yojson, of_yojson)

--- a/src/lib/coda_base/proof.mli
+++ b/src/lib/coda_base/proof.mli
@@ -1,11 +1,11 @@
 open Snark_params
 
-type t = Tock.Proof.t [@@deriving bin_io, sexp, yojson]
+type t = Tock.Proof.t [@@deriving sexp, yojson]
 
 val dummy : Tock.Proof.t
 
 module Stable : sig
   module V1 : sig
-    type nonrec t = t [@@deriving bin_io, sexp, yojson]
+    type nonrec t = t [@@deriving bin_io, sexp, yojson, version]
   end
 end

--- a/src/lib/coda_base/receipt_chain_database.ml
+++ b/src/lib/coda_base/receipt_chain_database.ml
@@ -4,7 +4,7 @@ module Payment = User_command
 
 module Tree_node = struct
   (* TODO : version *)
-  type t = (Receipt.Chain_hash.Stable.V1.t, Payment.t) Tree_node.t
+  type t = (Receipt.Chain_hash.Stable.V1.t, Payment.Stable.V1.t) Tree_node.t
   [@@deriving bin_io]
 end
 

--- a/src/lib/coda_base/signature.ml
+++ b/src/lib/coda_base/signature.ml
@@ -4,10 +4,13 @@ open Module_version
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
       type t = Snark_params.Tock.Field.t * Snark_params.Tock.Field.t
       [@@deriving sexp, eq, compare, hash, bin_io]
+
+      (* TODO : version Field in snarky *)
+      let version = 1
+
+      let __versioned__ = true
     end
 
     let to_base64 t = Binable.to_string (module T) t |> Base64.encode_string

--- a/src/lib/coda_base/signature.mli
+++ b/src/lib/coda_base/signature.mli
@@ -8,7 +8,7 @@ include Codable.S with type t := t
 module Stable : sig
   module V1 : sig
     type t = Snark_params.Tock.Field.t * Snark_params.Tock.Field.t
-    [@@deriving sexp, eq, bin_io, compare, hash]
+    [@@deriving sexp, eq, bin_io, compare, hash, version]
 
     include Codable.S with type t := t
   end

--- a/src/lib/coda_base/snark_transition.ml
+++ b/src/lib/coda_base/snark_transition.ml
@@ -93,7 +93,7 @@ module Make (Inputs : Inputs_intf) :
     ; consensus_data: 'consensus_data
     ; sok_digest: 'sok_digest
     ; supply_increase: 'amount
-    ; ledger_proof: Proof.t option
+    ; ledger_proof: Proof.Stable.V1.t option
     ; proposer: 'proposer_pk
     ; coinbase: 'amount }
   [@@deriving bin_io, sexp, fields]

--- a/src/lib/coda_base/sok_message.ml
+++ b/src/lib/coda_base/sok_message.ml
@@ -10,7 +10,7 @@ module Stable = struct
       type t =
         { fee: Currency.Fee.Stable.V1.t
         ; prover: Public_key.Compressed.Stable.V1.t }
-      [@@deriving bin_io, sexp, yojson]
+      [@@deriving bin_io, sexp, yojson, version]
     end
 
     include T
@@ -40,8 +40,6 @@ module Digest = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         include Random_oracle.Digest.Stable.V1
 
         let fold, typ, length_in_triples =

--- a/src/lib/coda_base/sok_message.mli
+++ b/src/lib/coda_base/sok_message.mli
@@ -9,7 +9,7 @@ module Stable : sig
   module V1 : sig
     type t =
       {fee: Currency.Fee.Stable.V1.t; prover: Public_key.Compressed.Stable.V1.t}
-    [@@deriving bin_io, sexp, yojson]
+    [@@deriving bin_io, sexp, yojson, version]
   end
 
   module Latest = V1
@@ -26,7 +26,8 @@ module Digest : sig
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving sexp, bin_io, hash, compare, eq, yojson]
+      type nonrec t = t
+      [@@deriving sexp, bin_io, hash, compare, eq, yojson, version]
     end
 
     module Latest = V1

--- a/src/lib/coda_base/stake_delegation.ml
+++ b/src/lib/coda_base/stake_delegation.ml
@@ -5,11 +5,9 @@ open Module_version
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
       type t =
         | Set_delegate of {new_delegate: Public_key.Compressed.Stable.V1.t}
-      [@@deriving bin_io, eq, sexp, hash, yojson]
+      [@@deriving bin_io, eq, sexp, hash, yojson, version]
     end
 
     include T

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -17,7 +17,7 @@ module type S = sig
         module Stable :
           sig
             module V1 : sig
-              type t [@@deriving bin_io, sexp]
+              type t [@@deriving bin_io, sexp, version]
             end
 
             module Latest = V1
@@ -118,7 +118,7 @@ module type S = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving sexp, bin_io]
+          type t [@@deriving sexp, bin_io, version]
         end
 
         module Latest = V1
@@ -205,13 +205,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         module Stable = struct
           module V1 = struct
             module T = struct
-              let version = 1
-
               type t =
                 { user_command: User_command.Stable.V1.t
                 ; previous_receipt_chain_hash: Receipt.Chain_hash.Stable.V1.t
                 }
-              [@@deriving sexp, bin_io]
+              [@@deriving sexp, bin_io, version]
             end
 
             include T
@@ -241,15 +239,13 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         module Stable = struct
           module V1 = struct
             module T = struct
-              let version = 1
-
               type t =
                 | Payment of
                     { previous_empty_accounts:
                         Public_key.Compressed.Stable.V1.t list }
                 | Stake_delegation of
                     { previous_delegate: Public_key.Compressed.Stable.V1.t }
-              [@@deriving sexp, bin_io]
+              [@@deriving sexp, bin_io, version]
             end
 
             include T
@@ -284,7 +280,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
             let version = 1
 
             type t = {common: Common.Stable.V1.t; body: Body.Stable.V1.t}
-            [@@deriving sexp, bin_io]
+            [@@deriving sexp, bin_io, version]
           end
 
           include T
@@ -313,13 +309,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       module Stable = struct
         module V1 = struct
           module T = struct
-            let version = 1
-
             type t =
               { fee_transfer: Fee_transfer.Stable.V1.t
               ; previous_empty_accounts: Public_key.Compressed.Stable.V1.t list
               }
-            [@@deriving sexp, bin_io]
+            [@@deriving sexp, bin_io, version]
           end
 
           include T
@@ -354,7 +348,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               { coinbase: Coinbase.Stable.V1.t
               ; previous_empty_accounts: Public_key.Compressed.Stable.V1.t list
               }
-            [@@deriving sexp, bin_io]
+            [@@deriving sexp, bin_io, version]
           end
 
           include T
@@ -390,7 +384,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               | User_command of User_command_undo.Stable.V1.t
               | Fee_transfer of Fee_transfer_undo.Stable.V1.t
               | Coinbase of Coinbase_undo.Stable.V1.t
-            [@@deriving sexp, bin_io]
+            [@@deriving sexp, bin_io, version]
           end
 
           include T
@@ -425,7 +419,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           type t =
             { previous_hash: Ledger_hash.Stable.V1.t
             ; varying: Varying.Stable.V1.t }
-          [@@deriving sexp, bin_io]
+          [@@deriving sexp, bin_io, version]
         end
 
         include T
@@ -486,7 +480,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           { Undo.User_command_undo.common
           ; body= Stake_delegation {previous_delegate= sender_account.delegate}
           }
-    | Payment {Payment_payload.amount; receiver} ->
+    | Payment Payment_payload.Poly.Stable.Latest.({amount; receiver}) ->
         let%bind sender_balance' = sub_amount sender_account.balance amount in
         let undo emptys : Undo.User_command_undo.t =
           {common; body= Payment {previous_empty_accounts= emptys}}

--- a/src/lib/coda_base/transaction_union.ml
+++ b/src/lib/coda_base/transaction_union.ml
@@ -38,7 +38,7 @@ let typ : (var, t) Typ.t =
 *)
 let of_transaction : Transaction.t -> t = function
   | User_command cmd ->
-      let {User_command.sender; payload; signature} =
+      let User_command.Poly.Stable.Latest.({sender; payload; signature}) =
         (cmd :> User_command.t)
       in
       { payload= Transaction_union_payload.of_user_command_payload payload

--- a/src/lib/coda_base/transaction_union_payload.ml
+++ b/src/lib/coda_base/transaction_union_payload.ml
@@ -81,12 +81,18 @@ module Body = struct
   end
 end
 
-type t = (User_command_payload.Common.t, Body.t) User_command_payload.t_
+type t =
+  ( User_command_payload.Common.t
+  , Body.t )
+  User_command_payload.Poly.Stable.Latest.t
 [@@deriving sexp]
 
 type payload = t [@@deriving sexp]
 
-type var = (User_command_payload.Common.var, Body.var) User_command_payload.t_
+type var =
+  ( User_command_payload.Common.var
+  , Body.var )
+  User_command_payload.Poly.Stable.Latest.t
 
 type payload_var = var
 
@@ -94,13 +100,15 @@ let gen =
   let open Quickcheck.Generator.Let_syntax in
   let%bind common = User_command_payload.Common.gen in
   let%map body = Body.gen ~fee:common.fee in
-  {User_command_payload.common; body}
+  User_command_payload.Poly.Stable.Latest.{common; body}
 
-let to_hlist ({common; body} : (_, _) User_command_payload.t_) =
+let to_hlist
+    ({common; body} : (_, _) User_command_payload.Poly.Stable.Latest.t) =
   H_list.[common; body]
 
 let of_hlist : type c v.
-    (unit, c -> v -> unit) H_list.t -> (c, v) User_command_payload.t_ =
+       (unit, c -> v -> unit) H_list.t
+    -> (c, v) User_command_payload.Poly.Stable.Latest.t =
  fun H_list.([common; body]) -> {common; body}
 
 let typ : (var, t) Typ.t =

--- a/src/lib/coda_base/transaction_witness.ml
+++ b/src/lib/coda_base/transaction_witness.ml
@@ -1,1 +1,21 @@
-type t = {ledger: Sparse_ledger.t} [@@deriving sexp, bin_io]
+open Module_version
+
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      let version = 1
+
+      let __versioned__ = true
+
+      (* TODO : version Sparse_ledger *)
+      type t = {ledger: Sparse_ledger.t} [@@deriving sexp, bin_io]
+    end
+
+    include T
+    include Registration.Make_latest_version (T)
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t = {ledger: Sparse_ledger.t} [@@deriving sexp]

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -10,17 +10,31 @@ open Module_version
 module Fee = Currency.Fee
 module Payload = User_command_payload
 
+module Poly = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type ('payload, 'pk, 'signature) t =
+          {payload: 'payload; sender: 'pk; signature: 'signature}
+        [@@deriving bin_io, eq, sexp, hash, yojson, version]
+      end
+
+      include T
+    end
+
+    module Latest = V1
+  end
+end
+
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
-      type ('payload, 'pk, 'signature) t_ =
-        {payload: 'payload; sender: 'pk; signature: 'signature}
-      [@@deriving bin_io, eq, sexp, hash, yojson]
-
-      type t = (Payload.Stable.V1.t, Public_key.Stable.V1.t, Signature.t) t_
-      [@@deriving bin_io, eq, sexp, hash, yojson]
+      type t =
+        ( Payload.Stable.V1.t
+        , Public_key.Stable.V1.t
+        , Signature.Stable.V1.t )
+        Poly.Stable.V1.t
+      [@@deriving bin_io, eq, sexp, hash, yojson, version]
 
       type with_seed = string * t [@@deriving hash]
 
@@ -60,15 +74,17 @@ module Stable = struct
   module Registered_V1 = Registrar.Register (V1)
 end
 
-include Stable.Latest
+type t = Stable.Latest.t [@@deriving sexp, yojson, hash]
+
+include Comparable.Make (Stable.Latest)
 
 type value = t
 
-let payload {payload; _} = payload
+let payload Poly.Stable.Latest.({payload; _}) = payload
 
 let fee = Fn.compose Payload.fee payload
 
-let sender t = Public_key.compress t.sender
+let sender t = Public_key.compress Poly.Stable.Latest.(t.sender)
 
 let accounts_accessed ({payload; sender; _} : value) =
   Public_key.compress sender :: Payload.accounts_accessed payload

--- a/src/lib/coda_base/user_command.mli
+++ b/src/lib/coda_base/user_command.mli
@@ -2,26 +2,32 @@ open Core
 open Import
 module Payload = User_command_payload
 
-type ('payload, 'pk, 'signature) t_ =
-  {payload: 'payload; sender: 'pk; signature: 'signature}
-[@@deriving bin_io, eq, sexp, hash, yojson]
+module Poly : sig
+  module Stable : sig
+    module V1 : sig
+      type ('payload, 'pk, 'signature) t =
+        {payload: 'payload; sender: 'pk; signature: 'signature}
+      [@@deriving bin_io, eq, sexp, hash, yojson]
+    end
 
-type t = (Payload.t, Public_key.t, Signature.t) t_
-[@@deriving bin_io, eq, sexp, hash, yojson]
+    module Latest = V1
+  end
+end
 
 module Stable : sig
   module V1 : sig
-    type nonrec ('payload, 'pk, 'signature) t_ =
-                                                ('payload, 'pk, 'signature) t_ =
-      {payload: 'payload; sender: 'pk; signature: 'signature}
-    [@@deriving bin_io, eq, sexp, hash, yojson]
-
-    type t = (Payload.Stable.V1.t, Public_key.t, Signature.t) t_
-    [@@deriving bin_io, eq, sexp, hash, yojson]
+    type t =
+      ( Payload.Stable.V1.t
+      , Public_key.Stable.V1.t
+      , Signature.Stable.V1.t )
+      Poly.Stable.V1.t
+    [@@deriving bin_io, eq, sexp, hash, yojson, version]
   end
 
   module Latest : module type of V1
 end
+
+type t = Stable.Latest.t [@@deriving sexp, yojson, hash]
 
 include Comparable.S with type t := t
 

--- a/src/lib/coda_base/user_command_memo.mli
+++ b/src/lib/coda_base/user_command_memo.mli
@@ -8,7 +8,8 @@ type t [@@deriving sexp, eq, compare, hash, yojson]
 
 module Stable : sig
   module V1 : sig
-    type nonrec t = t [@@deriving sexp, bin_io, eq, compare, hash, yojson]
+    type nonrec t = t
+    [@@deriving sexp, bin_io, eq, compare, hash, yojson, version]
   end
 end
 

--- a/src/lib/coda_base/user_command_payload.mli
+++ b/src/lib/coda_base/user_command_payload.mli
@@ -20,23 +20,31 @@ module Body : sig
 end
 
 module Common : sig
-  type ('fee, 'nonce, 'memo) t_ = {fee: 'fee; nonce: 'nonce; memo: 'memo}
-  [@@deriving bin_io, eq, sexp, hash]
+  module Poly : sig
+    module Stable : sig
+      module V1 : sig
+        type ('fee, 'nonce, 'memo) t = {fee: 'fee; nonce: 'nonce; memo: 'memo}
+        [@@deriving bin_io, eq, sexp, hash, yojson, version]
+      end
 
-  type t =
-    ( Currency.Fee.Stable.V1.t
-    , Coda_numbers.Account_nonce.Stable.V1.t
-    , User_command_memo.t )
-    t_
-  [@@deriving eq, sexp, hash]
+      module Latest = V1
+    end
+  end
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, eq, sexp, hash]
+      type t =
+        ( Currency.Fee.Stable.V1.t
+        , Coda_numbers.Account_nonce.Stable.V1.t
+        , User_command_memo.t )
+        Poly.Stable.V1.t
+      [@@deriving bin_io, eq, sexp, hash]
     end
 
     module Latest = V1
   end
+
+  type t = Stable.Latest.t [@@deriving eq, sexp, hash]
 
   val gen : t Quickcheck.Generator.t
 
@@ -44,7 +52,7 @@ module Common : sig
     ( Currency.Fee.var
     , Coda_numbers.Account_nonce.Unpacked.var
     , User_command_memo.Checked.t )
-    t_
+    Poly.Stable.Latest.t
 
   val typ : (var, t) Typ.t
 
@@ -57,10 +65,27 @@ module Common : sig
   end
 end
 
-type ('common, 'body) t_ = {common: 'common; body: 'body}
-[@@deriving bin_io, eq, sexp, hash]
+module Poly : sig
+  module Stable : sig
+    module V1 : sig
+      type ('common, 'body) t = {common: 'common; body: 'body}
+      [@@deriving bin_io, eq, sexp, hash, yojson, compare, version]
+    end
 
-type t = (Common.t, Body.t) t_ [@@deriving eq, sexp, hash]
+    module Latest = V1
+  end
+end
+
+module Stable : sig
+  module V1 : sig
+    type t = (Common.Stable.V1.t, Body.Stable.V1.t) Poly.Stable.V1.t
+    [@@deriving bin_io, eq, sexp, hash, yojson, version]
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t [@@deriving eq, sexp, hash]
 
 val create :
      fee:Currency.Fee.t
@@ -72,14 +97,6 @@ val create :
 val length_in_triples : int
 
 val dummy : t
-
-module Stable : sig
-  module V1 : sig
-    type nonrec t = t [@@deriving bin_io, eq, sexp, hash, yojson]
-  end
-
-  module Latest = V1
-end
 
 val fold : t -> bool Triple.t Fold.t
 

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -17,9 +17,15 @@ module Rpcs (Inputs : sig
     Protocols.Coda_pow.Staged_ledger_aux_hash_intf
 
   module Staged_ledger_aux : sig
-    module Stable : sig
-      module V1 : Binable.S
-    end
+    type t
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving bin_io, version]
+        end
+      end
+      with type V1.t = t
   end
 
   module Ledger_hash : Protocols.Coda_pow.Ledger_hash_intf
@@ -361,7 +367,7 @@ module type Inputs_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io]
+          type t [@@deriving bin_io, version]
         end
       end
       with type V1.t = t

--- a/src/lib/coda_networking/dune
+++ b/src/lib/coda_networking/dune
@@ -7,5 +7,5 @@
  (libraries core o1trace envelope async gossip_net coda_lib protocols
    async_extra coda_base unix_timestamp perf_histograms proof_carrying_data)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Networking layer for coda"))

--- a/src/lib/coda_numbers/dune
+++ b/src/lib/coda_numbers/dune
@@ -7,6 +7,6 @@
  (libraries fold_lib tuple_lib snark_bits snark_params unsigned_extended
    protocols core snarky crypto_params module_version)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
+  (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
     -conditional))
  (synopsis "Snark-friendly numbers used in Coda consensus"))

--- a/src/lib/coda_numbers/nat.ml
+++ b/src/lib/coda_numbers/nat.ml
@@ -13,7 +13,8 @@ module type S = sig
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+      type nonrec t = t
+      [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
     end
 
     module Latest = V1
@@ -83,9 +84,8 @@ struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
-        type t = N.t [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+        type t = N.t
+        [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
       end
 
       include T

--- a/src/lib/coda_numbers/nat.mli
+++ b/src/lib/coda_numbers/nat.mli
@@ -12,7 +12,8 @@ module type S = sig
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+      type nonrec t = t
+      [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
     end
 
     module Latest = V1

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -82,32 +82,39 @@ module type Signed_intf = sig
 
   type magnitude_var
 
-  type ('magnitude, 'sgn) t_
+  module Poly : sig
+    module Stable : sig
+      module V1 : sig
+        type ('magnitude, 'sgn) t [@@deriving version]
+      end
 
-  type t = (magnitude, Sgn.t) t_
-  [@@deriving sexp, hash, bin_io, compare, eq, yojson]
-
-  val gen : t Quickcheck.Generator.t
+      module Latest = V1
+    end
+  end
 
   module Stable : sig
     module V1 : sig
-      type nonrec ('magnitude, 'sgn) t_ = ('magnitude, 'sgn) t_
-
-      type nonrec t = t [@@deriving bin_io, sexp, hash, compare, eq, yojson]
+      type t = (magnitude, Sgn.Stable.V1.t) Poly.Stable.V1.t
+      [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
     end
 
     module Latest = V1
   end
 
+  type t = Stable.Latest.t [@@deriving sexp, hash, compare, eq, yojson]
+
+  val gen : t Quickcheck.Generator.t
+
   val length_in_triples : int
 
-  val create : magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) t_
+  val create :
+    magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) Poly.Stable.Latest.t
 
   val sgn : t -> Sgn.t
 
   val magnitude : t -> magnitude
 
-  type nonrec var = (magnitude_var, Sgn.var) t_
+  type var = (magnitude_var, Sgn.var) Poly.Stable.Latest.t
 
   val typ : (var, t) Typ.t
 
@@ -142,7 +149,8 @@ module type Signed_intf = sig
 
     val cswap :
          Boolean.var
-      -> (magnitude_var, Sgn.t) t_ * (magnitude_var, Sgn.t) t_
+      -> (magnitude_var, Sgn.t) Poly.Stable.Latest.t
+         * (magnitude_var, Sgn.t) Poly.Stable.Latest.t
       -> (var * var, _) Checked.t
   end
 end
@@ -242,6 +250,8 @@ end = struct
     module Registered_V1 = Registrar.Register (V1)
   end
 
+  (* bin_io, version omitted *)
+  (*  type t = Stable.Latest.t  [@@deriving sexp, compare, hash] *)
   include Stable.Latest
 
   let to_uint64 = Unsigned.to_uint64
@@ -317,7 +327,7 @@ end = struct
   let var_of_t t =
     List.init M.length ~f:(fun i -> Boolean.var_of_value (Vector.get t i))
 
-  type magnitude = t [@@deriving sexp, bin_io, hash, compare, eq, yojson]
+  type magnitude = t [@@deriving sexp, bin_io, hash, compare, yojson]
 
   let fold_bits = fold
 
@@ -328,18 +338,28 @@ end = struct
     >>= unpack_var
 
   module Signed = struct
+    module Poly = struct
+      module Stable = struct
+        module V1 = struct
+          module T = struct
+            type ('magnitude, 'sgn) t = {magnitude: 'magnitude; sgn: 'sgn}
+            [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
+          end
+
+          include T
+        end
+
+        module Latest = V1
+      end
+    end
+
+    module Stable_outer = Stable
+
     module Stable = struct
       module V1 = struct
         module T = struct
-          let version = 1
-
-          type ('magnitude, 'sgn) t_ = {magnitude: 'magnitude; sgn: 'sgn}
-          [@@deriving bin_io, sexp, hash, compare, fields, eq, yojson]
-
-          let create ~magnitude ~sgn = {magnitude; sgn}
-
-          type t = (magnitude, Sgn.t) t_
-          [@@deriving bin_io, sexp, hash, compare, eq, yojson]
+          type t = (Stable.V1.t, Sgn.Stable.V1.t) Poly.Stable.V1.t
+          [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
         end
 
         include T
@@ -358,7 +378,17 @@ end = struct
       module Registered_V1 = Registrar.Register (V1)
     end
 
-    include Stable.Latest
+    (* bin_io, version omitted *)
+    type t = (Stable_outer.V1.t, Sgn.Stable.V1.t) Poly.Stable.Latest.t
+    [@@deriving sexp, hash, compare, eq, yojson]
+
+    (* = Stable.Latest.t *)
+
+    let create ~magnitude ~sgn = Poly.Stable.V1.{magnitude; sgn}
+
+    let sgn Poly.Stable.Latest.({sgn; _}) = sgn
+
+    let magnitude Poly.Stable.Latest.({magnitude; _}) = magnitude
 
     let zero = create ~magnitude:zero ~sgn:Sgn.Pos
 
@@ -366,16 +396,19 @@ end = struct
       Quickcheck.Generator.map2 gen Sgn.gen ~f:(fun magnitude sgn ->
           create ~magnitude ~sgn )
 
-    type nonrec var = (var, Sgn.var) t_
+    type nonrec var = (var, Sgn.var) Poly.Stable.Latest.t
 
     let length_in_bits = Int.( + ) length_in_bits 1
 
     let length_in_triples = Int.((length_in_bits + 2) / 3)
 
-    let of_hlist : (unit, 'a -> 'b -> unit) Snarky.H_list.t -> ('a, 'b) t_ =
+    let of_hlist :
+           (unit, 'a -> 'b -> unit) Snarky.H_list.t
+        -> ('a, 'b) Poly.Stable.Latest.t =
       Snarky.H_list.(fun [magnitude; sgn] -> {magnitude; sgn})
 
-    let to_hlist {magnitude; sgn} = Snarky.H_list.[magnitude; sgn]
+    let to_hlist Poly.Stable.Latest.({magnitude; sgn}) =
+      Snarky.H_list.[magnitude; sgn]
 
     let typ =
       Typ.of_hlistable
@@ -401,39 +434,42 @@ end = struct
       | Neg, (Neg as sgn) | Pos, (Pos as sgn) ->
           let open Option.Let_syntax in
           let%map magnitude = add x.magnitude y.magnitude in
-          {sgn; magnitude}
+          create ~sgn ~magnitude
       | Pos, Neg | Neg, Pos ->
           let c = compare_magnitude x.magnitude y.magnitude in
           Some
             ( if Int.( < ) c 0 then
-              { sgn= y.sgn
-              ; magnitude= Unsigned.Infix.(y.magnitude - x.magnitude) }
+              create ~sgn:y.sgn
+                ~magnitude:Unsigned.Infix.(y.magnitude - x.magnitude)
             else if Int.( > ) c 0 then
-              { sgn= x.sgn
-              ; magnitude= Unsigned.Infix.(x.magnitude - y.magnitude) }
+              create ~sgn:x.sgn
+                ~magnitude:Unsigned.Infix.(x.magnitude - y.magnitude)
             else zero )
 
-    let negate t = {t with sgn= Sgn.negate t.sgn}
+    let negate t = Poly.Stable.Latest.{t with sgn= Sgn.negate t.sgn}
 
-    let of_unsigned magnitude = {magnitude; sgn= Sgn.Pos}
+    let of_unsigned magnitude = create ~magnitude ~sgn:Sgn.Pos
 
     let ( + ) = add
 
     module Checked = struct
-      let to_bits {magnitude; sgn} =
+      let to_bits Poly.Stable.Latest.({magnitude; sgn}) =
         (var_to_bits magnitude :> Boolean.var list) @ [Sgn.Checked.is_pos sgn]
 
-      let constant {magnitude; sgn} =
-        {magnitude= var_of_t magnitude; sgn= Sgn.Checked.constant sgn}
+      let constant Poly.Stable.Latest.({magnitude; sgn}) =
+        Poly.Stable.Latest.
+          {magnitude= var_of_t magnitude; sgn= Sgn.Checked.constant sgn}
 
-      let of_unsigned magnitude = {magnitude; sgn= Sgn.Checked.pos}
+      let of_unsigned magnitude =
+        Poly.Stable.Latest.{magnitude; sgn= Sgn.Checked.pos}
 
       let if_ cond ~then_ ~else_ =
-        let%map sgn = Sgn.Checked.if_ cond ~then_:then_.sgn ~else_:else_.sgn
-        and magnitude =
-          if_ cond ~then_:then_.magnitude ~else_:else_.magnitude
-        in
-        {sgn; magnitude}
+        Poly.Stable.Latest.(
+          let%map sgn = Sgn.Checked.if_ cond ~then_:then_.sgn ~else_:else_.sgn
+          and magnitude =
+            if_ cond ~then_:then_.magnitude ~else_:else_.magnitude
+          in
+          {sgn; magnitude})
 
       let to_triples t =
         Bitstring.pad_to_triple_list ~default:Boolean.false_ (to_bits t)
@@ -455,7 +491,7 @@ end = struct
           Tick.Field.Checked.mul (sgn :> Field.Var.t) (Field.Var.add xv yv)
         in
         let%map magnitude = unpack_var res in
-        {magnitude; sgn}
+        Poly.Stable.Latest.{magnitude; sgn}
 
       let ( + ) = add
 
@@ -469,7 +505,7 @@ end = struct
 
       let cswap b (x, y) =
         let l_sgn, r_sgn =
-          match (x.sgn, y.sgn) with
+          match Poly.Stable.Latest.(x.sgn, y.sgn) with
           | Sgn.Pos, Sgn.Pos -> Sgn.Checked.(pos, pos)
           | Neg, Neg -> Sgn.Checked.(neg, neg)
           | Pos, Neg -> (Sgn.Checked.neg_if_true b, Sgn.Checked.pos_if_true b)
@@ -482,7 +518,8 @@ end = struct
           let%map l = unpack_var l and r = unpack_var r in
           (l, r)
         in
-        ({sgn= l_sgn; magnitude= l_mag}, {sgn= r_sgn; magnitude= r_mag})
+        Poly.Stable.Latest.
+          ({sgn= l_sgn; magnitude= l_mag}, {sgn= r_sgn; magnitude= r_mag})
     end
   end
 

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -106,32 +106,39 @@ module type Signed_intf = sig
 
   type magnitude_var
 
-  type ('magnitude, 'sgn) t_
+  module Poly : sig
+    module Stable : sig
+      module V1 : sig
+        type ('magnitude, 'sgn) t [@@deriving version]
+      end
 
-  type t = (magnitude, Sgn.t) t_
-  [@@deriving sexp, hash, bin_io, compare, eq, yojson]
-
-  val gen : t Quickcheck.Generator.t
+      module Latest = V1
+    end
+  end
 
   module Stable : sig
     module V1 : sig
-      type nonrec ('magnitude, 'sgn) t_ = ('magnitude, 'sgn) t_
-
-      type nonrec t = t [@@deriving bin_io, sexp, hash, compare, eq, yojson]
+      type t = (magnitude, Sgn.Stable.V1.t) Poly.Stable.V1.t
+      [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
     end
 
     module Latest = V1
   end
 
+  type t = Stable.Latest.t [@@deriving sexp, hash, compare, eq, yojson]
+
+  val gen : t Quickcheck.Generator.t
+
   val length_in_triples : int
 
-  val create : magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) t_
+  val create :
+    magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) Poly.Stable.Latest.t
 
   val sgn : t -> Sgn.t
 
   val magnitude : t -> magnitude
 
-  type nonrec var = (magnitude_var, Sgn.var) t_
+  type var = (magnitude_var, Sgn.var) Poly.Stable.Latest.t
 
   val typ : (var, t) Typ.t
 
@@ -166,7 +173,8 @@ module type Signed_intf = sig
 
     val cswap :
          Boolean.var
-      -> (magnitude_var, Sgn.t) t_ * (magnitude_var, Sgn.t) t_
+      -> (magnitude_var, Sgn.t) Poly.Stable.Latest.t
+         * (magnitude_var, Sgn.t) Poly.Stable.Latest.t
       -> (var * var, _) Checked.t
   end
 end

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -316,7 +316,9 @@ end
 
 module Verify_proof = struct
   type query =
-    Public_key.Compressed.Stable.Latest.t * User_command.t * Payment_proof.t
+    Public_key.Compressed.Stable.Latest.t
+    * User_command.Stable.V1.t
+    * Payment_proof.t
   [@@deriving bin_io]
 
   type response = unit Or_error.t [@@deriving bin_io]

--- a/src/lib/parallel_scan/dune
+++ b/src/lib/parallel_scan/dune
@@ -6,5 +6,5 @@
  (library_flags -linkall)
  (libraries pipe_lib coda_digestif core async async_extra sgn)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_coda ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "Parallel scan over an infinite stream (incremental map-reduce)"))

--- a/src/lib/parallel_scan/parallel_scan.mli
+++ b/src/lib/parallel_scan/parallel_scan.mli
@@ -35,7 +35,15 @@ open Coda_digestif
 
 (** A ring-buffer that backs our state *)
 module Ring_buffer : sig
-  type 'a t [@@deriving sexp, bin_io]
+  type 'a t [@@deriving sexp]
+
+  module Stable : sig
+    module V1 : sig
+      type nonrec 'a t = 'a t [@@deriving sexp, bin_io, version]
+    end
+
+    module Latest = V1
+  end
 
   val read_all : 'a t -> 'a list
 
@@ -46,17 +54,35 @@ module State : sig
   module Job : sig
     (** An incomplete job -- base may contain data ['d], merge can have zero components, one component (either the left or the right), or two components in which case there is an integer (sequence_no) representing a set of (completed)jobs in a sequence of (completed)jobs created.
      *)
-    type sequence_no = int [@@deriving sexp, bin_io]
+    module Sequence_no : sig
+      module Stable : sig
+        module V1 : sig
+          type t = int [@@deriving sexp, bin_io, version]
+        end
 
-    type 'a merge =
-      | Empty
-      | Lcomp of 'a
-      | Rcomp of 'a
-      | Bcomp of ('a * 'a * sequence_no)
-    [@@deriving sexp, bin_io]
+        module Latest = V1
+      end
+    end
 
-    type ('a, 'd) t = Merge of 'a merge | Base of ('d * sequence_no) option
-    [@@deriving sexp, bin_io]
+    module Merge : sig
+      module Stable : sig
+        module V1 : sig
+          type 'a t =
+            | Empty
+            | Lcomp of 'a
+            | Rcomp of 'a
+            | Bcomp of ('a * 'a * Sequence_no.Stable.V1.t)
+          [@@deriving sexp, bin_io, version]
+        end
+
+        module Latest = V1
+      end
+    end
+
+    type ('a, 'd) t =
+      | Merge of 'a Merge.Stable.V1.t
+      | Base of ('d * Sequence_no.Stable.V1.t) option
+    [@@deriving sexp, bin_io, version]
   end
 
   module Completed_job : sig
@@ -70,18 +96,16 @@ module State : sig
    * and partially complete ['a option * 'a option] merges.
    *)
 
-  (* bin_io omitted intentionally *)
+  (* bin_io, version omitted intentionally *)
   type ('a, 'd) t [@@deriving sexp]
 
-  module Stable :
-    sig
-      module V1 : sig
-        type ('a, 'd) t [@@deriving sexp, bin_io]
-      end
-
-      module Latest = V1
+  module Stable : sig
+    module V1 : sig
+      type nonrec ('a, 'd) t = ('a, 'd) t [@@deriving sexp, bin_io, version]
     end
-    with type ('a, 'd) V1.t = ('a, 'd) t
+
+    module Latest = V1
+  end
 
   (** Fold chronologically through the state. This is not the same as iterating
    * through the ring-buffer, rather we traverse the data structure in the same

--- a/src/lib/parallel_scan/ring_buffer.ml
+++ b/src/lib/parallel_scan/ring_buffer.ml
@@ -1,7 +1,27 @@
 open Core_kernel
 open Async_kernel
 
-type 'a t = {data: 'a Array.t; mutable position: int} [@@deriving sexp, bin_io]
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      type 'a t = {data: 'a Array.t; mutable position: int}
+      [@@deriving sexp, bin_io]
+    end
+
+    include T
+
+    (* TODO : int doesn't need versioning; wrap Array *)
+    let version = 1
+
+    let __versioned__ = true
+  end
+
+  module Latest = V1
+end
+
+(* omit bin_io, version *)
+type 'a t = 'a Stable.Latest.t = {data: 'a Array.t; mutable position: int}
+[@@deriving sexp]
 
 let filter_map t = Array.filter_map t.data
 

--- a/src/lib/parallel_scan/state.ml
+++ b/src/lib/parallel_scan/state.ml
@@ -4,19 +4,50 @@ open Coda_digestif
 module Job = struct
   module Stable = struct
     module V1 = struct
-      type sequence_no = int [@@deriving sexp, bin_io]
+      module Sequence_no = struct
+        module Stable = struct
+          module V1 = struct
+            module T = struct
+              type t = int [@@deriving sexp, bin_io, version]
+            end
+
+            include T
+          end
+
+          module Latest = V1
+        end
+
+        type t = Stable.Latest.t [@@deriving sexp]
+      end
 
       (*A merge can have zero components, one component (either the left or the right), or two components in which case there is an integer (sequence_no) representing a set of (completed)jobs in a sequence of (completed)jobs created*)
-      type 'a merge =
-        | Empty
-        | Lcomp of 'a
-        | Rcomp of 'a
-        | Bcomp of ('a * 'a * sequence_no)
-      [@@deriving sexp, bin_io]
+      module Merge = struct
+        module Stable = struct
+          module V1 = struct
+            module T = struct
+              type 'a t =
+                | Empty
+                | Lcomp of 'a
+                | Rcomp of 'a
+                | Bcomp of ('a * 'a * Sequence_no.Stable.V1.t)
+              [@@deriving sexp, bin_io, version]
+            end
 
-      (* don't use version number and module registration here, because of type parameters *)
-      type ('a, 'd) t = Merge of 'a merge | Base of ('d * sequence_no) option
-      [@@deriving sexp, bin_io]
+            include T
+          end
+
+          module Latest = V1
+        end
+      end
+
+      module T = struct
+        type ('a, 'd) t =
+          | Merge of 'a Merge.Stable.V1.t
+          | Base of ('d * Sequence_no.Stable.V1.t) option
+        [@@deriving sexp, bin_io, version]
+      end
+
+      include T
     end
 
     module Latest = V1
@@ -61,19 +92,28 @@ end
 
 module Stable = struct
   module V1 = struct
-    (* don't use version number and module registration here, because of type parameters *)
-    type ('a, 'd) t =
-      { jobs: ('a, 'd) Job.t Ring_buffer.t
-      ; level_pointer: int Array.t
-      ; capacity: int
-      ; mutable acc: int * ('a * 'd list) option sexp_opaque
-      ; mutable current_data_length: int
-      ; mutable base_none_pos: int option
-      ; mutable recent_tree_data: 'd list sexp_opaque
-      ; mutable other_trees_data: 'd list list sexp_opaque
-      ; stateful_work_order: int Queue.t
-      ; mutable curr_job_seq_no: int }
-    [@@deriving sexp, bin_io]
+    (* don't use module registration here, because of type parameters *)
+    module T = struct
+      type ('a, 'd) t =
+        { jobs: ('a, 'd) Job.t Ring_buffer.Stable.V1.t
+        ; level_pointer: int Array.t
+        ; capacity: int
+        ; mutable acc: int * ('a * 'd list) option sexp_opaque
+        ; mutable current_data_length: int
+        ; mutable base_none_pos: int option
+        ; mutable recent_tree_data: 'd list sexp_opaque
+        ; mutable other_trees_data: 'd list list sexp_opaque
+        ; stateful_work_order: int Queue.t
+        ; mutable curr_job_seq_no: int }
+      [@@deriving sexp, bin_io]
+
+      (* TODO : wrap Array and Queue, all other types here don't need versioning *)
+      let version = 1
+
+      let __versioned__ = true
+    end
+
+    include T
   end
 
   module Latest = V1

--- a/src/lib/random_oracle/dune
+++ b/src/lib/random_oracle/dune
@@ -1,7 +1,7 @@
 (library
   (name random_oracle)
   (public_name random_oracle)
-  (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (preprocess (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson))
   (inline_tests)
   (libraries
     core_kernel

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -28,9 +28,7 @@ module Digest = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
-        type t = string [@@deriving sexp, bin_io, compare, hash]
+        type t = string [@@deriving sexp, bin_io, compare, hash, version]
       end
 
       include T

--- a/src/lib/random_oracle/random_oracle.mli
+++ b/src/lib/random_oracle/random_oracle.mli
@@ -6,7 +6,8 @@ module Digest : sig
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, sexp, compare, hash, yojson]
+      type nonrec t = t
+      [@@deriving bin_io, sexp, compare, hash, yojson, version]
 
       include Comparable.S with type t := t
     end

--- a/src/lib/sgn/dune
+++ b/src/lib/sgn/dune
@@ -7,6 +7,6 @@
  (libraries sgn_type snark_params core_kernel ppx_deriving_yojson.runtime
    yojson)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx ppx_deriving_yojson --
+  (pps ppx_jane ppx_coda ppx_deriving.eq bisect_ppx ppx_deriving_yojson --
     -conditional))
  (synopsis "sgn library"))

--- a/src/lib/sgn/sgn.mli
+++ b/src/lib/sgn/sgn.mli
@@ -2,7 +2,16 @@ open Core_kernel
 open Snark_params.Tick
 
 type t = Sgn_type.Sgn.t = Pos | Neg
-[@@deriving sexp, bin_io, hash, compare, eq, yojson]
+[@@deriving sexp, hash, compare, eq, yojson]
+
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t
+    [@@deriving sexp, bin_io, hash, compare, eq, yojson, version]
+  end
+
+  module Latest = V1
+end
 
 val to_field : t -> Field.t
 

--- a/src/lib/sgn_type/dune
+++ b/src/lib/sgn_type/dune
@@ -1,5 +1,5 @@
 (library
   (name sgn_type)
   (public_name sgn_type)
-  (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson))
-  (libraries core_kernel ppx_deriving_yojson.runtime yojson))
+  (preprocess (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson))
+  (libraries core_kernel module_version ppx_deriving_yojson.runtime yojson))

--- a/src/lib/sgn_type/sgn.ml
+++ b/src/lib/sgn_type/sgn.ml
@@ -1,3 +1,29 @@
 open Core_kernel
+open Module_version
 
-type t = Pos | Neg [@@deriving sexp, bin_io, hash, compare, eq, yojson]
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      type t = Pos | Neg
+      [@@deriving sexp, bin_io, hash, compare, eq, yojson, version]
+    end
+
+    include T
+    include Registration.Make_latest_version (T)
+  end
+
+  module Latest = V1
+
+  module Module_decl = struct
+    let name = "sgn_type_sgn"
+
+    type latest = Latest.t
+  end
+
+  module Registrar = Registration.Make (Module_decl)
+  module Registered_V1 = Registrar.Register (V1)
+end
+
+(* bin_io, version omitted *)
+type t = Stable.Latest.t = Pos | Neg
+[@@deriving sexp, hash, compare, eq, yojson]

--- a/src/lib/sgn_type/sgn.mli
+++ b/src/lib/sgn_type/sgn.mli
@@ -1,3 +1,12 @@
 open Core_kernel
 
-type t = Pos | Neg [@@deriving sexp, bin_io, hash, compare, eq, yojson]
+type t = Pos | Neg [@@deriving sexp, hash, compare, eq, yojson]
+
+module Stable : sig
+  module V1 : sig
+    type nonrec t = t
+    [@@deriving sexp, bin_io, hash, compare, eq, yojson, version]
+  end
+
+  module Latest = V1
+end

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -297,6 +297,9 @@ module Tock = struct
   module Proof = struct
     include Tock0.Proof
 
+    (* TODO : follow this include all the way and really version it *)
+    let __versioned__ = true
+
     let dummy = Dummy_values.Tock.GrothMaller17.proof
   end
 
@@ -353,7 +356,7 @@ module Tick = struct
 
     let size_in_triples = Int.((size_in_bits + 2) / 3)
 
-    (* for now, assert this type, derived from snarky, is versioned; can we 
+    (* for now, assert this type, derived from snarky, is versioned; can we
        prevent it changing?
      *)
     let __versioned__ = true

--- a/src/lib/snark_worker_lib/debug.ml
+++ b/src/lib/snark_worker_lib/debug.ml
@@ -29,7 +29,7 @@ module Inputs = struct
   module Transaction = Coda_base.Transaction
   module Sparse_ledger = Coda_base.Sparse_ledger
   module Pending_coinbase = Coda_base.Pending_coinbase
-  module Transaction_witness = Coda_base.Transaction_witness
+  module Transaction_witness = Coda_base.Transaction_witness.Stable.V1
 
   let perform_single () ~message s =
     Ok

--- a/src/lib/snark_worker_lib/prod.ml
+++ b/src/lib/snark_worker_lib/prod.ml
@@ -49,7 +49,7 @@ module Inputs = struct
   module Transaction = Coda_base.Transaction
   module Sparse_ledger = Coda_base.Sparse_ledger
   module Pending_coinbase = Coda_base.Pending_coinbase
-  module Transaction_witness = Coda_base.Transaction_witness
+  module Transaction_witness = Coda_base.Transaction_witness.Stable.V1
 
   (* TODO: Use public_key once SoK is implemented *)
   let perform_single ({m= (module M); cache} : Worker_state.t) ~message =

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -82,7 +82,7 @@ end) :
 
   type pre_diff_with_at_most_two_coinbase =
     { completed_works: Transaction_snark_work.Stable.V1.t list
-    ; user_commands: User_command.t list
+    ; user_commands: User_command.Stable.V1.t list
     ; coinbase: ft At_most_two.t }
   [@@deriving sexp, bin_io]
 
@@ -90,7 +90,7 @@ end) :
 
   type pre_diff_with_at_most_one_coinbase =
     { completed_works: Transaction_snark_work.Stable.V1.t list
-    ; user_commands: User_command.t list
+    ; user_commands: User_command.Stable.V1.t list
     ; coinbase: ft At_most_one.t }
   [@@deriving sexp, bin_io]
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -21,7 +21,7 @@ module Input = struct
   type t =
     { source: Frozen_ledger_hash.Stable.V1.t
     ; target: Frozen_ledger_hash.Stable.V1.t
-    ; fee_excess: Currency.Amount.Signed.t
+    ; fee_excess: Currency.Amount.Signed.Stable.V1.t
     ; pending_coinbase_before: Pending_coinbase.Stack.Stable.V1.t
     ; pending_coinbase_after: Pending_coinbase.Stack.Stable.V1.t }
   [@@deriving bin_io]
@@ -31,10 +31,8 @@ module Proof_type = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t = [`Base | `Merge]
-        [@@deriving bin_io, sexp, hash, compare, yojson]
+        [@@deriving bin_io, sexp, hash, compare, yojson, version]
       end
 
       include T
@@ -61,16 +59,38 @@ end
 
 module Pending_coinbase_stack_state = struct
   (*State of the coinbase stack for the current transaction snark*)
-  module T = struct
-    type t =
-      { source: Pending_coinbase.Stack.Stable.V1.t
-      ; target: Pending_coinbase.Stack.Stable.V1.t }
-    [@@deriving sexp, bin_io, hash, compare, eq, fields, yojson]
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t =
+          { source: Pending_coinbase.Stack.Stable.V1.t
+          ; target: Pending_coinbase.Stack.Stable.V1.t }
+        [@@deriving sexp, bin_io, hash, compare, eq, fields, yojson, version]
+      end
+
+      include T
+      include Registration.Make_latest_version (T)
+    end
+
+    module Latest = V1
+
+    module Module_decl = struct
+      let name = "transaction_snark_pending_coinbase_stack_state"
+
+      type latest = Latest.t
+    end
+
+    module Registrar = Registration.Make (Module_decl)
+    module Registered_V1 = Registrar.Register (V1)
   end
 
-  include T
-  include Hashable.Make_binable (T)
-  include Comparable.Make (T)
+  type t = Stable.Latest.t =
+    { source: Pending_coinbase.Stack.Stable.V1.t
+    ; target: Pending_coinbase.Stack.Stable.V1.t }
+  [@@deriving sexp, hash, compare, eq, yojson]
+
+  include Hashable.Make_binable (Stable.Latest)
+  include Comparable.Make (Stable.Latest)
 end
 
 module Statement = struct
@@ -83,10 +103,11 @@ module Statement = struct
           { source: Coda_base.Frozen_ledger_hash.Stable.V1.t
           ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
           ; supply_increase: Currency.Amount.Stable.V1.t
-          ; pending_coinbase_stack_state: Pending_coinbase_stack_state.t
+          ; pending_coinbase_stack_state:
+              Pending_coinbase_stack_state.Stable.V1.t
           ; fee_excess: Currency.Fee.Signed.Stable.V1.t
           ; proof_type: Proof_type.Stable.V1.t }
-        [@@deriving sexp, bin_io, hash, compare, yojson]
+        [@@deriving sexp, bin_io, hash, compare, yojson, version]
       end
 
       include T
@@ -167,11 +188,12 @@ module Stable = struct
         ; target: Frozen_ledger_hash.Stable.V1.t
         ; proof_type: Proof_type.Stable.V1.t
         ; supply_increase: Amount.Stable.V1.t
-        ; pending_coinbase_stack_state: Pending_coinbase_stack_state.t
+        ; pending_coinbase_stack_state:
+            Pending_coinbase_stack_state.Stable.V1.t
         ; fee_excess: Amount.Signed.Stable.V1.t
         ; sok_digest: Sok_message.Digest.Stable.V1.t
         ; proof: Proof.Stable.V1.t }
-      [@@deriving fields, sexp, bin_io, yojson]
+      [@@deriving fields, sexp, bin_io, yojson, version]
     end
 
     include T
@@ -1131,8 +1153,8 @@ let check_user_command ~sok_message ~source ~target pending_coinbase_stack t
     handler =
   check_transaction ~sok_message ~source ~target
     ~pending_coinbase_stack_state:
-      { Pending_coinbase_stack_state.source= pending_coinbase_stack
-      ; target= pending_coinbase_stack }
+      Pending_coinbase_stack_state.Stable.Latest.
+        {source= pending_coinbase_stack; target= pending_coinbase_stack}
     (User_command t) handler
 
 let generate_transaction_union_witness ?(preeval = false) sok_message source
@@ -1200,9 +1222,9 @@ struct
       merge_top_hash wrap_vk_bits ~sok_digest ~state1:ledger_hash1
         ~state2:ledger_hash3
         ~pending_coinbase_stack_state:
-          { Pending_coinbase_stack_state.source=
-              transition12.pending_coinbase_stack_state.source
-          ; target= transition23.pending_coinbase_stack_state.target }
+          Pending_coinbase_stack_state.Stable.Latest.
+            { source= transition12.pending_coinbase_stack_state.source
+            ; target= transition23.pending_coinbase_stack_state.target }
         ~fee_excess ~supply_increase
     in
     let prover_state =
@@ -1253,16 +1275,16 @@ struct
       user_command handler =
     of_transaction ~sok_digest ~source ~target
       ~pending_coinbase_stack_state:
-        { Pending_coinbase_stack_state.source= pending_coinbase_stack
-        ; target= pending_coinbase_stack }
+        Pending_coinbase_stack_state.Stable.Latest.
+          {source= pending_coinbase_stack; target= pending_coinbase_stack}
       (User_command user_command) handler
 
   let of_fee_transfer ~sok_digest ~source ~target ~pending_coinbase_stack
       transfer handler =
     of_transaction ~sok_digest ~source ~target
       ~pending_coinbase_stack_state:
-        { Pending_coinbase_stack_state.source= pending_coinbase_stack
-        ; target= pending_coinbase_stack }
+        Pending_coinbase_stack_state.Stable.Latest.
+          {source= pending_coinbase_stack; target= pending_coinbase_stack}
       (Fee_transfer transfer) handler
 
   let merge t1 t2 ~sok_digest =
@@ -1519,9 +1541,10 @@ let%test_module "transaction_snark" =
       in
       let signature = Schnorr.sign sender.private_key payload in
       User_command.check
-        { User_command.payload
-        ; sender= Public_key.of_private_key_exn sender.private_key
-        ; signature }
+        User_command.Poly.Stable.Latest.
+          { payload
+          ; sender= Public_key.of_private_key_exn sender.private_key
+          ; signature }
       |> Option.value_exn
 
     let keys = Keys.create ()
@@ -1600,9 +1623,9 @@ let%test_module "transaction_snark" =
                         ~len:User_command_memo.max_size_in_bytes))
               in
               let pending_coinbase_stack_state =
-                { Pending_coinbase_stack_state.source=
-                    Pending_coinbase.Stack.empty
-                ; target= Pending_coinbase.Stack.empty }
+                Pending_coinbase_stack_state.Stable.Latest.
+                  { source= Pending_coinbase.Stack.empty
+                  ; target= Pending_coinbase.Stack.empty }
               in
               let sok_digest =
                 Sok_message.create ~fee:Fee.zero

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -15,8 +15,21 @@ module Proof_type : sig
 end
 
 module Pending_coinbase_stack_state : sig
-  type t = {source: Pending_coinbase.Stack.t; target: Pending_coinbase.Stack.t}
-  [@@deriving sexp, bin_io, hash, compare, eq, fields]
+  module Stable : sig
+    module V1 : sig
+      type t =
+        { source: Pending_coinbase.Stack.Stable.V1.t
+        ; target: Pending_coinbase.Stack.Stable.V1.t }
+      [@@deriving sexp, bin_io, hash, compare, eq, fields, version]
+    end
+
+    module Latest = V1
+  end
+
+  type t = Stable.Latest.t =
+    { source: Pending_coinbase.Stack.Stable.V1.t
+    ; target: Pending_coinbase.Stack.Stable.V1.t }
+  [@@deriving sexp, hash, compare, eq]
 end
 
 module Statement : sig
@@ -39,7 +52,7 @@ module Statement : sig
           ; pending_coinbase_stack_state: Pending_coinbase_stack_state.t
           ; fee_excess: Currency.Fee.Signed.Stable.V1.t
           ; proof_type: Proof_type.Stable.V1.t }
-        [@@deriving sexp, bin_io, hash, compare, yojson]
+        [@@deriving sexp, bin_io, hash, compare, yojson, version]
       end
 
       module Latest = V1
@@ -60,7 +73,7 @@ type t [@@deriving sexp, yojson]
 module Stable :
   sig
     module V1 : sig
-      type t [@@deriving bin_io, sexp, yojson]
+      type t [@@deriving bin_io, sexp, yojson, version]
     end
 
     module Latest = V1

--- a/src/lib/transaction_snark_scan_state/dune
+++ b/src/lib/transaction_snark_scan_state/dune
@@ -8,6 +8,6 @@
    yojson module_version)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_base ppx_let ppx_sexp_conv ppx_bin_prot ppx_custom_printf
+  (pps ppx_base ppx_coda ppx_let ppx_sexp_conv ppx_bin_prot ppx_custom_printf
     ppx_deriving.eq ppx_deriving_yojson ppx_optcomp))
  (synopsis "Transaction-snark specialization of the parallel scan state"))

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -50,15 +50,12 @@ end = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          let version = 1
-
           (* TODO: The statement is redundant here - it can be computed from the witness and the transaction *)
-          (* TODO : version all fields *)
           type t =
             { transaction_with_info: Ledger.Undo.Stable.V1.t
             ; statement: Ledger_proof_statement.Stable.V1.t
-            ; witness: Transaction_witness.t sexp_opaque }
-          [@@deriving sexp, bin_io]
+            ; witness: Transaction_witness.Stable.V1.t sexp_opaque }
+          [@@deriving sexp, bin_io, version]
         end
 
         include T
@@ -88,10 +85,8 @@ end = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          let version = 1
-
           type t = Ledger_proof.Stable.V1.t * Sok_message.Stable.V1.t
-          [@@deriving sexp, bin_io]
+          [@@deriving sexp, bin_io, version]
         end
 
         include T
@@ -169,8 +164,6 @@ end = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t =
           { (*Job_count: Keeping track of the number of jobs added to the tree. Every transaction added amounts to two jobs*)
             tree:
@@ -178,7 +171,7 @@ end = struct
               , Transaction_with_witness.Stable.V1.t )
               Parallel_scan.State.Stable.V1.t
           ; mutable job_count: int }
-        [@@deriving sexp, bin_io]
+        [@@deriving sexp, bin_io, version]
       end
 
       include T

--- a/src/lib/transition_frontier_controller_tests/dune
+++ b/src/lib/transition_frontier_controller_tests/dune
@@ -3,5 +3,5 @@
   (public_name transition_frontier_controller_tests)
   (inline_tests)
   (libraries core_kernel consensus protocols coda_base sync_handler transition_handler transition_frontier_controller bootstrap_controller genesis_ledger quickcheck_lib protocol_state_validator root_prover ledger_catchup transition_frontier_persistence)
-  (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson)))
+  (preprocess (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson)))
   

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -26,9 +26,13 @@ struct
   module Ledger_proof = struct
     module Stable = struct
       module V1 = struct
-        type t =
-          Ledger_proof_statement.Stable.V1.t * Sok_message.Digest.Stable.V1.t
-        [@@deriving sexp, bin_io, yojson]
+        module T = struct
+          type t =
+            Ledger_proof_statement.Stable.V1.t * Sok_message.Digest.Stable.V1.t
+          [@@deriving sexp, bin_io, yojson, version]
+        end
+
+        include T
       end
 
       module Latest = V1

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -41,7 +41,7 @@ module type Sok_message_intf = sig
 
   module Stable : sig
     module V1 : sig
-      type t [@@deriving sexp, bin_io]
+      type t [@@deriving sexp, bin_io, version]
     end
 
     module Latest = V1
@@ -192,7 +192,13 @@ end
 module type Transaction_witness_intf = sig
   type sparse_ledger
 
-  type t = {ledger: sparse_ledger} [@@deriving bin_io, sexp]
+  type t = {ledger: sparse_ledger} [@@deriving sexp]
+
+  module Stable : sig
+    module V1 : sig
+      type nonrec t = t [@@deriving bin_io, sexp, version]
+    end
+  end
 end
 
 module type Protocol_state_hash_intf = sig
@@ -309,7 +315,7 @@ module type Ledger_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving sexp, bin_io]
+          type t [@@deriving sexp, bin_io, version]
         end
 
         module Latest = V1
@@ -357,9 +363,7 @@ module Fee = struct
 
     include (
       Currency.Fee.Signed.Stable.V1 :
-        module type of Currency.Fee.Signed.Stable.Latest
-        with type t := t
-         and type ('a, 'b) t_ := ('a, 'b) t_ )
+        module type of Currency.Fee.Signed.Stable.Latest with type t := t )
   end
 end
 
@@ -372,7 +376,13 @@ module type Snark_pool_proof_intf = sig
 end
 
 module type User_command_intf = sig
-  type t [@@deriving sexp, eq, bin_io, yojson]
+  type t [@@deriving sexp, eq, yojson]
+
+  module Stable : sig
+    module V1 : sig
+      type nonrec t = t [@@deriving bin_io, sexp, eq, yojson]
+    end
+  end
 
   type public_key
 
@@ -501,7 +511,7 @@ module type Pending_coinbase_stack_state_intf = sig
   type pending_coinbase_stack
 
   type t = {source: pending_coinbase_stack; target: pending_coinbase_stack}
-  [@@deriving sexp, bin_io, compare]
+  [@@deriving sexp, compare]
 end
 
 module type Ledger_proof_statement_intf = sig
@@ -528,7 +538,7 @@ module type Ledger_proof_statement_intf = sig
           ; pending_coinbase_stack_state: pending_coinbase_stack_state
           ; fee_excess: Fee.Signed.t
           ; proof_type: [`Base | `Merge] }
-        [@@deriving sexp, bin_io, compare]
+        [@@deriving sexp, bin_io, compare, version]
       end
     end
     with type V1.t = t
@@ -553,7 +563,7 @@ module type Ledger_proof_intf = sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io, yojson]
+        type t [@@deriving sexp, bin_io, yojson, version]
       end
 
       module Latest = V1
@@ -786,7 +796,7 @@ module type Transaction_snark_scan_state_intf = sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io]
+        type t [@@deriving sexp, bin_io, version]
 
         val hash : t -> staged_ledger_aux_hash
       end
@@ -945,7 +955,7 @@ module type Staged_ledger_base_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving sexp, bin_io]
+          type t [@@deriving sexp, bin_io, version]
 
           val hash : t -> staged_ledger_aux_hash
         end

--- a/src/protocols/dune
+++ b/src/protocols/dune
@@ -8,5 +8,5 @@
    pipe_lib logger with_hash unix_timestamp rose_tree truth
    ppx_deriving_yojson.runtime yojson proof_carrying_data trust_system)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson))
  (synopsis "Lib powering the client interactions with the daemon"))


### PR DESCRIPTION
More versioning  via ppx of types that feed into RPC types in `Coda_networking`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
