### PR TITLE
Unnumbered option to deriving version to eliminate unused value warnings

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -526,7 +526,16 @@ struct
   module Sparse_ledger = Coda_base.Sparse_ledger
 
   module Transaction_snark_work_proof = struct
-    type t = Ledger_proof.Stable.V1.t list [@@deriving sexp, bin_io, yojson]
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          type t = Ledger_proof.Stable.V1.t list
+          [@@deriving sexp, bin_io, yojson, version]
+        end
+
+        include T
+      end
+    end
   end
 
   module Pending_coinbase_hash = Pending_coinbase.Hash
@@ -726,42 +735,47 @@ struct
 
   module Snark_pool = struct
     module Work = Transaction_snark_work.Statement
-    module Proof = Transaction_snark_work_proof
+    module Proof = Transaction_snark_work_proof.Stable.V1
 
     module Fee = struct
-      (* TODO : version Fee *)
-      module T = struct
-        type t =
-          {fee: Fee.Unsigned.t; prover: Public_key.Compressed.Stable.V1.t}
-        [@@deriving bin_io, sexp, yojson]
+      module Stable = struct
+        module V1 = struct
+          module T = struct
+            type t =
+              {fee: Fee.Unsigned.t; prover: Public_key.Compressed.Stable.V1.t}
+            [@@deriving bin_io, sexp, yojson, version]
 
-        (* TODO: Compare in a better way than with public key, like in transaction pool *)
-        let compare t1 t2 =
-          let r = compare t1.fee t2.fee in
-          if Int.( <> ) r 0 then r
-          else Public_key.Compressed.compare t1.prover t2.prover
+            (* TODO: Compare in a better way than with public key, like in transaction pool *)
+            let compare t1 t2 =
+              let r = compare t1.fee t2.fee in
+              if Int.( <> ) r 0 then r
+              else Public_key.Compressed.compare t1.prover t2.prover
+
+            let gen =
+              (* This isn't really a valid public key, but good enough for testing *)
+              let pk =
+                let open Snark_params.Tick in
+                let open Quickcheck.Generator.Let_syntax in
+                let%map x = Bignum_bigint.(gen_incl zero (Field.size - one))
+                and is_odd = Bool.gen in
+                let x = Bigint.(to_field (of_bignum_bigint x)) in
+                {Public_key.Compressed.Poly.Stable.Latest.x; is_odd}
+              in
+              Quickcheck.Generator.map2 Fee.Unsigned.gen pk
+                ~f:(fun fee prover -> {fee; prover} )
+          end
+
+          include T
+          include Comparable.Make (T)
+        end
       end
-
-      include T
-      include Comparable.Make (T)
-
-      let gen =
-        (* This isn't really a valid public key, but good enough for testing *)
-        let pk =
-          let open Snark_params.Tick in
-          let open Quickcheck.Generator.Let_syntax in
-          let%map x = Bignum_bigint.(gen_incl zero (Field.size - one))
-          and is_odd = Bool.gen in
-          let x = Bigint.(to_field (of_bignum_bigint x)) in
-          {Public_key.Compressed.Poly.Stable.Latest.x; is_odd}
-        in
-        Quickcheck.Generator.map2 Fee.Unsigned.gen pk ~f:(fun fee prover ->
-            {fee; prover} )
     end
 
-    module Pool = Snark_pool.Make (Proof) (Fee) (Work) (Transition_frontier)
+    (* TODO : we're choosing versioned inputs, so the result should be versioned *)
+    module Pool =
+      Snark_pool.Make (Proof) (Fee.Stable.V1) (Work) (Transition_frontier)
     module Diff =
-      Network_pool.Snark_pool_diff.Make (Proof) (Fee) (Work)
+      Network_pool.Snark_pool_diff.Make (Proof) (Fee.Stable.V1) (Work)
         (Transition_frontier)
         (Pool)
 

--- a/src/lib/blockchain_snark/blockchain.ml
+++ b/src/lib/blockchain_snark/blockchain.ml
@@ -16,7 +16,10 @@ module Protocol_state = Consensus.Protocol_state
 module Stable = struct
   module V1 = struct
     module T = struct
+      (* TODO : use version ppx *)
       let version = 1
+
+      let __versioned__ = true
 
       type t =
         {state: Protocol_state.Value.Stable.V1.t; proof: Proof.Stable.V1.t}

--- a/src/lib/blockchain_snark/dune
+++ b/src/lib/blockchain_snark/dune
@@ -7,5 +7,5 @@
    transaction_snark bignum_bigint consensus module_version)
  (inline_tests)
  (preprocess
-  (pps ppx_snarky ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_snarky ppx_coda ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "blockchain state transition snarking library"))

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -49,7 +49,10 @@ type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'bool) t_ =
 module Stable = struct
   module V1 = struct
     module T = struct
+      (* TODO : use version ppx *)
       let version = 1
+
+      let __versioned__ = true
 
       type key = Public_key.Compressed.Stable.V1.t
       [@@deriving sexp, bin_io, eq, hash, compare, yojson]

--- a/src/lib/coda_base/ancestor.ml
+++ b/src/lib/coda_base/ancestor.ml
@@ -5,10 +5,8 @@ module Input = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t = {descendant: State_hash.Stable.V1.t; generations: int}
-        [@@deriving sexp, bin_io]
+        [@@deriving sexp, bin_io, version]
       end
 
       include T
@@ -36,9 +34,7 @@ module Proof = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
-        type t = State_body_hash.Stable.V1.t list [@@deriving bin_io]
+        type t = State_body_hash.Stable.V1.t list [@@deriving bin_io, version]
       end
 
       include T

--- a/src/lib/coda_base/block_time.ml
+++ b/src/lib/coda_base/block_time.ml
@@ -15,9 +15,8 @@ module Time = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
-        type t = UInt64.t [@@deriving bin_io, sexp, compare, eq, hash, yojson]
+        type t = UInt64.t
+        [@@deriving bin_io, sexp, compare, eq, hash, yojson, version]
       end
 
       include T
@@ -80,9 +79,7 @@ module Time = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          let version = 1
-
-          type t = UInt64.t [@@deriving bin_io, sexp, compare]
+          type t = UInt64.t [@@deriving bin_io, sexp, compare, version]
         end
 
         include T

--- a/src/lib/coda_base/blockchain_state.ml
+++ b/src/lib/coda_base/blockchain_state.ml
@@ -93,7 +93,10 @@ end) : S = struct
     module Stable = struct
       module V1 = struct
         module T = struct
+          (* TODO : use version ppx *)
           let version = 1
+
+          let __versioned__ = true
 
           type t =
             ( Staged_ledger_hash.Stable.V1.t

--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -119,7 +119,10 @@ end)
   module Stable = struct
     module V1 = struct
       module T = struct
+        (* TODO : use version ppx *)
         let version = 1
+
+        let __versioned__ = true
 
         type t =
           { protocol_state: Protocol_state.Value.Stable.V1.t

--- a/src/lib/coda_base/internal_transition.ml
+++ b/src/lib/coda_base/internal_transition.ml
@@ -70,7 +70,10 @@ end) :
   module Stable = struct
     module V1 = struct
       module T = struct
+        (* TODO : use version ppx *)
         let version = 1
+
+        let __versioned__ = true
 
         type t =
           { snark_transition: Snark_transition.value

--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -60,7 +60,7 @@ end
 module Stack_id : sig
   module Stable : sig
     module V1 : sig
-      type t [@@deriving bin_io, sexp, compare, eq, version]
+      type t [@@deriving bin_io, sexp, compare, eq]
     end
 
     module Latest = V1

--- a/src/lib/coda_base/protocol_state.ml
+++ b/src/lib/coda_base/protocol_state.ml
@@ -171,7 +171,10 @@ module Make
       module Stable = struct
         module V1 = struct
           module T = struct
+            (* TODO : use version ppx *)
             let version = 1
+
+            let __versioned__ = true
 
             type tt =
               ( Blockchain_state.Value.Stable.V1.t
@@ -248,7 +251,10 @@ module Make
     module Stable = struct
       module V1 = struct
         module T = struct
+          (* TODO : use version ppx *)
           let version = 1
+
+          let __versioned__ = true
 
           type t_ = (State_hash.Stable.V1.t, Body.Value.Stable.V1.t) t
           [@@deriving bin_io, sexp, hash, compare, eq, to_yojson]

--- a/src/lib/coda_base/sok_message.ml
+++ b/src/lib/coda_base/sok_message.ml
@@ -5,8 +5,6 @@ open Module_version
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
       type t =
         { fee: Currency.Fee.Stable.V1.t
         ; prover: Public_key.Compressed.Stable.V1.t }

--- a/src/lib/coda_base/staged_ledger_hash.ml
+++ b/src/lib/coda_base/staged_ledger_hash.ml
@@ -188,7 +188,8 @@ module Stable = struct
           type ('non_snark, 'pending_coinbase_hash) t =
             { non_snark: 'non_snark
             ; pending_coinbase_hash: 'pending_coinbase_hash }
-          [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
+          [@@deriving
+            bin_io, sexp, eq, compare, hash, yojson, version {unnumbered}]
         end
 
         include T

--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -42,7 +42,10 @@ module Answer = struct
   module Stable = struct
     module V1 = struct
       module T = struct
+        (* TODO : use version ppx *)
         let version = 1
+
+        let __versioned__ = true
 
         type t =
           ( Ledger_hash.Stable.V1.t
@@ -75,7 +78,10 @@ module Query = struct
   module Stable = struct
     module V1 = struct
       module T = struct
+        (* TODO : use version ppx *)
         let version = 1
+
+        let __versioned__ = true
 
         type t =
           Ledger.Location.Addr.Stable.V1.t Syncable_ledger.Query.Stable.V1.t

--- a/src/lib/coda_base/target.ml
+++ b/src/lib/coda_base/target.ml
@@ -6,9 +6,7 @@ open Module_version
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
-      type t = Tick.Field.t [@@deriving bin_io, sexp, eq, compare]
+      type t = Tick.Field.t [@@deriving bin_io, sexp, eq, compare, version]
     end
 
     include T

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -277,8 +277,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       module Stable = struct
         module V1 = struct
           module T = struct
-            let version = 1
-
             type t = {common: Common.Stable.V1.t; body: Body.Stable.V1.t}
             [@@deriving sexp, bin_io, version]
           end
@@ -342,8 +340,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       module Stable = struct
         module V1 = struct
           module T = struct
-            let version = 1
-
             type t =
               { coinbase: Coinbase.Stable.V1.t
               ; previous_empty_accounts: Public_key.Compressed.Stable.V1.t list
@@ -378,8 +374,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       module Stable = struct
         module V1 = struct
           module T = struct
-            let version = 1
-
             type t =
               | User_command of User_command_undo.Stable.V1.t
               | Fee_transfer of Fee_transfer_undo.Stable.V1.t
@@ -414,8 +408,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          let version = 1
-
           type t =
             { previous_hash: Ledger_hash.Stable.V1.t
             ; varying: Varying.Stable.V1.t }

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -16,7 +16,7 @@ module Poly = struct
       module T = struct
         type ('payload, 'pk, 'signature) t =
           {payload: 'payload; sender: 'pk; signature: 'signature}
-        [@@deriving bin_io, eq, sexp, hash, yojson, version]
+        [@@deriving bin_io, eq, sexp, hash, yojson, version {unnumbered}]
       end
 
       include T
@@ -117,9 +117,7 @@ module With_valid_signature = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
-        type t = Stable.V1.t [@@deriving sexp, eq, bin_io, yojson]
+        type t = Stable.V1.t [@@deriving sexp, eq, bin_io, yojson, version]
       end
 
       include T

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -22,7 +22,7 @@ module Rpcs (Inputs : sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io, version]
+          type t [@@deriving bin_io, version {unnumbered}]
         end
       end
       with type V1.t = t

--- a/src/lib/coda_numbers/nat.ml
+++ b/src/lib/coda_numbers/nat.ml
@@ -70,7 +70,7 @@ module type F = functor
   -> S with type t := N.t and module Bits := Bits
 
 module Make (N : sig
-  type t [@@deriving bin_io, sexp, compare, hash]
+  type t [@@deriving bin_io, sexp, compare, hash, version {unnumbered}]
 
   include Unsigned_extended.S with type t := t
 

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -108,7 +108,10 @@ module Consensus_state = struct
     module Stable = struct
       module V1 = struct
         module T = struct
+          (* TODO : use version ppx *)
           let version = 1
+
+          let __versioned__ = true
 
           type t = (Length.Stable.V1.t, Public_key.Compressed.Stable.V1.t) t_
           [@@deriving bin_io, sexp, hash, compare, to_yojson]

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1043,6 +1043,8 @@ module Consensus_state = struct
         module T = struct
           let version = 1
 
+          let __versioned__ = true
+
           (* TODO : version components *)
           type t =
             ( Length.Stable.V1.t

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -85,7 +85,7 @@ module type Signed_intf = sig
   module Poly : sig
     module Stable : sig
       module V1 : sig
-        type ('magnitude, 'sgn) t [@@deriving version]
+        type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
       end
 
       module Latest = V1
@@ -343,7 +343,8 @@ end = struct
         module V1 = struct
           module T = struct
             type ('magnitude, 'sgn) t = {magnitude: 'magnitude; sgn: 'sgn}
-            [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
+            [@@deriving
+              bin_io, sexp, hash, compare, eq, yojson, version {unnumbered}]
           end
 
           include T

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -109,7 +109,7 @@ module type Signed_intf = sig
   module Poly : sig
     module Stable : sig
       module V1 : sig
-        type ('magnitude, 'sgn) t [@@deriving version]
+        type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
       end
 
       module Latest = V1

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -131,7 +131,10 @@ end) : S = struct
         slice (bitstring_of_string string) 0 length
 
       module T = struct
+        (* TODO : use version ppx *)
         let version = 1
+
+        let __versioned__ = true
 
         type nonrec t = t
 

--- a/src/lib/module_version/dune
+++ b/src/lib/module_version/dune
@@ -1,6 +1,6 @@
 (library
  (name module_version)
  (public_name module_version)
- (preprocess (pps ppx_jane) )
+ (preprocess (pps ppx_jane ppx_coda) )
  (inline_tests)
  (libraries bin_prot core_kernel))

--- a/src/lib/module_version/registration.ml
+++ b/src/lib/module_version/registration.ml
@@ -26,9 +26,7 @@ module type Versioned_module_intf = sig
 end
 
 module type Version_intf = sig
-  type t [@@deriving bin_io]
-
-  val version : int
+  type t [@@deriving bin_io, version]
 end
 
 (* functor to create a registrar that can
@@ -86,7 +84,7 @@ module Make (Module_decl : Module_decl_intf) = struct
       registered := (module Versioned_module) :: !registered
 
     module With_version = struct
-      type nonrec t = {version: int; t: Versioned_module.t} [@@deriving bin_io]
+      type t = {version: int; t: Versioned_module.t} [@@deriving bin_io]
 
       let create t = {version; t}
     end
@@ -96,7 +94,7 @@ end
 (* functor to generate With_version and bin_io boilerplate *)
 module Make_version (Version : Version_intf) = struct
   module With_version = struct
-    type nonrec t = {version: int; t: Version.t} [@@deriving bin_io]
+    type t = {version: int; t: Version.t} [@@deriving bin_io]
 
     let create t = {version= Version.version; t}
   end
@@ -155,10 +153,8 @@ let%test_module "Test versioned modules" =
 
       module V2 = struct
         module T = struct
-          let version = 2
-
           (* string, int swapped in tuple from V1's t *)
-          type t = string * int [@@deriving bin_io]
+          type t = string * int [@@deriving bin_io, version]
         end
 
         include T
@@ -169,9 +165,7 @@ let%test_module "Test versioned modules" =
 
       module V1 = struct
         module T = struct
-          let version = 1
-
-          type t = int * string [@@deriving bin_io]
+          type t = int * string [@@deriving bin_io, version]
         end
 
         include T

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -5,7 +5,7 @@
  (library_flags -linkall)
  (libraries core async pipe_lib snark_pool)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx ppx_deriving_yojson -- -conditional))
+  (pps ppx_jane ppx_coda ppx_deriving.eq bisect_ppx ppx_deriving_yojson -- -conditional))
  (flags :standard -short-paths -warn-error -6-27-34-32-9-58)
  (synopsis
    "Network pool is an interface that processes incoming diffs and then broadcasts them"))

--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -112,6 +112,9 @@ let%test_module "network pool test" =
     module Mock_proof = struct
       type input = Int.t
 
+      (* fake versioning *)
+      let __versioned__ = true
+
       type t = Int.t [@@deriving sexp, bin_io, yojson]
 
       let verify _ _ = return true
@@ -151,7 +154,13 @@ let%test_module "network pool test" =
         reader
     end
 
-    module Mock_fee = Int
+    module Mock_fee = struct
+      include Int
+
+      (* fake versioning *)
+      let __versioned__ = true
+    end
+
     module Mock_snark_pool =
       Snark_pool.Make (Mock_proof) (Mock_fee) (Mock_work)
         (Mock_transition_frontier)

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -6,9 +6,9 @@ type ('work, 'priced_proof) diff = Add_solved_work of 'work * 'priced_proof
 [@@deriving bin_io, sexp, yojson]
 
 module Make (Proof : sig
-  type t [@@deriving bin_io, yojson]
+  type t [@@deriving bin_io, yojson, version {unnumbered}]
 end) (Fee : sig
-  type t [@@deriving bin_io, sexp, yojson]
+  type t [@@deriving bin_io, sexp, yojson, version {unnumbered}]
 end) (Work : sig
   type t [@@deriving sexp, yojson]
 
@@ -31,11 +31,8 @@ struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          let version = 1
-
-          (* TODO : version Proof and Fee *)
           type t = {proof: Proof.t sexp_opaque; fee: Fee.t}
-          [@@deriving bin_io, sexp]
+          [@@deriving bin_io, sexp, version]
 
           let to_yojson {proof; fee} =
             `Assoc
@@ -90,7 +87,10 @@ struct
   module Stable = struct
     module V1 = struct
       module T = struct
+        (* TODO : use version ppx *)
         let version = 1
+
+        let __versioned__ = true
 
         type t = (Work.Stable.V1.t, Priced_proof.Stable.V1.t) diff
         [@@deriving bin_io, sexp, yojson]

--- a/src/lib/ppx_coda/tests/Makefile
+++ b/src/lib/ppx_coda/tests/Makefile
@@ -25,6 +25,9 @@ positive-tests : unexpired.ml
 	@ echo -n "Versioned type, should succeed..."
 	@ dune build versioned_good.cma ${REDIRECT}
 	@ echo "OK"
+	@ echo -n "Versioned type with unnumbered, should succeed..."
+	@ dune build versioned_good_unnumbered.cma ${REDIRECT}
+	@ echo "OK"
 	@ echo -n "Versioned type_constructors type, should succeed..."
 	@ dune build versioned_good_type_constructors.cma ${REDIRECT}
 	@ echo "OK"
@@ -61,6 +64,9 @@ negative-tests :
 	@ echo "OK"
 	@ echo -n "Versioned type, bad module structure, should fail..."
 	@ ! dune build versioned_bad_module_structure.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned type, unnumbered, invalid use of 'version', should fail..."
+	@ ! dune build versioned_bad_unnumbered.cma ${REDIRECT}
 	@ echo "OK"
 	@ echo -n "Versioned type, bad wrapped module structure, should fail..."
 	@ ! dune build versioned_bad_wrapped_module_structure.cma ${REDIRECT}

--- a/src/lib/ppx_coda/tests/dune
+++ b/src/lib/ppx_coda/tests/dune
@@ -22,6 +22,12 @@
   (modules versioned_good))
 
 (library
+  (name versioned_good_unnumbered)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
+  (modules versioned_good_unnumbered))
+
+(library
   (name versioned_good_type_constructors)
   (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (libraries core_kernel)
@@ -73,6 +79,12 @@
  (name versioned_bad_module_structure)
  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
  (modules versioned_bad_module_structure))
+
+(library
+  (name versioned_bad_unnumbered)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
+  (modules versioned_bad_unnumbered))
 
 (library
  (name versioned_bad_wrapped_module_structure)

--- a/src/lib/ppx_coda/tests/versioned_bad_unnumbered.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_unnumbered.ml
@@ -1,0 +1,9 @@
+open Core_kernel
+
+module Make (M : sig
+  type t = Int.t [@@deriving version {unnumbered}]
+end) =
+struct
+  (* unnumbered option means M.version doesn't exist *)
+  let x = M.version
+end

--- a/src/lib/ppx_coda/tests/versioned_good_unnumbered.ml
+++ b/src/lib/ppx_coda/tests/versioned_good_unnumbered.ml
@@ -1,0 +1,19 @@
+open Core_kernel
+
+module Foo = struct
+  module Bar = struct
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          type t = int [@@deriving yojson, bin_io, version {unnumbered}]
+        end
+
+        include T
+      end
+    end
+  end
+end
+
+module type Quux = sig
+  type t = Int.t [@@deriving version {unnumbered}]
+end

--- a/src/lib/staged_ledger/dune
+++ b/src/lib/staged_ledger/dune
@@ -8,5 +8,5 @@
    protocols merkle_mask pipe_lib logger async async_extra module_version)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson))
+  (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson))
  (synopsis "Staged Ledger updates the current ledger with new transactions"))

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -102,11 +102,14 @@ end) :
   module Stable = struct
     module V1 = struct
       module T = struct
+        (* TODO : use version ppx *)
         let version = 1
+
+        let __versioned__ = true
 
         type t =
           { diff: diff
-          ; prev_hash: Staged_ledger_hash.t (* TODO : version *)
+          ; prev_hash: Staged_ledger_hash.t
           ; creator: Compressed_public_key.Stable.V1.t }
         [@@deriving sexp, bin_io]
       end

--- a/src/lib/staged_ledger/transaction_snark_work.ml
+++ b/src/lib/staged_ledger/transaction_snark_work.ml
@@ -30,7 +30,10 @@ end) :
     module Stable = struct
       module V1 = struct
         module T = struct
+          (* TODO : use version ppx *)
           let version = 1
+
+          let __versioned__ = true
 
           type t = Ledger_proof_statement.Stable.V1.t list
           [@@deriving bin_io, sexp, hash, compare, yojson]
@@ -67,7 +70,10 @@ end) :
     module Stable = struct
       module V1 = struct
         module T = struct
+          (* TODO : use version ppx *)
           let version = 1
+
+          let __versioned__ = true
 
           type t =
             { fee: Fee.Unsigned.t

--- a/src/lib/transaction_pool/dune
+++ b/src/lib/transaction_pool/dune
@@ -6,5 +6,5 @@
  (inline_tests)
  (libraries core async async_extra coda_base envelope protocols module_version)
  (preprocess
-  (pps ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_coda ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Ledger fetcher fetches ledgers over the network"))

--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -289,7 +289,10 @@ struct
     module Stable = struct
       module V1 = struct
         module T = struct
+          (* TODO : use version ppx *)
           let version = 1
+
+          let __versioned__ = true
 
           type t = User_command.Stable.V1.t list
           [@@deriving bin_io, sexp, yojson]

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -97,8 +97,6 @@ module Statement = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t =
           { source: Coda_base.Frozen_ledger_hash.Stable.V1.t
           ; target: Coda_base.Frozen_ledger_hash.Stable.V1.t
@@ -181,8 +179,6 @@ end
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
       type t =
         { source: Frozen_ledger_hash.Stable.V1.t
         ; target: Frozen_ledger_hash.Stable.V1.t


### PR DESCRIPTION
You can now write:
```
[@@deriving version {unnumbered}]
```
which suppresses generation of
```
let version = n
```
for structures, and
```
val version : int
```
for signatures.

Use this option to prevent annoying "unused value version" warnings or errors. You don't need the version number unless you're registering a versioned module.

Also: added `deriving version` to the input signature of the `Make_version` and `Make_latest_version` functors for module versioning. That forced manual entry of `let __versioned__` and `let version` in a few places, with TODOs for using the ppx.

And: in the version ppx implementation, made handling of options more general. I expect we'll add more options for RPC types.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
