### PR TITLE
Versioning for staged_ledger_diff

### DIFF
--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -37,7 +37,7 @@ module type S = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io, sexp]
+          type t [@@deriving bin_io, sexp, version]
         end
       end
       with type V1.t = t
@@ -103,7 +103,7 @@ module Make (Staged_ledger_diff : sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving bin_io, sexp]
+        type t [@@deriving bin_io, sexp, version]
       end
     end
     with type V1.t = t

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2335,6 +2335,11 @@ let%test_module "test" =
             type t =
               {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
             [@@deriving sexp, bin_io]
+
+            (* fake versioning *)
+            let version = 1
+
+            let __versioned__ = true
           end
 
           module Latest = V1

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -714,7 +714,7 @@ module type Staged_ledger_diff_intf = sig
       module V1 : sig
         type t =
           {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
-        [@@deriving sexp, bin_io]
+        [@@deriving sexp, bin_io, version]
       end
 
       module Latest = V1


### PR DESCRIPTION
Added `deriving version` for `Staged_ledger_diff` interfaces.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
