### PR TITLE
Add version {rpc} where possible, or in comment

### DIFF
--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -54,7 +54,7 @@ module type S = sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io, to_yojson]
+        type t [@@deriving sexp, bin_io, to_yojson, version]
       end
 
       module Latest = V1

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -194,8 +194,6 @@ struct
           External_transition.Stable.V1.t Non_empty_list.Stable.V1.t option
         [@@deriving bin_io, sexp, version {rpc}]
 
-        let version = 1
-
         let query_of_caller_model = Fn.id
 
         let callee_model_of_query = Fn.id

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -85,6 +85,9 @@ struct
           option
         [@@deriving bin_io]
 
+        (* , version{rpc} *)
+        
+        (* TODO : remove after uncommenting version{rpc} *)
         let version = 1
 
         let query_of_caller_model = Fn.id
@@ -132,11 +135,15 @@ struct
         type query =
           (Ledger_hash.Stable.V1.t * Sync_ledger.Query.Stable.V1.t)
           Envelope.Incoming.Stable.V1.t
-        [@@deriving bin_io, sexp]
+        [@@deriving bin_io, sexp, version {rpc}]
 
+        (* TODO : wrap Or_error *)
         type response = Sync_ledger.Answer.Stable.V1.t Or_error.t
         [@@deriving bin_io, sexp]
 
+        (* , version {rpc} *)
+        
+        (* TODO : remove this after uncommenting version{rpc} *)
         let version = 1
 
         let query_of_caller_model = Fn.id
@@ -181,11 +188,11 @@ struct
     module V1 = struct
       module T = struct
         type query = State_hash.Stable.V1.t Envelope.Incoming.Stable.V1.t
-        [@@deriving bin_io, sexp]
+        [@@deriving bin_io, sexp, version {rpc}]
 
         type response =
           External_transition.Stable.V1.t Non_empty_list.Stable.V1.t option
-        [@@deriving bin_io, sexp]
+        [@@deriving bin_io, sexp, version {rpc}]
 
         let version = 1
 
@@ -240,6 +247,8 @@ struct
           Envelope.Incoming.Stable.V1.t
         [@@deriving bin_io, sexp]
 
+        (* , version {rpc} *)
+
         type response =
           ( External_transition.Stable.V1.t
           , State_body_hash.Stable.V1.t list * External_transition.Stable.V1.t
@@ -248,6 +257,9 @@ struct
           option
         [@@deriving bin_io]
 
+        (* , version {rpc} *)
+        
+        (* TODO : remove after uncommenting version{rpc} *)
         let version = 1
 
         let query_of_caller_model = Fn.id
@@ -322,14 +334,20 @@ struct
 
   include Versioned_rpc.Both_convert.One_way.Make (T)
 
+  module Content = struct
+    module Wrapped = struct
+      module Stable = struct
+        module V1 = struct
+          type t = T.T.content [@@deriving bin_io, sexp, version {wrapped}]
+        end
+      end
+    end
+  end
+
   module V1 = struct
     module T = struct
-      type content = T.T.content [@@deriving bin_io, sexp]
-
-      type msg = content Envelope.Incoming.Stable.V1.t
-      [@@deriving bin_io, sexp]
-
-      let version = 1
+      type msg = Content.Wrapped.Stable.V1.t Envelope.Incoming.Stable.V1.t
+      [@@deriving bin_io, sexp, version {rpc}]
 
       let callee_model_of_msg = Fn.id
 
@@ -605,7 +623,7 @@ module Make (Inputs : Inputs_intf) = struct
             match response_or_error with
             | Ok (Some response) -> return (Ok response)
             | Ok None -> loop remaining_peers (2 * num_peers)
-            | Error e -> loop remaining_peers (2 * num_peers) )
+            | Error _e -> loop remaining_peers (2 * num_peers) )
     in
     loop peers 1
 

--- a/src/lib/non_empty_list/dune
+++ b/src/lib/non_empty_list/dune
@@ -2,4 +2,4 @@
   (name non_empty_list)
   (public_name non_empty_list)
   (libraries core_kernel)
-  (preprocess (pps ppx_jane ppx_deriving.eq)))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq)))

--- a/src/lib/non_empty_list/non_empty_list.ml
+++ b/src/lib/non_empty_list/non_empty_list.ml
@@ -4,7 +4,12 @@ open Core_kernel
 module Stable = struct
   (* underlying type has a parameter, so don't register versions *)
   module V1 = struct
-    type 'a t = 'a * 'a list [@@deriving sexp, compare, eq, hash, bin_io]
+    module T = struct
+      type 'a t = 'a * 'a list
+      [@@deriving sexp, compare, eq, hash, bin_io, version]
+    end
+
+    include T
   end
 
   module Latest = V1

--- a/src/lib/non_empty_list/non_empty_list.mli
+++ b/src/lib/non_empty_list/non_empty_list.mli
@@ -2,7 +2,7 @@
 
 module Stable : sig
   module V1 : sig
-    type 'a t [@@deriving sexp, compare, eq, hash, bin_io]
+    type 'a t [@@deriving sexp, compare, eq, hash, bin_io, version]
   end
 
   module Latest = V1

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1827,7 +1827,12 @@ let%test_module "test" =
       module Ledger_hash = struct
         module Stable = struct
           module V1 = struct
-            type t = int [@@deriving sexp, bin_io, compare, hash, eq, yojson]
+            module T = struct
+              type t = int
+              [@@deriving sexp, bin_io, compare, hash, eq, yojson, version]
+            end
+
+            include T
           end
 
           module Latest = V1

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -121,7 +121,7 @@ module type Ledger_hash_intf = sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving eq, sexp, compare, bin_io]
+        type t [@@deriving eq, sexp, compare, bin_io, version]
       end
 
       module Latest = V1


### PR DESCRIPTION
In `Coda_networking`, added `deriving version {rpc}`, or put that in a comment as a reminder to make that change when possible.

Added version ppx to `Non_empty_list` to allow one of those annotations to work.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
