### PR TITLE
strict_pipe: don't use option in exception data

### DIFF
--- a/src/lib/pipe_lib/strict_pipe.ml
+++ b/src/lib/pipe_lib/strict_pipe.ml
@@ -23,7 +23,7 @@ type (_, _) type_ =
       [`Capacity of int] * [`Overflow of 'b overflow_behavior]
       -> ('b buffered, unit) type_
 
-let value_or_empty = Option.value ~default:""
+let value_or_empty = Option.value ~default:"<unnamed>"
 
 module Reader0 = struct
   type 't t =

--- a/src/lib/pipe_lib/strict_pipe.mli
+++ b/src/lib/pipe_lib/strict_pipe.mli
@@ -1,8 +1,8 @@
 open Async_kernel
 
-exception Overflow of string option
+exception Overflow of string
 
-exception Multiple_reads_attempted of string option
+exception Multiple_reads_attempted of string
 
 type crash = Overflow_behavior_crash
 


### PR DESCRIPTION
`Printexc` doesn't know how to print out `option` values, so it always tells us `_`. Always include some string in the exceptions.