### PR TITLE
Rpc-version get-ancestry query type

### DIFF
--- a/src/lib/coda_base/protocol_state.ml
+++ b/src/lib/coda_base/protocol_state.ml
@@ -16,7 +16,8 @@ module type Consensus_state_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving hash, compare, bin_io, sexp, eq, to_yojson]
+          type t
+          [@@deriving hash, compare, bin_io, sexp, eq, to_yojson, version]
         end
       end
       with type V1.t = t
@@ -56,12 +57,11 @@ module type S = sig
     module Value : sig
       module Stable : sig
         module V1 : sig
-          (* TODO : version these pieces *)
           type nonrec t =
             ( Blockchain_state.Value.Stable.V1.t
             , Consensus_state.Value.Stable.V1.t )
             t
-          [@@deriving bin_io, sexp, to_yojson]
+          [@@deriving bin_io, sexp, to_yojson, version]
         end
 
         module Latest : module type of V1

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -243,9 +243,7 @@ struct
         type query =
           Consensus.Consensus_state.Value.Stable.V1.t
           Envelope.Incoming.Stable.V1.t
-        [@@deriving bin_io, sexp]
-
-        (* , version {rpc} *)
+        [@@deriving bin_io, sexp, version {rpc}]
 
         type response =
           ( External_transition.Stable.V1.t

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -19,5 +19,5 @@
     module_version
     yojson)
    (preprocessor_deps "../../config.mlh")
-   (preprocess (pps ppx_base ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson bisect_ppx -conditional))
+   (preprocess (pps ppx_base ppx_coda ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson bisect_ppx -conditional))
    (synopsis "Consensus mechanisms"))

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -55,7 +55,8 @@ module type S = sig
       module Stable :
         sig
           module V1 : sig
-            type t [@@deriving hash, eq, compare, bin_io, sexp, to_yojson]
+            type t
+            [@@deriving hash, eq, compare, bin_io, sexp, to_yojson, version]
           end
         end
         with type V1.t = t


### PR DESCRIPTION
Added `deriving version {rpc]` for get-ancestry RPC call.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
