### PR TITLE
Jane St versioned RPC for snark workers

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1527,14 +1527,14 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
             return (Coda_base.Ledger.Debug.visualize ~filename) ) ]
     in
     let snark_worker_impls =
-      [ implement Snark_worker.Rpcs.Get_work.rpc (fun () () ->
+      [ implement Snark_worker.Rpcs.Get_work.Latest.rpc (fun () () ->
             let r = request_work coda in
             Option.iter r ~f:(fun r ->
                 Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
                   !"Get_work: %{sexp:Snark_worker.Work.Spec.t}"
                   r ) ;
             return r )
-      ; implement Snark_worker.Rpcs.Submit_work.rpc
+      ; implement Snark_worker.Rpcs.Submit_work.Latest.rpc
           (fun () (work : Snark_worker.Work.Result.t) ->
             Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
               !"Submit_work: %{sexp:Snark_worker.Work.Spec.t}"

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -37,13 +37,13 @@ end) =
 struct
   open Inputs
 
-  (* see
+  (* for versioning of the types here, see
 
      RFC 0012, and
 
      https://ocaml.janestreet.com/ocaml-core/latest/doc/async_rpc_kernel/Async_rpc_kernel/Versioned_rpc/
 
-  *)
+   *)
 
   module Get_staged_ledger_aux_and_pending_coinbases_at_hash = struct
     module T = struct
@@ -85,7 +85,7 @@ struct
           option
         [@@deriving bin_io]
 
-        (* , version{rpc} *)
+        (* , version {rpc} *)
         
         (* TODO : remove after uncommenting version{rpc} *)
         let version = 1

--- a/src/lib/snark_worker_lib/dune
+++ b/src/lib/snark_worker_lib/dune
@@ -8,5 +8,5 @@
    blockchain_snark transaction_snark keys_lib perf_histograms
    sparse_ledger_lib)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Lib powering the snark_worker interactions with the daemon"))

--- a/src/lib/snark_worker_lib/intf.ml
+++ b/src/lib/snark_worker_lib/intf.ml
@@ -93,19 +93,27 @@ module type S = sig
 
   module Rpcs : sig
     module Get_work : sig
-      type query = unit
+      module V1 : sig
+        type query = unit
 
-      type response = Work.Spec.t option
+        type response = Work.Spec.t option
 
-      val rpc : (query, response) Rpc.Rpc.t
+        val rpc : (query, response) Rpc.Rpc.t
+      end
+
+      module Latest = V1
     end
 
     module Submit_work : sig
-      type query = Work.Result.t
+      module V1 : sig
+        type query = Work.Result.t
 
-      type response = unit
+        type response = unit
 
-      val rpc : (query, response) Rpc.Rpc.t
+        val rpc : (query, response) Rpc.Rpc.t
+      end
+
+      module Latest = V1
     end
   end
 

--- a/src/lib/snark_worker_lib/rpcs.ml
+++ b/src/lib/snark_worker_lib/rpcs.ml
@@ -1,42 +1,136 @@
 open Core_kernel
 open Async
 
+(* for versioning of the types here, see
+
+   RFC 0012, and
+
+   https://ocaml.janestreet.com/ocaml-core/latest/doc/async_rpc_kernel/Async_rpc_kernel/Versioned_rpc/
+
+*)
+
 module Make (Inputs : Intf.Inputs_intf) = struct
   open Inputs
   open Snark_work_lib
 
   module Get_work = struct
-    type query = unit [@@deriving bin_io]
+    module T = struct
+      let name = "get_work"
 
-    type response =
-      ( Statement.Stable.V1.t
-      , Transaction.t
-      , Transaction_witness.t
-      , Proof.t )
-      Work.Single.Spec.t
-      Work.Spec.t
-      option
-    [@@deriving bin_io]
+      module T = struct
+        (* "master" types, do not change *)
 
-    let rpc : (query, response) Rpc.Rpc.t =
-      Rpc.Rpc.create ~name:"Get_work" ~version:0 ~bin_query ~bin_response
+        type query = unit
+
+        type response =
+          ( Statement.Stable.V1.t
+          , Transaction.t
+          , Transaction_witness.t
+          , Proof.t )
+          Work.Single.Spec.t
+          Work.Spec.t
+          option
+      end
+
+      module Caller = T
+      module Callee = T
+    end
+
+    include T.T
+    module M = Versioned_rpc.Both_convert.Plain.Make (T)
+    include M
+
+    module V1 = struct
+      module T = struct
+        type query = unit [@@deriving bin_io, version {rpc}]
+
+        type response =
+          ( Statement.Stable.V1.t
+          , Transaction.t
+          , Transaction_witness.t
+          , Proof.t )
+          Work.Single.Spec.t
+          Work.Spec.t
+          option
+        [@@deriving bin_io]
+
+        (* , version {rpc} *)
+        
+        (* remove when version {rpc} uncommented *)
+        let version = 1
+
+        let query_of_caller_model = Fn.id
+
+        let callee_model_of_query = Fn.id
+
+        let response_of_callee_model = Fn.id
+
+        let caller_model_of_response = Fn.id
+      end
+
+      include T
+      include Register (T)
+    end
+
+    module Latest = V1
   end
 
   module Submit_work = struct
-    type query =
-      ( ( Statement.Stable.V1.t
-        , Transaction.t
-        , Transaction_witness.t
-        , Proof.t )
-        Work.Single.Spec.t
-        Work.Spec.t
-      , Proof.t )
-      Work.Result.t
-    [@@deriving bin_io]
+    module T = struct
+      let name = "submit_work"
 
-    type response = unit [@@deriving bin_io, sexp]
+      module T = struct
+        (* "master" types, do not change *)
+        type query =
+          ( ( Statement.Stable.V1.t
+            , Transaction.t
+            , Transaction_witness.t
+            , Proof.t )
+            Work.Single.Spec.t
+            Work.Spec.t
+          , Proof.t )
+          Work.Result.t
 
-    let rpc : (query, response) Rpc.Rpc.t =
-      Rpc.Rpc.create ~name:"Submit_work" ~version:0 ~bin_query ~bin_response
+        type response = unit
+      end
+
+      module Caller = T
+      module Callee = T
+    end
+
+    include T.T
+    include Versioned_rpc.Both_convert.Plain.Make (T)
+
+    module V1 = struct
+      module T = struct
+        type query =
+          ( ( Statement.Stable.V1.t
+            , Transaction.t
+            , Transaction_witness.t
+            , Proof.t )
+            Work.Single.Spec.t
+            Work.Spec.t
+          , Proof.t )
+          Work.Result.t
+        [@@deriving bin_io]
+
+        (* , version {rpc} *)
+
+        type response = unit [@@deriving bin_io, version {rpc}]
+
+        let query_of_caller_model = Fn.id
+
+        let callee_model_of_query = Fn.id
+
+        let response_of_callee_model = Fn.id
+
+        let caller_model_of_response = Fn.id
+      end
+
+      include T
+      include Register (T)
+    end
+
+    module Latest = V1
   end
 end

--- a/src/lib/snark_worker_lib/worker.ml
+++ b/src/lib/snark_worker_lib/worker.ml
@@ -98,7 +98,8 @@ module Make (Inputs : Intf.Inputs_intf) :
         go ()
       in
       match%bind
-        dispatch Rpcs.Get_work.rpc shutdown_on_disconnect () daemon_address
+        dispatch Rpcs.Get_work.Latest.rpc shutdown_on_disconnect ()
+          daemon_address
       with
       | Error e -> log_and_retry "getting work" e
       | Ok None ->
@@ -126,8 +127,8 @@ module Make (Inputs : Intf.Inputs_intf) :
                 Logger.info logger ~module_:__MODULE__ ~location:__LOC__
                   "Submitted work to %s%!"
                   (Host_and_port.to_string daemon_address) ;
-                dispatch Rpcs.Submit_work.rpc shutdown_on_disconnect result
-                  daemon_address
+                dispatch Rpcs.Submit_work.Latest.rpc shutdown_on_disconnect
+                  result daemon_address
               with
               | Error e -> log_and_retry "submitting work" e
               | Ok () -> go () ) )


### PR DESCRIPTION
Use Jane Street's versioned-RPC mechanism for snark worker RPCs, like we already have in `Coda_networking`.

@johnwu93 is working on versioning the types contained in these RPC types.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
