### PR TITLE
Avoid relative urls in the .gitmodules file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "src/lib/snarky"]
 	path = src/lib/snarky
-	url = ../../o1-labs/snarky
+	url = git@github.com:o1-labs/snarky
 [submodule "src/external/ppx_optcomp"]
 	path = src/external/ppx_optcomp
-	url = ../ppx_optcomp
+	url = git@github.com:CodaProtocol/ppx_optcomp
 [submodule "src/external/async_kernel"]
 	path = src/external/async_kernel
-	url = ../async_kernel
+	url = git@github.com:CodaProtocol/async_kernel
 [submodule "src/external/ocaml-extlib"]
 	path = src/external/ocaml-extlib
 	url = git@github.com:CodaProtocol/ocaml-extlib.git


### PR DESCRIPTION
This change makes it easier for new contributors to contribute to coda. 

After I forked coda and did `git submodule init && git submodule update --recursive`, I had a failure:
```
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:rahulmutt/async_kernel'  ...
```

It turns out that the submodule urls are defined relatively so I had to fork all the submodules in order to make it work.

This PR updates `.gitmodules` to use absolute instead of relative urls so that contributors don't have to fork unnecessarily.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? No
