### PR TITLE
build-wallet master + 3rd party PR builds

### DIFF
--- a/frontend/website/deploy-website.sh
+++ b/frontend/website/deploy-website.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 <staging | prod>"
+  echo "Usage: $0 <staging | prod | ci>"
   exit 1
 fi
 
@@ -27,15 +27,12 @@ cp site/static/verifier_main.bc.js lib/website/static
 # Keep all top-level except fonts.css
 rm lib/website/fonts.css
 
-read -p "To $1, did you deploy to CDN first? And are you sure? This can break the live site: [y/N]" -n 1 -r
-echo
-if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-  exit 1
-fi
-
-
+CI=no
 if [[ "$1" == "staging" ]]; then
   TARGET=coda-staging-84430
+elif [[ "$1" == "ci" ]]; then
+  TARGET=coda-staging-84430
+  CI=yes
 elif [[ "$1" == "prod" ]]; then
   TARGET=coda-203520
 else
@@ -43,7 +40,23 @@ else
   exit 1
 fi
 
+if [[ "$CI" != "yes" ]]; then
+  read -p "To $1, did you deploy to CDN first? And are you sure? This can break the live site: [y/N]" -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
+fi
+
 echo "*** Deploying to $1"
 
-./node_modules/firebase-tools/lib/bin/firebase.js --project $TARGET deploy
+if [[ "$CI" == "yes" ]]; then
+  if [[ -z "$FIREBASE_TOKEN" || "$FIREBASE_TOKEN" == "" ]]; then
+    echo "Skipping deployment as you don't have the creds to see our token!"
+  else
+    ./node_modules/firebase-tools/lib/bin/firebase.js --token "$FIREBASE_TOKEN" --project $TARGET deploy
+  fi
+else
+  ./node_modules/firebase-tools/lib/bin/firebase.js --project $TARGET deploy
+fi
 

--- a/frontend/website/package.json
+++ b/frontend/website/package.json
@@ -11,7 +11,7 @@
     "reformat": "bsrefmt --in-place src/*.re",
     "link-static": "ln -s $(pwd)/../../src/app/website/static site/static",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "deploy-ci": "firebase deploy --project coda-staging-84430 --token \"$FIREBASE_TOKEN\"",
+    "deploy-ci": "FIREBASE_TOKEN=\"$FIREBASE_TOKEN\" ./deploy-website.sh ci",
     "decrypt": "cd static/font && unzip PragmataPro.zip",
     "decrypt-ci": "cd static/font && unzip -P \"$PRAGMATA_ZIP_PASSWORD\" PragmataPro.zip"
   },

--- a/scripts/artifacts.sh
+++ b/scripts/artifacts.sh
@@ -10,6 +10,12 @@ if [[ ! "$CIRCLE_BUILD_NUM" ]]; then
     exit 0
 fi
 
+# No creds
+if [[ -z "$JSON_GCLOUD_CREDENTIALS" || "$JSON_GCLOUD_CREDENTIALS" == "" ]]; then
+    echo "Skipping artifact upload as creds are missing"
+    exit 0
+fi
+
 do_copy () {
     # GC credentials
     echo $JSON_GCLOUD_CREDENTIALS > google_creds.json


### PR DESCRIPTION
build-wallet master build's deploy script had bitrotted. That's fixed by
delegating to the new deploy-ci.sh script with a new option for CI.

There is also a short-circuit for 3rd party builds, so we can have
contributors. See https://github.com/CodaProtocol/coda/pull/2174 for an
example PR that should have it's CI jobs succeed after this PR.

I tested the build-wallet staging deploy by running as if I was in the
CI context.