### PR TITLE
"asserted" option to version ppx

### DIFF
--- a/src/lib/blockchain_snark/blockchain.ml
+++ b/src/lib/blockchain_snark/blockchain.ml
@@ -16,14 +16,9 @@ module Protocol_state = Consensus.Protocol_state
 module Stable = struct
   module V1 = struct
     module T = struct
-      (* TODO : use version ppx *)
-      let version = 1
-
-      let __versioned__ = true
-
       type t =
         {state: Protocol_state.Value.Stable.V1.t; proof: Proof.Stable.V1.t}
-      [@@deriving bin_io, fields]
+      [@@deriving bin_io, fields, version {asserted}]
     end
 
     include T

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -49,11 +49,6 @@ type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'bool) t_ =
 module Stable = struct
   module V1 = struct
     module T = struct
-      (* TODO : use version ppx *)
-      let version = 1
-
-      let __versioned__ = true
-
       type key = Public_key.Compressed.Stable.V1.t
       [@@deriving sexp, bin_io, eq, hash, compare, yojson]
 
@@ -64,7 +59,7 @@ module Stable = struct
         , Receipt.Chain_hash.Stable.V1.t
         , bool )
         t_
-      [@@deriving sexp, bin_io, eq, hash, compare, yojson]
+      [@@deriving sexp, bin_io, eq, hash, compare, yojson, version {asserted}]
     end
 
     include T

--- a/src/lib/coda_base/blockchain_state.ml
+++ b/src/lib/coda_base/blockchain_state.ml
@@ -93,17 +93,13 @@ end) : S = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          (* TODO : use version ppx *)
-          let version = 1
-
-          let __versioned__ = true
-
           type t =
             ( Staged_ledger_hash.Stable.V1.t
             , Frozen_ledger_hash.Stable.V1.t
             , Block_time.Stable.V1.t )
             t_
-          [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+          [@@deriving
+            bin_io, sexp, eq, compare, hash, yojson, version {asserted}]
         end
 
         include T

--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -80,8 +80,7 @@ struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        (* TODO : version Pedersen.Digest *)
-        type t = Pedersen.Digest.t
+        type t = Pedersen.Digest.Stable.V1.t
         [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
       end
 

--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -119,16 +119,11 @@ end)
   module Stable = struct
     module V1 = struct
       module T = struct
-        (* TODO : use version ppx *)
-        let version = 1
-
-        let __versioned__ = true
-
         type t =
           { protocol_state: Protocol_state.Value.Stable.V1.t
           ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
           ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t }
-        [@@deriving sexp, fields, bin_io]
+        [@@deriving sexp, fields, bin_io, version {asserted}]
 
         let to_yojson
             {protocol_state; protocol_state_proof= _; staged_ledger_diff= _} =

--- a/src/lib/coda_base/internal_transition.ml
+++ b/src/lib/coda_base/internal_transition.ml
@@ -70,16 +70,11 @@ end) :
   module Stable = struct
     module V1 = struct
       module T = struct
-        (* TODO : use version ppx *)
-        let version = 1
-
-        let __versioned__ = true
-
         type t =
           { snark_transition: Snark_transition.value
           ; prover_state: Prover_state.t
           ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t }
-        [@@deriving sexp, fields, bin_io]
+        [@@deriving sexp, fields, bin_io, version {asserted}]
       end
 
       include T

--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -84,12 +84,10 @@ end = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = Int.t [@@deriving sexp, compare, eq, bin_io]
+        type t = Int.t
+        [@@deriving sexp, compare, eq, bin_io, version {asserted}]
 
         (* TODO : wrap Int *)
-        let version = 1
-
-        let __versioned__ = true
       end
 
       include T

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -5,7 +5,8 @@ module Stable = struct
   module V1 = struct
     (* TODO: This should be stable. *)
     module T = struct
-      type t = Tock.Proof.t [@@deriving version]
+      (* Tock.Proof.t is not bin_io; should we wrap that snarky type? *)
+      type t = Tock.Proof.t [@@deriving version {asserted}]
 
       let to_string = Tock_backend.Proof.to_string
 

--- a/src/lib/coda_base/protocol_state.ml
+++ b/src/lib/coda_base/protocol_state.ml
@@ -171,18 +171,15 @@ module Make
       module Stable = struct
         module V1 = struct
           module T = struct
-            (* TODO : use version ppx *)
-            let version = 1
-
-            let __versioned__ = true
-
             type tt =
               ( Blockchain_state.Value.Stable.V1.t
               , Consensus_state.Value.Stable.V1.t )
               t
             [@@deriving eq, ord, bin_io, hash, sexp, to_yojson]
 
-            type t = tt [@@deriving eq, ord, bin_io, hash, sexp, to_yojson]
+            type t = tt
+            [@@deriving
+              eq, ord, bin_io, hash, sexp, to_yojson, version {asserted}]
           end
 
           include T
@@ -251,15 +248,12 @@ module Make
     module Stable = struct
       module V1 = struct
         module T = struct
-          (* TODO : use version ppx *)
-          let version = 1
-
-          let __versioned__ = true
-
           type t_ = (State_hash.Stable.V1.t, Body.Value.Stable.V1.t) t
           [@@deriving bin_io, sexp, hash, compare, eq, to_yojson]
 
-          type t = t_ [@@deriving bin_io, sexp, hash, compare, eq, to_yojson]
+          type t = t_
+          [@@deriving
+            bin_io, sexp, hash, compare, eq, to_yojson, version {asserted}]
         end
 
         include T

--- a/src/lib/coda_base/signature.ml
+++ b/src/lib/coda_base/signature.ml
@@ -5,12 +5,9 @@ module Stable = struct
   module V1 = struct
     module T = struct
       type t = Snark_params.Tock.Field.t * Snark_params.Tock.Field.t
-      [@@deriving sexp, eq, compare, hash, bin_io]
+      [@@deriving sexp, eq, compare, hash, bin_io, version {asserted}]
 
       (* TODO : version Field in snarky *)
-      let version = 1
-
-      let __versioned__ = true
     end
 
     let to_base64 t = Binable.to_string (module T) t |> Base64.encode_string

--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -42,16 +42,11 @@ module Answer = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        (* TODO : use version ppx *)
-        let version = 1
-
-        let __versioned__ = true
-
         type t =
           ( Ledger_hash.Stable.V1.t
           , Account.Stable.V1.t )
           Syncable_ledger.Answer.Stable.V1.t
-        [@@deriving bin_io, sexp]
+        [@@deriving bin_io, sexp, version {asserted}]
       end
 
       include T
@@ -78,14 +73,9 @@ module Query = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        (* TODO : use version ppx *)
-        let version = 1
-
-        let __versioned__ = true
-
         type t =
           Ledger.Location.Addr.Stable.V1.t Syncable_ledger.Query.Stable.V1.t
-        [@@deriving bin_io, sexp, to_yojson]
+        [@@deriving bin_io, sexp, to_yojson, version {asserted}]
       end
 
       include T

--- a/src/lib/coda_base/target.ml
+++ b/src/lib/coda_base/target.ml
@@ -6,7 +6,8 @@ open Module_version
 module Stable = struct
   module V1 = struct
     module T = struct
-      type t = Tick.Field.t [@@deriving bin_io, sexp, eq, compare, version]
+      type t = Tick.Field.t
+      [@@deriving bin_io, sexp, eq, compare, version {asserted}]
     end
 
     include T

--- a/src/lib/coda_base/transaction_witness.ml
+++ b/src/lib/coda_base/transaction_witness.ml
@@ -3,12 +3,8 @@ open Module_version
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
-      let __versioned__ = true
-
-      (* TODO : version Sparse_ledger *)
-      type t = {ledger: Sparse_ledger.t} [@@deriving sexp, bin_io]
+      type t = {ledger: Sparse_ledger.t}
+      [@@deriving sexp, bin_io, version {asserted}]
     end
 
     include T

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -108,13 +108,9 @@ module Consensus_state = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          (* TODO : use version ppx *)
-          let version = 1
-
-          let __versioned__ = true
-
           type t = (Length.Stable.V1.t, Public_key.Compressed.Stable.V1.t) t_
-          [@@deriving bin_io, sexp, hash, compare, to_yojson]
+          [@@deriving
+            bin_io, sexp, hash, compare, to_yojson, version {asserted}]
         end
 
         include T

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1041,11 +1041,6 @@ module Consensus_state = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          let version = 1
-
-          let __versioned__ = true
-
-          (* TODO : version components *)
           type t =
             ( Length.Stable.V1.t
             , Vrf.Output.t
@@ -1056,7 +1051,8 @@ module Consensus_state = struct
             , bool
             , Checkpoints.t )
             t_
-          [@@deriving sexp, bin_io, eq, compare, hash, to_yojson]
+          [@@deriving
+            sexp, bin_io, eq, compare, hash, to_yojson, version {asserted}]
         end
 
         include T

--- a/src/lib/merkle_address/dune
+++ b/src/lib/merkle_address/dune
@@ -6,6 +6,6 @@
  (inline_tests)
  (libraries core bitstring direction module_version)
  (preprocess
-  (pps ppx_jane ppx_hash ppx_deriving.eq ppx_deriving_yojson bitstring.ppx bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_hash ppx_deriving.eq ppx_deriving_yojson bitstring.ppx bisect_ppx --
     -conditional))
  (synopsis "Address for merkle database representations"))

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -131,12 +131,7 @@ end) : S = struct
         slice (bitstring_of_string string) 0 length
 
       module T = struct
-        (* TODO : use version ppx *)
-        let version = 1
-
-        let __versioned__ = true
-
-        type nonrec t = t
+        type t = Bitstring.t [@@deriving version {asserted}]
 
         include Binable.Of_binable (struct
                     type t = int * string [@@deriving bin_io]

--- a/src/lib/network_peer/dune
+++ b/src/lib/network_peer/dune
@@ -2,4 +2,4 @@
   (name network_peer)
   (public_name network_peer)
   (libraries core module_version)
-  (preprocess (pps ppx_jane ppx_deriving_yojson)))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving_yojson)))

--- a/src/lib/network_peer/peer.ml
+++ b/src/lib/network_peer/peer.ml
@@ -6,8 +6,6 @@ open Module_version
 module Stable = struct
   module V1 = struct
     module T = struct
-      let version = 1
-
       (* we using Blocking_sexp to be able to derive hash, sexp
          the base Inet_addr and Stable.V1 modules don't give that to you
        *)
@@ -16,13 +14,11 @@ module Stable = struct
         ; discovery_port: int (* UDP *)
         ; communication_port: int
         (* TCP *) }
-      [@@deriving bin_io, compare, hash, sexp]
+      [@@deriving bin_io, compare, hash, sexp, version {asserted}]
 
       (* TODO : the port int's don't need versioning; the host type should be wrapped
          for now, we assert the type is versioned
        *)
-      let __versioned__ = true
-
       let to_yojson {host; discovery_port; communication_port} =
         `Assoc
           [ ("host", `String (Unix.Inet_addr.to_string host))

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -87,13 +87,8 @@ struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        (* TODO : use version ppx *)
-        let version = 1
-
-        let __versioned__ = true
-
         type t = (Work.Stable.V1.t, Priced_proof.Stable.V1.t) diff
-        [@@deriving bin_io, sexp, yojson]
+        [@@deriving bin_io, sexp, yojson, version {asserted}]
       end
 
       include T

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -26,7 +26,7 @@ module Stable = struct
   module V1 = struct
     module T = struct
       type t = Tick.Field.t * Tick.Field.t
-      [@@deriving bin_io, sexp, eq, compare, hash, version]
+      [@@deriving bin_io, sexp, eq, compare, hash, version {asserted}]
     end
 
     include T
@@ -107,7 +107,7 @@ module Compressed = struct
     module V1 = struct
       module T = struct
         type t = (Field.t, bool) Poly.Stable.V1.t
-        [@@deriving bin_io, sexp, eq, compare, hash, version]
+        [@@deriving bin_io, sexp, eq, compare, hash, version {asserted}]
       end
 
       include T

--- a/src/lib/parallel_scan/ring_buffer.ml
+++ b/src/lib/parallel_scan/ring_buffer.ml
@@ -5,15 +5,12 @@ module Stable = struct
   module V1 = struct
     module T = struct
       type 'a t = {data: 'a Array.t; mutable position: int}
-      [@@deriving sexp, bin_io]
+      [@@deriving sexp, bin_io, version {asserted}]
     end
 
     include T
 
-    (* TODO : int doesn't need versioning; wrap Array *)
-    let version = 1
-
-    let __versioned__ = true
+    (* TODO : wrap Array *)
   end
 
   module Latest = V1

--- a/src/lib/parallel_scan/state.ml
+++ b/src/lib/parallel_scan/state.ml
@@ -105,12 +105,9 @@ module Stable = struct
         ; mutable other_trees_data: 'd list list sexp_opaque
         ; stateful_work_order: int Queue.t
         ; mutable curr_job_seq_no: int }
-      [@@deriving sexp, bin_io]
+      [@@deriving sexp, bin_io, version {asserted}]
 
-      (* TODO : wrap Array and Queue, all other types here don't need versioning *)
-      let version = 1
-
-      let __versioned__ = true
+      (* TODO : wrap Array and Queue *)
     end
 
     include T

--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -193,3 +193,16 @@ module M10 = struct
     end
   end
 end
+
+(* assert versionedness *)
+module M11 = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = Int.t List.t [@@deriving bin_io, version {asserted}]
+      end
+
+      include T
+    end
+  end
+end

--- a/src/lib/snark_params/dune
+++ b/src/lib/snark_params/dune
@@ -8,7 +8,7 @@
    core_kernel snarky snarky_verifier snarky_field_extensions snarky_curves
    snarky_pairing snark_bits dummy_values crypto_params chunked_triples)
  (preprocess
-  (pps ppx_base ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot
+  (pps ppx_coda ppx_base ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot
     ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky bisect_ppx --
     -conditional))
  (preprocessor_deps ../../config.mlh)

--- a/src/lib/snark_params/pedersen.ml
+++ b/src/lib/snark_params/pedersen.ml
@@ -17,10 +17,17 @@ module type S = sig
   type curve
 
   module Digest : sig
-    type t [@@deriving bin_io, sexp, eq, hash, compare, yojson]
+    type t [@@deriving sexp, eq, hash, compare, yojson]
 
-    (* TODO : really version *)
-    val __versioned__ : bool
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io, compare, hash, eq, version, yojson]
+        end
+
+        module Latest = V1
+      end
+      with type V1.t = t
 
     val size_in_bits : int
 
@@ -81,10 +88,31 @@ struct
   open Inputs
 
   module Digest = struct
-    type t = Field.t [@@deriving sexp, bin_io, compare, hash, eq]
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          type t = Field.t
+          [@@deriving sexp, bin_io, compare, hash, eq, version {asserted}]
+        end
 
-    (* TODO : really version *)
-    let __versioned__ = true
+        include T
+
+        let to_yojson t = `String (Field.to_string t)
+
+        let of_yojson = function
+          | `String s -> (
+            try Ok (Field.of_string s) with exn ->
+              Error Error.(to_string_hum (of_exn exn)) )
+          | _ -> Error "expected string"
+      end
+
+      module Latest = V1
+    end
+
+    (* omit bin_io, version *)
+    type t = Stable.Latest.t [@@deriving sexp, eq, hash, compare]
+
+    let of_yojson, to_yojson = Stable.Latest.(of_yojson, to_yojson)
 
     let size_in_bits = Field.size_in_bits
 
@@ -92,14 +120,6 @@ struct
 
     module Snarkable = Bits.Snarkable.Field
     module Bits = Bits.Make_field (Field) (Bigint)
-
-    let to_yojson t = `String (Field.to_string t)
-
-    let of_yojson = function
-      | `String s -> (
-        try Ok (Field.of_string s) with exn ->
-          Error Error.(to_string_hum (of_exn exn)) )
-      | _ -> Error "expected string"
 
     let fold t = Fold.group3 ~default:false (Bits.fold t)
   end

--- a/src/lib/snark_params/pedersen.mli
+++ b/src/lib/snark_params/pedersen.mli
@@ -15,10 +15,17 @@ module type S = sig
   type curve
 
   module Digest : sig
-    type t [@@deriving bin_io, sexp, eq, hash, compare, yojson]
+    type t [@@deriving sexp, eq, hash, compare, yojson]
 
-    (* TODO: assert versioned, for now *)
-    val __versioned__ : bool
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io, compare, hash, eq, version, yojson]
+        end
+
+        module Latest = V1
+      end
+      with type V1.t = t
 
     val size_in_bits : int
 

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -284,9 +284,6 @@ module Tock = struct
   module Proof = struct
     include Tock0.Proof
 
-    (* TODO : follow this include all the way and really version it *)
-    let __versioned__ = true
-
     let dummy = Dummy_values.Tock.GrothMaller17.proof
   end
 
@@ -342,11 +339,6 @@ module Tick = struct
     module Bits = Bits.Make_field (Tick0.Field) (Tick0.Bigint)
 
     let size_in_triples = Int.((size_in_bits + 2) / 3)
-
-    (* for now, assert this type, derived from snarky, is versioned; can we
-       prevent it changing?
-     *)
-    let __versioned__ = true
   end
 
   module Fq = Snarky_field_extensions.Field_extensions.F (Tick0)

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1637,12 +1637,11 @@ let%test_module "test" =
       module Sok_message = struct
         module Stable = struct
           module V1 = struct
-            type t = unit [@@deriving bin_io, sexp, yojson]
+            module T = struct
+              type t = unit [@@deriving bin_io, sexp, yojson, version]
+            end
 
-            (* test code, don't need actual versioning *)
-            let version = 1
-
-            let __versioned__ = true
+            include T
           end
 
           module Latest = V1
@@ -1947,19 +1946,19 @@ let%test_module "test" =
       module Ledger_proof_statement = struct
         module Stable = struct
           module V1 = struct
-            type t =
-              { source: Ledger_hash.Stable.V1.t
-              ; target: Ledger_hash.Stable.V1.t
-              ; supply_increase: Currency.Amount.Stable.V1.t
-              ; pending_coinbase_stack_state: Pending_coinbase_stack_state.t
-              ; fee_excess: Fee.Signed.t
-              ; proof_type: [`Base | `Merge] }
-            [@@deriving sexp, bin_io, compare, hash, yojson, eq]
+            module T = struct
+              type t =
+                { source: Ledger_hash.Stable.V1.t
+                ; target: Ledger_hash.Stable.V1.t
+                ; supply_increase: Currency.Amount.Stable.V1.t
+                ; pending_coinbase_stack_state: Pending_coinbase_stack_state.t
+                ; fee_excess: Fee.Signed.t
+                ; proof_type: [`Base | `Merge] }
+              [@@deriving
+                sexp, bin_io, compare, hash, yojson, eq, version {asserted}]
+            end
 
-            (* test code, don't need to assure this type is actually versioned *)
-            let version = 1
-
-            let __versioned__ = true
+            include T
 
             let merge s1 s2 =
               let open Or_error.Let_syntax in
@@ -2060,12 +2059,12 @@ let%test_module "test" =
 
           module Stable = struct
             module V1 = struct
-              type t = transaction [@@deriving sexp, bin_io]
+              module T = struct
+                type t = transaction
+                [@@deriving sexp, bin_io, version {asserted}]
+              end
 
-              (* test code, don't need to assure this type is actually versioned *)
-              let version = 1
-
-              let __versioned__ = true
+              include T
             end
 
             module Latest = V1
@@ -2337,14 +2336,13 @@ let%test_module "test" =
 
         module Stable = struct
           module V1 = struct
-            type t =
-              {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
-            [@@deriving sexp, bin_io]
+            module T = struct
+              type t =
+                {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
+              [@@deriving sexp, bin_io, version {asserted}]
+            end
 
-            (* fake versioning *)
-            let version = 1
-
-            let __versioned__ = true
+            include T
           end
 
           module Latest = V1
@@ -2418,12 +2416,12 @@ let%test_module "test" =
       module Transaction_witness = struct
         module Stable = struct
           module V1 = struct
-            type t = {ledger: Sparse_ledger.t} [@@deriving bin_io, sexp]
+            module T = struct
+              type t = {ledger: Sparse_ledger.t}
+              [@@deriving bin_io, sexp, version {asserted}]
+            end
 
-            (* test code, don't need to assure this type is actually versioned *)
-            let version = 1
-
-            let __versioned__ = true
+            include T
           end
 
           module Latest = V1

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -102,16 +102,11 @@ end) :
   module Stable = struct
     module V1 = struct
       module T = struct
-        (* TODO : use version ppx *)
-        let version = 1
-
-        let __versioned__ = true
-
         type t =
           { diff: diff
           ; prev_hash: Staged_ledger_hash.t
           ; creator: Compressed_public_key.Stable.V1.t }
-        [@@deriving sexp, bin_io]
+        [@@deriving sexp, bin_io, version {asserted}]
       end
 
       include T

--- a/src/lib/staged_ledger/transaction_snark_work.ml
+++ b/src/lib/staged_ledger/transaction_snark_work.ml
@@ -30,13 +30,8 @@ end) :
     module Stable = struct
       module V1 = struct
         module T = struct
-          (* TODO : use version ppx *)
-          let version = 1
-
-          let __versioned__ = true
-
           type t = Ledger_proof_statement.Stable.V1.t list
-          [@@deriving bin_io, sexp, hash, compare, yojson]
+          [@@deriving bin_io, sexp, hash, compare, yojson, version {asserted}]
         end
 
         include T
@@ -70,16 +65,11 @@ end) :
     module Stable = struct
       module V1 = struct
         module T = struct
-          (* TODO : use version ppx *)
-          let version = 1
-
-          let __versioned__ = true
-
           type t =
             { fee: Fee.Unsigned.t
             ; proofs: Ledger_proof.t list
             ; prover: Public_key.Compressed.Stable.V1.t }
-          [@@deriving sexp, bin_io]
+          [@@deriving sexp, bin_io, version {asserted}]
         end
 
         include T

--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -289,13 +289,8 @@ struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          (* TODO : use version ppx *)
-          let version = 1
-
-          let __versioned__ = true
-
           type t = User_command.Stable.V1.t list
-          [@@deriving bin_io, sexp, yojson]
+          [@@deriving bin_io, sexp, yojson, version {asserted}]
         end
 
         include T


### PR DESCRIPTION
Added `asserted` option to version ppx. Use that instead of manually entering `let __versioned__ =` and `let version =`. This option asserts that a type is versioned, so we can make progress. Eventually, those uses should be removed, except in test code, where they're still handy.

I removed all those manual declarations, except for 1 or 2.

There's some refactoring to do on `Nat` and `Unsigned_extended` for versioning that I haven't worked out yet.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
