### PR TITLE
Version Job in parallel-scan-state

### DIFF
--- a/src/lib/parallel_scan/parallel_scan.mli
+++ b/src/lib/parallel_scan/parallel_scan.mli
@@ -79,10 +79,21 @@ module State : sig
       end
     end
 
-    type ('a, 'd) t =
+    module Stable : sig
+      module V1 : sig
+        type ('a, 'd) t =
+          | Merge of 'a Merge.Stable.V1.t
+          | Base of ('d * Sequence_no.Stable.V1.t) option
+        [@@deriving bin_io, sexp, version]
+      end
+
+      module Latest = V1
+    end
+
+    type ('a, 'd) t = ('a, 'd) Stable.Latest.t =
       | Merge of 'a Merge.Stable.V1.t
       | Base of ('d * Sequence_no.Stable.V1.t) option
-    [@@deriving sexp, bin_io, version]
+    [@@deriving sexp]
   end
 
   module Completed_job : sig

--- a/src/lib/parallel_scan/state.ml
+++ b/src/lib/parallel_scan/state.ml
@@ -2,43 +2,44 @@ open Core_kernel
 open Coda_digestif
 
 module Job = struct
+  module Sequence_no = struct
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          type t = int [@@deriving sexp, bin_io, version]
+        end
+
+        include T
+      end
+
+      module Latest = V1
+    end
+
+    type t = Stable.Latest.t [@@deriving sexp]
+  end
+
+  module Merge = struct
+    module Stable = struct
+      module V1 = struct
+        module T = struct
+          type 'a t =
+            | Empty
+            | Lcomp of 'a
+            | Rcomp of 'a
+            | Bcomp of ('a * 'a * Sequence_no.Stable.V1.t)
+          [@@deriving sexp, bin_io, version]
+        end
+
+        include T
+      end
+
+      module Latest = V1
+    end
+  end
+
   module Stable = struct
     module V1 = struct
-      module Sequence_no = struct
-        module Stable = struct
-          module V1 = struct
-            module T = struct
-              type t = int [@@deriving sexp, bin_io, version]
-            end
-
-            include T
-          end
-
-          module Latest = V1
-        end
-
-        type t = Stable.Latest.t [@@deriving sexp]
-      end
-
       (*A merge can have zero components, one component (either the left or the right), or two components in which case there is an integer (sequence_no) representing a set of (completed)jobs in a sequence of (completed)jobs created*)
-      module Merge = struct
-        module Stable = struct
-          module V1 = struct
-            module T = struct
-              type 'a t =
-                | Empty
-                | Lcomp of 'a
-                | Rcomp of 'a
-                | Bcomp of ('a * 'a * Sequence_no.Stable.V1.t)
-              [@@deriving sexp, bin_io, version]
-            end
-
-            include T
-          end
-
-          module Latest = V1
-        end
-      end
 
       module T = struct
         type ('a, 'd) t =
@@ -53,7 +54,10 @@ module Job = struct
     module Latest = V1
   end
 
-  include Stable.Latest
+  type ('a, 'd) t = ('a, 'd) Stable.Latest.t =
+    | Merge of 'a Merge.Stable.V1.t
+    | Base of ('d * Sequence_no.Stable.V1.t) option
+  [@@deriving sexp]
 
   let gen a_gen d_gen =
     let open Quickcheck.Generator in
@@ -95,7 +99,7 @@ module Stable = struct
     (* don't use module registration here, because of type parameters *)
     module T = struct
       type ('a, 'd) t =
-        { jobs: ('a, 'd) Job.t Ring_buffer.Stable.V1.t
+        { jobs: ('a, 'd) Job.Stable.V1.t Ring_buffer.Stable.V1.t
         ; level_pointer: int Array.t
         ; capacity: int
         ; mutable acc: int * ('a * 'd list) option sexp_opaque


### PR DESCRIPTION
Version `Job` in `Parallel_scan.State`.

This is a preface to wrapping the `Queue` and `Array` types so that `State.Stable.V1.t` can rightfully be said to be versioned.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
