### PR TITLE
Keep app open on window close

### DIFF
--- a/frontend/wallet/src/App.re
+++ b/frontend/wallet/src/App.re
@@ -74,3 +74,7 @@ App.on(
     createWindow();
   },
 );
+
+App.on(`WindowAllClosed, () =>
+  print_endline("Closing window, menu staying open")
+);


### PR DESCRIPTION
Tested by closing the window and then verifying the menu was still
there. We can later spawn a new application window.