### PR TITLE
Refactor App logic a bit

### DIFF
--- a/frontend/wallet/src/App.re
+++ b/frontend/wallet/src/App.re
@@ -1,50 +1,20 @@
 open BsElectron;
 
-let win = ref(Js.null);
-
-let tray = ref(Js.null);
-
 let dev = true;
-
-let projectRoot =
-  Node_path.join2(Belt.Option.getExn([%bs.node __dirname]), "../../../");
-
-module AppBrowserWindow = BrowserWindow.MakeBrowserWindow(Messages);
-let createWindow = () => {
-  win :=
-    Js.Null.return(
-      AppBrowserWindow.make(
-        AppBrowserWindow.makeWindowConfig(
-          ~transparent=true,
-          ~width=880,
-          ~height=500,
-          ~frame=false,
-          ~fullscreenable=false,
-          ~resizeable=false,
-          ~title="Coda Wallet",
-          ~backgroundColor="#DD" ++ StyleGuide.Colors.(hexToString(bgColor)),
-          (),
-        ),
-      ),
-    );
-
-  AppBrowserWindow.loadURL(
-    Js.Null.getExn(win^),
-    "file://" ++ projectRoot ++ "public/index.html",
-  );
-  Js.log("file://" ++ projectRoot ++ "public/index.html");
-  AppBrowserWindow.on(Js.Null.getExn(win^), `Closed, () => win := Js.null);
-};
 
 let sendMoney = () => {
   print_endline("Sending!");
 };
 
 let createTray = () => {
-  let t = Tray.make(projectRoot ++ "public/icon.png");
+  let t = AppTray.get();
   let items =
     Menu.Item.[
-      make(Label("Synced"), ~icon=projectRoot ++ "public/circle-16.png", ()),
+      make(
+        Label("Synced"),
+        ~icon=ProjectRoot.path ++ "public/circle-16.png",
+        (),
+      ),
       make(Separator, ()),
       make(Label("Wallets:"), ~enabled=false, ()),
       make(Radio({js|    Wallet_1  □ 100|js}), ()),
@@ -64,14 +34,14 @@ let createTray = () => {
   List.iter(Menu.append(menu), items);
 
   Tray.setContextMenu(t, menu);
-  tray := Js.Null.return(t);
 };
 
 App.on(
   `Ready,
   () => {
     createTray();
-    createWindow();
+    let _ = AppWindow.get();
+    ();
   },
 );
 

--- a/frontend/wallet/src/AppTray.re
+++ b/frontend/wallet/src/AppTray.re
@@ -1,0 +1,11 @@
+open BsElectron;
+
+include Single.Make({
+  type input = unit;
+  type t = Tray.t;
+
+  let make: (~drop: unit => unit, unit) => t =
+    (~drop as _, ()) => {
+      Tray.make(ProjectRoot.path ++ "public/icon.png");
+    };
+});

--- a/frontend/wallet/src/AppWindow.re
+++ b/frontend/wallet/src/AppWindow.re
@@ -1,0 +1,30 @@
+open BsElectron;
+
+include BrowserWindow.MakeBrowserWindow(Messages);
+
+include Single.Make({
+  type input = unit;
+  type t = BrowserWindow.t;
+
+  let make: (~drop: unit => unit, input) => t =
+    (~drop, ()) => {
+      let window =
+        make(
+          makeWindowConfig(
+            ~transparent=true,
+            ~width=880,
+            ~height=500,
+            ~frame=false,
+            ~fullscreenable=false,
+            ~resizeable=false,
+            ~title="Coda Wallet",
+            ~backgroundColor=
+              "#DD" ++ StyleGuide.Colors.(hexToString(bgColor)),
+            (),
+          ),
+        );
+      loadURL(window, "file://" ++ ProjectRoot.path ++ "public/index.html");
+      on(window, `Closed, drop);
+      window;
+    };
+});

--- a/frontend/wallet/src/ProjectRoot.re
+++ b/frontend/wallet/src/ProjectRoot.re
@@ -1,0 +1,2 @@
+let path =
+  Node_path.join2(Belt.Option.getExn([%bs.node __dirname]), "../../../");

--- a/frontend/wallet/src/Single.re
+++ b/frontend/wallet/src/Single.re
@@ -1,0 +1,20 @@
+module Make =
+       (
+         T: {
+           type input;
+           type t;
+           let make: (~drop: unit => unit, input) => t;
+         },
+       ) => {
+  let cache: ref(option(T.t)) = ref(None);
+
+  let get = input => {
+    switch (cache^) {
+    | Some(w) => w
+    | None =>
+      let res = T.make(~drop=() => cache := None, input);
+      cache := Some(res);
+      res;
+    };
+  };
+};


### PR DESCRIPTION
Tray and window logic was quite similar and not necessary to be inside
of App. Moved it out.

Single is a singleton-like holder (but not quite a singleton) that can
also drop it's cached item. The specific Tray and Window modules we need
have an App prefix because BsElectron will shadow Tray and Window
modules.