### PR TITLE
Allow OCaml array constructor in version ppx

### DIFF
--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -121,6 +121,15 @@ module M6 = struct
 
       include T
     end
+
+    module V5 = struct
+      module T = struct
+        type t = Stable.V1.t array array sexp_opaque
+        [@@deriving sexp, bin_io, version]
+      end
+
+      include T
+    end
   end
 end
 

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -130,24 +130,18 @@ let validate_type_decl inner3_modules generation_kind type_decl =
 
 let module_name_from_plain_path inner3_modules =
   match inner3_modules with
-  | ["T"; module_version; "Stable"] ->
-      module_version
-  | _ ->
-      failwith "module_name_from_plain_path: unexpected module path"
+  | ["T"; module_version; "Stable"] -> module_version
+  | _ -> failwith "module_name_from_plain_path: unexpected module path"
 
 let module_name_from_wrapped_path inner3_modules =
   match inner3_modules with
-  | [module_version; "Stable"; "Wrapped"] ->
-      module_version
-  | _ ->
-      failwith "module_name_from_wrapped_path: unexpected module path"
+  | [module_version; "Stable"; "Wrapped"] -> module_version
+  | _ -> failwith "module_name_from_wrapped_path: unexpected module path"
 
 let module_name_from_rpc_path inner3_modules =
   match List.take inner3_modules 2 with
-  | ["T"; module_version] ->
-      module_version
-  | _ ->
-      failwith "module_name_from_rpc_path: unexpected module path"
+  | ["T"; module_version] -> module_version
+  | _ -> failwith "module_name_from_rpc_path: unexpected module path"
 
 (* generate "let version = n", when version module is Vn *)
 let generate_version_number_decl inner3_modules loc generation_kind =
@@ -158,12 +152,9 @@ let generate_version_number_decl inner3_modules loc generation_kind =
   let open E in
   let module_name =
     match generation_kind with
-    | Plain ->
-        module_name_from_plain_path inner3_modules
-    | Wrapped ->
-        module_name_from_wrapped_path inner3_modules
-    | Rpc ->
-        module_name_from_rpc_path inner3_modules
+    | Plain -> module_name_from_plain_path inner3_modules
+    | Wrapped -> module_name_from_wrapped_path inner3_modules
+    | Rpc -> module_name_from_rpc_path inner3_modules
   in
   let version =
     String.sub module_name ~pos:1 ~len:(String.length module_name - 1)
@@ -194,8 +185,7 @@ let rec generate_core_type_version_decls type_name core_type =
           || List.mem jane_street_type_constructors id ~equal:String.equal
         then
           match core_types with
-          | [_] ->
-              generate_version_lets_for_core_types type_name core_types
+          | [_] -> generate_version_lets_for_core_types type_name core_types
           | _ ->
               Ppx_deriving.raise_errorf ~loc:core_type.ptyp_loc
                 "Type constructor \"%s\" expects one type argument, got %d" id
@@ -223,12 +213,10 @@ let rec generate_core_type_version_decls type_name core_type =
   | Ptyp_tuple core_types ->
       (* type t = t1 * t2 * t3 *)
       generate_version_lets_for_core_types type_name core_types
-  | Ptyp_variant _ ->
-      (* type t = [ `A | `B ] *)
-      []
-  | Ptyp_var _ ->
-      (* type variable *)
-      []
+  | Ptyp_variant _ -> (* type t = [ `A | `B ] *)
+                      []
+  | Ptyp_var _ -> (* type variable *)
+                  []
   | _ ->
       Ppx_deriving.raise_errorf ~loc:core_type.ptyp_loc
         "Can't determine versioning for contained type"
@@ -310,8 +298,7 @@ let check_for_option s options =
     match opt with
     | str1, {pexp_desc= Pexp_ident {txt= Lident str2; _}; _} ->
         String.equal s str1 && String.equal s str2
-    | _ ->
-        false
+    | _ -> false
   in
   List.find options ~f:is_s_opt |> Option.is_some
 
@@ -344,12 +331,9 @@ let generate_let_bindings_for_type_decl_str ~options ~path type_decls =
        options" ;
   let generation_kind =
     match (rpc, wrapped) with
-    | true, false ->
-        Rpc
-    | false, true ->
-        Wrapped
-    | false, false ->
-        Plain
+    | true, false -> Rpc
+    | false, true -> Wrapped
+    | false, false -> Plain
     | true, true ->
         Ppx_deriving.raise_errorf ~loc:type_decl.ptype_loc
           "RPC versioned type cannot also be wrapped"

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -130,18 +130,24 @@ let validate_type_decl inner3_modules generation_kind type_decl =
 
 let module_name_from_plain_path inner3_modules =
   match inner3_modules with
-  | ["T"; module_version; "Stable"] -> module_version
-  | _ -> failwith "module_name_from_plain_path: unexpected module path"
+  | ["T"; module_version; "Stable"] ->
+      module_version
+  | _ ->
+      failwith "module_name_from_plain_path: unexpected module path"
 
 let module_name_from_wrapped_path inner3_modules =
   match inner3_modules with
-  | [module_version; "Stable"; "Wrapped"] -> module_version
-  | _ -> failwith "module_name_from_wrapped_path: unexpected module path"
+  | [module_version; "Stable"; "Wrapped"] ->
+      module_version
+  | _ ->
+      failwith "module_name_from_wrapped_path: unexpected module path"
 
 let module_name_from_rpc_path inner3_modules =
   match List.take inner3_modules 2 with
-  | ["T"; module_version] -> module_version
-  | _ -> failwith "module_name_from_rpc_path: unexpected module path"
+  | ["T"; module_version] ->
+      module_version
+  | _ ->
+      failwith "module_name_from_rpc_path: unexpected module path"
 
 (* generate "let version = n", when version module is Vn *)
 let generate_version_number_decl inner3_modules loc generation_kind =
@@ -152,9 +158,12 @@ let generate_version_number_decl inner3_modules loc generation_kind =
   let open E in
   let module_name =
     match generation_kind with
-    | Plain -> module_name_from_plain_path inner3_modules
-    | Wrapped -> module_name_from_wrapped_path inner3_modules
-    | Rpc -> module_name_from_rpc_path inner3_modules
+    | Plain ->
+        module_name_from_plain_path inner3_modules
+    | Wrapped ->
+        module_name_from_wrapped_path inner3_modules
+    | Rpc ->
+        module_name_from_rpc_path inner3_modules
   in
   let version =
     String.sub module_name ~pos:1 ~len:(String.length module_name - 1)
@@ -164,7 +173,7 @@ let generate_version_number_decl inner3_modules loc generation_kind =
 
 let ocaml_builtin_types = ["int"; "float"; "char"; "string"; "bool"; "unit"]
 
-let ocaml_builtin_type_constructors = ["list"; "option"; "ref"]
+let ocaml_builtin_type_constructors = ["list"; "array"; "option"; "ref"]
 
 let jane_street_type_constructors = ["sexp_opaque"]
 
@@ -185,7 +194,8 @@ let rec generate_core_type_version_decls type_name core_type =
           || List.mem jane_street_type_constructors id ~equal:String.equal
         then
           match core_types with
-          | [_] -> generate_version_lets_for_core_types type_name core_types
+          | [_] ->
+              generate_version_lets_for_core_types type_name core_types
           | _ ->
               Ppx_deriving.raise_errorf ~loc:core_type.ptyp_loc
                 "Type constructor \"%s\" expects one type argument, got %d" id
@@ -213,10 +223,12 @@ let rec generate_core_type_version_decls type_name core_type =
   | Ptyp_tuple core_types ->
       (* type t = t1 * t2 * t3 *)
       generate_version_lets_for_core_types type_name core_types
-  | Ptyp_variant _ -> (* type t = [ `A | `B ] *)
-                      []
-  | Ptyp_var _ -> (* type variable *)
-                  []
+  | Ptyp_variant _ ->
+      (* type t = [ `A | `B ] *)
+      []
+  | Ptyp_var _ ->
+      (* type variable *)
+      []
   | _ ->
       Ppx_deriving.raise_errorf ~loc:core_type.ptyp_loc
         "Can't determine versioning for contained type"
@@ -298,7 +310,8 @@ let check_for_option s options =
     match opt with
     | str1, {pexp_desc= Pexp_ident {txt= Lident str2; _}; _} ->
         String.equal s str1 && String.equal s str2
-    | _ -> false
+    | _ ->
+        false
   in
   List.find options ~f:is_s_opt |> Option.is_some
 
@@ -331,9 +344,12 @@ let generate_let_bindings_for_type_decl_str ~options ~path type_decls =
        options" ;
   let generation_kind =
     match (rpc, wrapped) with
-    | true, false -> Rpc
-    | false, true -> Wrapped
-    | false, false -> Plain
+    | true, false ->
+        Rpc
+    | false, true ->
+        Wrapped
+    | false, false ->
+        Plain
     | true, true ->
         Ppx_deriving.raise_errorf ~loc:type_decl.ptype_loc
           "RPC versioned type cannot also be wrapped"


### PR DESCRIPTION
Allow OCaml's built-in array constructor in the version ppx.

The new ocamlformat made some formatting changes that appear in the diffs, sorry.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
