### PR TITLE
Use OCaml array constructor to avoid wrapping

### DIFF
--- a/src/lib/parallel_scan/state.ml
+++ b/src/lib/parallel_scan/state.ml
@@ -100,7 +100,7 @@ module Stable = struct
     module T = struct
       type ('a, 'd) t =
         { jobs: ('a, 'd) Job.Stable.V1.t Ring_buffer.Stable.V1.t
-        ; level_pointer: int Array.t
+        ; level_pointer: int array
         ; capacity: int
         ; mutable acc: int * ('a * 'd list) option sexp_opaque
         ; mutable current_data_length: int
@@ -111,7 +111,7 @@ module Stable = struct
         ; mutable curr_job_seq_no: int }
       [@@deriving sexp, bin_io, version {asserted}]
 
-      (* TODO : wrap Array and Queue *)
+      (* TODO : wrap Queue *)
     end
 
     include T
@@ -123,7 +123,7 @@ end
 (* bin_io omitted from deriving list intentionally *)
 type ('a, 'd) t = ('a, 'd) Stable.Latest.t =
   { jobs: ('a, 'd) Job.t Ring_buffer.t
-  ; level_pointer: int Array.t
+  ; level_pointer: int array
   ; capacity: int
   ; mutable acc: int * ('a * 'd list) option
   ; mutable current_data_length: int


### PR DESCRIPTION
Substitute `array` for `Array.t` so we don't have to wrap `Array` for versioning.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
