### PR TITLE
Use int instead of Int.t to avoid wrapping

### DIFF
--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -84,10 +84,7 @@ end = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = Int.t
-        [@@deriving sexp, compare, eq, bin_io, version {asserted}]
-
-        (* TODO : wrap Int *)
+        type t = int [@@deriving sexp, compare, eq, bin_io, version]
       end
 
       include T


### PR DESCRIPTION
Use `int` so we don't have to wrap `Int` (and we have actual versioning, instead of asserting it).

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
