### PR TITLE
Remove asserted from deriving version in Blockchain

### DIFF
--- a/src/lib/blockchain_snark/blockchain.ml
+++ b/src/lib/blockchain_snark/blockchain.ml
@@ -18,7 +18,7 @@ module Stable = struct
     module T = struct
       type t =
         {state: Protocol_state.Value.Stable.V1.t; proof: Proof.Stable.V1.t}
-      [@@deriving bin_io, fields, version {asserted}]
+      [@@deriving bin_io, fields, version]
     end
 
     include T

--- a/src/lib/coda_base/protocol_state.ml
+++ b/src/lib/coda_base/protocol_state.ml
@@ -82,7 +82,7 @@ module type S = sig
     module Stable : sig
       module V1 : sig
         type nonrec t = (State_hash.Stable.V1.t, Body.Value.Stable.V1.t) t
-        [@@deriving sexp, bin_io, compare, eq, to_yojson]
+        [@@deriving sexp, bin_io, compare, eq, to_yojson, version]
       end
 
       module Latest : module type of V1


### PR DESCRIPTION
Removed an `asserted` from a `deriving version` in `Blockchain`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
