### PR TITLE
Remove asserted from deriving version in Account

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -1099,7 +1099,7 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
   let get_balance t (addr : Public_key.Compressed.t) =
     let open Participating_state.Option.Let_syntax in
     let%map account = get_account t addr in
-    account.Account.balance
+    account.Account.Poly.Stable.Latest.balance
 
   let get_accounts t =
     let open Participating_state.Let_syntax in
@@ -1119,7 +1119,8 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
     let%map accounts = get_accounts t in
     List.map accounts ~f:(fun account ->
         ( string_of_public_key account
-        , Account.balance account |> Currency.Balance.to_int ) )
+        , account.Account.Poly.Stable.Latest.balance |> Currency.Balance.to_int
+        ) )
 
   let is_valid_payment t (txn : User_command.t) account_opt =
     let remainder =
@@ -1132,7 +1133,8 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
             Some (Currency.Amount.of_fee fee)
         | Payment {amount; _} -> Currency.Amount.add_fee amount fee
       in
-      Currency.Balance.sub_amount account.Account.balance cost
+      Currency.Balance.sub_amount account.Account.Poly.Stable.Latest.balance
+        cost
     in
     Option.is_some remainder
 
@@ -1140,7 +1142,7 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
   let txn_count = ref 0
 
   let record_payment ~logger t (txn : User_command.t) account =
-    let previous = Account.receipt_chain_hash account in
+    let previous = account.Account.Poly.Stable.Latest.receipt_chain_hash in
     let receipt_chain_database = receipt_chain_database t in
     match Receipt_chain_database.add receipt_chain_database ~previous txn with
     | `Ok hash ->
@@ -1187,7 +1189,9 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
     let open Participating_state.Let_syntax in
     let%map account = get_account t addr in
     let account = Option.value_exn account in
-    let resulting_receipt = Account.receipt_chain_hash account in
+    let resulting_receipt =
+      account.Account.Poly.Stable.Latest.receipt_chain_hash
+    in
     let open Or_error.Let_syntax in
     let%bind () = Payment_verifier.verify ~resulting_receipt proof in
     if
@@ -1254,7 +1258,7 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
     let open Option.Let_syntax in
     let%bind location = Ledger.location_of_key ledger addr in
     let%map account = Ledger.get ledger location in
-    account.Account.nonce
+    account.Account.Poly.Stable.Latest.nonce
 
   let start_time = Time_ns.now ()
 
@@ -1496,7 +1500,8 @@ module Run (Config_in : Config_intf) (Program : Main_intf) = struct
               |> Deferred.return
             in
             prove_receipt coda ~proving_receipt
-              ~resulting_receipt:(Account.receipt_chain_hash account) )
+              ~resulting_receipt:
+                account.Account.Poly.Stable.Latest.receipt_chain_hash )
       ; implement Daemon_rpcs.Get_public_keys_with_balances.rpc (fun () () ->
             return
               (get_keys_with_balances coda |> Participating_state.active_exn)

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -256,7 +256,7 @@ let run_test () : unit Deferred.t =
             (List.map accounts
                ~f:(fun ((keypair : Signature_lib.Keypair.t), account) ->
                  ( Public_key.compress keypair.public_key
-                 , Account.balance account ) ))
+                 , account.Account.Poly.Stable.Latest.balance ) ))
         in
         let%bind updated_balance_sheet =
           send_payments accounts pks balance_sheet (fun i ->

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -256,7 +256,7 @@ let run_test () : unit Deferred.t =
             (List.map accounts
                ~f:(fun ((keypair : Signature_lib.Keypair.t), account) ->
                  ( Public_key.compress keypair.public_key
-                 , account.Account.Poly.Stable.Latest.balance ) ))
+                 , account.Account.Poly.balance ) ))
         in
         let%bind updated_balance_sheet =
           send_payments accounts pks balance_sheet (fun i ->

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -56,6 +56,21 @@ module Poly = struct
 
     module Latest = V1
   end
+
+  type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'bool) t =
+                                                             ( 'pk
+                                                             , 'amount
+                                                             , 'nonce
+                                                             , 'receipt_chain_hash
+                                                             , 'bool )
+                                                             Stable.Latest.t =
+    { public_key: 'pk
+    ; balance: 'amount
+    ; nonce: 'nonce
+    ; receipt_chain_hash: 'receipt_chain_hash
+    ; delegate: 'pk
+    ; participated: 'bool }
+  [@@deriving sexp, eq, compare, hash, yojson]
 end
 
 module Stable = struct
@@ -107,7 +122,7 @@ type var =
   , Nonce.Unpacked.var
   , Receipt.Chain_hash.var
   , Boolean.var )
-  Poly.Stable.Latest.t
+  Poly.t
 
 type value =
   ( Public_key.Compressed.t
@@ -115,7 +130,7 @@ type value =
   , Nonce.t
   , Receipt.Chain_hash.t
   , bool )
-  Poly.Stable.Latest.t
+  Poly.t
 [@@deriving sexp]
 
 let key_gen = Public_key.Compressed.gen
@@ -141,20 +156,19 @@ let typ : (var, value) Typ.t =
   let of_hlist
         : 'a 'b 'c 'd 'e.    ( unit
                              , 'a -> 'b -> 'c -> 'd -> 'a -> 'e -> unit )
-                             H_list.t
-          -> ('a, 'b, 'c, 'd, 'e) Poly.Stable.Latest.t =
+                             H_list.t -> ('a, 'b, 'c, 'd, 'e) Poly.t =
     let open H_list in
     fun [public_key; balance; nonce; receipt_chain_hash; delegate; participated]
         ->
       {public_key; balance; nonce; receipt_chain_hash; delegate; participated}
   in
   let to_hlist
-      Poly.Stable.Latest.({ public_key
-                          ; balance
-                          ; nonce
-                          ; receipt_chain_hash
-                          ; delegate
-                          ; participated }) =
+      Poly.({ public_key
+            ; balance
+            ; nonce
+            ; receipt_chain_hash
+            ; delegate
+            ; participated }) =
     H_list.
       [public_key; balance; nonce; receipt_chain_hash; delegate; participated]
   in
@@ -164,7 +178,7 @@ let typ : (var, value) Typ.t =
 let var_of_t
     ({public_key; balance; nonce; receipt_chain_hash; delegate; participated} :
       value) =
-  { Poly.Stable.Latest.public_key= Public_key.Compressed.var_of_t public_key
+  { Poly.public_key= Public_key.Compressed.var_of_t public_key
   ; balance= Balance.var_of_t balance
   ; nonce= Nonce.Unpacked.var_of_value nonce
   ; receipt_chain_hash= Receipt.Chain_hash.var_of_t receipt_chain_hash
@@ -172,12 +186,12 @@ let var_of_t
   ; participated= Boolean.var_of_value participated }
 
 let var_to_triples
-    Poly.Stable.Latest.({ public_key
-                        ; balance
-                        ; nonce
-                        ; receipt_chain_hash
-                        ; delegate
-                        ; participated }) =
+    Poly.({ public_key
+          ; balance
+          ; nonce
+          ; receipt_chain_hash
+          ; delegate
+          ; participated }) =
   let%map public_key = Public_key.Compressed.var_to_triples public_key
   and receipt_chain_hash = Receipt.Chain_hash.var_to_triples receipt_chain_hash
   and delegate = Public_key.Compressed.var_to_triples delegate in
@@ -201,7 +215,7 @@ let crypto_hash_prefix = Hash_prefix.account
 let crypto_hash t = Pedersen.hash_fold crypto_hash_prefix (fold t)
 
 let empty =
-  Poly.Stable.Latest.
+  Poly.
     { public_key= Public_key.Compressed.empty
     ; balance= Balance.zero
     ; nonce= Nonce.zero
@@ -212,7 +226,7 @@ let empty =
 let digest t = Pedersen.State.digest (crypto_hash t)
 
 let create public_key balance =
-  Poly.Stable.Latest.
+  Poly.
     { public_key
     ; balance
     ; nonce= Nonce.zero

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -37,14 +37,26 @@ end
 
 module Nonce = Account_nonce
 
-type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'bool) t_ =
-  { public_key: 'pk
-  ; balance: 'amount
-  ; nonce: 'nonce
-  ; receipt_chain_hash: 'receipt_chain_hash
-  ; delegate: 'pk
-  ; participated: 'bool }
-[@@deriving fields, sexp, bin_io, eq, compare, hash, yojson]
+module Poly = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'bool) t =
+          { public_key: 'pk
+          ; balance: 'amount
+          ; nonce: 'nonce
+          ; receipt_chain_hash: 'receipt_chain_hash
+          ; delegate: 'pk
+          ; participated: 'bool }
+        [@@deriving sexp, bin_io, eq, compare, hash, yojson, version]
+      end
+
+      include T
+    end
+
+    module Latest = V1
+  end
+end
 
 module Stable = struct
   module V1 = struct
@@ -53,19 +65,18 @@ module Stable = struct
       [@@deriving sexp, bin_io, eq, hash, compare, yojson]
 
       type t =
-        ( key
+        ( Public_key.Compressed.Stable.V1.t
         , Balance.Stable.V1.t
         , Nonce.Stable.V1.t
         , Receipt.Chain_hash.Stable.V1.t
         , bool )
-        t_
-      [@@deriving sexp, bin_io, eq, hash, compare, yojson, version {asserted}]
+        Poly.Stable.V1.t
+      [@@deriving sexp, bin_io, eq, hash, compare, yojson, version]
     end
 
     include T
     include Registration.Make_latest_version (T)
 
-    (* monomorphize field selector *)
     let public_key (t : t) : key = t.public_key
   end
 
@@ -83,8 +94,10 @@ module Stable = struct
   module Registered_V1 = Registrar.Register (V1)
 end
 
-(* DO NOT ADD bin_io to the list of deriving *)
+(* bin_io, version omitted *)
 type t = Stable.Latest.t [@@deriving sexp, eq, hash, compare]
+
+let public_key = Stable.Latest.(public_key)
 
 type key = Stable.Latest.key
 
@@ -94,10 +107,15 @@ type var =
   , Nonce.Unpacked.var
   , Receipt.Chain_hash.var
   , Boolean.var )
-  t_
+  Poly.Stable.Latest.t
 
 type value =
-  (Public_key.Compressed.t, Balance.t, Nonce.t, Receipt.Chain_hash.t, bool) t_
+  ( Public_key.Compressed.t
+  , Balance.t
+  , Nonce.t
+  , Receipt.Chain_hash.t
+  , bool )
+  Poly.Stable.Latest.t
 [@@deriving sexp]
 
 let key_gen = Public_key.Compressed.gen
@@ -123,15 +141,20 @@ let typ : (var, value) Typ.t =
   let of_hlist
         : 'a 'b 'c 'd 'e.    ( unit
                              , 'a -> 'b -> 'c -> 'd -> 'a -> 'e -> unit )
-                             H_list.t -> ('a, 'b, 'c, 'd, 'e) t_ =
+                             H_list.t
+          -> ('a, 'b, 'c, 'd, 'e) Poly.Stable.Latest.t =
     let open H_list in
     fun [public_key; balance; nonce; receipt_chain_hash; delegate; participated]
         ->
       {public_key; balance; nonce; receipt_chain_hash; delegate; participated}
   in
   let to_hlist
-      {public_key; balance; nonce; receipt_chain_hash; delegate; participated}
-      =
+      Poly.Stable.Latest.({ public_key
+                          ; balance
+                          ; nonce
+                          ; receipt_chain_hash
+                          ; delegate
+                          ; participated }) =
     H_list.
       [public_key; balance; nonce; receipt_chain_hash; delegate; participated]
   in
@@ -141,7 +164,7 @@ let typ : (var, value) Typ.t =
 let var_of_t
     ({public_key; balance; nonce; receipt_chain_hash; delegate; participated} :
       value) =
-  { public_key= Public_key.Compressed.var_of_t public_key
+  { Poly.Stable.Latest.public_key= Public_key.Compressed.var_of_t public_key
   ; balance= Balance.var_of_t balance
   ; nonce= Nonce.Unpacked.var_of_value nonce
   ; receipt_chain_hash= Receipt.Chain_hash.var_of_t receipt_chain_hash
@@ -149,7 +172,12 @@ let var_of_t
   ; participated= Boolean.var_of_value participated }
 
 let var_to_triples
-    {public_key; balance; nonce; receipt_chain_hash; delegate; participated} =
+    Poly.Stable.Latest.({ public_key
+                        ; balance
+                        ; nonce
+                        ; receipt_chain_hash
+                        ; delegate
+                        ; participated }) =
   let%map public_key = Public_key.Compressed.var_to_triples public_key
   and receipt_chain_hash = Receipt.Chain_hash.var_to_triples receipt_chain_hash
   and delegate = Public_key.Compressed.var_to_triples delegate in
@@ -173,22 +201,24 @@ let crypto_hash_prefix = Hash_prefix.account
 let crypto_hash t = Pedersen.hash_fold crypto_hash_prefix (fold t)
 
 let empty =
-  { public_key= Public_key.Compressed.empty
-  ; balance= Balance.zero
-  ; nonce= Nonce.zero
-  ; receipt_chain_hash= Receipt.Chain_hash.empty
-  ; delegate= Public_key.Compressed.empty
-  ; participated= false }
+  Poly.Stable.Latest.
+    { public_key= Public_key.Compressed.empty
+    ; balance= Balance.zero
+    ; nonce= Nonce.zero
+    ; receipt_chain_hash= Receipt.Chain_hash.empty
+    ; delegate= Public_key.Compressed.empty
+    ; participated= false }
 
 let digest t = Pedersen.State.digest (crypto_hash t)
 
 let create public_key balance =
-  { public_key
-  ; balance
-  ; nonce= Nonce.zero
-  ; receipt_chain_hash= Receipt.Chain_hash.empty
-  ; delegate= public_key
-  ; participated= false }
+  Poly.Stable.Latest.
+    { public_key
+    ; balance
+    ; nonce= Nonce.zero
+    ; receipt_chain_hash= Receipt.Chain_hash.empty
+    ; delegate= public_key
+    ; participated= false }
 
 let gen =
   let open Quickcheck.Let_syntax in

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -45,11 +45,9 @@ module Ledger_inner = struct
 
     let public_key = Account.public_key
 
-    let balance = Account.balance
+    let balance Account.Poly.Stable.Latest.({balance; _}) = balance
 
     let initialize = Account.initialize
-
-    let balance = Account.balance
   end
 
   module Inputs = struct

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -45,7 +45,7 @@ module Ledger_inner = struct
 
     let public_key = Account.public_key
 
-    let balance Account.Poly.Stable.Latest.({balance; _}) = balance
+    let balance Account.Poly.({balance; _}) = balance
 
     let initialize = Account.initialize
   end

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -104,7 +104,8 @@ let genesis_ledger_total_currency =
   Coda_base.Ledger.to_list Genesis_ledger.t
   |> List.fold_left ~init:Balance.zero ~f:(fun sum account ->
          Balance.add_amount sum
-           (Balance.to_amount @@ Coda_base.Account.balance account)
+           ( Balance.to_amount
+           @@ account.Coda_base.Account.Poly.Stable.Latest.balance )
          |> Option.value_exn ?here:None ?error:None
               ~message:"failed to calculate total currency in genesis ledger"
      )

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -104,8 +104,7 @@ let genesis_ledger_total_currency =
   Coda_base.Ledger.to_list Genesis_ledger.t
   |> List.fold_left ~init:Balance.zero ~f:(fun sum account ->
          Balance.add_amount sum
-           ( Balance.to_amount
-           @@ account.Coda_base.Account.Poly.Stable.Latest.balance )
+           (Balance.to_amount @@ account.Coda_base.Account.Poly.balance)
          |> Option.value_exn ?here:None ?error:None
               ~message:"failed to calculate total currency in genesis ledger"
      )

--- a/src/lib/genesis_ledger/functor.ml
+++ b/src/lib/genesis_ledger/functor.ml
@@ -17,7 +17,6 @@ module Make_from_base (Base : Base_intf) : Intf.S = struct
   let t =
     let ledger = Ledger.create_ephemeral () in
     List.iter accounts ~f:(fun (_, account) ->
-        let open Account in
         Ledger.create_new_account_exn ledger account.public_key account ) ;
     ledger
 
@@ -42,7 +41,7 @@ module Make_from_base (Base : Base_intf) : Intf.S = struct
     let private_key = Option.value_exn private_key ~message:sk_error_msg in
     let public_key =
       Option.value_exn
-        (Public_key.decompress account.public_key)
+        (Public_key.decompress account.Poly.Stable.Latest.public_key)
         ~message:pk_error_msg
     in
     {Keypair.public_key; private_key}
@@ -54,7 +53,7 @@ module Make_from_base (Base : Base_intf) : Intf.S = struct
     in
     Memo.unit (fun () ->
         List.max_elt accounts ~compare:(fun (_, a) (_, b) ->
-            Balance.compare (Account.balance a) (Account.balance b) )
+            Balance.compare a.balance b.balance )
         |> Option.value_exn ?here:None ?error:None ~message:error_msg )
 
   let largest_account_keypair_exn =

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -21,9 +21,9 @@ module Account = struct
 
   let create = Coda_base.Account.create
 
-  let balance = Coda_base.Account.balance
+  let balance Coda_base.Account.Poly.({balance; _}) = balance
 
-  let update_balance t bal = {t with Coda_base.Account.balance= bal}
+  let update_balance t bal = {t with Coda_base.Account.Poly.balance= bal}
 end
 
 (* below are alternative modules that use strings as public keys and UInt64 as balances for

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -409,7 +409,7 @@ module Base = struct
              let%map balance =
                Balance.Checked.add_signed_amount account.balance sender_delta
              in
-             { Account.balance
+             { Account.Poly.Stable.Latest.balance
              ; public_key= sender_compressed
              ; nonce= next_nonce
              ; receipt_chain_hash

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -409,7 +409,7 @@ module Base = struct
              let%map balance =
                Balance.Checked.add_signed_amount account.balance sender_delta
              in
-             { Account.Poly.Stable.Latest.balance
+             { Account.Poly.balance
              ; public_key= sender_compressed
              ; nonce= next_nonce
              ; receipt_chain_hash

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -166,12 +166,12 @@ struct
         let%bind receiver_pk = List.random_element public_keys in
         let send_amount = Currency.Amount.of_int 1 in
         let sender_account_amount =
-          Account.balance sender_account |> Currency.Balance.to_amount
+          sender_account.Account.Poly.balance |> Currency.Balance.to_amount
         in
         let%map _ = Currency.Amount.sub sender_account_amount send_amount in
         let payload : User_command.Payload.t =
           User_command.Payload.create ~fee:Fee.Unsigned.zero
-            ~nonce:(Account.nonce sender_account)
+            ~nonce:sender_account.Account.Poly.nonce
             ~memo:User_command_memo.dummy
             ~body:(Payment {receiver= receiver_pk; amount= send_amount})
         in
@@ -404,7 +404,7 @@ struct
             ~root_staged_ledger
             ~consensus_local_state:
               (Consensus.Local_state.create
-                 (Some proposer_account.Account.public_key))
+                 (Some (Account.public_key proposer_account)))
         in
         frontier
     | Error err -> Error.raise err


### PR DESCRIPTION
In `Account`, remove the `asserted` from `deriving version`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
