### PR TITLE
Use Poly.t not Poly.Stable.Latest.t

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -759,7 +759,7 @@ struct
                 let%map x = Bignum_bigint.(gen_incl zero (Field.size - one))
                 and is_odd = Bool.gen in
                 let x = Bigint.(to_field (of_bignum_bigint x)) in
-                {Public_key.Compressed.Poly.Stable.Latest.x; is_odd}
+                {Public_key.Compressed.Poly.x; is_odd}
               in
               Quickcheck.Generator.map2 Fee.Unsigned.gen pk
                 ~f:(fun fee prover -> {fee; prover} )

--- a/src/lib/coda_base/payment_payload.ml
+++ b/src/lib/coda_base/payment_payload.ml
@@ -19,6 +19,10 @@ module Poly = struct
 
     module Latest = V1
   end
+
+  type ('pk, 'amount) t = ('pk, 'amount) Stable.Latest.t =
+    {receiver: 'pk; amount: 'amount}
+  [@@deriving eq, sexp, hash, yojson, compare]
 end
 
 module Stable = struct
@@ -50,37 +54,31 @@ end
 (* bin_io, version omitted *)
 type t = Stable.Latest.t [@@deriving eq, sexp, hash, yojson]
 
-let dummy =
-  Poly.Stable.Latest.
-    {receiver= Public_key.Compressed.empty; amount= Amount.zero}
+let dummy = Poly.{receiver= Public_key.Compressed.empty; amount= Amount.zero}
 
-type var = (Public_key.Compressed.var, Amount.var) Poly.Stable.Latest.t
+type var = (Public_key.Compressed.var, Amount.var) Poly.t
 
 let typ : (var, t) Typ.t =
   let spec =
     let open Data_spec in
     [Public_key.Compressed.typ; Amount.typ]
   in
-  let of_hlist
-        : 'a 'b.    (unit, 'a -> 'b -> unit) H_list.t
-          -> ('a, 'b) Poly.Stable.Latest.t =
+  let of_hlist : 'a 'b. (unit, 'a -> 'b -> unit) H_list.t -> ('a, 'b) Poly.t =
     let open H_list in
     fun [receiver; amount] -> {receiver; amount}
   in
-  let to_hlist Poly.Stable.Latest.({receiver; amount}) =
-    H_list.[receiver; amount]
-  in
+  let to_hlist Poly.({receiver; amount}) = H_list.[receiver; amount] in
   Typ.of_hlistable spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
     ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
 
-let fold Poly.Stable.Latest.({receiver; amount}) =
+let fold Poly.({receiver; amount}) =
   let open Fold in
   Public_key.Compressed.fold receiver +> Amount.fold amount
 
 (* TODO: This could be a bit more efficient by packing across triples,
    but I think the added confusion-possibility
    is not worth it. *)
-let%snarkydef var_to_triples Poly.Stable.Latest.({receiver; amount}) =
+let%snarkydef var_to_triples Poly.({receiver; amount}) =
   let%map receiver = Public_key.Compressed.var_to_triples receiver in
   let amount = Amount.var_to_triples amount in
   receiver @ amount
@@ -94,15 +92,15 @@ let gen ~max_amount =
   let open Quickcheck.Generator.Let_syntax in
   let%map receiver = Public_key.Compressed.gen
   and amount = Amount.gen_incl Amount.zero max_amount in
-  Poly.Stable.Latest.{receiver; amount}
+  Poly.{receiver; amount}
 
 let%test_unit "to_bits" =
   let open Test_util in
   with_randomness 123456789 (fun () ->
       let input =
-        Poly.Stable.Latest.
+        Poly.
           { receiver=
-              { Public_key.Compressed.Poly.Stable.Latest.x= Field.random ()
+              { Public_key.Compressed.Poly.x= Field.random ()
               ; is_odd= Random.bool () }
           ; amount= Amount.of_int (Random.int Int.max_value) }
       in

--- a/src/lib/coda_base/payment_payload.mli
+++ b/src/lib/coda_base/payment_payload.mli
@@ -5,14 +5,19 @@ open Snark_params.Tick
 open Import
 
 module Poly : sig
-  module Stable : sig
-    module V1 : sig
-      type nonrec ('pk, 'amount) t = {receiver: 'pk; amount: 'amount}
-      [@@deriving bin_io, eq, sexp, hash, yojson, version]
-    end
+  type ('pk, 'amount) t = {receiver: 'pk; amount: 'amount}
+  [@@deriving eq, sexp, hash, yojson]
 
-    module Latest = V1
-  end
+  module Stable :
+    sig
+      module V1 : sig
+        type nonrec ('pk, 'amount) t
+        [@@deriving bin_io, eq, sexp, hash, yojson, version]
+      end
+
+      module Latest = V1
+    end
+    with type ('pk, 'amount) V1.t = ('pk, 'amount) t
 end
 
 module Stable : sig
@@ -33,8 +38,7 @@ val dummy : t
 
 val gen : max_amount:Currency.Amount.t -> t Quickcheck.Generator.t
 
-type var =
-  (Public_key.Compressed.var, Currency.Amount.var) Poly.Stable.Latest.t
+type var = (Public_key.Compressed.var, Currency.Amount.var) Poly.t
 
 val length_in_triples : int
 

--- a/src/lib/coda_base/staged_ledger_hash.ml
+++ b/src/lib/coda_base/staged_ledger_hash.ml
@@ -197,6 +197,13 @@ module Stable = struct
 
       module Latest = V1
     end
+
+    type ('non_snark, 'pending_coinbase_hash) t =
+                                                 ( 'non_snark
+                                                 , 'pending_coinbase_hash )
+                                                 Stable.Latest.t =
+      {non_snark: 'non_snark; pending_coinbase_hash: 'pending_coinbase_hash}
+    [@@deriving sexp, eq, compare, hash, yojson]
   end
 
   module V1 = struct
@@ -233,7 +240,7 @@ end
 (* bin_io, version omitted *)
 type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash, yojson]
 
-type ('a, 'b) t_ = ('a, 'b) Stable.Poly.Stable.Latest.t
+type ('a, 'b) t_ = ('a, 'b) Stable.Poly.t
 
 type value = t [@@deriving sexp, eq, compare, hash]
 

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -472,7 +472,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           { Undo.User_command_undo.common
           ; body= Stake_delegation {previous_delegate= sender_account.delegate}
           }
-    | Payment Payment_payload.Poly.Stable.Latest.({amount; receiver}) ->
+    | Payment Payment_payload.Poly.({amount; receiver}) ->
         let%bind sender_balance' = sub_amount sender_account.balance amount in
         let undo emptys : Undo.User_command_undo.t =
           {common; body= Payment {previous_empty_accounts= emptys}}

--- a/src/lib/coda_base/transaction_union_payload.ml
+++ b/src/lib/coda_base/transaction_union_payload.ml
@@ -81,18 +81,13 @@ module Body = struct
   end
 end
 
-type t =
-  ( User_command_payload.Common.t
-  , Body.t )
-  User_command_payload.Poly.Stable.Latest.t
+type t = (User_command_payload.Common.t, Body.t) User_command_payload.Poly.t
 [@@deriving sexp]
 
 type payload = t [@@deriving sexp]
 
 type var =
-  ( User_command_payload.Common.var
-  , Body.var )
-  User_command_payload.Poly.Stable.Latest.t
+  (User_command_payload.Common.var, Body.var) User_command_payload.Poly.t
 
 type payload_var = var
 
@@ -100,15 +95,13 @@ let gen =
   let open Quickcheck.Generator.Let_syntax in
   let%bind common = User_command_payload.Common.gen in
   let%map body = Body.gen ~fee:common.fee in
-  User_command_payload.Poly.Stable.Latest.{common; body}
+  User_command_payload.Poly.{common; body}
 
-let to_hlist
-    ({common; body} : (_, _) User_command_payload.Poly.Stable.Latest.t) =
+let to_hlist ({common; body} : (_, _) User_command_payload.Poly.t) =
   H_list.[common; body]
 
 let of_hlist : type c v.
-       (unit, c -> v -> unit) H_list.t
-    -> (c, v) User_command_payload.Poly.Stable.Latest.t =
+    (unit, c -> v -> unit) H_list.t -> (c, v) User_command_payload.Poly.t =
  fun H_list.([common; body]) -> {common; body}
 
 let typ : (var, t) Typ.t =

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -24,6 +24,14 @@ module Poly = struct
 
     module Latest = V1
   end
+
+  type ('payload, 'pk, 'signature) t =
+                                      ( 'payload
+                                      , 'pk
+                                      , 'signature )
+                                      Stable.Latest.t =
+    {payload: 'payload; sender: 'pk; signature: 'signature}
+  [@@deriving eq, sexp, hash, yojson]
 end
 
 module Stable = struct
@@ -80,11 +88,11 @@ include Comparable.Make (Stable.Latest)
 
 type value = t
 
-let payload Poly.Stable.Latest.({payload; _}) = payload
+let payload Poly.({payload; _}) = payload
 
 let fee = Fn.compose Payload.fee payload
 
-let sender t = Public_key.compress Poly.Stable.Latest.(t.sender)
+let sender t = Public_key.compress Poly.(t.sender)
 
 let accounts_accessed ({payload; sender; _} : value) =
   Public_key.compress sender :: Payload.accounts_accessed payload

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -19,6 +19,10 @@ module Common = struct
 
       module Latest = V1
     end
+
+    type ('fee, 'nonce, 'memo) t = ('fee, 'nonce, 'memo) Stable.Latest.t =
+      {fee: 'fee; nonce: 'nonce; memo: 'memo}
+    [@@deriving eq, sexp, hash, yojson]
   end
 
   module Stable = struct
@@ -66,20 +70,16 @@ module Common = struct
       String.gen_with_length Memo.max_size_in_bytes Char.gen
       >>| Memo.create_exn
     in
-    Poly.Stable.Latest.{fee; nonce; memo}
+    Poly.{fee; nonce; memo}
 
   type var =
-    ( Currency.Fee.var
-    , Account_nonce.Unpacked.var
-    , Memo.Checked.t )
-    Poly.Stable.Latest.t
+    (Currency.Fee.var, Account_nonce.Unpacked.var, Memo.Checked.t) Poly.t
 
-  let to_hlist Poly.Stable.Latest.({fee; nonce; memo}) =
-    H_list.[fee; nonce; memo]
+  let to_hlist Poly.({fee; nonce; memo}) = H_list.[fee; nonce; memo]
 
   let of_hlist : type fee nonce memo.
          (unit, fee -> nonce -> memo -> unit) H_list.t
-      -> (fee, nonce, memo) Poly.Stable.Latest.t =
+      -> (fee, nonce, memo) Poly.t =
    fun H_list.([fee; nonce; memo]) -> {fee; nonce; memo}
 
   let typ =
@@ -173,6 +173,10 @@ module Poly = struct
 
     module Latest = V1
   end
+
+  type ('common, 'body) t = ('common, 'body) Stable.Latest.t =
+    {common: 'common; body: 'body}
+  [@@deriving eq, sexp, hash, yojson, compare]
 end
 
 module Stable = struct
@@ -233,4 +237,4 @@ let gen =
     |> Option.value_exn ?here:None ?error:None ?message:None
   in
   let%map body = Body.gen ~max_amount in
-  Poly.Stable.Latest.{common; body}
+  Poly.{common; body}

--- a/src/lib/coda_base/user_command_payload.mli
+++ b/src/lib/coda_base/user_command_payload.mli
@@ -21,14 +21,19 @@ end
 
 module Common : sig
   module Poly : sig
-    module Stable : sig
-      module V1 : sig
-        type ('fee, 'nonce, 'memo) t = {fee: 'fee; nonce: 'nonce; memo: 'memo}
-        [@@deriving bin_io, eq, sexp, hash, yojson, version]
-      end
+    type ('fee, 'nonce, 'memo) t = {fee: 'fee; nonce: 'nonce; memo: 'memo}
+    [@@deriving eq, sexp, hash, yojson]
 
-      module Latest = V1
-    end
+    module Stable :
+      sig
+        module V1 : sig
+          type ('fee, 'nonce, 'memo) t
+          [@@deriving bin_io, eq, sexp, hash, yojson, version]
+        end
+
+        module Latest = V1
+      end
+      with type ('fee, 'nonce, 'memo) V1.t = ('fee, 'nonce, 'memo) t
   end
 
   module Stable : sig
@@ -52,7 +57,7 @@ module Common : sig
     ( Currency.Fee.var
     , Coda_numbers.Account_nonce.Unpacked.var
     , User_command_memo.Checked.t )
-    Poly.Stable.Latest.t
+    Poly.t
 
   val typ : (var, t) Typ.t
 
@@ -66,14 +71,19 @@ module Common : sig
 end
 
 module Poly : sig
-  module Stable : sig
-    module V1 : sig
-      type ('common, 'body) t = {common: 'common; body: 'body}
-      [@@deriving bin_io, eq, sexp, hash, yojson, compare, version]
-    end
+  type ('common, 'body) t = {common: 'common; body: 'body}
+  [@@deriving eq, sexp, hash, yojson, compare]
 
-    module Latest = V1
-  end
+  module Stable :
+    sig
+      module V1 : sig
+        type ('common, 'body) t
+        [@@deriving bin_io, eq, sexp, hash, yojson, compare, version]
+      end
+
+      module Latest = V1
+    end
+    with type ('common, 'body) V1.t = ('common, 'body) t
 end
 
 module Stable : sig

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -83,13 +83,17 @@ module type Signed_intf = sig
   type magnitude_var
 
   module Poly : sig
-    module Stable : sig
-      module V1 : sig
-        type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
-      end
+    type ('magnitude, 'sgn) t
 
-      module Latest = V1
-    end
+    module Stable :
+      sig
+        module V1 : sig
+          type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
+        end
+
+        module Latest = V1
+      end
+      with type ('magnitude, 'sgn) V1.t = ('magnitude, 'sgn) t
   end
 
   module Stable : sig
@@ -107,14 +111,13 @@ module type Signed_intf = sig
 
   val length_in_triples : int
 
-  val create :
-    magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) Poly.Stable.Latest.t
+  val create : magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) Poly.t
 
   val sgn : t -> Sgn.t
 
   val magnitude : t -> magnitude
 
-  type var = (magnitude_var, Sgn.var) Poly.Stable.Latest.t
+  type var = (magnitude_var, Sgn.var) Poly.t
 
   val typ : (var, t) Typ.t
 
@@ -149,8 +152,7 @@ module type Signed_intf = sig
 
     val cswap :
          Boolean.var
-      -> (magnitude_var, Sgn.t) Poly.Stable.Latest.t
-         * (magnitude_var, Sgn.t) Poly.Stable.Latest.t
+      -> (magnitude_var, Sgn.t) Poly.t * (magnitude_var, Sgn.t) Poly.t
       -> (var * var, _) Checked.t
   end
 end
@@ -352,6 +354,9 @@ end = struct
 
         module Latest = V1
       end
+
+      type ('magnitude, 'sgn) t = ('magnitude, 'sgn) Stable.Latest.t =
+        {magnitude: 'magnitude; sgn: 'sgn}
     end
 
     module Stable_outer = Stable
@@ -380,16 +385,16 @@ end = struct
     end
 
     (* bin_io, version omitted *)
-    type t = (Stable_outer.V1.t, Sgn.Stable.V1.t) Poly.Stable.Latest.t
+    type t = (Stable_outer.V1.t, Sgn.Stable.V1.t) Poly.Stable.V1.t
     [@@deriving sexp, hash, compare, eq, yojson]
 
     (* = Stable.Latest.t *)
 
-    let create ~magnitude ~sgn = Poly.Stable.V1.{magnitude; sgn}
+    let create ~magnitude ~sgn = Poly.{magnitude; sgn}
 
-    let sgn Poly.Stable.Latest.({sgn; _}) = sgn
+    let sgn Poly.({sgn; _}) = sgn
 
-    let magnitude Poly.Stable.Latest.({magnitude; _}) = magnitude
+    let magnitude Poly.({magnitude; _}) = magnitude
 
     let zero = create ~magnitude:zero ~sgn:Sgn.Pos
 
@@ -397,19 +402,17 @@ end = struct
       Quickcheck.Generator.map2 gen Sgn.gen ~f:(fun magnitude sgn ->
           create ~magnitude ~sgn )
 
-    type nonrec var = (var, Sgn.var) Poly.Stable.Latest.t
+    type nonrec var = (var, Sgn.var) Poly.t
 
     let length_in_bits = Int.( + ) length_in_bits 1
 
     let length_in_triples = Int.((length_in_bits + 2) / 3)
 
-    let of_hlist :
-           (unit, 'a -> 'b -> unit) Snarky.H_list.t
-        -> ('a, 'b) Poly.Stable.Latest.t =
+    let of_hlist : (unit, 'a -> 'b -> unit) Snarky.H_list.t -> ('a, 'b) Poly.t
+        =
       Snarky.H_list.(fun [magnitude; sgn] -> {magnitude; sgn})
 
-    let to_hlist Poly.Stable.Latest.({magnitude; sgn}) =
-      Snarky.H_list.[magnitude; sgn]
+    let to_hlist Poly.({magnitude; sgn}) = Snarky.H_list.[magnitude; sgn]
 
     let typ =
       Typ.of_hlistable
@@ -447,22 +450,20 @@ end = struct
                 ~magnitude:Unsigned.Infix.(x.magnitude - y.magnitude)
             else zero )
 
-    let negate t = Poly.Stable.Latest.{t with sgn= Sgn.negate t.sgn}
+    let negate t = Poly.{t with sgn= Sgn.negate t.sgn}
 
     let of_unsigned magnitude = create ~magnitude ~sgn:Sgn.Pos
 
     let ( + ) = add
 
     module Checked = struct
-      let to_bits Poly.Stable.Latest.({magnitude; sgn}) =
+      let to_bits Poly.({magnitude; sgn}) =
         (var_to_bits magnitude :> Boolean.var list) @ [Sgn.Checked.is_pos sgn]
 
-      let constant Poly.Stable.Latest.({magnitude; sgn}) =
-        Poly.Stable.Latest.
-          {magnitude= var_of_t magnitude; sgn= Sgn.Checked.constant sgn}
+      let constant Poly.({magnitude; sgn}) =
+        Poly.{magnitude= var_of_t magnitude; sgn= Sgn.Checked.constant sgn}
 
-      let of_unsigned magnitude =
-        Poly.Stable.Latest.{magnitude; sgn= Sgn.Checked.pos}
+      let of_unsigned magnitude = Poly.{magnitude; sgn= Sgn.Checked.pos}
 
       let if_ cond ~then_ ~else_ =
         Poly.Stable.Latest.(
@@ -492,7 +493,7 @@ end = struct
           Tick.Field.Checked.mul (sgn :> Field.Var.t) (Field.Var.add xv yv)
         in
         let%map magnitude = unpack_var res in
-        Poly.Stable.Latest.{magnitude; sgn}
+        Poly.{magnitude; sgn}
 
       let ( + ) = add
 
@@ -506,7 +507,7 @@ end = struct
 
       let cswap b (x, y) =
         let l_sgn, r_sgn =
-          match Poly.Stable.Latest.(x.sgn, y.sgn) with
+          match Poly.(x.sgn, y.sgn) with
           | Sgn.Pos, Sgn.Pos -> Sgn.Checked.(pos, pos)
           | Neg, Neg -> Sgn.Checked.(neg, neg)
           | Pos, Neg -> (Sgn.Checked.neg_if_true b, Sgn.Checked.pos_if_true b)
@@ -519,8 +520,7 @@ end = struct
           let%map l = unpack_var l and r = unpack_var r in
           (l, r)
         in
-        Poly.Stable.Latest.
-          ({sgn= l_sgn; magnitude= l_mag}, {sgn= r_sgn; magnitude= r_mag})
+        Poly.({sgn= l_sgn; magnitude= l_mag}, {sgn= r_sgn; magnitude= r_mag})
     end
   end
 

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -107,13 +107,17 @@ module type Signed_intf = sig
   type magnitude_var
 
   module Poly : sig
-    module Stable : sig
-      module V1 : sig
-        type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
-      end
+    type ('magnitude, 'sgn) t
 
-      module Latest = V1
-    end
+    module Stable :
+      sig
+        module V1 : sig
+          type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
+        end
+
+        module Latest = V1
+      end
+      with type ('magnitude, 'sgn) V1.t = ('magnitude, 'sgn) t
   end
 
   module Stable : sig
@@ -131,14 +135,13 @@ module type Signed_intf = sig
 
   val length_in_triples : int
 
-  val create :
-    magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) Poly.Stable.Latest.t
+  val create : magnitude:'magnitude -> sgn:'sgn -> ('magnitude, 'sgn) Poly.t
 
   val sgn : t -> Sgn.t
 
   val magnitude : t -> magnitude
 
-  type var = (magnitude_var, Sgn.var) Poly.Stable.Latest.t
+  type var = (magnitude_var, Sgn.var) Poly.t
 
   val typ : (var, t) Typ.t
 
@@ -173,8 +176,7 @@ module type Signed_intf = sig
 
     val cswap :
          Boolean.var
-      -> (magnitude_var, Sgn.t) Poly.Stable.Latest.t
-         * (magnitude_var, Sgn.t) Poly.Stable.Latest.t
+      -> (magnitude_var, Sgn.t) Poly.t * (magnitude_var, Sgn.t) Poly.t
       -> (var * var, _) Checked.t
   end
 end

--- a/src/lib/lite_base/lite_chain.ml
+++ b/src/lib/lite_base/lite_chain.ml
@@ -6,5 +6,5 @@ type t =
       ( Pedersen.Digest.t
       , Public_key.Compressed.Stable.V1.t
       , Account.Stable.V1.t )
-      Sparse_ledger_lib.Sparse_ledger.Poly.Stable.Latest.t }
+      Sparse_ledger_lib.Sparse_ledger.Poly.Stable.V1.t }
 [@@deriving bin_io, sexp]

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -101,6 +101,10 @@ module Compressed = struct
 
       module Latest = V1
     end
+
+    type ('field, 'boolean) t = ('field, 'boolean) Stable.Latest.t =
+      {x: 'field; is_odd: 'boolean}
+    [@@deriving sexp, compare, eq, hash]
   end
 
   module Stable = struct
@@ -128,8 +132,7 @@ module Compressed = struct
   end
 
   (* bin_io omitted *)
-  type t = (Field.t, bool) Poly.Stable.Latest.t
-  [@@deriving sexp, compare, hash]
+  type t = (Field.t, bool) Poly.t [@@deriving sexp, compare, hash]
 
   include Comparable.Make_binable (Stable.Latest)
   include Hashable.Make_binable (Stable.Latest)
@@ -139,24 +142,22 @@ module Compressed = struct
 
   let to_string = to_base64
 
-  let empty = Poly.Stable.Latest.{x= Field.zero; is_odd= false}
+  let empty = Poly.{x= Field.zero; is_odd= false}
 
   let gen =
     let open Quickcheck.Generator.Let_syntax in
     let%map x = Field.gen and is_odd = Bool.gen in
-    Poly.Stable.Latest.{x; is_odd}
+    Poly.{x; is_odd}
 
   let bit_length_to_triple_length n = (n + 2) / 3
 
   let length_in_triples = bit_length_to_triple_length (1 + Field.size_in_bits)
 
-  type var = (Field.Var.t, Boolean.var) Poly.Stable.Latest.t
+  type var = (Field.Var.t, Boolean.var) Poly.t
 
   let to_hlist Poly.Stable.Latest.({x; is_odd}) = Snarky.H_list.[x; is_odd]
 
-  let of_hlist :
-      (unit, 'a -> 'b -> unit) Snarky.H_list.t -> ('a, 'b) Poly.Stable.Latest.t
-      =
+  let of_hlist : (unit, 'a -> 'b -> unit) Snarky.H_list.t -> ('a, 'b) Poly.t =
     Snarky.H_list.(fun [x; is_odd] -> {x; is_odd})
 
   let typ : (var, t) Typ.t =
@@ -173,7 +174,7 @@ module Compressed = struct
     and () = Boolean.Assert.(t1.is_odd = t2.is_odd) in
     ()
 
-  let fold_bits Poly.Stable.Latest.({is_odd; x}) =
+  let fold_bits Poly.({is_odd; x}) =
     {Fold.fold= (fun ~init ~f -> f ((Field.Bits.fold x).fold ~init ~f) is_odd)}
 
   let fold t = Fold.group3 ~default:false (fold_bits t)
@@ -190,24 +191,18 @@ module Compressed = struct
 
   module Checked = struct
     let equal t1 t2 =
-      let%bind x_eq =
-        Field.Checked.equal t1.Poly.Stable.Latest.x t2.Poly.Stable.Latest.x
-      in
+      let%bind x_eq = Field.Checked.equal t1.Poly.x t2.Poly.x in
       let%bind odd_eq = Boolean.equal t1.is_odd t2.is_odd in
       Boolean.(x_eq && odd_eq)
 
     let if_ cond ~then_:t1 ~else_:t2 =
-      let%map x =
-        Field.Checked.if_ cond ~then_:t1.Poly.Stable.Latest.x
-          ~else_:t2.Poly.Stable.Latest.x
+      let%map x = Field.Checked.if_ cond ~then_:t1.Poly.x ~else_:t2.Poly.x
       and is_odd = Boolean.if_ cond ~then_:t1.is_odd ~else_:t2.is_odd in
-      Poly.Stable.Latest.{x; is_odd}
+      Poly.{x; is_odd}
 
     module Assert = struct
       let equal t1 t2 =
-        let%map () =
-          Field.Checked.Assert.equal t1.Poly.Stable.Latest.x
-            t2.Poly.Stable.Latest.x
+        let%map () = Field.Checked.Assert.equal t1.Poly.x t2.Poly.x
         and () = Boolean.Assert.(t1.is_odd = t2.is_odd) in
         ()
     end
@@ -244,7 +239,7 @@ let compress : t -> Compressed.t = Compressed.compress
 
 let%snarkydef compress_var ((x, y) : var) : (Compressed.var, _) Checked.t =
   let%map is_odd = parity_var y in
-  {Compressed.Poly.Stable.Latest.x; is_odd}
+  {Compressed.Poly.x; is_odd}
 
 let of_bigstring, to_bigstring = Stable.Latest.(of_bigstring, to_bigstring)
 

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -29,16 +29,20 @@ val of_private_key_exn : Private_key.t -> t
 
 module Compressed : sig
   module Poly : sig
-    module Stable : sig
-      module V1 : sig
-        type ('field, 'boolean) t = {x: 'field; is_odd: 'boolean}
-      end
+    type ('field, 'boolean) t = {x: 'field; is_odd: 'boolean}
 
-      module Latest = V1
-    end
+    module Stable :
+      sig
+        module V1 : sig
+          type ('field, 'boolean) t
+        end
+
+        module Latest = V1
+      end
+      with type ('field, 'boolean) V1.t = ('field, 'boolean) t
   end
 
-  type t = (Field.t, bool) Poly.Stable.Latest.t [@@deriving sexp, hash]
+  type t = (Field.t, bool) Poly.t [@@deriving sexp, hash]
 
   include Codable.S with type t := t
 
@@ -58,7 +62,7 @@ module Compressed : sig
 
   val length_in_triples : int
 
-  type var = (Field.Var.t, Boolean.var) Poly.Stable.Latest.t
+  type var = (Field.Var.t, Boolean.var) Poly.t
 
   val typ : (var, t) Typ.t
 

--- a/src/lib/snarky_blake2/snarky_blake2.ml
+++ b/src/lib/snarky_blake2/snarky_blake2.ml
@@ -157,8 +157,7 @@ module Make (Impl : Snarky.Snark_intf.S) : S with module Impl := Impl = struct
          personalization = personalization *)
       Array.map
         ~f:(Fn.compose UInt32.constant UInt32.Unchecked.of_int)
-        [| 0x6A09E667 lxor 0x01010000 (* depth = 1, fanout = 1 *)
-           lxor 32
+        [| 0x6A09E667 lxor 0x01010000 (* depth = 1, fanout = 1 *) lxor 32
            (* digest_length = 32 *)
          ; 0xBB67AE85
          ; 0x3C6EF372


### PR DESCRIPTION
In many places, we were using `Poly.Stable.Latest.t` where we can use `Poly.t`, because there's no `bin_io`. The code is less cluttered this way.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
