### PR TITLE
Remove asserted from External_transition deriving version

### DIFF
--- a/src/lib/coda_base/external_transition.ml
+++ b/src/lib/coda_base/external_transition.ml
@@ -123,7 +123,7 @@ end)
           { protocol_state: Protocol_state.Value.Stable.V1.t
           ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
           ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t }
-        [@@deriving sexp, fields, bin_io, version {asserted}]
+        [@@deriving sexp, fields, bin_io, version]
 
         let to_yojson
             {protocol_state; protocol_state_proof= _; staged_ledger_diff= _} =


### PR DESCRIPTION
Removed `asserted` from `deriving version` for `External_transition` functor result. It was no longer needed.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
