### PR TITLE
Version Prover_state

### DIFF
--- a/src/app/cli/src/prover.ml
+++ b/src/app/cli/src/prover.ml
@@ -191,7 +191,7 @@ module Functions = struct
         Blockchain.t
         * Consensus_mechanism.Protocol_state.Value.Stable.V1.t
         * Consensus_mechanism.Snark_transition.Value.Stable.V1.t
-        * Consensus_mechanism.Prover_state.t
+        * Consensus_mechanism.Prover_state.Stable.V1.t
         * Pending_coinbase_witness.t] Blockchain.bin_t
       (fun w
       ( ({Blockchain.state= prev_state; proof= prev_proof} as chain)

--- a/src/lib/coda_base/internal_transition.ml
+++ b/src/lib/coda_base/internal_transition.ml
@@ -15,7 +15,17 @@ module type S = sig
   end
 
   module Prover_state : sig
-    type t [@@deriving sexp, bin_io]
+    type t [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io, version]
+        end
+
+        module Latest : module type of V1
+      end
+      with type V1.t = t
   end
 
   module Snark_transition : Snark_transition.S
@@ -51,13 +61,23 @@ module Make (Staged_ledger_diff : sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving bin_io, sexp]
+        type t [@@deriving bin_io, sexp, version]
       end
     end
     with type V1.t = t
 end)
 (Snark_transition : Snark_transition.S) (Prover_state : sig
-    type t [@@deriving sexp, bin_io]
+    type t [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io, version]
+        end
+
+        module Latest : module type of V1
+      end
+      with type V1.t = t
 end) :
   S
   with module Staged_ledger_diff = Staged_ledger_diff
@@ -72,9 +92,9 @@ end) :
       module T = struct
         type t =
           { snark_transition: Snark_transition.Value.Stable.V1.t
-          ; prover_state: Prover_state.t
+          ; prover_state: Prover_state.Stable.V1.t
           ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t }
-        [@@deriving sexp, fields, bin_io, version {asserted}]
+        [@@deriving sexp, fields, bin_io, version]
       end
 
       include T
@@ -96,7 +116,7 @@ end) :
   (* bin_io, version omitted *)
   type t = Stable.Latest.t =
     { snark_transition: Snark_transition.Value.Stable.V1.t
-    ; prover_state: Prover_state.t
+    ; prover_state: Prover_state.Stable.V1.t
     ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t }
   [@@deriving sexp, fields]
 

--- a/src/lib/coda_base/stake_proof.ml
+++ b/src/lib/coda_base/stake_proof.ml
@@ -1,8 +1,23 @@
 open Core
 
-(* TODO: version *)
-type t =
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      type t =
+        { delegator: Account.Index.t
+        ; ledger: Sparse_ledger.Stable.V1.t
+        ; private_key: Signature_lib.Private_key.t }
+      [@@deriving bin_io, sexp, version {asserted}]
+    end
+
+    include T
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t =
   { delegator: Account.Index.t
   ; ledger: Sparse_ledger.Stable.V1.t
   ; private_key: Signature_lib.Private_key.t }
-[@@deriving bin_io, sexp]
+[@@deriving sexp]

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -4,7 +4,17 @@ open Fold_lib
 open Coda_numbers
 
 module type Prover_state_intf = sig
-  type t [@@deriving bin_io, sexp]
+  type t [@@deriving sexp]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving bin_io, sexp, version]
+      end
+
+      module Latest : module type of V1
+    end
+    with type V1.t = t
 
   type pending_coinbase_witness
 

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -45,7 +45,19 @@ module Local_state = struct
 end
 
 module Prover_state = struct
-  include Unit
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = unit [@@deriving bin_io, sexp, version]
+      end
+
+      include T
+    end
+
+    module Latest = V1
+  end
+
+  type t = Stable.Latest.t [@@deriving sexp]
 
   let precomputed_handler =
     unstage

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -93,7 +93,7 @@ end
 module Proposal_data = struct
   (* TODO : version *)
   type t =
-    { stake_proof: Coda_base.Stake_proof.t
+    { stake_proof: Coda_base.Stake_proof.Stable.V1.t
     ; vrf_result: Random_oracle.Digest.Stable.V1.t }
   [@@deriving bin_io]
 

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -1495,7 +1495,17 @@ module type Consensus_mechanism_intf = sig
      and type consensus_state := Consensus_state.Value.t
 
   module Prover_state : sig
-    type t [@@deriving bin_io]
+    type t
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving bin_io]
+        end
+
+        module Latest : module type of V1
+      end
+      with type V1.t = t
   end
 
   module Proposal_data : sig


### PR DESCRIPTION
Version `Prover_state` for posig and postake. That allows removal of the `{asserted}` versioning of `Internal_transition`. Another `{asserted}` is added for `Stake_proof`, which is further down the tree of types.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
