### PR TITLE
Add for_test option to version ppx

### DIFF
--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -32,7 +32,9 @@
   The "asserted" option asserts that the type is versioned, to allow compilation
   to proceed. The types referred to in the type are not checked for versioning
   with this option. The type must be contained in the module hierarchy "Stable.Vn.T". 
-  Eventually, all uses of this option should be removed, except in test code.
+  Eventually, all uses of this option should be removed.
+
+  The "for_test" option is a synonym of "asserted" that can be used in test code.
 
   If "rpc" is true, again, the type must be named "query", "response", or "msg",
   and the type definition occurs in the hierarchy "Vn.T".
@@ -319,16 +321,20 @@ let validate_options valid options =
 
 let generate_let_bindings_for_type_decl_str ~options ~path type_decls =
   ignore
-    (validate_options ["wrapped"; "unnumbered"; "rpc"; "asserted"] options) ;
+    (validate_options
+       ["wrapped"; "unnumbered"; "rpc"; "asserted"; "for_test"]
+       options) ;
   let type_decl = get_type_decl_representative type_decls in
   let wrapped = check_for_option "wrapped" options in
   let unnumbered = check_for_option "unnumbered" options in
-  let asserted = check_for_option "asserted" options in
+  let asserted =
+    check_for_option "asserted" options || check_for_option "for_test" options
+  in
   let rpc = check_for_option "rpc" options in
   if asserted && (wrapped || rpc) then
     Ppx_deriving.raise_errorf ~loc:type_decl.ptype_loc
-      "Option \"asserted\" cannot be combined with \"wrapped\" or \"rpc\" \
-       options" ;
+      "Options \"asserted\" or \"for_test\" cannot be combined with \
+       \"wrapped\" or \"rpc\" options" ;
   let generation_kind =
     match (rpc, wrapped) with
     | true, false -> Rpc

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1971,7 +1971,7 @@ let%test_module "test" =
                 ; fee_excess: Fee.Signed.t
                 ; proof_type: [`Base | `Merge] }
               [@@deriving
-                sexp, bin_io, compare, hash, yojson, eq, version {asserted}]
+                sexp, bin_io, compare, hash, yojson, eq, version {for_test}]
             end
 
             include T
@@ -2077,7 +2077,7 @@ let%test_module "test" =
             module V1 = struct
               module T = struct
                 type t = transaction
-                [@@deriving sexp, bin_io, version {asserted}]
+                [@@deriving sexp, bin_io, version {for_test}]
               end
 
               include T
@@ -2355,7 +2355,7 @@ let%test_module "test" =
             module T = struct
               type t =
                 {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
-              [@@deriving sexp, bin_io, version {asserted}]
+              [@@deriving sexp, bin_io, version {for_test}]
             end
 
             include T
@@ -2434,7 +2434,7 @@ let%test_module "test" =
           module V1 = struct
             module T = struct
               type t = {ledger: Sparse_ledger.t}
-              [@@deriving bin_io, sexp, version {asserted}]
+              [@@deriving bin_io, sexp, version {for_test}]
             end
 
             include T


### PR DESCRIPTION
We want to get rid of the `asserted` option to `deriving version` wherever possible, yet that option is useful in test code, where the actual versioning is not significant.

This PR creates the `for_test` option, which is a synonym to `asserted`, that we can keep in test code.

Used this option in the `Staged_ledger` tests. There may be other uses of `asserted` where we can use this new option.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
