### PR TITLE
Remove asserted from deriving version in Staged_ledger_diff

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -39,7 +39,7 @@ module Staged_ledger_aux_hash = struct
 end
 
 module Staged_ledger_hash = struct
-  include Staged_ledger_hash.Stable.Latest
+  include Staged_ledger_hash
 
   let ledger_hash = Staged_ledger_hash.ledger_hash
 

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -881,7 +881,7 @@ end = struct
       , List.length jobs )
     in
     let apply_pre_diff_with_at_most_two
-        (pre_diff1 : Staged_ledger_diff.pre_diff_with_at_most_two_coinbase) =
+        (pre_diff1 : Staged_ledger_diff.Pre_diff_with_at_most_two_coinbase.t) =
       let coinbase_parts =
         match pre_diff1.coinbase with
         | Zero -> `Zero
@@ -892,7 +892,7 @@ end = struct
         pre_diff1.completed_works
     in
     let apply_pre_diff_with_at_most_one
-        (pre_diff2 : Staged_ledger_diff.pre_diff_with_at_most_one_coinbase) =
+        (pre_diff2 : Staged_ledger_diff.Pre_diff_with_at_most_one_coinbase.t) =
       let coinbase_added =
         match pre_diff2.coinbase with Zero -> `Zero | One x -> `One x
       in
@@ -1638,8 +1638,12 @@ let%test_module "test" =
 
         module Stable = struct
           module V1 = struct
-            type t = string
-            [@@deriving sexp, bin_io, compare, eq, yojson, hash]
+            module T = struct
+              type t = string
+              [@@deriving sexp, bin_io, compare, eq, yojson, hash, version]
+            end
+
+            include T
           end
         end
 
@@ -1683,8 +1687,13 @@ let%test_module "test" =
 
         module Stable = struct
           module V1 = struct
-            type t = txn_amt * txn_fee
-            [@@deriving sexp, bin_io, compare, eq, yojson]
+            module T = struct
+              type t = txn_amt * txn_fee
+              [@@deriving
+                sexp, bin_io, compare, eq, yojson, version {for_test}]
+            end
+
+            include T
           end
 
           module Latest = V1
@@ -1717,8 +1726,13 @@ let%test_module "test" =
         module Single = struct
           module Stable = struct
             module V1 = struct
-              type t = public_key * fee
-              [@@deriving bin_io, sexp, compare, eq, yojson, hash]
+              module T = struct
+                type t = public_key * fee
+                [@@deriving
+                  bin_io, sexp, compare, eq, yojson, hash, version {for_test}]
+              end
+
+              include T
             end
 
             module Latest = V1
@@ -1729,10 +1743,20 @@ let%test_module "test" =
 
         module Stable = struct
           module V1 = struct
-            type t =
-              | One of Single.Stable.V1.t
-              | Two of Single.Stable.V1.t * Single.Stable.V1.t
-            [@@deriving bin_io, sexp, compare, eq, yojson]
+            module T = struct
+              type t =
+                | One of Single.Stable.V1.t
+                | Two of Single.Stable.V1.t * Single.Stable.V1.t
+              [@@deriving
+                bin_io
+                , sexp
+                , compare
+                , eq
+                , yojson
+                , version {for_test; unnumbered}]
+            end
+
+            include T
           end
 
           module Latest = V1
@@ -2195,7 +2219,21 @@ let%test_module "test" =
       end
 
       module Staged_ledger_hash = struct
-        include String
+        module Stable = struct
+          module V1 = struct
+            module T = struct
+              type t = string
+              [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
+            end
+
+            include T
+            include Hashable.Make_binable (T)
+          end
+
+          module Latest = V1
+        end
+
+        type t = string [@@deriving sexp, eq, compare]
 
         type ledger_hash = Ledger_hash.t
 
@@ -2229,8 +2267,12 @@ let%test_module "test" =
 
         module Stable = struct
           module V1 = struct
-            type t = {fee: fee; proofs: proof list; prover: public_key}
-            [@@deriving sexp, bin_io, compare, yojson]
+            module T = struct
+              type t = {fee: fee; proofs: proof list; prover: public_key}
+              [@@deriving sexp, bin_io, compare, yojson, version {for_test}]
+            end
+
+            include T
           end
 
           module Latest = V1
@@ -2302,15 +2344,31 @@ let%test_module "test" =
         type public_key = Compressed_public_key.Stable.V1.t
         [@@deriving sexp, bin_io, compare, yojson]
 
-        type staged_ledger_hash = Staged_ledger_hash.t
+        type staged_ledger_hash = Staged_ledger_hash.Stable.V1.t
         [@@deriving sexp, bin_io, compare, yojson]
 
         module At_most_two = struct
-          type 'a t =
+          module Stable = struct
+            module V1 = struct
+              module T = struct
+                type 'a t =
+                  | Zero
+                  | One of 'a option
+                  | Two of ('a * 'a option) option
+                [@@deriving sexp, bin_io, yojson, version]
+              end
+
+              include T
+            end
+
+            module Latest = V1
+          end
+
+          type 'a t = 'a Stable.Latest.t =
             | Zero
             | One of 'a option
             | Two of ('a * 'a option) option
-          [@@deriving sexp, bin_io, yojson]
+          [@@deriving sexp, yojson]
 
           let increase t ws =
             match (t, ws) with
@@ -2323,8 +2381,21 @@ let%test_module "test" =
         end
 
         module At_most_one = struct
-          type 'a t = Zero | One of 'a option
-          [@@deriving sexp, bin_io, yojson]
+          module Stable = struct
+            module V1 = struct
+              module T = struct
+                type 'a t = Zero | One of 'a option
+                [@@deriving sexp, bin_io, yojson, version]
+              end
+
+              include T
+            end
+
+            module Latest = V1
+          end
+
+          type 'a t = 'a Stable.Latest.t = Zero | One of 'a option
+          [@@deriving sexp, yojson]
 
           let increase t ws =
             match (t, ws) with
@@ -2333,28 +2404,83 @@ let%test_module "test" =
             | _ -> Or_error.error_string "Error incrementing coinbase parts"
         end
 
-        type pre_diff_with_at_most_two_coinbase =
-          { completed_works: completed_work list
-          ; user_commands: user_command list
-          ; coinbase: fee_transfer_single At_most_two.t }
-        [@@deriving sexp, bin_io, yojson]
+        module Pre_diff_with_at_most_two_coinbase = struct
+          module Stable = struct
+            module V1 = struct
+              module T = struct
+                type t =
+                  { completed_works: completed_work list
+                  ; user_commands: user_command list
+                  ; coinbase: fee_transfer_single At_most_two.Stable.Latest.t
+                  }
+                [@@deriving
+                  sexp, bin_io, yojson, version {for_test; unnumbered}]
+              end
 
-        type pre_diff_with_at_most_one_coinbase =
-          { completed_works: completed_work list
-          ; user_commands: user_command list
-          ; coinbase: fee_transfer_single At_most_one.t }
-        [@@deriving sexp, bin_io, yojson]
+              include T
+            end
 
-        type diff =
-          pre_diff_with_at_most_two_coinbase
-          * pre_diff_with_at_most_one_coinbase option
-        [@@deriving sexp, bin_io, yojson]
+            module Latest = V1
+          end
+
+          type t = Stable.Latest.t =
+            { completed_works: completed_work list
+            ; user_commands: user_command list
+            ; coinbase: fee_transfer_single At_most_two.t }
+          [@@deriving sexp, yojson]
+        end
+
+        module Pre_diff_with_at_most_one_coinbase = struct
+          module Stable = struct
+            module V1 = struct
+              module T = struct
+                type t =
+                  { completed_works: completed_work list
+                  ; user_commands: user_command list
+                  ; coinbase: fee_transfer_single At_most_one.Stable.Latest.t
+                  }
+                [@@deriving sexp, bin_io, yojson, version {for_test}]
+              end
+
+              include T
+            end
+
+            module Latest = V1
+          end
+
+          type t = Stable.Latest.t =
+            { completed_works: completed_work list
+            ; user_commands: user_command list
+            ; coinbase: fee_transfer_single At_most_one.t }
+          [@@deriving sexp, yojson]
+        end
+
+        module Diff = struct
+          module Stable = struct
+            module V1 = struct
+              module T = struct
+                type t =
+                  Pre_diff_with_at_most_two_coinbase.Stable.V1.t
+                  * Pre_diff_with_at_most_one_coinbase.Stable.V1.t option
+                [@@deriving sexp, bin_io, yojson, version]
+              end
+
+              include T
+            end
+
+            module Latest = V1
+          end
+
+          type t = Stable.Latest.t [@@deriving sexp, yojson]
+        end
 
         module Stable = struct
           module V1 = struct
             module T = struct
               type t =
-                {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
+                { diff: Diff.Stable.V1.t
+                ; prev_hash: staged_ledger_hash
+                ; creator: public_key }
               [@@deriving sexp, bin_io, version {for_test}]
             end
 
@@ -2365,7 +2491,9 @@ let%test_module "test" =
         end
 
         type t = Stable.Latest.t =
-          {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
+          { diff: Diff.Stable.V1.t
+          ; prev_hash: staged_ledger_hash
+          ; creator: public_key }
         [@@deriving sexp, yojson]
 
         module With_valid_signatures_and_proofs = struct
@@ -2403,7 +2531,7 @@ let%test_module "test" =
             (pre_diff :
               With_valid_signatures_and_proofs
               .pre_diff_with_at_most_two_coinbase) :
-            pre_diff_with_at_most_two_coinbase =
+            Pre_diff_with_at_most_two_coinbase.t =
           { completed_works= forget_cw pre_diff.completed_works
           ; user_commands= (pre_diff.user_commands :> User_command.t list)
           ; coinbase= pre_diff.coinbase }
@@ -2411,7 +2539,8 @@ let%test_module "test" =
         let forget_pre_diff_with_at_most_one
             (pre_diff :
               With_valid_signatures_and_proofs
-              .pre_diff_with_at_most_one_coinbase) =
+              .pre_diff_with_at_most_one_coinbase) :
+            Pre_diff_with_at_most_one_coinbase.t =
           { completed_works= forget_cw pre_diff.completed_works
           ; user_commands= (pre_diff.user_commands :> User_command.t list)
           ; coinbase= pre_diff.coinbase }
@@ -2685,7 +2814,7 @@ let%test_module "test" =
             ; prev_hash
             ; creator= "C" }
         | Some _ ->
-            let diff : Staged_ledger_diff.diff =
+            let diff : Staged_ledger_diff.Diff.t =
               ( { completed_works
                 ; user_commands= List.take txns partition.first
                 ; coinbase= Zero }

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -98,7 +98,7 @@ struct
     Staged_ledger.Make_completed_work (Ledger_proof) (Ledger_proof_statement)
 
   module Staged_ledger_hash_binable = struct
-    include Staged_ledger_hash.Stable.V1
+    include Staged_ledger_hash
 
     let ( of_aux_ledger_and_coinbase_hash
         , aux_hash

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -222,7 +222,17 @@ module type Staged_ledger_aux_hash_intf = sig
 end
 
 module type Staged_ledger_hash_intf = sig
-  type t [@@deriving bin_io, sexp, eq, compare]
+  type t [@@deriving sexp, eq, compare]
+
+  module Stable :
+    sig
+      module V1 : sig
+        type t [@@deriving bin_io, sexp, eq, compare, version]
+
+        include Hashable.S_binable with type t := t
+      end
+    end
+    with type V1.t = t
 
   type ledger_hash
 
@@ -240,8 +250,6 @@ module type Staged_ledger_hash_intf = sig
 
   val of_aux_ledger_and_coinbase_hash :
     staged_ledger_aux_hash -> ledger_hash -> pending_coinbase -> t
-
-  include Hashable.S_binable with type t := t
 end
 
 module type Proof_intf = sig
@@ -380,7 +388,7 @@ module type User_command_intf = sig
 
   module Stable : sig
     module V1 : sig
-      type nonrec t = t [@@deriving bin_io, sexp, eq, yojson]
+      type nonrec t = t [@@deriving bin_io, sexp, eq, yojson, version]
     end
   end
 
@@ -409,7 +417,7 @@ module type Compressed_public_key_intf = sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io, compare, yojson]
+        type t [@@deriving sexp, bin_io, compare, yojson, version]
       end
     end
     with type V1.t = t
@@ -458,7 +466,7 @@ module type Fee_transfer_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving sexp, bin_io, yojson]
+          type t [@@deriving sexp, bin_io, yojson, version]
         end
       end
       with type V1.t = t
@@ -632,14 +640,14 @@ module type Transaction_snark_work_intf = sig
      H(all_statements_in_bundle || fee || public_key)
   *)
 
-  type t = {fee: Fee.Unsigned.t; proofs: proof list; prover: public_key}
+  type t =
+    {fee: Fee.Unsigned.Stable.V1.t; proofs: proof list; prover: public_key}
   [@@deriving sexp]
 
   module Stable :
     sig
       module V1 : sig
-        type t = {fee: Fee.Unsigned.t; proofs: proof list; prover: public_key}
-        [@@deriving sexp, bin_io]
+        type t [@@deriving sexp, bin_io, version]
       end
     end
     with type V1.t = t
@@ -678,42 +686,88 @@ module type Staged_ledger_diff_intf = sig
 
   module At_most_two : sig
     type 'a t = Zero | One of 'a option | Two of ('a * 'a option) option
-    [@@deriving sexp, bin_io]
+    [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type 'a t [@@deriving sexp, bin_io, version]
+        end
+      end
+      with type 'a V1.t = 'a t
 
     val increase : 'a t -> 'a list -> 'a t Or_error.t
   end
 
   module At_most_one : sig
-    type 'a t = Zero | One of 'a option [@@deriving sexp, bin_io]
+    type 'a t = Zero | One of 'a option [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type 'a t [@@deriving sexp, bin_io, version]
+        end
+      end
+      with type 'a V1.t = 'a t
 
     val increase : 'a t -> 'a list -> 'a t Or_error.t
   end
 
-  type pre_diff_with_at_most_two_coinbase =
-    { completed_works: completed_work list
-    ; user_commands: user_command list
-    ; coinbase: fee_transfer_single At_most_two.t }
-  [@@deriving sexp, bin_io]
+  module Pre_diff_with_at_most_two_coinbase : sig
+    type t =
+      { completed_works: completed_work list
+      ; user_commands: user_command list
+      ; coinbase: fee_transfer_single At_most_two.Stable.V1.t }
+    [@@deriving sexp]
 
-  type pre_diff_with_at_most_one_coinbase =
-    { completed_works: completed_work list
-    ; user_commands: user_command list
-    ; coinbase: fee_transfer_single At_most_one.t }
-  [@@deriving sexp, bin_io]
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io, version {unnumbered}]
+        end
+      end
+      with type V1.t = t
+  end
 
-  type diff =
-    pre_diff_with_at_most_two_coinbase
-    * pre_diff_with_at_most_one_coinbase option
-  [@@deriving sexp, bin_io]
+  module Pre_diff_with_at_most_one_coinbase : sig
+    type t =
+      { completed_works: completed_work list
+      ; user_commands: user_command list
+      ; coinbase: fee_transfer_single At_most_one.t }
+    [@@deriving sexp]
 
-  type t = {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io, version]
+        end
+      end
+      with type V1.t = t
+  end
+
+  module Diff : sig
+    type t =
+      Pre_diff_with_at_most_two_coinbase.Stable.V1.t
+      * Pre_diff_with_at_most_one_coinbase.Stable.V1.t option
+    [@@deriving sexp]
+
+    module Stable :
+      sig
+        module V1 : sig
+          type t [@@deriving sexp, bin_io, version]
+        end
+      end
+      with type V1.t = t
+  end
+
+  type t = {diff: Diff.t; prev_hash: staged_ledger_hash; creator: public_key}
   [@@deriving sexp]
 
   module Stable :
     sig
       module V1 : sig
         type t =
-          {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
+          {diff: Diff.t; prev_hash: staged_ledger_hash; creator: public_key}
         [@@deriving sexp, bin_io, version]
       end
 


### PR DESCRIPTION
Remove `asserted` from the `Stable.V1.t` in `Staged_ledger_diff`. Several other types had to be versioned, and the change in module structure propagated to the `Staged_ledger` tests.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
