### PR TITLE
Add int32 and int64 types as OCaml builtins for version ppx

### DIFF
--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -215,3 +215,29 @@ module M11 = struct
     end
   end
 end
+
+(* int32 *)
+module M12 = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = int32 [@@deriving bin_io, version]
+      end
+
+      include T
+    end
+  end
+end
+
+(* int64 *)
+module M13 = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = int64 [@@deriving bin_io, version]
+      end
+
+      include T
+    end
+  end
+end

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -164,7 +164,8 @@ let generate_version_number_decl inner3_modules loc generation_kind =
   in
   [%stri let version = [%e eint version]]
 
-let ocaml_builtin_types = ["int"; "float"; "char"; "string"; "bool"; "unit"]
+let ocaml_builtin_types =
+  ["int"; "int32"; "int64"; "float"; "char"; "string"; "bool"; "unit"]
 
 let ocaml_builtin_type_constructors = ["list"; "array"; "option"; "ref"]
 


### PR DESCRIPTION
You can do `derive bin_io` on OCaml types `int32` and `int64`, so allow these types for `deriving version`.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
