### PR TITLE
Remove version number, generated by ppx

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -85,9 +85,6 @@ struct
           option
         [@@deriving bin_io, version {rpc}]
 
-        (* TODO : remove after uncommenting version{rpc} *)
-        let version = 1
-
         let query_of_caller_model = Fn.id
 
         let callee_model_of_query = Fn.id


### PR DESCRIPTION
Removed `let version = ...`, it's already generated by the version ppx (and the comment told us to remove it come the time).

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
