### PR TITLE
Removed version{asserted} in Transaction Pool

### DIFF
--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -41,7 +41,7 @@ module type User_command_intf = sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io, yojson]
+        type t [@@deriving sexp, bin_io, yojson, version]
       end
     end
     with type V1.t = t
@@ -290,7 +290,7 @@ struct
       module V1 = struct
         module T = struct
           type t = User_command.Stable.V1.t list
-          [@@deriving bin_io, sexp, yojson, version {asserted}]
+          [@@deriving bin_io, sexp, yojson, version]
         end
 
         include T
@@ -442,7 +442,13 @@ let%test_module _ =
     module Test =
       Make0 (struct
           module Stable = struct
-            module V1 = Int
+            module V1 = struct
+              module T = struct
+                type t = int [@@deriving bin_io, version, sexp, yojson]
+              end
+
+              include T
+            end
           end
 
           include (Int : module type of Int with module Stable := Int.Stable)


### PR DESCRIPTION
Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

Explain your changes here.

Explain how you tested your changes here.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
