### PR TITLE
Use OCaml array instead of Array.t to allow versioning

### DIFF
--- a/src/lib/parallel_scan/ring_buffer.ml
+++ b/src/lib/parallel_scan/ring_buffer.ml
@@ -4,13 +4,11 @@ open Async_kernel
 module Stable = struct
   module V1 = struct
     module T = struct
-      type 'a t = {data: 'a Array.t; mutable position: int}
-      [@@deriving sexp, bin_io, version {asserted}]
+      type 'a t = {data: 'a array; mutable position: int}
+      [@@deriving sexp, bin_io, version]
     end
 
     include T
-
-    (* TODO : wrap Array *)
   end
 
   module Latest = V1


### PR DESCRIPTION
In `Ring_buffer`, use OCaml's `array` constructor instead of `Array.t`, to allow versioning.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
