### PR TITLE
Add bytes type to version ppx

### DIFF
--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -241,3 +241,16 @@ module M13 = struct
     end
   end
 end
+
+(* bytes *)
+module M14 = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = bytes [@@deriving bin_io, version]
+      end
+
+      include T
+    end
+  end
+end

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -165,7 +165,7 @@ let generate_version_number_decl inner3_modules loc generation_kind =
   [%stri let version = [%e eint version]]
 
 let ocaml_builtin_types =
-  ["int"; "int32"; "int64"; "float"; "char"; "string"; "bool"; "unit"]
+  ["bytes"; "int"; "int32"; "int64"; "float"; "char"; "string"; "bool"; "unit"]
 
 let ocaml_builtin_type_constructors = ["list"; "array"; "option"; "ref"]
 


### PR DESCRIPTION
Another OCaml builtin type is `bytes`.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
