### PR TITLE
Remove asserted from versioning in Stake_proof

### DIFF
--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -38,7 +38,7 @@ open Input
 module Send_payment_input = struct
   (* TODO : version *)
   type t =
-    Private_key.t
+    Private_key.Stable.V1.t
     * Public_key.Compressed.Stable.V1.t
     * Currency.Amount.Stable.V1.t
     * Currency.Fee.Stable.V1.t

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -24,6 +24,8 @@ module Index = struct
 
   type t = Stable.Latest.t [@@deriving sexp]
 
+  let to_int = Int.to_int
+
   let gen = Int.gen_incl 0 ((1 lsl Snark_params.ledger_depth) - 1)
 
   module Table = Int.Table

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -17,6 +17,7 @@ module Index = struct
       end
 
       include T
+      module Table = Int.Table
     end
 
     module Latest = V1

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -10,7 +10,19 @@ open Fold_lib
 open Module_version
 
 module Index = struct
-  include Int
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = int [@@deriving bin_io, sexp, version]
+      end
+
+      include T
+    end
+
+    module Latest = V1
+  end
+
+  type t = Stable.Latest.t [@@deriving sexp]
 
   let gen = Int.gen_incl 0 ((1 lsl Snark_params.ledger_depth) - 1)
 

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -17,7 +17,6 @@ module Index = struct
       end
 
       include T
-      module Table = Int.Table
     end
 
     module Latest = V1
@@ -26,6 +25,8 @@ module Index = struct
   type t = Stable.Latest.t [@@deriving sexp]
 
   let gen = Int.gen_incl 0 ((1 lsl Snark_params.ledger_depth) - 1)
+
+  module Table = Int.Table
 
   module Vector = struct
     include Int

--- a/src/lib/coda_base/stake_proof.ml
+++ b/src/lib/coda_base/stake_proof.ml
@@ -4,10 +4,10 @@ module Stable = struct
   module V1 = struct
     module T = struct
       type t =
-        { delegator: Account.Index.t
+        { delegator: Account.Index.Stable.V1.t
         ; ledger: Sparse_ledger.Stable.V1.t
-        ; private_key: Signature_lib.Private_key.t }
-      [@@deriving bin_io, sexp, version {asserted}]
+        ; private_key: Signature_lib.Private_key.Stable.V1.t }
+      [@@deriving bin_io, sexp, version]
     end
 
     include T

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -2,11 +2,20 @@ open Core_kernel
 open Async_kernel
 open Snark_params
 
-module T = struct
-  type t = Tick.Inner_curve.Scalar.t [@@deriving bin_io, sexp]
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      type t = Tick.Inner_curve.Scalar.t
+      [@@deriving bin_io, sexp, version {asserted}]
+    end
+
+    include T
+  end
+
+  module Latest = V1
 end
 
-include T
+type t = Stable.Latest.t [@@deriving sexp]
 
 let create () =
   (* This calls into libsnark which uses /dev/urandom *)
@@ -18,9 +27,9 @@ let gen =
     (gen_incl one (Snark_params.Tick.Inner_curve.Scalar.size - one))
     ~f:Snark_params.Tock.Bigint.(Fn.compose to_field of_bignum_bigint)
 
-let of_bigstring_exn = Binable.of_bigstring (module T)
+let of_bigstring_exn = Binable.of_bigstring (module Stable.Latest)
 
-let to_bigstring = Binable.to_bigstring (module T)
+let to_bigstring = Binable.to_bigstring (module Stable.Latest)
 
 let to_base64 t = to_bigstring t |> Bigstring.to_string |> Base64.encode_string
 


### PR DESCRIPTION
Removed `asserted` from `deriving version` in `Stake_proof`. Added a new `asserted` for `Private_key`, though.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
