### PR TITLE
Remove asserted from deriving version for Snark_pool_diff

### DIFF
--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -129,7 +129,6 @@ let%test_module "network pool test" =
     end
 
     module Mock_work = struct
-      (* no bin_io except in Stable versions *)
       module T = struct
         type t = Int.t [@@deriving sexp, hash, compare, yojson]
 
@@ -140,7 +139,19 @@ let%test_module "network pool test" =
       include Hashable.Make (T)
 
       module Stable = struct
-        module V1 = Int
+        module V1 = struct
+          module T = struct
+            type t = int
+            [@@deriving bin_io, sexp, yojson, hash, compare, version]
+          end
+
+          include T
+          module Table = Int.Table
+          module Hash_queue = Int.Hash_queue
+          module Hash_set = Int.Hash_set
+
+          let hashable = Int.hashable
+        end
       end
     end
 
@@ -200,7 +211,9 @@ let%test_module "network pool test" =
       let priced_proof =
         {Mock_snark_pool_diff.Priced_proof.proof= 0; fee= 0}
       in
-      let command = Snark_pool_diff.Add_solved_work (work, priced_proof) in
+      let command =
+        Snark_pool_diff.Diff.Add_solved_work (work, priced_proof)
+      in
       (fun () ->
         don't_wait_for
         @@ Linear_pipe.iter (Mock_network_pool.broadcasts network_pool)
@@ -221,7 +234,7 @@ let%test_module "network pool test" =
         let work_diffs =
           List.map works ~f:(fun work ->
               Envelope.Incoming.local
-                (Snark_pool_diff.Add_solved_work
+                (Snark_pool_diff.Diff.Add_solved_work
                    (work, Mock_snark_pool_diff.Priced_proof.{proof= 0; fee= 0}))
           )
           |> Linear_pipe.of_list
@@ -239,7 +252,7 @@ let%test_module "network pool test" =
              ~f:(fun work_command ->
                let work =
                  match work_command
-                 with Snark_pool_diff.Add_solved_work (work, _) -> work
+                 with Snark_pool_diff.Diff.Add_solved_work (work, _) -> work
                in
                assert (List.mem works work ~equal:( = )) ;
                Deferred.unit ) ;

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -2,8 +2,25 @@ open Core_kernel
 open Async
 open Module_version
 
-type ('work, 'priced_proof) diff = Add_solved_work of 'work * 'priced_proof
-[@@deriving bin_io, sexp, yojson]
+module Diff = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type ('work, 'priced_proof) t =
+          | Add_solved_work of 'work * 'priced_proof
+        [@@deriving bin_io, sexp, yojson, version]
+      end
+
+      include T
+    end
+
+    module Latest = V1
+  end
+
+  type ('work, 'priced_proof) t = ('work, 'priced_proof) Stable.Latest.t =
+    | Add_solved_work of 'work * 'priced_proof
+  [@@deriving sexp, yojson]
+end
 
 module Make (Proof : sig
   type t [@@deriving bin_io, yojson, version {unnumbered}]
@@ -15,7 +32,7 @@ end) (Work : sig
   module Stable :
     sig
       module V1 : sig
-        type t [@@deriving sexp, bin_io, yojson]
+        type t [@@deriving sexp, bin_io, yojson, version]
       end
     end
     with type V1.t = t
@@ -87,8 +104,8 @@ struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = (Work.Stable.V1.t, Priced_proof.Stable.V1.t) diff
-        [@@deriving bin_io, sexp, yojson, version {asserted}]
+        type t = (Work.Stable.V1.t, Priced_proof.Stable.V1.t) Diff.Stable.V1.t
+        [@@deriving bin_io, sexp, yojson, version]
       end
 
       include T
@@ -111,7 +128,7 @@ struct
   type t = Stable.Latest.t [@@deriving sexp, yojson]
 
   let summary = function
-    | Add_solved_work (_, Priced_proof.({proof= _; fee})) ->
+    | Diff.Add_solved_work (_, Priced_proof.({proof= _; fee})) ->
         Printf.sprintf !"Snark_pool_diff add with fee %{sexp: Fee.t}" fee
 
   let apply (pool : Pool.t) (t : t Envelope.Incoming.t) :

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -2287,7 +2287,8 @@ let%test_module "test" =
             module V1 = struct
               module T = struct
                 type t = statement list
-                [@@deriving sexp, bin_io, compare, hash, eq, yojson]
+                [@@deriving
+                  sexp, bin_io, compare, hash, eq, yojson, version {for_test}]
               end
 
               include T

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -620,7 +620,7 @@ module type Transaction_snark_work_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving yojson]
+          type t [@@deriving yojson, version]
 
           include Sexpable.S with type t := t
 


### PR DESCRIPTION
Removed an `{asserted}`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
