### PR TITLE
Support for modals and deeplinking

### DIFF
--- a/frontend/wallet/src/App.re
+++ b/frontend/wallet/src/App.re
@@ -3,10 +3,6 @@ open Tc;
 
 let dev = true;
 
-let sendMoney = () => {
-  print_endline("Sending!");
-};
-
 let createTray = () => {
   let t = AppTray.get();
   let items =
@@ -21,7 +17,12 @@ let createTray = () => {
       make(Radio({js|    Wallet_1  □ 100|js}), ()),
       make(Radio({js|    Vault  □ 100,000|js}), ()),
       make(Separator, ()),
-      make(Label("Send"), ~accelerator="CmdOrCtrl+S", ~click=sendMoney, ()),
+      make(
+        Label("Send"),
+        ~accelerator="CmdOrCtrl+S",
+        ~click=() => AppWindow.deepLink(Route.Send),
+        (),
+      ),
       make(Separator, ()),
       make(Label("Request"), ~accelerator="CmdOrCtrl+R", ()),
       make(Separator, ()),
@@ -41,14 +42,13 @@ App.on(
   `Ready,
   () => {
     createTray();
-    let _ = AppWindow.get();
-    ();
+    AppWindow.deepLink(Route.Home);
   },
 );
 
-App.on(`WindowAllClosed, () =>
-  print_endline("Closing window, menu staying open")
-);
+// We need this handler here to prevent the application from exiting on all
+// windows closed. Keep in mind, we have the tray.
+App.on(`WindowAllClosed, () => ());
 
 // Proof of concept on "database"
 let hello_world: Js.Json.t = Js.Json.string("hello world");

--- a/frontend/wallet/src/AppWindow.re
+++ b/frontend/wallet/src/AppWindow.re
@@ -3,11 +3,11 @@ open BsElectron;
 include BrowserWindow.MakeBrowserWindow(Messages);
 
 include Single.Make({
-  type input = unit;
+  type input = Route.t;
   type t = BrowserWindow.t;
 
   let make: (~drop: unit => unit, input) => t =
-    (~drop, ()) => {
+    (~drop, route) => {
       let window =
         make(
           makeWindowConfig(
@@ -23,8 +23,22 @@ include Single.Make({
             (),
           ),
         );
-      loadURL(window, "file://" ++ ProjectRoot.path ++ "public/index.html");
+      loadURL(
+        window,
+        "file://"
+        ++ ProjectRoot.path
+        ++ "public/index.html#"
+        ++ Route.print(route),
+      );
       on(window, `Closed, drop);
       window;
     };
 });
+
+let deepLink = route => {
+  let w = get(route);
+  // route handling is idempotent so doesn't matter if we also send the message
+  // if window already exists
+  send(w, `Deep_link(route));
+  ();
+};

--- a/frontend/wallet/src/Delete.re
+++ b/frontend/wallet/src/Delete.re
@@ -1,0 +1,7 @@
+[@react.component]
+let make = () => {
+  <div>
+    <h1> {ReasonReact.string("Delete Wallet")} </h1>
+    <p> {ReasonReact.string("etc.")} </p>
+  </div>;
+};

--- a/frontend/wallet/src/MainCommunication.re
+++ b/frontend/wallet/src/MainCommunication.re
@@ -1,0 +1,3 @@
+open BsElectron;
+
+include IpcRenderer.MakeIpcRenderer(Messages);

--- a/frontend/wallet/src/Messages.re
+++ b/frontend/wallet/src/Messages.re
@@ -1,4 +1,4 @@
 let message = __MODULE__;
-type mainToRendererMessages = [ | `Hello_world];
+type mainToRendererMessages = [ | `Deep_link(Route.t)];
 
 type rendererToMainMessages = [ | `HelloBack];

--- a/frontend/wallet/src/Modal.re
+++ b/frontend/wallet/src/Modal.re
@@ -1,0 +1,24 @@
+[@react.component]
+let make = (~view) => {
+  switch (view) {
+  | None => <span />
+  | Some(view) =>
+    <div
+      className=Css.(
+        style([
+          position(`absolute),
+          left(`zero),
+          top(`zero),
+          display(`flex),
+          justifyContent(`center),
+          alignItems(`center),
+          width(`percent(100.)),
+          height(`percent(100.)),
+          backgroundColor(StyleGuide.Colors.savilleAlpha(0.95)),
+        ])
+      )
+      onClick={_ => Router.navigate(Home)}>
+      view
+    </div>
+  };
+};

--- a/frontend/wallet/src/Page.re
+++ b/frontend/wallet/src/Page.re
@@ -6,8 +6,22 @@ let httpLink =
 let instance =
   ReasonApollo.createApolloClient(~link=httpLink, ~cache=inMemoryCache, ());
 
+Router.listenToMain();
+
 [@react.component]
-let make = (~message) =>
+let make = (~message) => {
+  let url = ReasonReact.Router.useUrl();
+
+  let modalView =
+    switch (Route.parse(url.hash)) {
+    | Some(Route.Send) => Some(<Send />)
+    | Some(DeleteWallet) => Some(<Delete />)
+    | Some(Home) => None
+    | None =>
+      Js.log2("Failed to parse route: ", url.hash);
+      None;
+    };
+
   <ApolloShim.Provider client=instance>
     <div
       style={ReactDOMRe.Style.make(
@@ -17,11 +31,19 @@ let make = (~message) =>
         ~right="0",
         ~bottom="0",
         ~left="0",
-        ~display="flex",
-        ~flexDirection="column",
         (),
       )}>
-      <Header />
-      <Body message />
+      <div className=Css.(style([display(`flex), flexDirection(`column)]))>
+        <Header />
+        <Body message />
+      </div>
+      <button onClick={_e => Router.(navigate(Send))}>
+        {ReasonReact.string("Send")}
+      </button>
+      <button onClick={_e => Router.(navigate(DeleteWallet))}>
+        {ReasonReact.string("Delete wallet")}
+      </button>
+      <Modal view=modalView />
     </div>
   </ApolloShim.Provider>;
+};

--- a/frontend/wallet/src/RendererCommunication.re
+++ b/frontend/wallet/src/RendererCommunication.re
@@ -1,0 +1,2 @@
+open BsElectron;
+include IpcMain.MakeIpcMain(Messages);

--- a/frontend/wallet/src/Route.re
+++ b/frontend/wallet/src/Route.re
@@ -1,0 +1,26 @@
+// TODO: If we start to get crazy routes, we should implement
+// http://www.informatik.uni-marburg.de/~rendel/unparse/
+// as demonstrated in https://github.com/pointfreeco/swift-web/
+
+// Law: All route handlers are idempotent!
+// (1) It's a good user experience to _see_ what's going to happen in the UI
+//     before actions happen
+// (2) Other code depends on this property
+
+type t =
+  | Send
+  | DeleteWallet // TODO: include wallet id in payload
+  | Home;
+
+let parse =
+  fun
+  | "send" => Some(Send)
+  | "wallet/delete" => Some(DeleteWallet)
+  | "" => Some(Home)
+  | _ => None;
+
+let print =
+  fun
+  | Send => "send"
+  | DeleteWallet => "wallet/delete"
+  | Home => "";

--- a/frontend/wallet/src/Router.re
+++ b/frontend/wallet/src/Router.re
@@ -1,0 +1,8 @@
+let navigate = route => ReasonReact.Router.push("#" ++ Route.print(route));
+
+let listenToMain = () =>
+  MainCommunication.on((. _event, message) =>
+    switch (message) {
+    | `Deep_link(route) => navigate(route)
+    }
+  );

--- a/frontend/wallet/src/Send.re
+++ b/frontend/wallet/src/Send.re
@@ -1,0 +1,7 @@
+[@react.component]
+let make = () => {
+  <div>
+    <h1> {ReasonReact.string("Send Coda")} </h1>
+    <p> {ReasonReact.string("etc.")} </p>
+  </div>;
+};

--- a/frontend/wallet/src/StyleGuide.re
+++ b/frontend/wallet/src/StyleGuide.re
@@ -5,6 +5,9 @@ module Colors = {
   let hexToString = (`hex(s)) => s;
 
   let bgColor = `hex("121F2B");
+  let savilleAlpha = a => `rgba((31, 45, 61, a));
+  let saville = savilleAlpha(1.);
+
   let headerBgColor = `hex("06111bBB");
   let headerGreyText = `hex("516679");
   let textColor = white;


### PR DESCRIPTION
Typesafe routes can be sent across the process boundary via a
`Deep_link` message.

Currently all deep links just open different modals. The modals are
simple absolutely positioned divs that sit on top of the whole
application.

Opening the modals from within the webapp works. Opening the modals from
within the tray while the webapp window is open works. Opening the
modals from the tray while the webapp window is closed works.

The MainCommunication and RendererCommunication files must be separate
modules, one for the renderer process (this consumes main communication
to communicate with the main process), and one for the main process
(this consumes renderer communication to communicate with the render
process).

Styling intentionally unimplemented for now.