### PR TITLE
Whitelist Jane St stable modules in version ppx

### DIFF
--- a/src/lib/parallel_scan/state.ml
+++ b/src/lib/parallel_scan/state.ml
@@ -107,12 +107,10 @@ module Stable = struct
         ; mutable base_none_pos: int option
         ; mutable recent_tree_data: 'd list sexp_opaque
         ; mutable other_trees_data: 'd list list sexp_opaque
-        ; stateful_work_order: int Queue.t
+        ; stateful_work_order: int Core.Queue.Stable.V1.t
         ; mutable curr_job_seq_no: int
         ; root_at_depth: int }
-      [@@deriving sexp, bin_io, version {asserted}]
-
-      (* TODO : wrap Queue *)
+      [@@deriving sexp, bin_io, version]
     end
 
     include T

--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -254,3 +254,16 @@ module M14 = struct
     end
   end
 end
+
+(* Jane Street whitelisting *)
+module M15 = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = int Core_kernel.Queue.Stable.V1.t [@@deriving bin_io, version]
+      end
+
+      include T
+    end
+  end
+end

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -171,6 +171,36 @@ let ocaml_builtin_type_constructors = ["list"; "array"; "option"; "ref"]
 
 let jane_street_type_constructors = ["sexp_opaque"]
 
+(* for module path A.B.C represented by a longident, produce [A;B;C] *)
+let rec list_of_longident longident ~loc =
+  match longident with
+  | Lident id -> [id]
+  | Ldot (longident2, s) -> list_of_longident longident2 ~loc @ [s]
+  | Lapply _ ->
+      Ppx_deriving.raise_errorf ~loc
+        "Type name contains unexpected application"
+
+(* true iff module_path is of form M. ... .Stable.Vn, where M is Core or Core_kernel, and n is integer *)
+let is_jane_street_stable_module module_path =
+  let hd_elt = List.hd_exn module_path in
+  let jane_street_libs = ["Core_kernel"; "Core"] in
+  List.mem jane_street_libs hd_elt ~equal:String.equal
+  &&
+  match List.rev module_path with
+  | vn :: "Stable" :: _ ->
+      let len = String.length vn in
+      len > 1
+      && Char.equal vn.[0] 'V'
+      &&
+      let numeric_part = String.sub vn ~pos:1 ~len:(len - 1) in
+      String.for_all numeric_part ~f:Char.is_digit
+      && not (Int.equal (Char.get_digit_exn numeric_part.[0]) 0)
+  | _ -> false
+
+let whitelisted_prefix prefix ~loc =
+  let module_path = list_of_longident prefix ~loc in
+  is_jane_street_stable_module module_path
+
 let rec generate_core_type_version_decls type_name core_type =
   match core_type.ptyp_desc with
   | Ptyp_constr ({txt; _}, core_types) -> (
@@ -199,17 +229,22 @@ let rec generate_core_type_version_decls type_name core_type =
             id
     | Ldot (prefix, "t") ->
         (* type t = A.B.t
-           generate: let _ = A.B.__versioned__
+           if prefix not whitelisted, generate: let _ = A.B.__versioned__
         *)
-        let loc = core_type.ptyp_loc in
-        let pexp_loc = loc in
-        let versioned_ident =
-          { pexp_desc= Pexp_ident {txt= Ldot (prefix, "__versioned__"); loc}
-          ; pexp_loc
-          ; pexp_attributes= [] }
+        let core_type_decls =
+          generate_version_lets_for_core_types type_name core_types
         in
-        [%str let _ = [%e versioned_ident]]
-        @ generate_version_lets_for_core_types type_name core_types
+        if whitelisted_prefix prefix ~loc:core_type.ptyp_loc then
+          core_type_decls
+        else
+          let loc = core_type.ptyp_loc in
+          let pexp_loc = loc in
+          let versioned_ident =
+            { pexp_desc= Pexp_ident {txt= Ldot (prefix, "__versioned__"); loc}
+            ; pexp_loc
+            ; pexp_attributes= [] }
+          in
+          [%str let _ = [%e versioned_ident]] @ core_type_decls
     | _ ->
         Ppx_deriving.raise_errorf ~loc:core_type.ptyp_loc
           "Unrecognized type constructor for versioned type" )


### PR DESCRIPTION
Jane St stable modules of form `Core. ... . Stable.Vn` (or `Core_kernel`) are whitelisted in the version ppx.

Use this feature to remove the `asserted` in versioning of `Parallel_scan.State.t`.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
