### PR TITLE
Whitelist Bitstring; unit test to detect changes

### DIFF
--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -3,13 +3,15 @@ open Bitstring
 open Module_version
 
 module type S = sig
-  type t [@@deriving sexp, bin_io, hash, eq, compare, to_yojson]
+  type t [@@deriving sexp, hash, eq, compare, to_yojson]
 
   module Stable : sig
     module V1 : sig
       val version : int
 
-      type nonrec t = t [@@deriving sexp, bin_io, hash, eq, compare, to_yojson]
+      type nonrec t = t
+      [@@deriving
+        sexp, bin_io, hash, eq, compare, to_yojson, version {unnumbered}]
     end
 
     module Latest : module type of V1
@@ -131,7 +133,7 @@ end) : S = struct
         slice (bitstring_of_string string) 0 length
 
       module T = struct
-        type t = Bitstring.t [@@deriving version {asserted}]
+        type t = Bitstring.t [@@deriving version]
 
         include Binable.Of_binable (struct
                     type t = int * string [@@deriving bin_io]
@@ -168,7 +170,6 @@ end) : S = struct
 
       include T
       include Registration.Make_latest_version (T)
-      include Hashable.Make_binable (T)
     end
 
     module Latest = V1
@@ -183,7 +184,12 @@ end) : S = struct
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  include Stable.Latest
+  type t = Stable.Latest.t
+
+  let t_of_sexp, sexp_of_t, to_yojson, compare, equal =
+    Stable.Latest.(t_of_sexp, sexp_of_t, to_yojson, compare, equal)
+
+  include Hashable.Make_binable (Stable.Latest)
 
   let of_byte_string = bitstring_of_string
 
@@ -338,6 +344,23 @@ end) : S = struct
                 Option.map (next current_node) ~f:(fun next_node ->
                     (current_node, (next_node, `Don't_stop)) ))
   end
+
+  let%test "Bitstring bin_io serialization does not change" =
+    (* Bitstring.t is whitelisted as a versioned type. This test assures that serializations of that type haven't changed *)
+    let buff = Bin_prot.Common.create_buf 256 in
+    let text =
+      "Contrary to popular belief, Lorem Ipsum is not simply random text. It \
+       has roots in a piece of classical Latin literature."
+    in
+    let known_good_serialization =
+      Bytes.of_string
+        "\x01\xFE\xC8\x03\x79\x43\x6F\x6E\x74\x72\x61\x72\x79\x20\x74\x6F\x20\x70\x6F\x70\x75\x6C\x61\x72\x20\x62\x65\x6C\x69\x65\x66\x2C\x20\x4C\x6F\x72\x65\x6D\x20\x49\x70\x73\x75\x6D\x20\x69\x73\x20\x6E\x6F\x74\x20\x73\x69\x6D\x70\x6C\x79\x20\x72\x61\x6E\x64\x6F\x6D\x20\x74\x65\x78\x74\x2E\x20\x49\x74\x20\x68\x61\x73\x20\x72\x6F\x6F\x74\x73\x20\x69\x6E\x20\x61\x20\x70\x69\x65\x63\x65\x20\x6F\x66\x20\x63\x6C\x61\x73\x73\x69\x63\x61\x6C\x20\x4C\x61\x74\x69\x6E\x20\x6C\x69\x74\x65\x72\x61\x74\x75\x72\x65\x2E"
+    in
+    let bs = Bitstring.bitstring_of_string text in
+    let len = Stable.Latest.bin_write_t buff ~pos:0 bs in
+    let bytes = Bytes.create len in
+    Bin_prot.Common.blit_buf_bytes buff bytes ~len ;
+    Bytes.equal bytes known_good_serialization
 
   let%test "the merkle root should have no path" =
     dirs_from_root (root ()) = []

--- a/src/lib/merkle_ledger/location.ml
+++ b/src/lib/merkle_ledger/location.ml
@@ -38,14 +38,15 @@ module Make (Depth : Intf.Depth) = struct
     include Hashable.Make (T)
   end
 
+  (* TODO : version *)
   module T = struct
     type t =
       | Generic of Bigstring.t
           [@printer
             fun fmt bstr ->
               Format.pp_print_string fmt (Bigstring.to_string bstr)]
-      | Account of Addr.t
-      | Hash of Addr.t
+      | Account of Addr.Stable.V1.t
+      | Hash of Addr.Stable.V1.t
     [@@deriving hash, sexp, compare, eq, bin_io]
   end
 

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -198,8 +198,14 @@ let is_jane_street_stable_module module_path =
   | _ -> false
 
 let whitelisted_prefix prefix ~loc =
-  let module_path = list_of_longident prefix ~loc in
-  is_jane_street_stable_module module_path
+  match prefix with
+  | Lident id -> String.equal id "Bitstring"
+  | Ldot _ ->
+      let module_path = list_of_longident prefix ~loc in
+      is_jane_street_stable_module module_path
+  | Lapply _ ->
+      Ppx_deriving.raise_errorf ~loc
+        "Type name contains unexpected application"
 
 let rec generate_core_type_version_decls type_name core_type =
   match core_type.ptyp_desc with


### PR DESCRIPTION
Whitelist `Bitstring` in the version ppx, so that we can remove `asserted` in `deriving version` for `Merkle_address`.

Wrote a unit test that compares the current serialization of a `Bitstring.t` value against one created when we added the whitelist (now, that is). If that ever changes (unlikely), we could wrap the library.

Also removed `bin_io` from `Merkle_address.t`.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
