### PR TITLE
Remove asserted from Sync_ledger deriving version

### DIFF
--- a/src/lib/coda_base/sync_ledger.ml
+++ b/src/lib/coda_base/sync_ledger.ml
@@ -46,7 +46,7 @@ module Answer = struct
           ( Ledger_hash.Stable.V1.t
           , Account.Stable.V1.t )
           Syncable_ledger.Answer.Stable.V1.t
-        [@@deriving bin_io, sexp, version {asserted}]
+        [@@deriving bin_io, sexp, version]
       end
 
       include T
@@ -75,7 +75,7 @@ module Query = struct
       module T = struct
         type t =
           Ledger.Location.Addr.Stable.V1.t Syncable_ledger.Query.Stable.V1.t
-        [@@deriving bin_io, sexp, to_yojson, version {asserted}]
+        [@@deriving bin_io, sexp, to_yojson, version]
       end
 
       include T

--- a/src/lib/syncable_ledger/dune
+++ b/src/lib/syncable_ledger/dune
@@ -7,7 +7,7 @@
  (libraries core async async_extra pipe_lib merkle_ledger logger trust_system
    interruptible envelope)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
  (synopsis "Synchronization of Merkle-tree backed ledgers"))
 
 (library

--- a/src/lib/syncable_ledger/syncable_ledger.ml
+++ b/src/lib/syncable_ledger/syncable_ledger.ml
@@ -9,16 +9,20 @@ let rec funpow n f r = if n > 0 then funpow (n - 1) f (f r) else r
 module Query = struct
   module Stable = struct
     module V1 = struct
-      type 'addr t =
-        | What_child_hashes of 'addr
-            (** What are the hashes of the children of this address? *)
-        | What_contents of 'addr
-            (** What accounts are at this address? addr must have depth
+      module T = struct
+        type 'addr t =
+          | What_child_hashes of 'addr
+              (** What are the hashes of the children of this address? *)
+          | What_contents of 'addr
+              (** What accounts are at this address? addr must have depth
             tree_depth - account_subtree_height *)
-        | Num_accounts
-            (** How many accounts are there? Used to size data structure and
+          | Num_accounts
+              (** How many accounts are there? Used to size data structure and
             figure out what part of the tree is filled in. *)
-      [@@deriving bin_io, sexp, yojson]
+        [@@deriving bin_io, sexp, yojson, version]
+      end
+
+      include T
     end
 
     module Latest = V1
@@ -35,15 +39,19 @@ end
 module Answer = struct
   module Stable = struct
     module V1 = struct
-      type ('hash, 'account) t =
-        | Child_hashes_are of 'hash * 'hash
-            (** The requested address's children have these hashes **)
-        | Contents_are of 'account list
-            (** The requested address has these accounts *)
-        | Num_accounts of int * 'hash
-            (** There are this many accounts and the smallest subtree that
+      module T = struct
+        type ('hash, 'account) t =
+          | Child_hashes_are of 'hash * 'hash
+              (** The requested address's children have these hashes **)
+          | Contents_are of 'account list
+              (** The requested address has these accounts *)
+          | Num_accounts of int * 'hash
+              (** There are this many accounts and the smallest subtree that
                 contains all non-empty nodes has this hash. *)
-      [@@deriving bin_io, sexp, yojson]
+        [@@deriving bin_io, sexp, yojson, version]
+      end
+
+      include T
     end
 
     module Latest = V1


### PR DESCRIPTION
Removed two `{asserted}` instances from `deriving version` in `Sync_ledger`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [X] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
