### PR TITLE
Special-case Jane St library with unusual module path

### DIFF
--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -267,3 +267,16 @@ module M15 = struct
     end
   end
 end
+
+(* Jane Street special case *)
+module M16 = struct
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = Core_kernel.Time.Stable.Span.V1.t [@@deriving bin_io, version]
+      end
+
+      include T
+    end
+  end
+end

--- a/src/lib/ppx_coda/versioned.ml
+++ b/src/lib/ppx_coda/versioned.ml
@@ -175,17 +175,22 @@ let jane_street_type_constructors = ["sexp_opaque"]
 let is_jane_street_stable_module module_path =
   let hd_elt = List.hd_exn module_path in
   let jane_street_libs = ["Core_kernel"; "Core"] in
+  let is_version_module vn =
+    let len = String.length vn in
+    len > 1
+    && Char.equal vn.[0] 'V'
+    &&
+    let numeric_part = String.sub vn ~pos:1 ~len:(len - 1) in
+    String.for_all numeric_part ~f:Char.is_digit
+    && not (Int.equal (Char.get_digit_exn numeric_part.[0]) 0)
+  in
   List.mem jane_street_libs hd_elt ~equal:String.equal
   &&
   match List.rev module_path with
-  | vn :: "Stable" :: _ ->
-      let len = String.length vn in
-      len > 1
-      && Char.equal vn.[0] 'V'
-      &&
-      let numeric_part = String.sub vn ~pos:1 ~len:(len - 1) in
-      String.for_all numeric_part ~f:Char.is_digit
-      && not (Int.equal (Char.get_digit_exn numeric_part.[0]) 0)
+  | vn :: "Stable" :: _ -> is_version_module vn
+  | vn :: "Span" :: "Stable" :: "Time" :: _ ->
+      (* special case, maybe improper module structure *)
+      is_version_module vn
   | _ -> false
 
 let whitelisted_prefix prefix ~loc =


### PR DESCRIPTION
In Jane St libraries, the type `Time.Stable.Span.V1.t` doesn't conform to the format `M.Stable.V1.t`. We special-case this one, since it appears to be a stable versioned type.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
