### PR TITLE
Correctly mutates shared state

### DIFF
--- a/frontend/wallet/src/CallTable.re
+++ b/frontend/wallet/src/CallTable.re
@@ -24,9 +24,9 @@ let make = () => {table: Js.Dict.empty(), id: ref(0)};
 
 let nextPending = (t, ~loc) => {
   let id = t.id^;
+  incr(t.id);
   let task =
     Task.create(cb => {
-      incr(t.id);
       let key = Ident.toString((id, loc));
       Js.Dict.set(
         t.table,


### PR DESCRIPTION
@cmr noticed that `incr` was applied to shared mutable state inside the
Task context which causes non-determinism.