### PR TITLE
Ppx for mirroring definitions locally

### DIFF
--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -128,7 +128,8 @@ end
 (* bin_io, version omitted *)
 type t = Stable.Latest.t [@@deriving sexp, eq, hash, compare]
 
-let public_key = Stable.Latest.(public_key)
+[%%define_locally
+Stable.Latest.(public_key)]
 
 type key = Stable.Latest.key
 

--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -264,31 +264,20 @@ module T = struct
 
     let data_hash = Stable.Latest.data_hash
 
-    let ( to_bits
-        , to_bytes
-        , fold
-        , equal_var
-        , length_in_triples
-        , var_to_triples
-        , hash_fold_t
-        , empty
-        , push
-        , gen
-        , var_of_t
-        , typ ) =
-      Stack_builder.
-        ( to_bits
-        , to_bytes
-        , fold
-        , equal_var
-        , length_in_triples
-        , var_to_triples
-        , hash_fold_t
-        , empty
-        , push
-        , gen
-        , var_of_t
-        , typ )
+    [%%define_locally
+    Stack_builder.
+      ( to_bits
+      , to_bytes
+      , fold
+      , equal_var
+      , length_in_triples
+      , var_to_triples
+      , hash_fold_t
+      , empty
+      , push
+      , gen
+      , var_of_t
+      , typ )]
 
     module Checked = Stack_builder.Checked
   end
@@ -326,36 +315,24 @@ module T = struct
 
     type var = Stable.Latest.var
 
-    let merge = Stable.Latest.(merge)
+    [%%define_locally
+    Stable.Latest.(merge)]
 
-    (* we should have a ppx for this *)
-    let ( of_digest
-        , empty_hash
-        , gen
-        , to_bits
-        , to_bytes
-        , fold
-        , equal_var
-        , length_in_triples
-        , var_to_triples
-        , var_of_t
-        , var_of_hash_packed
-        , var_to_hash_packed
-        , typ ) =
-      Hash_builder.
-        ( of_digest
-        , empty_hash
-        , gen
-        , to_bits
-        , to_bytes
-        , fold
-        , equal_var
-        , length_in_triples
-        , var_to_triples
-        , var_of_t
-        , var_of_hash_packed
-        , var_to_hash_packed
-        , typ )
+    [%%define_locally
+    Hash_builder.
+      ( of_digest
+      , empty_hash
+      , gen
+      , to_bits
+      , to_bytes
+      , fold
+      , equal_var
+      , length_in_triples
+      , var_to_triples
+      , var_of_t
+      , var_of_hash_packed
+      , var_to_hash_packed
+      , typ )]
   end
 
   (* the arguments to Sparse_ledger.Make are all versioned; a particular choice of those
@@ -381,23 +358,16 @@ module T = struct
 
     module Latest_make = V1_make
 
-    let ( of_hash
-        , get_exn
-        , path_exn
-        , set_exn
-        , find_index_exn
-        , add_path
-        , merkle_root
-        , iteri ) =
-      Latest_make.
-        ( of_hash
-        , get_exn
-        , path_exn
-        , set_exn
-        , find_index_exn
-        , add_path
-        , merkle_root
-        , iteri )
+    [%%define_locally
+    Latest_make.
+      ( of_hash
+      , get_exn
+      , path_exn
+      , set_exn
+      , find_index_exn
+      , add_path
+      , merkle_root
+      , iteri )]
   end
 
   module Checked = struct

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -44,4 +44,5 @@ let dummy = Tock.Proof.dummy
 
 include Sexpable.Of_stringable (Stable.Latest)
 
-let to_yojson, of_yojson = Stable.Latest.(to_yojson, of_yojson)
+[%%define_locally
+Stable.Latest.(to_yojson, of_yojson)]

--- a/src/lib/coda_base/sok_message.ml
+++ b/src/lib/coda_base/sok_message.ml
@@ -65,8 +65,8 @@ module Digest = struct
 
   module Checked = Random_oracle.Digest.Checked
 
-  let fold, typ, length_in_triples =
-    Stable.Latest.(fold, typ, length_in_triples)
+  [%%define_locally
+  Stable.Latest.(fold, typ, length_in_triples)]
 
   let default =
     let open Random_oracle.Digest in

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -186,8 +186,8 @@ end) : S = struct
 
   type t = Stable.Latest.t
 
-  let t_of_sexp, sexp_of_t, to_yojson, compare, equal =
-    Stable.Latest.(t_of_sexp, sexp_of_t, to_yojson, compare, equal)
+  [%%define_locally
+  Stable.Latest.(t_of_sexp, sexp_of_t, to_yojson, compare, equal)]
 
   include Hashable.Make_binable (Stable.Latest)
 

--- a/src/lib/network_peer/peer.ml
+++ b/src/lib/network_peer/peer.ml
@@ -71,7 +71,8 @@ type t = Stable.Latest.t =
   ; communication_port: int }
 [@@deriving compare, sexp]
 
-let of_yojson, to_yojson = Stable.Latest.(of_yojson, to_yojson)
+[%%define_locally
+Stable.Latest.(of_yojson, to_yojson)]
 
 include Hashable.Make (Stable.Latest)
 include Comparable.Make_binable (Stable.Latest)

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -241,7 +241,8 @@ let%snarkydef compress_var ((x, y) : var) : (Compressed.var, _) Checked.t =
   let%map is_odd = parity_var y in
   {Compressed.Poly.x; is_odd}
 
-let of_bigstring, to_bigstring = Stable.Latest.(of_bigstring, to_bigstring)
+[%%define_locally
+Stable.Latest.(of_bigstring, to_bigstring)]
 
 let%test_unit "point-compression: decompress . compress = id" =
   Quickcheck.test gen ~f:(fun pk ->

--- a/src/lib/ppx_coda/define_locally.ml
+++ b/src/lib/ppx_coda/define_locally.ml
@@ -1,0 +1,53 @@
+open Core_kernel
+open Ppxlib
+open Asttypes
+open Ast_helper
+
+(* define_locally mirrors local definitions from some other module
+
+   Example:
+
+     [%%define_locally M.(x,y,z)]
+
+   expands to
+
+     let x,y,z = M.(x,y,z)
+
+ *)
+
+let name = "define_locally"
+
+let raise_errorf = Location.raise_errorf
+
+let expand ~loc ~path:_ override (module_name : longident) defs =
+  match defs.pexp_desc with
+  | Pexp_tuple exps ->
+      let names =
+        List.map exps ~f:(fun {pexp_desc= item; pexp_loc= loc; _} ->
+            match item with
+            | Pexp_ident {txt= Lident id; _} -> id
+            | __ ->
+                raise_errorf ~loc "Item in opened module is not an identifier"
+        )
+      in
+      let vars =
+        List.map names ~f:(fun name -> Pat.var ~loc {txt= name; loc})
+      in
+      Str.value ~loc Nonrecursive
+        [ Vb.mk ~loc (Pat.tuple ~loc vars)
+            (Exp.open_ ~loc override {txt= module_name; loc} defs) ]
+  | Pexp_ident {txt= Lident id; _} ->
+      Str.value ~loc Nonrecursive
+        [ Vb.mk ~loc
+            (Pat.var ~loc {txt= id; loc})
+            (Exp.open_ ~loc override {txt= module_name; loc} defs) ]
+  | _ -> raise_errorf ~loc "Must provide an identifier or tuple of identifiers"
+
+let ext =
+  (* TODO : separate entry point for defining from enclosing module *)
+  Extension.declare name Extension.Context.structure_item
+    Ast_pattern.(single_expr_payload (pexp_open __ __ __))
+    expand
+
+let () =
+  Driver.register_transformation name ~rules:[Context_free.Rule.extension ext]

--- a/src/lib/ppx_coda/tests/Makefile
+++ b/src/lib/ppx_coda/tests/Makefile
@@ -22,6 +22,10 @@ positive-tests : unexpired.ml
 	@ echo -n "Versioned types, should succeed..."
 	@ dune build versioned_good.cma ${REDIRECT}
 	@ echo "OK"
+# define locally
+	@ echo -n "Define locally, should succeed..."
+	@ dune build define_locally_good.cma ${REDIRECT}
+	@ echo "OK"
 
 negative-tests :
 # expiration

--- a/src/lib/ppx_coda/tests/define_locally_good.ml
+++ b/src/lib/ppx_coda/tests/define_locally_good.ml
@@ -1,0 +1,25 @@
+module M1 = struct
+  let x = 42
+
+  let y = "This is a string"
+
+  let z = (x, y)
+
+  let q = (x, y, z)
+end
+
+module M2 = struct
+  [%%define_locally
+  M1.(x, y, z)]
+
+  [%%define_locally
+  M1.(q)]
+
+  let _ = x
+
+  let _ = y
+
+  let _ = z
+
+  let _ = q
+end

--- a/src/lib/ppx_coda/tests/dune
+++ b/src/lib/ppx_coda/tests/dune
@@ -16,6 +16,13 @@
   (libraries core_kernel)
   (modules versioned_good))
 
+;; define locally
+
+(library
+  (name define_locally_good)
+  (preprocess (pps ppx_coda))
+  (modules define_locally_good))
+
 ;;; should fail
 
 ;; expiration

--- a/src/lib/snark_params/pedersen.ml
+++ b/src/lib/snark_params/pedersen.ml
@@ -112,7 +112,8 @@ struct
     (* omit bin_io, version *)
     type t = Stable.Latest.t [@@deriving sexp, eq, hash, compare]
 
-    let of_yojson, to_yojson = Stable.Latest.(of_yojson, to_yojson)
+    [%%define_locally
+    Stable.Latest.(of_yojson, to_yojson)]
 
     let size_in_bits = Field.size_in_bits
 

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -300,7 +300,8 @@ let%test_module "sparse-ledger-test" =
       type t = Stable.Latest.t = {name: string; favorite_number: int}
       [@@deriving sexp, eq]
 
-      let key, gen, data_hash = Stable.Latest.(key, gen, data_hash)
+      [%%define_locally
+      Stable.Latest.(key, gen, data_hash)]
     end
 
     module Key = struct

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -227,7 +227,8 @@ end = struct
     ; mutable job_count: int }
   [@@deriving sexp]
 
-  let hash, is_valid = Stable.Latest.(hash, is_valid)
+  [%%define_locally
+  Stable.Latest.(hash, is_valid)]
 
   (**********Helpers*************)
 


### PR DESCRIPTION
A ppx to eliminate boilerplate when mirroring definitions from another module.

Write:
```
[%%define_locally M.(x,y,z)]
```
which expands to
```
let x,y,z = M.(x,y,z)
```

I applied this at several places in the code.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #2141
