### PR TITLE
print out spec on snark worker failure

### DIFF
--- a/src/lib/snark_worker_lib/prod.ml
+++ b/src/lib/snark_worker_lib/prod.ml
@@ -51,41 +51,51 @@ module Inputs = struct
   module Pending_coinbase = Coda_base.Pending_coinbase.Stable.V1
   module Transaction_witness = Coda_base.Transaction_witness.Stable.V1
 
+  type single_spec =
+    ( Statement.t
+    , Transaction.t
+    , Transaction_witness.t
+    , Transaction_snark.t )
+    Snark_work_lib.Work.Single.Spec.t
+  [@@deriving sexp]
+
   (* TODO: Use public_key once SoK is implemented *)
   let perform_single ({m= (module M); cache} : Worker_state.t) ~message =
     let open Snark_work_lib in
     let sok_digest = Coda_base.Sok_message.digest message in
-    fun (single :
-          ( Statement.t
-          , Transaction.t
-          , Transaction_witness.t
-          , Transaction_snark.t )
-          Work.Single.Spec.t) ->
+    fun (single : single_spec) ->
       let statement = Work.Single.Spec.statement single in
+      let process k =
+        let start = Time.now () in
+        match k () with
+        | Error e ->
+            Logger.error (Logger.create ()) ~module_:__MODULE__
+              ~location:__LOC__
+              ~metadata:
+                [ ( "spec"
+                  , `String (Sexp.to_string (sexp_of_single_spec single)) ) ]
+              "Worker failed: %s" (Error.to_string_hum e) ;
+            Error e
+        | Ok res ->
+            Cache.add cache ~statement ~proof:res ;
+            let total = Time.abs_diff (Time.now ()) start in
+            Ok (res, total)
+      in
       match Cache.find cache statement with
       | Some proof -> Or_error.return (proof, Time.Span.zero)
       | None -> (
         match single with
         | Work.Single.Spec.Transition (input, t, (w : Transaction_witness.t))
           ->
-            let start = Time.now () in
-            let res =
-              M.of_transaction ~sok_digest ~source:input.Statement.source
-                ~target:input.target t
-                ~pending_coinbase_stack_state:
-                  input.Statement.pending_coinbase_stack_state
-                (unstage (Coda_base.Sparse_ledger.handler w.ledger))
-            in
-            Cache.add cache ~statement ~proof:res ;
-            let total = Time.abs_diff (Time.now ()) start in
-            Or_error.return (res, total)
+            process (fun () ->
+                Or_error.try_with (fun () ->
+                    M.of_transaction ~sok_digest ~source:input.Statement.source
+                      ~target:input.target t
+                      ~pending_coinbase_stack_state:
+                        input.Statement.pending_coinbase_stack_state
+                      (unstage (Coda_base.Sparse_ledger.handler w.ledger)) ) )
         | Merge (_, proof1, proof2) ->
-            let open Or_error.Let_syntax in
-            let start = Time.now () in
-            let%map res = M.merge ~sok_digest proof1 proof2 in
-            Cache.add cache ~statement ~proof:res ;
-            let total = Time.abs_diff (Time.now ()) start in
-            (res, total) )
+            process (fun () -> M.merge ~sok_digest proof1 proof2) )
 end
 
 module Worker = Worker.Make (Inputs)


### PR DESCRIPTION
This prints out the snark worker spec when there is a failure to aid in debugging https://github.com/CodaProtocol/coda/issues/2224