### PR TITLE
Make snark worker spec non-opaque for sexp

### DIFF
--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -6,11 +6,8 @@ module Single = struct
       module V1 = struct
         module T = struct
           type ('statement, 'transition, 'witness, 'ledger_proof) t =
-            | Transition of 'statement * 'transition * 'witness sexp_opaque
-            | Merge of
-                'statement
-                * 'ledger_proof sexp_opaque
-                * 'ledger_proof sexp_opaque
+            | Transition of 'statement * 'transition * 'witness
+            | Merge of 'statement * 'ledger_proof * 'ledger_proof
           [@@deriving bin_io, sexp, version]
         end
 
@@ -27,7 +24,7 @@ module Single = struct
                                                                , 'ledger_proof
                                                                )
                                                                Stable.Latest.t =
-      | Transition of 'statement * 'transition * 'witness sexp_opaque
+      | Transition of 'statement * 'transition * 'witness
       | Merge of
           'statement * 'ledger_proof sexp_opaque * 'ledger_proof sexp_opaque
     [@@deriving sexp]

--- a/src/lib/snark_worker_lib/prod.ml
+++ b/src/lib/snark_worker_lib/prod.ml
@@ -75,7 +75,7 @@ module Inputs = struct
                 [ ( "spec"
                   , `String (Sexp.to_string (sexp_of_single_spec single)) ) ]
               "Worker failed: %s" (Error.to_string_hum e) ;
-            Error e
+            Error.raise e
         | Ok res ->
             Cache.add cache ~statement ~proof:res ;
             let total = Time.abs_diff (Time.now ()) start in


### PR DESCRIPTION
Make snark worker spec non-opaque for sexp. This is to aid in debugging a SNARK assertion failure @jkrauska had seen