### PR TITLE
Put logic in place for transactions view

### DIFF
--- a/frontend/wallet/src/Body.re
+++ b/frontend/wallet/src/Body.re
@@ -22,6 +22,7 @@ module HooksTest = {
 [@react.component]
 let make = (~message) =>
   <div
+    className=Css.(style([width(`percent(100.))]))
     style={ReactDOMRe.Style.make(
       ~color="white",
       ~background="#121f2b11",
@@ -43,7 +44,9 @@ let make = (~message) =>
       <WalletItem name="Hot Wallet2" balance=100.0 />
       <WalletItem name="Vault" balance=234122.123 />
     </div>
-    <div style={ReactDOMRe.Style.make(~margin="10px", ())}>
+    <div
+      className=Css.(style([width(`percent(100.))]))
+      style={ReactDOMRe.Style.make(~margin="10px", ())}>
       <TestQuery>
         {result =>
            ReasonReact.string(
@@ -56,5 +59,6 @@ let make = (~message) =>
       </TestQuery>
       <HooksTest name="test-hooks" />
       <p> {ReasonReact.string(message)} </p>
+      <TransactionsView />
     </div>
   </div>;

--- a/frontend/wallet/src/ConsensusState.re
+++ b/frontend/wallet/src/ConsensusState.re
@@ -1,0 +1,13 @@
+module Status = {
+  type t =
+    | Submitted
+    | Included
+    | Finalized
+    | Snarked
+    | Failed;
+};
+
+type t = {
+  status: Status.t,
+  estimatedPercentConfirmed: float,
+};

--- a/frontend/wallet/src/PublicKey.re
+++ b/frontend/wallet/src/PublicKey.re
@@ -4,3 +4,5 @@ type t = string;
 let ofStringExn = s => s;
 
 let toString = s => s;
+
+let equal = (a, b) => a === b;

--- a/frontend/wallet/src/PublicKey.rei
+++ b/frontend/wallet/src/PublicKey.rei
@@ -2,3 +2,4 @@ type t;
 
 let ofStringExn: string => t;
 let toString: t => string;
+let equal: (t, t) => bool;

--- a/frontend/wallet/src/StyleGuide.re
+++ b/frontend/wallet/src/StyleGuide.re
@@ -10,9 +10,17 @@ module Colors = {
 
   let serpentine = `hex("479056");
 
+  let roseBud = `hex("a3536f");
+
+  let sage = `hex("65906e");
+
   let headerBgColor = `hex("06111bBB");
   let headerGreyText = `hex("516679");
   let textColor = white;
+};
+
+module Typeface = {
+  let lucidaGrande = fontFamily("LucidaGrande");
 };
 
 module CssElectron = {

--- a/frontend/wallet/src/TransactionCell.re
+++ b/frontend/wallet/src/TransactionCell.re
@@ -271,6 +271,9 @@ module InfoSection = {
   };
 };
 
+// TODO: As suggested in https://github.com/CodaProtocol/coda/pull/2260 , we
+// should probably switch to CSS Grid
+//
 // We can represent one of these cells as a row in an HTML table in the
 // following manner:
 //

--- a/frontend/wallet/src/TransactionCell.re
+++ b/frontend/wallet/src/TransactionCell.re
@@ -1,0 +1,318 @@
+open Tc;
+
+module Transaction = {
+  module RewardDetails = {
+    type t = {
+      key: PublicKey.t,
+      coinbase: int,
+      transactionFees: int,
+      proofFees: int,
+      delegationFees: int,
+      includedAt: Js.Date.t,
+    };
+  };
+
+  module PaymentDetails = {
+    type t = {
+      from: PublicKey.t,
+      to_: PublicKey.t,
+      amount: int,
+      fee: int,
+      memo: option(string),
+      submittedAt: Js.Date.t,
+      includedAt: option(Js.Date.t),
+    };
+  };
+
+  module UnknownDetails = {
+    type t = {
+      key: PublicKey.t,
+      amount: int,
+    };
+  };
+
+  type t =
+    | Minted(RewardDetails.t)
+    | Payment(PaymentDetails.t, ConsensusState.t)
+    | Unknown(UnknownDetails.t);
+};
+
+module ViewModel = {
+  open Transaction;
+
+  module Actor = {
+    type t =
+      | Minted
+      | Key(PublicKey.t)
+      | Unknown;
+  };
+
+  module Action = {
+    type t =
+      | Transfer
+      | Pending
+      | Failed;
+  };
+
+  module Info = {
+    type t =
+      | Memo(string, Js.Date.t)
+      | Empty(Js.Date.t)
+      | StakingReward(list((string, int)), Js.Date.t)
+      | MissingReceipts;
+  };
+
+  type t = {
+    sender: Actor.t,
+    recipient: Actor.t,
+    action: Action.t,
+    info: Info.t,
+    amountDelta: int // signed
+  };
+
+  let ofTransaction =
+      (transaction: Transaction.t, ~myWallets: list(PublicKey.t)) => {
+    switch (transaction) {
+    | Minted({
+        RewardDetails.key,
+        coinbase,
+        transactionFees,
+        proofFees,
+        delegationFees,
+        includedAt,
+      }) => {
+        sender: Actor.Minted,
+        recipient: Actor.Key(key),
+        action: Action.Transfer,
+        info:
+          Info.StakingReward(
+            [
+              ("Coinbase", coinbase),
+              ("Transaction fees", transactionFees),
+              ("Proof fees", (-1) * proofFees),
+              ("Delegation fees", (-1) * delegationFees),
+            ],
+            includedAt,
+          ),
+        amountDelta: coinbase + transactionFees - proofFees - delegationFees,
+      }
+    | Payment(
+        {
+          PaymentDetails.from,
+          to_,
+          amount,
+          fee,
+          memo,
+          submittedAt,
+          includedAt,
+        },
+        {ConsensusState.status, _},
+      ) =>
+      let date = Option.withDefault(includedAt, ~default=submittedAt);
+      {
+        sender: Actor.Key(from),
+        recipient: Actor.Key(to_),
+        action:
+          switch (status) {
+          | ConsensusState.Status.Failed => Action.Failed
+          | Submitted => Action.Pending
+          | Included
+          | Snarked
+          | Finalized => Action.Transfer
+          },
+        info:
+          Option.map(memo, ~f=x => Info.Memo(x, date))
+          |> Option.withDefault(~default=Info.Empty(date)),
+        amountDelta:
+          Caml.List.exists(PublicKey.equal(from), myWallets)
+            ? (-1) * amount - fee : amount,
+      };
+    | Unknown({UnknownDetails.key, amount}) => {
+        sender: Actor.Unknown,
+        recipient: Actor.Key(key),
+        action: Action.Transfer,
+        info: Info.MissingReceipts,
+        amountDelta: amount,
+      }
+    };
+  };
+};
+
+module ActorName = {
+  [@react.component]
+  let make = (~value: ViewModel.Actor.t) => {
+    switch (value) {
+    | Key(key) =>
+      <span> {ReasonReact.string(PublicKey.toString(key))} </span>
+    | Unknown => <span />
+    | Minted =>
+      <span className=Css.(style([backgroundColor(StyleGuide.Colors.sage)]))>
+        {ReasonReact.string("Minted")}
+      </span>
+    };
+  };
+};
+
+module TimeDisplay = {
+  [@react.component]
+  let make = (~date: Js.Date.t) => {
+    <span
+      className=Css.(
+        style([
+          whiteSpace(`nowrap),
+          overflow(`hidden),
+          textOverflow(`ellipsis),
+          maxWidth(`rem(6.0)),
+        ])
+      )>
+       {ReasonReact.string(Js.Date.toString(date))} </span>;
+      // TODO: Format properly
+  };
+};
+
+module Amount = {
+  [@react.component]
+  let make = (~decorated: bool, ~value: int) => {
+    <span>
+      <span
+        className=Css.(
+          style([
+            StyleGuide.Typeface.lucidaGrande,
+            color(
+              value >= 0
+                ? StyleGuide.Colors.serpentine : StyleGuide.Colors.roseBud,
+            ),
+          ])
+        )>
+        {ReasonReact.string({j|■|j})}
+      </span>
+      <span> {ReasonReact.string(Js.Int.toString(value))} </span>
+      {decorated
+         ? <span> {ReasonReact.string(value >= 0 ? "+" : "-")} </span>
+         : <span />}
+    </span>;
+  };
+};
+
+module InfoSection = {
+  [@react.component]
+  let make = (~expanded: bool, ~viewModel: ViewModel.t) => {
+    let mainRow = message => {
+      <div
+        className=Css.(
+          style([
+            display(`flex),
+            justifyContent(`spaceBetween),
+            alignItems(`center),
+          ])
+        )>
+        <p> {ReasonReact.string(message)} </p>
+        <Amount decorated=false value={viewModel.amountDelta} />
+      </div>;
+    };
+    <div>
+      <div
+        className=Css.(style([display(`flex), justifyContent(`flexEnd)]))>
+        {expanded
+           ? <span> {ReasonReact.string({j|Collapse 🠻|j})} </span>
+           : (
+             switch (viewModel.info) {
+             | Memo(_, date)
+             | Empty(date)
+             | StakingReward(_, date) =>
+               <>
+                 {switch (viewModel.action) {
+                  | Transfer => <span />
+                  | Pending =>
+                    <span className=Css.(style([textTransform(`uppercase)]))>
+                      {ReasonReact.string("pending")}
+                    </span>
+                  | Failed =>
+                    <span className=Css.(style([textTransform(`uppercase)]))>
+                      {ReasonReact.string("failed")}
+                    </span>
+                  }}
+                 <TimeDisplay date />
+               </>
+             | MissingReceipts => <span />
+             }
+           )}
+      </div>
+      {switch (viewModel.info) {
+       | Memo(message, _) => mainRow(message)
+       | Empty(_) => mainRow("")
+       | MissingReceipts => mainRow("+ Insert transaction receipts")
+       | StakingReward(rewards, _) =>
+         <>
+           {mainRow("Staking reward")}
+           {expanded
+              ? <ul>
+                  {List.map(rewards, ~f=((message, amount)) =>
+                     <li
+                       key=message
+                       className=Css.(
+                         style([
+                           display(`flex),
+                           justifyContent(`spaceBetween),
+                           alignItems(`center),
+                         ])
+                       )>
+                       <p> {ReasonReact.string(message)} </p>
+                       <Amount decorated=true value=amount />
+                     </li>
+                   )
+                   |> Array.fromList
+                   |> ReasonReact.array}
+                </ul>
+              : <span />}
+         </>
+       }}
+    </div>;
+  };
+};
+
+// We can represent one of these cells as a row in an HTML table in the
+// following manner:
+//
+// ┌────────┬────┬───────────┬─────────────────────────
+// │ Sender │ -> │ Recipient │ Info (including amount)
+//
+// The final column is info and amount in order to more easily support the
+// expanded view of the staking reward
+
+[@react.component]
+let make = (~transaction: Transaction.t, ~myWallets: list(PublicKey.t)) => {
+  let (expanded, setExpanded) = React.useState(() => false);
+
+  let viewModel = ViewModel.ofTransaction(transaction, ~myWallets);
+
+  <tr
+    onClick={_e =>
+      switch (viewModel.info) {
+      | StakingReward(_, _) => setExpanded(expanded => !expanded)
+      | _ => ()
+      }
+    }>
+    <td className=Css.(style([verticalAlign(`baseline)]))>
+      <ActorName value={viewModel.sender} />
+    </td>
+    <td className=Css.(style([verticalAlign(`baseline)]))>
+      {ReasonReact.string(
+         switch (viewModel.action) {
+         | Transfer => "->"
+         | Pending => ">>"
+         | Failed => "x"
+         },
+       )}
+    </td>
+    <td className=Css.(style([verticalAlign(`baseline)]))>
+      <ActorName value={viewModel.recipient} />
+    </td>
+    <td
+      className=Css.(
+        style([verticalAlign(`baseline), width(`percent(100.))])
+      )>
+      <InfoSection expanded viewModel />
+    </td>
+  </tr>;
+};

--- a/frontend/wallet/src/TransactionsView.re
+++ b/frontend/wallet/src/TransactionsView.re
@@ -1,0 +1,125 @@
+open Tc;
+
+[@react.component]
+let make = () => {
+  let myWallets = [PublicKey.ofStringExn("123456789")];
+  let otherKey = PublicKey.ofStringExn("BDK342322");
+
+  <table className=Css.(style([overflow(`scroll)]))>
+    <tr>
+      <th className=Css.(style([textAlign(`left)]))>
+        {ReasonReact.string("Sender")}
+      </th>
+      <th />
+      <th className=Css.(style([textAlign(`left)]))>
+        {ReasonReact.string("Recipient")}
+      </th>
+      <th className=Css.(style([textAlign(`left)]))>
+        {ReasonReact.string("Info")}
+      </th>
+    </tr>
+    // Transaction Cells as in the mockup
+    <TransactionCell
+      transaction={
+        TransactionCell.Transaction.Unknown({
+          key: List.head(myWallets) |> Option.getExn,
+          amount: 2415,
+        })
+      }
+      myWallets
+    />
+    <TransactionCell
+      transaction={
+        TransactionCell.Transaction.Payment(
+          {
+            from: otherKey,
+            to_: List.head(myWallets) |> Option.getExn,
+            amount: 2415,
+            fee: 10,
+            memo: Some("Funds received memo"),
+            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+          },
+          {
+            status: ConsensusState.Status.Included,
+            estimatedPercentConfirmed: 0.95,
+          },
+        )
+      }
+      myWallets
+    />
+    <TransactionCell
+      transaction={
+        TransactionCell.Transaction.Payment(
+          {
+            from: List.head(myWallets) |> Option.getExn,
+            to_: otherKey,
+            amount: 1540,
+            fee: 10,
+            memo: Some("Funds sent"),
+            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+          },
+          {
+            status: ConsensusState.Status.Finalized,
+            estimatedPercentConfirmed: 0.95,
+          },
+        )
+      }
+      myWallets
+    />
+    <TransactionCell
+      transaction={
+        TransactionCell.Transaction.Minted({
+          key: List.head(myWallets) |> Option.getExn,
+          coinbase: 2000,
+          transactionFees: 858,
+          proofFees: 200,
+          delegationFees: 215,
+          includedAt: Js.Date.fromString("16 Apr 2019 21:46:00 PST"),
+        })
+      }
+      myWallets
+    />
+    <TransactionCell
+      transaction={
+        TransactionCell.Transaction.Payment(
+          {
+            from: otherKey,
+            to_: List.head(myWallets) |> Option.getExn,
+            amount: 1540,
+            fee: 10,
+            memo: Some("Remitance payment"),
+            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+          },
+          {
+            status: ConsensusState.Status.Submitted,
+            estimatedPercentConfirmed: 0.0,
+          },
+        )
+      }
+      myWallets
+    />
+    <TransactionCell
+      transaction={
+        TransactionCell.Transaction.Payment(
+          {
+            from: otherKey,
+            to_: List.head(myWallets) |> Option.getExn,
+            amount: 2415,
+            fee: 10,
+            memo: Some("Order #: 2347B342"),
+            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+          },
+          {
+            status: ConsensusState.Status.Failed,
+            estimatedPercentConfirmed: 0.0,
+          },
+        )
+      }
+      myWallets
+    />
+  </table>;
+};


### PR DESCRIPTION
Logic in place for rendering all transactions in the spec.

Some layout is completed, but styling still needs a ton of work.

Tables were used as this is semantically a table, but it's unclear
whether it should just all be flex or not.

`TransactionsView` for now just hardcodes all the cells present in
the mockup to make sure we can look at all of them (for the
purposes of testing).

### The Spec (non-expanded)

<img width="919" alt="Screen Shot 2019-04-17 at 5 12 43 PM" src="https://user-images.githubusercontent.com/515445/56328485-0ca75f80-6134-11e9-8709-bbfc39f7e142.png">

### The Implementation (non-expanded)

<img width="919" alt="Screen Shot 2019-04-17 at 5 04 53 PM" src="https://user-images.githubusercontent.com/515445/56328493-19c44e80-6134-11e9-9069-db1383ae1f31.png">

### The Spec (expanded)

<img width="919" alt="Screen Shot 2019-04-17 at 5 12 48 PM" src="https://user-images.githubusercontent.com/515445/56328508-25b01080-6134-11e9-851f-21f060475723.png">

### The Implementation (expanded)

<img width="919" alt="Screen Shot 2019-04-17 at 5 05 40 PM" src="https://user-images.githubusercontent.com/515445/56328518-33fe2c80-6134-11e9-81bc-0c1118a2ea51.png">
