### PR TITLE
Add content to Send/Delete modals

### DIFF
--- a/frontend/wallet/src/Delete.re
+++ b/frontend/wallet/src/Delete.re
@@ -1,7 +1,32 @@
 [@react.component]
-let make = () => {
-  <div>
+let make = (~closeModal, ~walletName) => {
+  <div onClick={e => ReactEvent.Synthetic.stopPropagation(e)}>
     <h1> {ReasonReact.string("Delete Wallet")} </h1>
-    <p> {ReasonReact.string("etc.")} </p>
+    <div
+      className=Css.(
+        style([
+          display(`flex),
+          justifyContent(`center),
+          alignItems(`center),
+        ])
+      )>
+      <p> {ReasonReact.string("Are you sure you would like to delete:")} </p>
+      <span> {ReasonReact.string(walletName)} </span>
+      <span> {ReasonReact.string("?")} </span>
+    </div>
+    <br />
+    <p>
+      {ReasonReact.string("Please type in the wallet name on continue")}
+    </p>
+    <br />
+    <label> {ReasonReact.string("Wallet:")} </label>
+    <input type_="text" />
+    <br />
+    <ModalButtons
+      onSecondaryClick={_e => closeModal()}
+      onPrimaryClick={_e => ()}
+      primaryColor=StyleGuide.Colors.roseBud
+      primaryCopy="Delete"
+    />
   </div>;
 };

--- a/frontend/wallet/src/ModalButtons.re
+++ b/frontend/wallet/src/ModalButtons.re
@@ -1,0 +1,44 @@
+module Button = {
+  [@react.component]
+  let make = (~className="", ~onClick, ~bgColor, ~copy) => {
+    <button
+      onClick
+      className=Css.(
+        merge([
+          className,
+          style([
+            backgroundColor(bgColor),
+            color(StyleGuide.Colors.blanco),
+            paddingLeft(`rem(2.0)),
+            paddingRight(`rem(2.0)),
+            paddingTop(`rem(1.0)),
+            paddingBottom(`rem(1.0)),
+            borderRadius(`px(6)),
+            border(`zero, `none, Css.white),
+          ]),
+        ])
+      )>
+      {ReasonReact.string(copy)}
+    </button>;
+  };
+};
+
+[@react.component]
+let make = (~onSecondaryClick, ~onPrimaryClick, ~primaryColor, ~primaryCopy) => {
+  <div
+    className=Css.(
+      style([
+        display(`flex),
+        justifyContent(`spaceBetween),
+        alignItems(`center),
+      ])
+    )>
+    <Button
+      className=Css.(style([marginRight(`rem(1.0))]))
+      onClick=onSecondaryClick
+      bgColor={StyleGuide.Colors.slateAlpha(0.3)}
+      copy="Cancel"
+    />
+    <Button onClick=onPrimaryClick bgColor=primaryColor copy=primaryCopy />
+  </div>;
+};

--- a/frontend/wallet/src/Page.re
+++ b/frontend/wallet/src/Page.re
@@ -65,7 +65,8 @@ let make = (~message) => {
           }
         />,
       )
-    | DeleteWallet => Some(<Delete closeModal walletName="Hot Wallet" />)
+    | Some(DeleteWallet) =>
+      Some(<Delete closeModal walletName="Hot Wallet" />)
     | Some(Home) => None
     };
 

--- a/frontend/wallet/src/Page.re
+++ b/frontend/wallet/src/Page.re
@@ -45,11 +45,27 @@ let useRoute = () => {
 let make = (~message) => {
   let (path, settingsOrError, setSettingsOrError) = useRoute();
 
+  let closeModal = () => Router.navigate({path: Home, settingsOrError});
   let modalView =
     switch (path) {
     | None => None
-    | Some(Route.Path.Send) => Some(<Send />)
-    | Some(DeleteWallet) => Some(<Delete />)
+    | Some(Route.Path.Send) =>
+      Some(
+        <Send
+          closeModal
+          myWallets=[
+            {Wallet.key: PublicKey.ofStringExn("BK123123123"), balance: 100},
+            {Wallet.key: PublicKey.ofStringExn("BK8888888"), balance: 783},
+          ]
+          settings={
+            switch (settingsOrError) {
+            | `Settings(settings) => settings
+            | _ => failwith("Bad; we need settings")
+            }
+          }
+        />,
+      )
+    | DeleteWallet => Some(<Delete closeModal walletName="Hot Wallet" />)
     | Some(Home) => None
     };
 
@@ -107,9 +123,6 @@ let make = (~message) => {
             <Header />
             <Body message={message ++ ";; " ++ settingsInfo} />
           </div>
-          {testButton("Send", ~f=() =>
-             Router.(navigate({path: Send, settingsOrError}))
-           )}
           {testButton("Delete wallet", ~f=() =>
              Router.(navigate({path: DeleteWallet, settingsOrError}))
            )}

--- a/frontend/wallet/src/Send.re
+++ b/frontend/wallet/src/Send.re
@@ -1,7 +1,47 @@
+open Tc;
+
 [@react.component]
-let make = () => {
-  <div>
+let make = (~closeModal, ~myWallets, ~settings) => {
+  <div onClick={e => ReactEvent.Synthetic.stopPropagation(e)}>
     <h1> {ReasonReact.string("Send Coda")} </h1>
-    <p> {ReasonReact.string("etc.")} </p>
+    <label> {ReasonReact.string("From:")} </label>
+    <select>
+      {List.map(myWallets, ~f=(wallet: Wallet.t)
+         // TODO: Replace option/select tags with a custom dropdown
+         // You can't put arbitrary html in the options, and styling
+         // is hard.
+         =>
+           <option
+             key={wallet.key |> PublicKey.toString}
+             value={wallet.key |> PublicKey.toString}>
+             {ReasonReact.string(
+                (
+                  Settings.lookup(settings, wallet.key)
+                  |> Option.withDefault(
+                       ~default=wallet.key |> PublicKey.toString,
+                     )
+                )
+                ++ {j|( ■ |j}
+                ++ Js.Int.toString(wallet.balance)
+                ++ " )",
+              )}
+           </option>
+         )
+       |> Array.fromList
+       |> ReasonReact.array}
+    </select>
+    <br />
+    <label> {ReasonReact.string("To:")} </label>
+    <input name="to" type_="text" />
+    <br />
+    <label> {ReasonReact.string("Qty:")} </label>
+    <input name="qty" type_="number" />
+    <br />
+    <ModalButtons
+      onSecondaryClick={_e => closeModal()}
+      onPrimaryClick={_e => ()}
+      primaryColor=StyleGuide.Colors.serpentine
+      primaryCopy="Send"
+    />
   </div>;
 };

--- a/frontend/wallet/src/StyleGuide.re
+++ b/frontend/wallet/src/StyleGuide.re
@@ -8,11 +8,14 @@ module Colors = {
   let savilleAlpha = a => `rgba((31, 45, 61, a));
   let saville = savilleAlpha(1.);
 
-  let serpentine = `hex("479056");
+  let slateAlpha = a => `rgba((81, 102, 121, a));
 
   let roseBud = `hex("a3536f");
 
+  let serpentine = `hex("479056");
+
   let sage = `hex("65906e");
+  let blanco = `hex("e3e0d5");
 
   let headerBgColor = `hex("06111bBB");
   let headerGreyText = `hex("516679");

--- a/frontend/wallet/src/Wallet.re
+++ b/frontend/wallet/src/Wallet.re
@@ -1,0 +1,4 @@
+type t = {
+  key: PublicKey.t,
+  balance: int // TODO: Make this uint64
+};


### PR DESCRIPTION
Content in place for Send/Delete modals. Cancel button correctly closes
the modals and clicking outside the content window also closes.

ModalButtons are reused between the two modal states and it seems like
this is the only area with that style Button is used, so I inlined the
"Button" definition in the ModalButtons module.

TODO: to add the + Add memo button on the Send modal

### Spec Send Modal

<img width="464" alt="Screen Shot 2019-04-17 at 6 35 23 PM" src="https://user-images.githubusercontent.com/515445/56331062-9b6da980-613f-11e9-8424-3d7428ed9db0.png">


### Implementation Send Modal

<img width="464" alt="Screen Shot 2019-04-17 at 6 32 38 PM" src="https://user-images.githubusercontent.com/515445/56331057-97da2280-613f-11e9-9f21-8c4a0b98f5c8.png">

### Spec Delete Modal

<img width="464" alt="Screen Shot 2019-04-17 at 6 35 17 PM" src="https://user-images.githubusercontent.com/515445/56331078-ac1e1f80-613f-11e9-8914-7d5a2303d512.png">


### Implementation Delete Modal

<img width="464" alt="Screen Shot 2019-04-17 at 6 32 45 PM" src="https://user-images.githubusercontent.com/515445/56331087-b4765a80-613f-11e9-821a-6e60c39d69e5.png">
