### PR TITLE
Use define_locally in Coda_main

### DIFF
--- a/src/app/cli/src/coda_main.ml
+++ b/src/app/cli/src/coda_main.ml
@@ -394,21 +394,15 @@ module Pending_coinbase = struct
   module V1 = struct
     include Coda_base.Pending_coinbase.Stable.V1
 
-    let ( hash_extra
-        , oldest_stack
-        , latest_stack
-        , create
-        , remove_coinbase_stack
-        , update_coinbase_stack
-        , merkle_root ) =
-      Coda_base.Pending_coinbase.
-        ( hash_extra
-        , oldest_stack
-        , latest_stack
-        , create
-        , remove_coinbase_stack
-        , update_coinbase_stack
-        , merkle_root )
+    [%%define_locally
+    Coda_base.Pending_coinbase.
+      ( hash_extra
+      , oldest_stack
+      , latest_stack
+      , create
+      , remove_coinbase_stack
+      , update_coinbase_stack
+      , merkle_root )]
 
     module Stack = Coda_base.Pending_coinbase.Stack
     module Coinbase_data = Coda_base.Pending_coinbase.Coinbase_data


### PR DESCRIPTION
Spotted a place to use `define_locally` in `Coda_main`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
