### PR TITLE
Settings reactively updates across processes

### DIFF
--- a/frontend/wallet/src/AppWindow.re
+++ b/frontend/wallet/src/AppWindow.re
@@ -15,14 +15,25 @@ include Single.Make({
           switch (settingsOrError) {
           | `Settings(settings) =>
             let task = SettingsMain.add(settings, ~key, ~name);
-            Task.attempt(
-              task,
-              ~f=_res => {
-                Js.log2("Settings updated", settings);
-                send(t, `Respond(pendingIdent));
-              },
+            Task.attempt(task, ~f=_res =>
+              send(
+                t,
+                `Respond_new_settings((
+                  pendingIdent,
+                  Js.Json.stringify(
+                    Route.SettingsOrError.Encode.t(`Settings(settings)),
+                  ),
+                )),
+              )
             );
-          | _ => send(t, `Respond(pendingIdent))
+          | e =>
+            send(
+              t,
+              `Respond_new_settings((
+                pendingIdent,
+                Js.Json.stringify(Route.SettingsOrError.Encode.t(e)),
+              )),
+            )
           }
         };
     RendererCommunication.on(cb);

--- a/frontend/wallet/src/CallTable.re
+++ b/frontend/wallet/src/CallTable.re
@@ -1,50 +1,102 @@
 open Tc;
 
-module Ident = {
-  type t = (int, string);
+module Make =
+       (
+         Typ: {
+           type t('a);
+           let if_eq:
+             (
+               t('a),
+               t('b),
+               'b,
+               ~is_equal: 'a => unit,
+               ~not_equal: 'b => unit
+             ) =>
+             unit;
+         },
+       ) => {
+  module Ident = {
+    type t('a) = {
+      id: int,
+      loc: string,
+      typ: Typ.t('a),
+    };
 
-  let toString = ((i, s)) => Js.Int.toString(i) ++ s;
-};
+    module Encode = {
+      type t0('a) = t('a);
+      type t = (int, string);
+      let t = ({id, loc, typ: _}) => (id, loc);
+    };
+    module Decode = {
+      let t = ((id, loc), typ) => {id, loc, typ};
+    };
 
-// TODO: GADT this to support responses tthat aren't just unit
-// call number -> Task completer
-type t = {
-  table: Js.Dict.t(unit => unit),
-  id: ref(int),
-};
-
-module Pending = {
-  type t('x) = {
-    ident: Ident.t,
-    task: Task.t('x, unit),
+    let toString = ({id, loc, typ: _}) => Js.Int.toString(id) ++ loc;
   };
-};
 
-let make = () => {table: Js.Dict.empty(), id: ref(0)};
+  module Any = {
+    type t =
+      | T('a, Typ.t('a)): t;
+  };
 
-let nextPending = (t, ~loc) => {
-  let id = t.id^;
-  incr(t.id);
-  let task =
-    Task.create(cb => {
-      let key = Ident.toString((id, loc));
-      Js.Dict.set(
-        t.table,
-        key,
-        () => {
-          Js.Dict.set(t.table, key, Obj.magic(Js.Nullable.undefined));
-          cb(Belt.Result.Ok());
-        },
-      );
-    });
-  {Pending.ident: (id, loc), task};
-};
+  type t = {
+    table: Js.Dict.t(Any.t => unit),
+    id: ref(int),
+  };
 
-// assuming responses are one-shot for now
-let resolve = (t, ident) => {
-  switch (Js.Dict.get(t.table, Ident.toString(ident))) {
-  | None =>
-    Js.log2("Unexpected missing identifier from call table, ignoring ", ident)
-  | Some(f) => f()
+  module Pending = {
+    type t('x, 'a) = {
+      ident: Ident.t('a),
+      task: Task.t('x, 'a),
+    };
+  };
+
+  let make = () => {table: Js.Dict.empty(), id: ref(0)};
+
+  let nextPending = (type a, t, typ: Typ.t(a), ~loc) => {
+    let id = t.id^;
+    incr(t.id);
+    let task =
+      Task.create(cb => {
+        let key = Ident.toString({id, loc, typ});
+        Js.Dict.set(t.table, key, (Any.T(v, typ2)) =>
+          Typ.if_eq(
+            typ,
+            typ2,
+            v,
+            ~is_equal=
+              a => {
+                Js.Dict.set(t.table, key, Obj.magic(Js.Nullable.undefined));
+                cb(Belt.Result.Ok(a));
+              },
+            ~not_equal=
+              b =>
+                Js.log2(
+                  "Type witnesses are different, not resolving call table pending",
+                  b,
+                ),
+          )
+        );
+      });
+    {
+      Pending.ident: {
+        id,
+        loc,
+        typ,
+      },
+      task,
+    };
+  };
+
+  // assuming responses are one-shot for now
+  let resolve = (type a, t, ident: Ident.t(a), v: a) => {
+    switch (Js.Dict.get(t.table, Ident.toString(ident))) {
+    | None =>
+      Js.log2(
+        "Unexpected missing identifier from call table, ignoring ",
+        ident,
+      )
+    | Some(f) => f(Any.T(v, ident.typ))
+    };
   };
 };

--- a/frontend/wallet/src/CallTable.rei
+++ b/frontend/wallet/src/CallTable.rei
@@ -1,9 +1,26 @@
 open Tc;
 
+/// The CallTable is used to bridge the world of a single event listener with
+/// the world of tasks.
+///
+/// Given type witnesses for the different kinds of Tasks you wish to
+/// bootstrap, CallTable can generate `Pending.t('x, 'a)`, or tasks coupled
+/// with an identifier that you can feed later to resolve the underlying task.
+
 module Make:
   (
     Typ: {
+      /// All witnesses to types that you want in Task returns
+      /// To support `int` and `unit` for example:
+      ///
+      /// ```reason
+      /// type t('a) =
+      ///   | Int: t(int)
+      ///   | Unit: t(unit)
+      /// ```
       type t('a);
+
+      /// If `'a == 'b` then call `is_equal` on the `'b`, otherwise call `not_equal`
       let if_eq:
         (t('a), t('b), 'b, ~is_equal: 'a => unit, ~not_equal: 'b => unit) =>
         unit;
@@ -11,6 +28,8 @@ module Make:
   ) =>
    {
     module Ident: {
+      /// Identifiers that can be serialized and deserialized for the purposes
+      /// of RPC/IPC
       type t('a);
 
       module Encode: {
@@ -23,6 +42,7 @@ module Make:
     };
 
     module Pending: {
+      /// A Task that is waiting for the `ident` to be resolved.
       type t('x, 'a) = {
         ident: Ident.t('a),
         task: Task.t('x, 'a),
@@ -32,6 +52,8 @@ module Make:
     type t;
 
     let make: unit => t;
+    /// Get the next Pending.t
     let nextPending: (t, Typ.t('a), ~loc: string) => Pending.t('x, 'a);
+    /// Resolve some Pending.t with a value
     let resolve: (t, Ident.t('a), 'a) => unit;
   };

--- a/frontend/wallet/src/CallTable.rei
+++ b/frontend/wallet/src/CallTable.rei
@@ -1,16 +1,37 @@
 open Tc;
 
-module Ident: {type t;};
+module Make:
+  (
+    Typ: {
+      type t('a);
+      let if_eq:
+        (t('a), t('b), 'b, ~is_equal: 'a => unit, ~not_equal: 'b => unit) =>
+        unit;
+    },
+  ) =>
+   {
+    module Ident: {
+      type t('a);
 
-module Pending: {
-  type t('x) = {
-    ident: Ident.t,
-    task: Task.t('x, unit),
+      module Encode: {
+        type t0('a) = t('a);
+        type t;
+        let t: t0('a) => t;
+      };
+
+      module Decode: {let t: (Encode.t, Typ.t('a)) => t('a);};
+    };
+
+    module Pending: {
+      type t('x, 'a) = {
+        ident: Ident.t('a),
+        task: Task.t('x, 'a),
+      };
+    };
+
+    type t;
+
+    let make: unit => t;
+    let nextPending: (t, Typ.t('a), ~loc: string) => Pending.t('x, 'a);
+    let resolve: (t, Ident.t('a), 'a) => unit;
   };
-};
-
-type t;
-
-let make: unit => t;
-let nextPending: (t, ~loc: string) => Pending.t('x);
-let resolve: (t, Ident.t) => unit;

--- a/frontend/wallet/src/MainCommunication.re
+++ b/frontend/wallet/src/MainCommunication.re
@@ -3,19 +3,44 @@ open Tc;
 
 include IpcRenderer.MakeIpcRenderer(Messages);
 
+module CallTable = Messages.CallTable;
+
 let callTable = CallTable.make();
 
 let setName = (key, name) => {
-  let pending = CallTable.nextPending(callTable, ~loc=__LOC__);
-  send(`Set_name((key, name, pending.ident)));
+  let pending =
+    CallTable.nextPending(
+      callTable,
+      Messages.Typ.SettingsOrError,
+      ~loc=__LOC__,
+    );
+  send(`Set_name((key, name, CallTable.Ident.Encode.t(pending.ident))));
   pending.task;
 };
 
-let listen = () =>
-  on((. _event, message) =>
-    switch (message) {
-    | `Respond(ident) => CallTable.resolve(callTable, ident)
-    | `Deep_link(routeString) =>
-      Router.navigate(Route.parse(routeString) |> Option.getExn)
-    }
-  );
+module ListenToken = {
+  type t = messageCallback(Messages.mainToRendererMessages);
+};
+
+let listen = () => {
+  let cb =
+    (. _event, message: Messages.mainToRendererMessages) =>
+      switch (message) {
+      | `Respond_new_settings(ident, settingsOrErrorJson) =>
+        let settingsOrError =
+          Route.SettingsOrError.Decode.t(
+            Js.Json.parseExn(settingsOrErrorJson),
+          );
+        CallTable.resolve(
+          callTable,
+          CallTable.Ident.Decode.t(ident, Messages.Typ.SettingsOrError),
+          settingsOrError,
+        );
+      | `Deep_link(routeString) =>
+        Router.navigate(Route.parse(routeString) |> Option.getExn)
+      };
+  on(cb);
+  cb;
+};
+
+let stopListening: ListenToken.t => unit = removeListener;

--- a/frontend/wallet/src/MainCommunication.rei
+++ b/frontend/wallet/src/MainCommunication.rei
@@ -1,0 +1,8 @@
+open Tc;
+
+module ListenToken: {type t;};
+
+let setName: (PublicKey.t, string) => Task.t('x, Route.SettingsOrError.t);
+
+let listen: unit => ListenToken.t;
+let stopListening: ListenToken.t => unit;

--- a/frontend/wallet/src/Messages.re
+++ b/frontend/wallet/src/Messages.re
@@ -1,10 +1,34 @@
 let message = __MODULE__;
 
+module Typ = {
+  type t('a) =
+    | SettingsOrError: t(Route.SettingsOrError.t);
+
+  let if_eq =
+      (
+        type a,
+        type b,
+        ta: t(a),
+        tb: t(b),
+        v: b,
+        ~is_equal: a => unit,
+        ~not_equal as _: b => unit,
+      ) => {
+    switch (ta, tb) {
+    | (SettingsOrError, SettingsOrError) => is_equal(v)
+    };
+  };
+};
+module CallTable = CallTable.Make(Typ);
+
 type mainToRendererMessages = [
-  | `Respond(CallTable.Ident.t)
+  | `Respond_new_settings(
+      CallTable.Ident.Encode.t,
+      /* Route.SettingsOrError.t */ string,
+    )
   | `Deep_link(/*Route.t*/ string)
 ];
 
 type rendererToMainMessages = [
-  | `Set_name(PublicKey.t, string, CallTable.Ident.t)
+  | `Set_name(PublicKey.t, string, CallTable.Ident.Encode.t)
 ];

--- a/frontend/wallet/src/SettingsRenderer.rei
+++ b/frontend/wallet/src/SettingsRenderer.rei
@@ -1,1 +1,0 @@
-include Settings.S;


### PR DESCRIPTION
CallTable now is typed with GADTs and handles the settings changes by
the tray process responding with the new settings.

Luckily we only need to update the settings after the application starts
via changes initiated by the render process. Whenever this is no longer
true we'll need to handle the extra messages and correctly call
`setSettingsOrError`.

![out](https://user-images.githubusercontent.com/515445/56394906-923b1600-61ed-11e9-96f4-188f6618b4b2.gif)
