### PR TITLE
Replace faulty_peer by trust system record in Coda_networking

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -668,13 +668,12 @@ module Make (Inputs : Inputs_intf) = struct
             record t.trust_system t.logger peer.host
               Actions.
                 ( Violated_protocol
-                , Some
-                    ( "When querying preferred peer $peer, got no response"
-                    , [("peer", Peer.to_yojson peer)] ) ))
+                , Some ("When querying preferred peer, got no response", []) ))
         in
         let peers = get_random_peers () in
         try_non_preferred_peers t envelope peers ~rpc
     | Error _ ->
+        (* TODO: determine what punishments apply here *)
         Logger.error t.logger ~module_:__MODULE__ ~location:__LOC__
           !"get error from %{sexp: Peer.t}"
           peer ;


### PR DESCRIPTION
In `Coda_networking`, replaced one call of `Logger.faulty_peer` with a call to `Trust_system.record`.

Another, I changed to `Logger.error`, since it's not clear to me it's worthy of punishment.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
