### PR TITLE
Ledger catchup uses trust system

### DIFF
--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -47,8 +47,8 @@ module Make (Inputs : Inputs.S) :
    and type network := Inputs.Network.t = struct
   open Inputs
 
-  let verify_transition ~logger ~frontier ~unprocessed_transition_cache
-      transition_enveloped =
+  let verify_transition ~logger ~trust_system ~frontier
+      ~unprocessed_transition_cache transition_enveloped =
     let cached_verified_transition =
       let open Deferred.Result.Let_syntax in
       let transition = Envelope.Incoming.data transition_enveloped in
@@ -97,9 +97,17 @@ module Make (Inputs : Inputs.S) :
         | `Success hash ->
             Ok (Either.First hash) )
     | Error (`Invalid reason) ->
-        Logger.faulty_peer logger ~module_:__MODULE__ ~location:__LOC__
-          "transition queried during ledger catchup was not valid because %s"
-          reason ;
+        let%bind () =
+          Trust_system.(
+            record_envelope_sender trust_system logger
+              (Envelope.Incoming.sender transition_enveloped)
+              Actions.
+                ( Violated_protocol
+                , Some
+                    ( "Transition queried during ledger catchup was not valid \
+                       because $reason"
+                    , [("reason", `String reason)] ) ))
+        in
         Deferred.return @@ Error (Error.of_string reason)
 
   let take_while_map_result_rev ~f list =
@@ -123,8 +131,8 @@ module Make (Inputs : Inputs.S) :
     in
     (result, Option.value_exn initial_state_hash)
 
-  let get_transitions_and_compute_breadcrumbs ~logger ~network ~frontier
-      ~num_peers ~unprocessed_transition_cache ~target_forest =
+  let get_transitions_and_compute_breadcrumbs ~logger ~trust_system ~network
+      ~frontier ~num_peers ~unprocessed_transition_cache ~target_forest =
     let peers = Network.random_peers network num_peers in
     let target_hash, subtrees = target_forest in
     let open Deferred.Or_error.Let_syntax in
@@ -152,18 +160,22 @@ module Make (Inputs : Inputs.S) :
                       target_hash
                   then return ()
                   else (
-                    Logger.faulty_peer logger ~module_:__MODULE__
-                      ~location:__LOC__
-                      !"Peer %{sexp:Network_peer.Peer.t} returned an \
-                        different target transition than we requested"
-                      peer ;
+                    ignore
+                      Trust_system.(
+                        record trust_system logger peer.host
+                          Actions.
+                            ( Violated_protocol
+                            , Some
+                                ( "Peer returned a different target \
+                                   transition than requested"
+                                , [] ) )) ;
                     Deferred.return (Error (Error.of_string "")) )
                 in
                 let%bind verified_transitions, initial_state_hash =
                   take_while_map_result_rev
                     Non_empty_list.(to_list rev_queried_transitions)
                     ~f:(fun transition ->
-                      verify_transition ~logger ~frontier
+                      verify_transition ~logger ~trust_system ~frontier
                         ~unprocessed_transition_cache
                         (Envelope.Incoming.wrap ~data:transition
                            ~sender:(Envelope.Sender.Remote peer)) )
@@ -197,12 +209,12 @@ module Make (Inputs : Inputs.S) :
                       ~f:(Fn.compose ignore Cached.invalidate_with_failure) ;
                     Deferred.return error ) ) )
 
-  let run ~logger ~network ~frontier ~catchup_job_reader
+  let run ~logger ~trust_system ~network ~frontier ~catchup_job_reader
       ~catchup_breadcrumbs_writer ~unprocessed_transition_cache =
     Strict_pipe.Reader.iter catchup_job_reader ~f:(fun (hash, subtrees) ->
         ( match%bind
-            get_transitions_and_compute_breadcrumbs ~logger ~network ~frontier
-              ~num_peers:8 ~unprocessed_transition_cache
+            get_transitions_and_compute_breadcrumbs ~logger ~trust_system
+              ~network ~frontier ~num_peers:8 ~unprocessed_transition_cache
               ~target_forest:(hash, subtrees)
           with
         | Ok trees ->

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -69,8 +69,9 @@ module Make (Inputs : Inputs_intf) :
     Strict_pipe.Reader.clear reader ;
     Strict_pipe.Writer.close writer
 
-  let run ~logger ~network ~time_controller ~collected_transitions ~frontier
-      ~network_transition_reader ~proposer_transition_reader ~clear_reader =
+  let run ~logger ~trust_system ~network ~time_controller
+      ~collected_transitions ~frontier ~network_transition_reader
+      ~proposer_transition_reader ~clear_reader =
     let valid_transition_pipe_capacity = 30 in
     let valid_transition_reader, valid_transition_writer =
       Strict_pipe.create ~name:"valid transitions"
@@ -122,7 +123,7 @@ module Make (Inputs : Inputs_intf) :
       ~clean_up_catchup_scheduler ~catchup_job_writer
       ~catchup_breadcrumbs_reader ~catchup_breadcrumbs_writer
       ~processed_transition_writer ~unprocessed_transition_cache ;
-    Catchup.run ~logger ~network ~frontier ~catchup_job_reader
+    Catchup.run ~logger ~trust_system ~network ~frontier ~catchup_job_reader
       ~catchup_breadcrumbs_writer ~unprocessed_transition_cache ;
     Strict_pipe.Reader.iter_without_pushback clear_reader ~f:(fun _ ->
         kill valid_transition_reader valid_transition_writer ;

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -187,8 +187,8 @@ module Make (Inputs : Inputs_intf) :
       Logger.info logger ~module_:__MODULE__ ~location:__LOC__
         "Starting Transition Frontier Controller phase" ;
       let new_verified_transition_reader =
-        Transition_frontier_controller.run ~logger ~network ~time_controller
-          ~collected_transitions ~frontier
+        Transition_frontier_controller.run ~logger ~trust_system ~network
+          ~time_controller ~collected_transitions ~frontier
           ~network_transition_reader:transition_reader
           ~proposer_transition_reader ~clear_reader
       in

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -450,6 +450,7 @@ module type Catchup_intf = sig
 
   val run :
        logger:Logger.t
+    -> trust_system:Trust_system.t
     -> network:network
     -> frontier:transition_frontier
     -> catchup_job_reader:( state_hash
@@ -785,6 +786,7 @@ module type Transition_frontier_controller_intf = sig
 
   val run :
        logger:Logger.t
+    -> trust_system:Trust_system.t
     -> network:network
     -> time_controller:time_controller
     -> collected_transitions:( external_transition_verified


### PR DESCRIPTION
Replace `Logger.faulty_peer` with calls to trust system in `Ledger_catchup`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
