### PR TITLE
Integrate sync status to bootstrap test

### DIFF
--- a/src/app/cli/src/coda_bootstrap_test.ml
+++ b/src/app/cli/src/coda_bootstrap_test.ml
@@ -23,10 +23,27 @@ let main () =
     Coda_worker_testnet.test logger n proposers snark_work_public_keys
       Protocols.Coda_pow.Work_selection.Seq ~max_concurrent_connections:None
   in
+  let previous_status = Sync_status.Hash_set.create () in
+  let bootstrapping_node = 1 in
+  (let%bind sync_status_pipe_opt =
+     Coda_worker_testnet.Api.sync_status testnet bootstrapping_node
+   in
+   Pipe_lib.Linear_pipe.iter (Option.value_exn sync_status_pipe_opt)
+     ~f:(fun sync_status ->
+       Logger.info logger ~module_:__MODULE__ ~location:__LOC__
+         !"Bootstrap node received status: %{sexp:Sync_status.t}"
+         sync_status ;
+       Hash_set.add previous_status sync_status ;
+       Deferred.unit ))
+  |> don't_wait_for ;
   let%bind () =
-    Coda_worker_testnet.Restarts.trigger_bootstrap testnet ~logger ~node:1
+    Coda_worker_testnet.Restarts.trigger_bootstrap testnet ~logger
+      ~node:bootstrapping_node
   in
   let%bind () = after (Time.Span.of_sec 180.) in
+  (* TODO: one of the previous_statuses should be `Bootstrap. The broadcast pip 
+    coda.transition_frontier never gets set to None *)
+  assert (Hash_set.mem previous_status `Synced) ;
   Coda_worker_testnet.Api.teardown testnet
 
 let command =

--- a/src/app/cli/src/coda_bootstrap_test.ml
+++ b/src/app/cli/src/coda_bootstrap_test.ml
@@ -30,7 +30,7 @@ let main () =
    in
    Pipe_lib.Linear_pipe.iter (Option.value_exn sync_status_pipe_opt)
      ~f:(fun sync_status ->
-       Logger.info logger ~module_:__MODULE__ ~location:__LOC__
+       Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
          !"Bootstrap node received status: %{sexp:Sync_status.t}"
          sync_status ;
        Hash_set.add previous_status sync_status ;

--- a/src/app/cli/src/coda_process.ml
+++ b/src/app/cli/src/coda_process.ml
@@ -86,6 +86,13 @@ let prove_receipt_exn (conn, proc, _) proving_receipt resulting_receipt =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.prove_receipt
     ~arg:(proving_receipt, resulting_receipt)
 
+let sync_status_exn (conn, proc, _) =
+  let%map r =
+    Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.sync_status
+      ~arg:()
+  in
+  Linear_pipe.wrap_reader r
+
 let verified_transitions_exn (conn, proc, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -1,6 +1,3 @@
-[%%import
-"../../../config.mlh"]
-
 open Core
 open Async
 open Coda_base
@@ -99,6 +96,8 @@ module T = struct
         Rpc_parallel.Function.t
     ; verified_transitions:
         ('worker, unit, State_hashes.t Pipe.Reader.t) Rpc_parallel.Function.t
+    ; sync_status:
+        ('worker, unit, Sync_status.t Pipe.Reader.t) Rpc_parallel.Function.t
     ; root_diff:
         ( 'worker
         , unit
@@ -131,6 +130,8 @@ module T = struct
         User_command.t -> Receipt.Chain_hash.t Or_error.t Deferred.t
     ; coda_verified_transitions:
         unit -> State_hashes.t Pipe.Reader.t Deferred.t
+    ; coda_sync_status:
+        unit -> Sync_status.Stable.V1.t Pipe.Reader.t Deferred.t
     ; coda_root_diff:
            unit
         -> User_command.t Protocols.Coda_transition_frontier.Root_diff_view.t
@@ -162,6 +163,9 @@ module T = struct
 
     let verified_transitions_impl ~worker_state ~conn_state:() () =
       worker_state.coda_verified_transitions ()
+
+    let sync_status_impl ~worker_state ~conn_state:() () =
+      worker_state.coda_sync_status ()
 
     let root_diff_impl ~worker_state ~conn_state:() () =
       worker_state.coda_root_diff ()
@@ -241,6 +245,10 @@ module T = struct
             User_command.Stable.Latest.t
             Protocols.Coda_transition_frontier.Root_diff_view.t] ()
 
+    let sync_status =
+      C.create_pipe ~f:sync_status_impl ~bin_input:Unit.bin_t
+        ~bin_output:[%bin_type_class: Sync_status.Stable.V1.t] ()
+
     let dump_tf =
       C.create_rpc ~f:dump_tf_impl ~bin_input:Unit.bin_t
         ~bin_output:String.bin_t ()
@@ -261,7 +269,8 @@ module T = struct
       ; process_payment
       ; prove_receipt
       ; dump_tf
-      ; best_path }
+      ; best_path
+      ; sync_status }
 
     let init_worker_state
         { host
@@ -476,6 +485,34 @@ module T = struct
             let path = Main.best_path coda in
             Deferred.return (Option.value ~default:[] path)
           in
+          let parse_sync_status_exn = function
+            | `Assoc [("data", `Assoc [("new_sync_update", `String status)])]
+              ->
+                Sync_status.of_string status |> Or_error.ok_exn
+            | unexpected_json ->
+                failwithf
+                  !"could not parse sync status from json. Got: %s"
+                  (Yojson.Basic.to_string unexpected_json)
+                  ()
+          in
+          let coda_sync_status () =
+            let schema = Run.Graphql.schema in
+            match Graphql_parser.parse "subscription { new_sync_update }" with
+            | Ok query -> (
+                match%map Graphql_async.Schema.execute schema coda query with
+                | Ok (`Stream pipe) ->
+                    Async.Pipe.map pipe ~f:(function
+                      | Ok json ->
+                          parse_sync_status_exn json
+                      | Error e ->
+                          failwith "Receiving sync status error: " )
+                | _ ->
+                    failwith "Expected to get a stream of sync updates" )
+            | Error e ->
+                failwithf
+                  !"unable to retrieve sync update subscription: %s"
+                  e ()
+          in
           { coda_peers= with_monitor coda_peers
           ; coda_verified_transitions= with_monitor coda_verified_transitions
           ; coda_root_diff= with_monitor coda_root_diff
@@ -487,7 +524,8 @@ module T = struct
           ; coda_prove_receipt= with_monitor coda_prove_receipt
           ; coda_start= with_monitor coda_start
           ; coda_dump_tf= with_monitor coda_dump_tf
-          ; coda_best_path= with_monitor coda_best_path } )
+          ; coda_best_path= with_monitor coda_best_path
+          ; coda_sync_status= with_monitor coda_sync_status } )
 
     let init_connection_state ~connection:_ ~worker_state:_ = return
   end

--- a/src/app/cli/src/coda_worker_testnet.ml
+++ b/src/app/cli/src/coda_worker_testnet.ml
@@ -76,6 +76,10 @@ module Api = struct
       ~f:(fun ~worker () -> Coda_process.best_path worker)
       t i
 
+  let sync_status =
+    run_online_worker ~arg:() ~f:(fun ~worker () ->
+        Coda_process.sync_status_exn worker )
+
   let start t i =
     Linear_pipe.write t.start_writer
       ( i

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -515,10 +515,11 @@ module Make (Inputs : Inputs_intf) = struct
 
   let sync_status t =
     let open Incr_status in
+    let transition_frontier_incr = Var.watch @@ Incr.transition_frontier t in
     let incremental_status =
       Incr_status.map2
         (Var.watch @@ Incr.online_status t)
-        (Var.watch @@ Incr.transition_frontier t)
+        transition_frontier_incr
         ~f:(fun online_status active_status ->
           match online_status with
           | `Offline ->

--- a/src/lib/sync_status/dune
+++ b/src/lib/sync_status/dune
@@ -1,6 +1,7 @@
 (library
  (name sync_status)
  (public_name sync_status)
+ (inline_tests)
  (libraries core_kernel currency signature_lib)
  (preprocess
   (pps ppx_jane ppx_coda ppx_deriving_yojson))

--- a/src/lib/sync_status/sync_status.ml
+++ b/src/lib/sync_status/sync_status.ml
@@ -25,7 +25,7 @@ module Stable = struct
   module V1 = struct
     module T = struct
       type t = [`Offline | `Bootstrap | `Synced]
-      [@@deriving bin_io, version, sexp, hash, compare]
+      [@@deriving bin_io, version, sexp, hash, compare, equal]
 
       let to_yojson = to_yojson
     end
@@ -37,6 +37,11 @@ module Stable = struct
   module Latest = V1
 end
 
-type t = [`Offline | `Bootstrap | `Synced] [@@deriving sexp, hash]
+type t = [`Offline | `Bootstrap | `Synced] [@@deriving sexp, hash, equal]
 
 include Hashable.Make (Stable.Latest.T)
+
+let%test "of_string (to_string x) == x" =
+  List.for_all [`Offline; `Bootstrap; `Synced] ~f:(fun sync_status ->
+      equal sync_status (of_string (to_string sync_status) |> Or_error.ok_exn)
+  )


### PR DESCRIPTION
A test to show that subscriptions work

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
