### PR TITLE
Reward response in RPC calls

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -656,6 +656,14 @@ module Make (Inputs : Inputs_intf) = struct
             in
             match response_or_error with
             | Ok (Some response) ->
+                let%bind () =
+                  Trust_system.(
+                    record t.trust_system t.logger peer.host
+                      Actions.
+                        ( Fulfilled_request
+                        , Some ("Nonpreferred peer returned valid response", [])
+                        ))
+                in
                 return (Ok response)
             | Ok None ->
                 loop remaining_peers (2 * num_peers)
@@ -674,6 +682,13 @@ module Make (Inputs : Inputs_intf) = struct
     in
     match response with
     | Ok (Some data) ->
+        let%bind () =
+          Trust_system.(
+            record t.trust_system t.logger peer.host
+              Actions.
+                ( Fulfilled_request
+                , Some ("Preferred peer returned valid response", []) ))
+        in
         return (Ok data)
     | Ok None ->
         let%bind () =


### PR DESCRIPTION
Reward preferred, nonpreferred peers returning valid responses to RPC calls.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
