### PR TITLE
Remove unused version number in Ledger_proof

### DIFF
--- a/src/app/cli/src/ledger_proof.ml
+++ b/src/app/cli/src/ledger_proof.ml
@@ -74,8 +74,6 @@ module Debug :
   module Stable = struct
     module V1 = struct
       module T = struct
-        let version = 1
-
         type t =
           Transaction_snark.Statement.Stable.V1.t
           * Sok_message.Digest.Stable.V1.t


### PR DESCRIPTION
`version` is derived automatically from the `deriving version`, the definition is shadowed, so unused.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
