### PR TITLE
Fix/update snarky cleanup params

### DIFF
--- a/src/app/cli/src/prover.ml
+++ b/src/app/cli/src/prover.ml
@@ -97,8 +97,8 @@ module Worker_state = struct
                         state_for_handler ~pending_coinbase)
                  in
                  let prev_proof =
-                   Tick.Groth16.prove
-                     (Tick.Groth16.Keypair.pk Keys.Step.keys)
+                   Tick.prove
+                     (Tick.Keypair.pk Keys.Step.keys)
                      (Keys.Step.input ()) prover_state main next_state_top_hash
                  in
                  { Blockchain.state= next_state
@@ -139,7 +139,7 @@ module Worker_state = struct
                         state_for_handler ~pending_coinbase)
                  in
                  match
-                   Tick.Groth16.check
+                   Tick.check
                      (main @@ Tick.Field.Var.constant next_state_top_hash)
                      prover_state
                  with

--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -24,7 +24,7 @@ module Keys = struct
       Md5.digest_string
         ("Blockchain_transition_proving" ^ Md5.to_hex step ^ Md5.to_hex wrap)
 
-    type t = {step: Tick.Groth16.Proving_key.t; wrap: Tock.Proving_key.t}
+    type t = {step: Tick.Proving_key.t; wrap: Tock.Proving_key.t}
 
     let dummy =
       { step= Dummy_values.Tick.Groth16.proving_key
@@ -34,7 +34,7 @@ module Keys = struct
       let open Storage in
       let logger = Logger.create () in
       let tick_controller =
-        Controller.create ~logger (module Tick.Groth16.Proving_key)
+        Controller.create ~logger (module Tick.Proving_key)
       in
       let tock_controller =
         Controller.create ~logger (module Tock.Proving_key)
@@ -64,7 +64,7 @@ module Keys = struct
         ^ Md5.to_hex wrap )
 
     type t =
-      {step: Tick.Groth16.Verification_key.t; wrap: Tock.Verification_key.t}
+      {step: Tick.Verification_key.t; wrap: Tock.Verification_key.t}
 
     let dummy =
       { step= Dummy_values.Tick.Groth16.verification_key
@@ -74,7 +74,7 @@ module Keys = struct
       let open Storage in
       let logger = Logger.create () in
       let tick_controller =
-        Controller.create ~logger (module Tick.Groth16.Verification_key)
+        Controller.create ~logger (module Tick.Verification_key)
       in
       let tock_controller =
         Controller.create ~logger (module Tock.Verification_key)
@@ -203,7 +203,7 @@ struct
 
     let step_cached =
       let load =
-        let open Tick.Groth16 in
+        let open Tick in
         let open Cached.Let_syntax in
         let%map verification =
           Cached.component ~label:"verification" ~f:Keypair.vk
@@ -218,9 +218,9 @@ struct
         ~manual_install_path:Cache_dir.manual_install_path
         ~digest_input:
           (Fn.compose Md5.to_hex Tick.R1CS_constraint_system.digest)
-        ~create_env:Tick.Groth16.Keypair.generate
+        ~create_env:Tick.Keypair.generate
         ~input:
-          (Tick.Groth16.constraint_system ~exposing:(Step_base.input ())
+          (Tick.constraint_system ~exposing:(Step_base.input ())
              Step_base.main)
 
     let cached () =
@@ -281,7 +281,7 @@ let constraint_system_digests () =
   let digest' = Tock.R1CS_constraint_system.digest in
   [ ( "blockchain-step"
     , digest
-        M.Step_base.(Tick.Groth16.constraint_system ~exposing:(input ()) main)
+        M.Step_base.(Tick.constraint_system ~exposing:(input ()) main)
     )
   ; ("blockchain-wrap", digest' W.(Tock.constraint_system ~exposing:input main))
   ]

--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -63,8 +63,7 @@ module Keys = struct
         ( "Blockchain_transition_verification" ^ Md5.to_hex step
         ^ Md5.to_hex wrap )
 
-    type t =
-      {step: Tick.Verification_key.t; wrap: Tock.Verification_key.t}
+    type t = {step: Tick.Verification_key.t; wrap: Tock.Verification_key.t}
 
     let dummy =
       { step= Dummy_values.Tick.Groth16.verification_key
@@ -220,8 +219,7 @@ struct
           (Fn.compose Md5.to_hex Tick.R1CS_constraint_system.digest)
         ~create_env:Tick.Keypair.generate
         ~input:
-          (Tick.constraint_system ~exposing:(Step_base.input ())
-             Step_base.main)
+          (Tick.constraint_system ~exposing:(Step_base.input ()) Step_base.main)
 
     let cached () =
       let paths = Fn.compose Cache_dir.possible_paths Filename.basename in
@@ -280,8 +278,6 @@ let constraint_system_digests () =
   let digest = Tick.R1CS_constraint_system.digest in
   let digest' = Tock.R1CS_constraint_system.digest in
   [ ( "blockchain-step"
-    , digest
-        M.Step_base.(Tick.constraint_system ~exposing:(input ()) main)
-    )
+    , digest M.Step_base.(Tick.constraint_system ~exposing:(input ()) main) )
   ; ("blockchain-wrap", digest' W.(Tock.constraint_system ~exposing:input main))
   ]

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -8,9 +8,9 @@ module Stable = struct
       (* Tock.Proof.t is not bin_io; should we wrap that snarky type? *)
       type t = Tock.Proof.t [@@deriving version {asserted}]
 
-      let to_string = Tock_backend.Proof.to_string
+      let to_string = Binable.to_string (module Tock_backend.Proof)
 
-      let of_string = Tock_backend.Proof.of_string
+      let of_string = Binable.of_string (module Tock_backend.Proof)
     end
 
     include T

--- a/src/lib/coda_base/transition_system.ml
+++ b/src/lib/coda_base/transition_system.ml
@@ -39,7 +39,7 @@ module type S = sig
 end
 
 module type Tick_keypair_intf = sig
-  val keys : Tick.Groth16.Keypair.t
+  val keys : Tick.Keypair.t
 end
 
 module type Tock_keypair_intf = sig
@@ -57,9 +57,9 @@ module Make (Digest : sig
 end)
 (System : S) =
 struct
-  let step_input () = Tick.Groth16.Data_spec.[Tick.Groth16.Field.typ]
+  let step_input () = Tick.Data_spec.[Tick.Field.typ]
 
-  let step_input_size = Tick.Groth16.Data_spec.size (step_input ())
+  let step_input_size = Tick.Data_spec.size (step_input ())
 
   module Step_base = struct
     open System
@@ -181,7 +181,7 @@ struct
   end
 
   module type Step_vk_intf = sig
-    val verification_key : Tick.Groth16.Verification_key.t
+    val verification_key : Tick.Verification_key.t
   end
 
   module Wrap_base (Step_vk : Step_vk_intf) = struct
@@ -192,7 +192,7 @@ struct
     module Verifier = Tock.Groth_verifier
 
     module Prover_state = struct
-      type t = {proof: Tick.Groth16.Proof.t} [@@deriving fields]
+      type t = {proof: Tick.Proof.t} [@@deriving fields]
     end
 
     let step_vk = Verifier.vk_of_backend_vk Step_vk.verification_key

--- a/src/lib/crypto_params/crypto_params_init/crypto_params_init.ml
+++ b/src/lib/crypto_params/crypto_params_init/crypto_params_init.ml
@@ -23,7 +23,7 @@ curve_size]
 
 module Tick_backend = struct
   module Full = Cycle.Mnt4
-  include Full.GM
+  include Full.Default
   module Inner_curve = Cycle.Mnt6.G1
   module Inner_twisted_curve = Cycle.Mnt6.G2
 end

--- a/src/lib/dummy_values/gen_values/gen_values.ml
+++ b/src/lib/dummy_values/gen_values/gen_values.ml
@@ -43,7 +43,7 @@ struct
       let keypair = generate_keypair main ~exposing in
       prove (Keypair.pk keypair) exposing () main Field.one
     in
-    B.Proof.to_string proof
+    Binable.to_string (module Proof) proof
 
   let vk_string, pk_string =
     let open Impl in
@@ -96,7 +96,11 @@ struct
           [%e estring str]]
     in
     let proof_stri =
-      [%stri let proof = [%e of_string_expr "Proof" proof_string]]
+      [%stri
+        let proof =
+          Core_kernel.Binable.of_string
+            [%e pexp_pack (pmod_ident (ident (curve_module_name ^. "Proof")))]
+            [%e estring proof_string]]
     in
     let vk_stri =
       [%stri

--- a/src/lib/keys_lib/keys.ml
+++ b/src/lib/keys_lib/keys.ml
@@ -12,13 +12,13 @@ module type S = sig
   end
 
   module Wrap_prover_state : sig
-    type t = {proof: Tick.Groth16.Proof.t}
+    type t = {proof: Tick.Proof.t}
   end
 
   val transaction_snark_keys : Transaction_snark.Keys.Verification.t
 
   module Step : sig
-    val keys : Tick.Groth16.Keypair.t
+    val keys : Tick.Keypair.t
 
     val input :
          unit
@@ -26,7 +26,7 @@ module type S = sig
          , 'b
          , Tick.Field.Var.t -> 'a
          , Tick.Field.t -> 'b )
-         Tick.Groth16.Data_spec.t
+         Tick.Data_spec.t
 
     module Verification_key : sig
       val to_bool_list : Tock.Verification_key.t -> bool list
@@ -75,7 +75,7 @@ let create () : (module S) Async.Deferred.t =
         Blockchain_snark.Blockchain_transition.Make (Consensus) (T)
       in
       let module Step = B.Step (struct
-        let keys = Tick.Groth16.Keypair.create ~pk:bc_pk.step ~vk:bc_vk.step
+        let keys = Tick.Keypair.create ~pk:bc_pk.step ~vk:bc_vk.step
       end) in
       let module Wrap =
         B.Wrap (struct
@@ -97,7 +97,7 @@ let create () : (module S) Async.Deferred.t =
         end
 
         module Wrap_prover_state = struct
-          type t = {proof: Tick.Groth16.Proof.t}
+          type t = {proof: Tick.Proof.t}
         end
 
         module Step = struct

--- a/src/lib/keys_lib/keys.ml
+++ b/src/lib/keys_lib/keys.ml
@@ -22,11 +22,7 @@ module type S = sig
 
     val input :
          unit
-      -> ( 'a
-         , 'b
-         , Tick.Field.Var.t -> 'a
-         , Tick.Field.t -> 'b )
-         Tick.Data_spec.t
+      -> ('a, 'b, Tick.Field.Var.t -> 'a, Tick.Field.t -> 'b) Tick.Data_spec.t
 
     module Verification_key : sig
       val to_bool_list : Tock.Verification_key.t -> bool list

--- a/src/lib/keys_lib/keys.mli
+++ b/src/lib/keys_lib/keys.mli
@@ -20,11 +20,7 @@ module type S = sig
 
     val input :
          unit
-      -> ( 'a
-         , 'b
-         , Tick.Field.Var.t -> 'a
-         , Tick.Field.t -> 'b )
-         Tick.Data_spec.t
+      -> ('a, 'b, Tick.Field.Var.t -> 'a, Tick.Field.t -> 'b) Tick.Data_spec.t
 
     module Verification_key : sig
       val to_bool_list : Tock.Verification_key.t -> bool list

--- a/src/lib/keys_lib/keys.mli
+++ b/src/lib/keys_lib/keys.mli
@@ -10,13 +10,13 @@ module type S = sig
   end
 
   module Wrap_prover_state : sig
-    type t = {proof: Tick.Groth16.Proof.t}
+    type t = {proof: Tick.Proof.t}
   end
 
   val transaction_snark_keys : Transaction_snark.Keys.Verification.t
 
   module Step : sig
-    val keys : Tick.Groth16.Keypair.t
+    val keys : Tick.Keypair.t
 
     val input :
          unit
@@ -24,7 +24,7 @@ module type S = sig
          , 'b
          , Tick.Field.Var.t -> 'a
          , Tick.Field.t -> 'b )
-         Tick.Groth16.Data_spec.t
+         Tick.Data_spec.t
 
     module Verification_key : sig
       val to_bool_list : Tock.Verification_key.t -> bool list

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -65,8 +65,8 @@ module Make_real (Keys : Keys_lib.Keys.S) = struct
       Tick.handle (Keys.Step.main x) Consensus.Prover_state.precomputed_handler
     in
     let tick =
-      Tick.Groth16.prove
-        (Tick.Groth16.Keypair.pk Keys.Step.keys)
+      Tick.prove
+        (Tick.Keypair.pk Keys.Step.keys)
         (Keys.Step.input ()) prover_state main base_hash
     in
     let proof = wrap base_hash tick in

--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -126,7 +126,6 @@ end
 module Tock = struct
   include (Tock0 : module type of Tock0 with module Proof := Tock0.Proof)
 
-  module Groth16 = Snarky.Snark.Make (Tock_backend.Full.Default)
   module Fq = Snarky_field_extensions.Field_extensions.F (Tock0)
   module Snarkette_tock = Snarkette.Mnt4_80
 
@@ -287,8 +286,6 @@ module Tock = struct
     let dummy = Dummy_values.Tock.GrothMaller17.proof
   end
 
-  module Groth_maller_verifier = Snarky_verifier.Groth_maller.Make (Pairing)
-
   module Groth_verifier = struct
     include Snarky_verifier.Groth.Make (Pairing)
 
@@ -330,8 +327,6 @@ end
 
 module Tick = struct
   include (Tick0 : module type of Tick0 with module Field := Tick0.Field)
-
-  module Groth16 = Snarky.Snark.Make (Tick_backend.Full.Default)
 
   module Field = struct
     include Tick0.Field
@@ -682,8 +677,6 @@ module Tick = struct
       ; h_gamma= Pairing.G2.constant vk.h_gamma
       ; g_alpha_h_beta= Pairing.Fqk.constant vk.g_alpha_h_beta }
   end
-
-  module Groth_verifier = Snarky_verifier.Groth.Make (Pairing)
 end
 
 let tock_vk_to_bool_list vk =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -12,7 +12,7 @@ open Module_version
 let state_hash_size_in_triples = Tick.Field.size_in_triples
 
 let tick_input () =
-  let open Tick.Groth16 in
+  let open Tick in
   Data_spec.[Field.typ]
 
 let wrap_input = Tock.Data_spec.[Wrap_input.typ]
@@ -273,9 +273,9 @@ let merge_top_hash wrap_vk_bits =
 
 module Verification_keys = struct
   type t =
-    { base: Tick.Groth16.Verification_key.t
+    { base: Tick.Verification_key.t
     ; wrap: Tock.Verification_key.t
-    ; merge: Tick.Groth16.Verification_key.t }
+    ; merge: Tick.Verification_key.t }
   [@@deriving bin_io]
 
   let dummy : t =
@@ -289,9 +289,9 @@ module Keys0 = struct
 
   module Proving = struct
     type t =
-      { base: Tick.Groth16.Proving_key.t
+      { base: Tick.Proving_key.t
       ; wrap: Tock.Proving_key.t
-      ; merge: Tick.Groth16.Proving_key.t }
+      ; merge: Tick.Proving_key.t }
     [@@deriving bin_io]
 
     let dummy =
@@ -516,9 +516,9 @@ module Base = struct
     in
     ()
 
-  let reduced_main = lazy (Groth16.reduce_to_prover (tick_input ()) main)
+  let reduced_main = lazy (reduce_to_prover (tick_input ()) main)
 
-  let create_keys () = Groth16.generate_keypair main ~exposing:(tick_input ())
+  let create_keys () = generate_keypair main ~exposing:(tick_input ())
 
   let transaction_union_proof ?(preeval = false) ~proving_key sok_digest state1
       state2 pending_coinbase_stack_state (transaction : Transaction_union.t)
@@ -537,17 +537,17 @@ module Base = struct
         ~pending_coinbase_stack_state
     in
     ( top_hash
-    , Groth16.prove proving_key (tick_input ()) prover_state main top_hash )
+    , prove proving_key (tick_input ()) prover_state main top_hash )
 
   let cached =
     let load =
       let open Cached.Let_syntax in
       let%map verification =
-        Cached.component ~label:"verification" ~f:Groth16.Keypair.vk
-          (module Groth16.Verification_key)
+        Cached.component ~label:"verification" ~f:Keypair.vk
+          (module Verification_key)
       and proving =
-        Cached.component ~label:"proving" ~f:Groth16.Keypair.pk
-          (module Groth16.Proving_key)
+        Cached.component ~label:"proving" ~f:Keypair.pk
+          (module Proving_key)
       in
       (verification, {proving with value= ()})
     in
@@ -556,8 +556,8 @@ module Base = struct
       ~manual_install_path:Cache_dir.manual_install_path
       ~digest_input:(fun x ->
         Md5.to_hex (R1CS_constraint_system.digest (Lazy.force x)) )
-      ~input:(lazy (Groth16.constraint_system ~exposing:(tick_input ()) main))
-      ~create_env:(fun x -> Groth16.Keypair.generate (Lazy.force x))
+      ~input:(lazy (constraint_system ~exposing:(tick_input ()) main))
+      ~create_env:(fun x -> Keypair.generate (Lazy.force x))
 end
 
 module Transition_data = struct
@@ -822,17 +822,17 @@ module Merge = struct
     in
     Boolean.Assert.all [verify_12; verify_23]
 
-  let create_keys () = Groth16.generate_keypair ~exposing:(input ()) main
+  let create_keys () = generate_keypair ~exposing:(input ()) main
 
   let cached =
     let load =
       let open Cached.Let_syntax in
       let%map verification =
-        Cached.component ~label:"verification" ~f:Groth16.Keypair.vk
-          (module Groth16.Verification_key)
+        Cached.component ~label:"verification" ~f:Keypair.vk
+          (module Verification_key)
       and proving =
-        Cached.component ~label:"proving" ~f:Groth16.Keypair.pk
-          (module Groth16.Proving_key)
+        Cached.component ~label:"proving" ~f:Keypair.pk
+          (module Proving_key)
       in
       (verification, {proving with value= ()})
     in
@@ -841,8 +841,8 @@ module Merge = struct
       ~manual_install_path:Cache_dir.manual_install_path
       ~digest_input:(fun x ->
         Md5.to_hex (R1CS_constraint_system.digest (Lazy.force x)) )
-      ~input:(lazy (Groth16.constraint_system ~exposing:(input ()) main))
-      ~create_env:(fun x -> Groth16.Keypair.generate (Lazy.force x))
+      ~input:(lazy (constraint_system ~exposing:(input ()) main))
+      ~create_env:(fun x -> Keypair.generate (Lazy.force x))
 end
 
 module Verification = struct
@@ -1008,9 +1008,9 @@ module Verification = struct
 end
 
 module Wrap (Vk : sig
-  val merge : Tick.Groth16.Verification_key.t
+  val merge : Tick.Verification_key.t
 
-  val base : Tick.Groth16.Verification_key.t
+  val base : Tick.Verification_key.t
 end) =
 struct
   open Tock
@@ -1027,7 +1027,7 @@ struct
     Verifier.Verification_key.Precomputation.create_constant base_vk
 
   module Prover_state = struct
-    type t = {proof_type: Proof_type.t; proof: Tick.Groth16.Proof.t}
+    type t = {proof_type: Proof_type.t; proof: Tick.Proof.t}
     [@@deriving fields]
   end
 
@@ -1183,7 +1183,7 @@ let generate_transaction_union_witness ?(preeval = false) sok_message source
       ~supply_increase:(Transaction_union.supply_increase transaction)
       ~pending_coinbase_stack_state
   in
-  let open Tick.Groth16 in
+  let open Tick in
   let main =
     if preeval then failwith "preeval currently disabled" else Base.main
   in
@@ -1257,7 +1257,7 @@ struct
       ; tock_vk= keys.verification.wrap }
     in
     ( top_hash
-    , Tick.Groth16.prove keys.proving.merge (tick_input ()) prover_state
+    , Tick.prove keys.proving.merge (tick_input ()) prover_state
         Merge.main top_hash )
 
   let of_transaction_union ?preeval sok_digest source target
@@ -1375,7 +1375,7 @@ module Keys = struct
       let open Storage in
       let logger = Logger.create () in
       let tick_controller =
-        Controller.create ~logger (module Tick.Groth16.Verification_key)
+        Controller.create ~logger (module Tick.Verification_key)
       in
       let tock_controller =
         Controller.create ~logger (module Tock.Verification_key)
@@ -1410,7 +1410,7 @@ module Keys = struct
       let open Storage in
       let logger = Logger.create () in
       let tick_controller =
-        Controller.create ~logger (module Tick.Groth16.Proving_key)
+        Controller.create ~logger (module Tick.Proving_key)
       in
       let tock_controller =
         Controller.create ~logger (module Tock.Proving_key)
@@ -1456,19 +1456,19 @@ module Keys = struct
     let merge = Merge.create_keys () in
     let wrap =
       let module Wrap = Wrap (struct
-        let base = Tick.Groth16.Keypair.vk base
+        let base = Tick.Keypair.vk base
 
-        let merge = Tick.Groth16.Keypair.vk merge
+        let merge = Tick.Keypair.vk merge
       end) in
       Wrap.create_keys ()
     in
     { proving=
-        { base= Tick.Groth16.Keypair.pk base
-        ; merge= Tick.Groth16.Keypair.pk merge
+        { base= Tick.Keypair.pk base
+        ; merge= Tick.Keypair.pk merge
         ; wrap= Tock.Keypair.pk wrap }
     ; verification=
-        { base= Tick.Groth16.Keypair.vk base
-        ; merge= Tick.Groth16.Keypair.vk merge
+        { base= Tick.Keypair.vk base
+        ; merge= Tick.Keypair.vk merge
         ; wrap= Tock.Keypair.vk wrap } }
 
   let cached () =
@@ -1761,10 +1761,10 @@ let constraint_system_digests () =
   let digest = Tick.R1CS_constraint_system.digest in
   let digest' = Tock.R1CS_constraint_system.digest in
   [ ( "transaction-merge"
-    , digest Merge.(Tick.Groth16.constraint_system ~exposing:(input ()) main)
+    , digest Merge.(Tick.constraint_system ~exposing:(input ()) main)
     )
   ; ( "transaction-base"
     , digest
-        Base.(Tick.Groth16.constraint_system ~exposing:(tick_input ()) main) )
+        Base.(Tick.constraint_system ~exposing:(tick_input ()) main) )
   ; ( "transaction-wrap"
     , digest' W.(Tock.constraint_system ~exposing:wrap_input main) ) ]

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -536,8 +536,7 @@ module Base = struct
         ~supply_increase:(Transaction_union.supply_increase transaction)
         ~pending_coinbase_stack_state
     in
-    ( top_hash
-    , prove proving_key (tick_input ()) prover_state main top_hash )
+    (top_hash, prove proving_key (tick_input ()) prover_state main top_hash)
 
   let cached =
     let load =
@@ -546,8 +545,7 @@ module Base = struct
         Cached.component ~label:"verification" ~f:Keypair.vk
           (module Verification_key)
       and proving =
-        Cached.component ~label:"proving" ~f:Keypair.pk
-          (module Proving_key)
+        Cached.component ~label:"proving" ~f:Keypair.pk (module Proving_key)
       in
       (verification, {proving with value= ()})
     in
@@ -831,8 +829,7 @@ module Merge = struct
         Cached.component ~label:"verification" ~f:Keypair.vk
           (module Verification_key)
       and proving =
-        Cached.component ~label:"proving" ~f:Keypair.pk
-          (module Proving_key)
+        Cached.component ~label:"proving" ~f:Keypair.pk (module Proving_key)
       in
       (verification, {proving with value= ()})
     in
@@ -1257,8 +1254,8 @@ struct
       ; tock_vk= keys.verification.wrap }
     in
     ( top_hash
-    , Tick.prove keys.proving.merge (tick_input ()) prover_state
-        Merge.main top_hash )
+    , Tick.prove keys.proving.merge (tick_input ()) prover_state Merge.main
+        top_hash )
 
   let of_transaction_union ?preeval sok_digest source target
       ~pending_coinbase_stack_state transaction handler =
@@ -1761,10 +1758,8 @@ let constraint_system_digests () =
   let digest = Tick.R1CS_constraint_system.digest in
   let digest' = Tock.R1CS_constraint_system.digest in
   [ ( "transaction-merge"
-    , digest Merge.(Tick.constraint_system ~exposing:(input ()) main)
-    )
+    , digest Merge.(Tick.constraint_system ~exposing:(input ()) main) )
   ; ( "transaction-base"
-    , digest
-        Base.(Tick.constraint_system ~exposing:(tick_input ()) main) )
+    , digest Base.(Tick.constraint_system ~exposing:(tick_input ()) main) )
   ; ( "transaction-wrap"
     , digest' W.(Tock.constraint_system ~exposing:wrap_input main) ) ]

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -100,9 +100,9 @@ val sok_digest : t -> Sok_message.Digest.t
 module Keys : sig
   module Proving : sig
     type t =
-      { base: Tick.Groth16.Proving_key.t
+      { base: Tick.Proving_key.t
       ; wrap: Tock.Proving_key.t
-      ; merge: Tick.Groth16.Proving_key.t }
+      ; merge: Tick.Proving_key.t }
     [@@deriving bin_io]
 
     val dummy : t
@@ -114,9 +114,9 @@ module Keys : sig
 
   module Verification : sig
     type t =
-      { base: Tick.Groth16.Verification_key.t
+      { base: Tick.Verification_key.t
       ; wrap: Tock.Verification_key.t
-      ; merge: Tick.Groth16.Verification_key.t }
+      ; merge: Tick.Verification_key.t }
     [@@deriving bin_io]
 
     val dummy : t


### PR DESCRIPTION
This PR bumps the snarky version and removes Tick.GM, which was extremely confusing. Groth16 is now the one and only backend which is used in conjunction with the Tick curve.