### PR TITLE
Add currentSnarkWorker to graphql api

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -351,7 +351,7 @@ let daemon logger =
        let%bind coda =
          Run.create
            (Run.Config.make ~logger ~trust_system ~net_config
-              ~run_snark_worker:(Option.is_some run_snark_worker_flag)
+              ?snark_worker_key:run_snark_worker_flag
               ~transaction_pool_disk_location:(conf_dir ^/ "transaction_pool")
               ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")
               ~wallets_disk_location:(conf_dir ^/ "wallets")

--- a/src/app/cli/src/coda_inputs.ml
+++ b/src/app/cli/src/coda_inputs.ml
@@ -326,7 +326,7 @@ module type Main_intf = sig
       { logger: Logger.t
       ; trust_system: Trust_system.t
       ; propose_keypair: Keypair.t option
-      ; run_snark_worker: bool
+      ; snark_worker_key: Public_key.Compressed.Stable.V1.t option
       ; net_config: Inputs.Net.Config.t
       ; transaction_pool_disk_location: string
       ; snark_pool_disk_location: string
@@ -346,7 +346,9 @@ module type Main_intf = sig
 
   val propose_keypair : t -> Keypair.t option
 
-  val run_snark_worker : t -> bool
+  val snark_worker_key : t -> Public_key.Compressed.Stable.V1.t option
+
+  val snark_work_fee : t -> Currency.Fee.t
 
   val request_work : t -> Inputs.Snark_worker.Work.Spec.t option
 

--- a/src/app/cli/src/coda_run.ml
+++ b/src/app/cli/src/coda_run.ml
@@ -218,7 +218,7 @@ struct
           |> Host_and_port.to_string )
     in
     let user_commands_sent = !txn_count in
-    let run_snark_worker = run_snark_worker t in
+    let run_snark_worker = snark_worker_key t <> None in
     let propose_pubkey =
       Option.map ~f:(fun kp -> kp.public_key) (propose_keypair t)
     in

--- a/src/app/cli/src/coda_run.ml
+++ b/src/app/cli/src/coda_run.ml
@@ -218,7 +218,7 @@ struct
           |> Host_and_port.to_string )
     in
     let user_commands_sent = !txn_count in
-    let run_snark_worker = snark_worker_key t <> None in
+    let run_snark_worker = Option.is_some (snark_worker_key t) in
     let propose_pubkey =
       Option.map ~f:(fun kp -> kp.public_key) (propose_keypair t)
     in

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -368,7 +368,8 @@ module T = struct
           let%bind coda =
             Main.create
               (Main.Config.make ~logger ~trust_system ~net_config
-                 ~run_snark_worker:(Option.is_some snark_worker_config)
+                 ?snark_worker_key:
+                   (Option.map snark_worker_config ~f:(fun c -> c.public_key))
                  ~transaction_pool_disk_location:
                    (conf_dir ^/ "transaction_pool")
                  ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -90,10 +90,19 @@ let run_test () : unit Deferred.t =
       in
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;
+      let largest_account_keypair =
+        Genesis_ledger.largest_account_keypair_exn ()
+      in
+      let run_snark_worker =
+        `With_public_key
+          (Public_key.compress largest_account_keypair.public_key)
+      in
       let%bind coda =
         Main.create
           (Main.Config.make ~logger ~trust_system ~net_config
-             ~propose_keypair:keypair ~run_snark_worker:true
+             ~propose_keypair:keypair
+             ~snark_worker_key:
+               (Public_key.compress largest_account_keypair.public_key)
              ~transaction_pool_disk_location:
                (temp_conf_dir ^/ "transaction_pool")
              ~snark_pool_disk_location:(temp_conf_dir ^/ "snark_pool")
@@ -142,13 +151,6 @@ let run_test () : unit Deferred.t =
               (sprintf !"Invalid Account: %{sexp: Public_key.Compressed.t}" pk)
       in
       let client_port = 8123 in
-      let largest_account_keypair =
-        Genesis_ledger.largest_account_keypair_exn ()
-      in
-      let run_snark_worker =
-        `With_public_key
-          (Public_key.compress largest_account_keypair.public_key)
-      in
       Run.setup_local_server ~client_port ~coda ~logger () ;
       Run.run_snark_worker ~logger ~client_port run_snark_worker ;
       (* Let the system settle *)

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -425,7 +425,7 @@ module Make (Inputs : Inputs_intf) = struct
 
   type t =
     { propose_keypair: Keypair.t option
-    ; run_snark_worker: bool
+    ; snark_worker_key: Public_key.Compressed.Stable.V1.t option
     ; net: Net.t
           (* TODO: Is this the best spot for the transaction_pool ref? *)
     ; wallets: Secrets.Wallets.t
@@ -461,7 +461,7 @@ module Make (Inputs : Inputs_intf) = struct
 
   let wallets t = t.wallets
 
-  let run_snark_worker t = t.run_snark_worker
+  let snark_worker_key t = t.snark_worker_key
 
   let propose_keypair t = t.propose_keypair
 
@@ -625,7 +625,7 @@ module Make (Inputs : Inputs_intf) = struct
       { logger: Logger.t
       ; trust_system: Trust_system.t
       ; propose_keypair: Keypair.t option
-      ; run_snark_worker: bool
+      ; snark_worker_key: Public_key.Compressed.Stable.V1.t option
       ; net_config: Net.Config.t
       ; transaction_pool_disk_location: string
       ; snark_pool_disk_location: string
@@ -886,7 +886,7 @@ module Make (Inputs : Inputs_intf) = struct
                    Deferred.unit )) ;
             return
               { propose_keypair= config.propose_keypair
-              ; run_snark_worker= config.run_snark_worker
+              ; snark_worker_key= config.snark_worker_key
               ; net
               ; wallets
               ; transaction_pool


### PR DESCRIPTION
This exposes the snark worker fee and public key when the node has the public key set.
Had to change a couple of places to track the pub key of the snark worker rather than just whether one was running. Feel free to lmk if there's a better way to get it.