### PR TITLE
Support proposing from wallet db

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -49,7 +49,7 @@ let daemon logger =
          ~doc:
            "PUBLICKEY Public key for the associated private key that is being \
             tracked by this daemon. You cannot provide both `propose-key` and \
-            `propose-public-key`. (default:don't propose)"
+            `propose-public-key`. (default: don't propose)"
          (optional public_key_compressed)
      and peers =
        flag "peer"

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -151,10 +151,9 @@ struct
         ~typ:(non_null (list (non_null Types.Wallet.wallet)))
         ~args:Arg.[]
         ~resolve:(fun {ctx= coda; _} () ->
-          Program.wallets coda |> Secrets.Wallets.get
-          |> List.map ~f:(fun kp ->
+          Program.wallets coda |> Secrets.Wallets.pks
+          |> List.map ~f:(fun pk ->
                  (* TODO: Is it a performance issue to recompress the PK every query? *)
-                 let pk = kp.Keypair.public_key |> Public_key.compress in
                  (pk, balance_of_pk coda pk) ) )
 
     let wallet =
@@ -211,8 +210,8 @@ struct
         ~args:Arg.[]
         ~resolve:(fun {ctx= coda; _} () ->
           let open Deferred.Let_syntax in
-          let%map kp = Program.wallets coda |> Secrets.Wallets.generate_new in
-          Result.return (kp.Keypair.public_key |> Public_key.compress) )
+          let%map pk = Program.wallets coda |> Secrets.Wallets.generate_new in
+          Result.return pk )
 
     let commands = [add_wallet]
   end

--- a/src/lib/secrets/wallets.mli
+++ b/src/lib/secrets/wallets.mli
@@ -5,6 +5,8 @@ type t
 
 val load : logger:Logger.t -> disk_location:string -> t Deferred.t
 
-val generate_new : t -> Keypair.t Deferred.t
+val generate_new : t -> Public_key.Compressed.t Deferred.t
 
-val get : t -> Keypair.t list
+val pks : t -> Public_key.Compressed.t list
+
+val find : t -> needle:Public_key.Compressed.t -> Keypair.t option


### PR DESCRIPTION
For now, in order to keep things simple, the frontend will restart the
daemon process whenever we wish to switch proposers.

Since the frontend doesn't track private keys, this change will allow
the frontend to start the daemon with propose keys from our tracked
wallet.