### PR TITLE
Remove unused binio in transaction_snark

### DIFF
--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -292,7 +292,6 @@ module Keys0 = struct
       { base: Tick.Proving_key.t
       ; wrap: Tock.Proving_key.t
       ; merge: Tick.Proving_key.t }
-    [@@deriving bin_io]
 
     let dummy =
       { merge= Dummy_values.Tick.Groth16.proving_key

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -103,7 +103,6 @@ module Keys : sig
       { base: Tick.Proving_key.t
       ; wrap: Tock.Proving_key.t
       ; merge: Tick.Proving_key.t }
-    [@@deriving bin_io]
 
     val dummy : t
 


### PR DESCRIPTION
Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: