### PR TITLE
Fewer value version warnings

### DIFF
--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -347,7 +347,8 @@ module T = struct
     module Stable = struct
       module V1 = struct
         module T = struct
-          type t = V1_make.Stable.V1.t [@@deriving bin_io, sexp, version]
+          type t = V1_make.Stable.V1.t
+          [@@deriving bin_io, sexp, version {unnumbered}]
         end
 
         include T
@@ -539,7 +540,7 @@ module T = struct
       module T = struct
         type t =
           (Merkle_tree.Stable.V1.t, Stack_id.Stable.V1.t) Poly.Stable.V1.t
-        [@@deriving bin_io, sexp, version]
+        [@@deriving bin_io, sexp, version {unnumbered}]
       end
 
       include T

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -6,7 +6,7 @@ module Stable = struct
     (* TODO: This should be stable. *)
     module T = struct
       (* Tock.Proof.t is not bin_io; should we wrap that snarky type? *)
-      type t = Tock.Proof.t [@@deriving version {asserted}]
+      type t = Tock.Proof.t [@@deriving version {asserted; unnumbered}]
 
       let to_string = Binable.to_string (module Tock_backend.Proof)
 

--- a/src/lib/coda_base/snark_transition.ml
+++ b/src/lib/coda_base/snark_transition.ml
@@ -204,7 +204,7 @@ module Make (Inputs : Inputs_intf) :
             , Currency.Amount.Stable.V1.t
             , Signature_lib.Public_key.Compressed.Stable.V1.t )
             Poly.Stable.V1.t
-          [@@deriving bin_io, sexp, version]
+          [@@deriving bin_io, sexp, version {unnumbered}]
         end
 
         include T

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -18,7 +18,8 @@ module V1_make =
 module Stable = struct
   module V1 = struct
     module T = struct
-      type t = V1_make.Stable.V1.t [@@deriving bin_io, sexp, version]
+      type t = V1_make.Stable.V1.t
+      [@@deriving bin_io, sexp, version {unnumbered}]
     end
 
     include T

--- a/src/lib/coda_base/staged_ledger_hash.ml
+++ b/src/lib/coda_base/staged_ledger_hash.ml
@@ -194,8 +194,7 @@ module Stable = struct
           type ('non_snark, 'pending_coinbase_hash) t =
             { non_snark: 'non_snark
             ; pending_coinbase_hash: 'pending_coinbase_hash }
-          [@@deriving
-            bin_io, sexp, eq, compare, hash, yojson, version {unnumbered}]
+          [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
         end
 
         include T

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -16,7 +16,7 @@ module Poly = struct
       module T = struct
         type ('payload, 'pk, 'signature) t =
           {payload: 'payload; sender: 'pk; signature: 'signature}
-        [@@deriving bin_io, eq, sexp, hash, yojson, version {unnumbered}]
+        [@@deriving bin_io, eq, sexp, hash, yojson, version]
       end
 
       include T

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -25,7 +25,7 @@ module Rpcs (Inputs : sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io, version {unnumbered}]
+          type t [@@deriving bin_io, version]
         end
       end
       with type V1.t = t

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -259,7 +259,7 @@ module Message (Inputs : sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io, sexp, to_yojson, version {unnumbered}]
+          type t [@@deriving bin_io, sexp, to_yojson, version]
         end
       end
       with type V1.t = t
@@ -271,7 +271,7 @@ module Message (Inputs : sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving bin_io, sexp, to_yojson, version {unnumbered}]
+          type t [@@deriving bin_io, sexp, to_yojson, version]
         end
       end
       with type V1.t = t

--- a/src/lib/coda_numbers/nat.ml
+++ b/src/lib/coda_numbers/nat.ml
@@ -77,7 +77,7 @@ module type F = functor
   -> S with type t := N.t and module Bits := Bits
 
 module Make (N : sig
-  type t [@@deriving bin_io, sexp, compare, hash, version {unnumbered}]
+  type t [@@deriving bin_io, sexp, compare, hash, version]
 
   include Unsigned_extended.S with type t := t
 

--- a/src/lib/consensus/proof_of_signature.ml
+++ b/src/lib/consensus/proof_of_signature.ml
@@ -48,7 +48,7 @@ module Prover_state = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = unit [@@deriving bin_io, sexp, version]
+        type t = unit [@@deriving bin_io, sexp, version {unnumbered}]
       end
 
       include T

--- a/src/lib/currency/currency.ml
+++ b/src/lib/currency/currency.ml
@@ -88,7 +88,7 @@ module type Signed_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
+          type ('magnitude, 'sgn) t [@@deriving version]
         end
 
         module Latest = V1
@@ -345,8 +345,7 @@ end = struct
         module V1 = struct
           module T = struct
             type ('magnitude, 'sgn) t = {magnitude: 'magnitude; sgn: 'sgn}
-            [@@deriving
-              bin_io, sexp, hash, compare, eq, yojson, version {unnumbered}]
+            [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
           end
 
           include T

--- a/src/lib/currency/currency.mli
+++ b/src/lib/currency/currency.mli
@@ -112,7 +112,7 @@ module type Signed_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type ('magnitude, 'sgn) t [@@deriving version {unnumbered}]
+          type ('magnitude, 'sgn) t [@@deriving version]
         end
 
         module Latest = V1

--- a/src/lib/lite_base/nat.ml
+++ b/src/lib/lite_base/nat.ml
@@ -1,5 +1,5 @@
 module Make (Type : sig
-  type t [@@deriving bin_io, eq, sexp, compare, version {unnumbered}]
+  type t [@@deriving bin_io, eq, sexp, compare, version]
 end)
 (Impl : sig
           type t

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -10,8 +10,7 @@ module type S = sig
       val version : int
 
       type nonrec t = t
-      [@@deriving
-        sexp, bin_io, hash, eq, compare, to_yojson, version {unnumbered}]
+      [@@deriving sexp, bin_io, hash, eq, compare, to_yojson, version]
     end
 
     module Latest : module type of V1

--- a/src/lib/module_version/registration.ml
+++ b/src/lib/module_version/registration.ml
@@ -26,7 +26,7 @@ module type Versioned_module_intf = sig
 end
 
 module type Version_intf = sig
-  type t [@@deriving bin_io, version]
+  type t [@@deriving bin_io, version {numbered}]
 end
 
 (* functor to create a registrar that can

--- a/src/lib/network_pool/network_pool.ml
+++ b/src/lib/network_pool/network_pool.ml
@@ -142,7 +142,8 @@ let%test_module "network pool test" =
         module V1 = struct
           module T = struct
             type t = int
-            [@@deriving bin_io, sexp, yojson, hash, compare, version]
+            [@@deriving
+              bin_io, sexp, yojson, hash, compare, version {unnumbered}]
           end
 
           include T

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -23,9 +23,9 @@ module Diff = struct
 end
 
 module Make (Proof : sig
-  type t [@@deriving bin_io, yojson, version {unnumbered}]
+  type t [@@deriving bin_io, yojson, version]
 end) (Fee : sig
-  type t [@@deriving bin_io, sexp, yojson, version {unnumbered}]
+  type t [@@deriving bin_io, sexp, yojson, version]
 end) (Work : sig
   type t [@@deriving sexp, yojson]
 

--- a/src/lib/random_oracle/random_oracle.mli
+++ b/src/lib/random_oracle/random_oracle.mli
@@ -7,7 +7,7 @@ module Digest : sig
   module Stable : sig
     module V1 : sig
       type nonrec t = t
-      [@@deriving bin_io, sexp, compare, hash, yojson, version]
+      [@@deriving bin_io, sexp, compare, hash, yojson, version {numbered}]
 
       include Comparable.S with type t := t
     end

--- a/src/lib/snark_params/pedersen.ml
+++ b/src/lib/snark_params/pedersen.ml
@@ -92,7 +92,8 @@ struct
       module V1 = struct
         module T = struct
           type t = Field.t
-          [@@deriving sexp, bin_io, compare, hash, eq, version {asserted}]
+          [@@deriving
+            sexp, bin_io, compare, hash, eq, version {asserted; unnumbered}]
         end
 
         include T

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -111,7 +111,7 @@ end = struct
     module V1 = struct
       module T = struct
         type t = (Hash.t, Key.t, Account.t) Poly.Stable.V1.t
-        [@@deriving bin_io, sexp, version]
+        [@@deriving bin_io, sexp, version {unnumbered}]
       end
 
       include T
@@ -259,11 +259,11 @@ let%test_module "sparse-ledger-test" =
       module Stable = struct
         module V1 = struct
           module T = struct
-            let __versioned__ = true
+            type t = Core_kernel.Md5.Stable.V1.t
+            [@@deriving bin_io, sexp, version {unnumbered}]
 
-            let version = 1
-
-            type t = Md5.t [@@deriving bin_io, eq, sexp]
+            [%%define_locally
+            Md5.(equal)]
 
             let compare a b = String.compare (Md5.to_hex a) (Md5.to_hex b)
 
@@ -294,7 +294,7 @@ let%test_module "sparse-ledger-test" =
         module V1 = struct
           module T = struct
             type t = {name: string; favorite_number: int}
-            [@@deriving bin_io, eq, sexp, version]
+            [@@deriving bin_io, eq, sexp, version {unnumbered}]
           end
 
           include T
@@ -324,7 +324,7 @@ let%test_module "sparse-ledger-test" =
       module Stable = struct
         module V1 = struct
           module T = struct
-            type t = string [@@deriving bin_io, eq, sexp, version]
+            type t = string [@@deriving bin_io, eq, sexp, version {unnumbered}]
           end
 
           include T

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1729,7 +1729,8 @@ let%test_module "test" =
           module V1 = struct
             module T = struct
               type t = string
-              [@@deriving sexp, bin_io, compare, eq, yojson, hash, version]
+              [@@deriving
+                sexp, bin_io, compare, eq, yojson, hash, version {unnumbered}]
             end
 
             include T
@@ -1747,7 +1748,8 @@ let%test_module "test" =
         module Stable = struct
           module V1 = struct
             module T = struct
-              type t = unit [@@deriving bin_io, sexp, yojson, version]
+              type t = unit
+              [@@deriving bin_io, sexp, yojson, version {unnumbered}]
             end
 
             include T
@@ -1837,12 +1839,7 @@ let%test_module "test" =
                 | One of Single.Stable.V1.t
                 | Two of Single.Stable.V1.t * Single.Stable.V1.t
               [@@deriving
-                bin_io
-                , sexp
-                , compare
-                , eq
-                , yojson
-                , version {for_test; unnumbered}]
+                bin_io, sexp, compare, eq, yojson, version {for_test}]
             end
 
             include T
@@ -1969,7 +1966,8 @@ let%test_module "test" =
           module V1 = struct
             module T = struct
               type t = int
-              [@@deriving sexp, bin_io, compare, hash, eq, yojson, version]
+              [@@deriving
+                sexp, bin_io, compare, hash, eq, yojson, version {unnumbered}]
             end
 
             include T
@@ -2332,7 +2330,8 @@ let%test_module "test" =
           module V1 = struct
             module T = struct
               type t = string
-              [@@deriving bin_io, sexp, hash, compare, eq, yojson, version]
+              [@@deriving
+                bin_io, sexp, hash, compare, eq, yojson, version {unnumbered}]
             end
 
             include T
@@ -2532,8 +2531,7 @@ let%test_module "test" =
                   ; user_commands: user_command list
                   ; coinbase: fee_transfer_single At_most_two.Stable.Latest.t
                   }
-                [@@deriving
-                  sexp, bin_io, yojson, version {for_test; unnumbered}]
+                [@@deriving sexp, bin_io, yojson, version {for_test}]
               end
 
               include T
@@ -2581,7 +2579,7 @@ let%test_module "test" =
                 type t =
                   Pre_diff_with_at_most_two_coinbase.Stable.V1.t
                   * Pre_diff_with_at_most_one_coinbase.Stable.V1.t option
-                [@@deriving sexp, bin_io, yojson, version]
+                [@@deriving sexp, bin_io, yojson, version {unnumbered}]
               end
 
               include T

--- a/src/lib/staged_ledger/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger/staged_ledger_diff.ml
@@ -165,7 +165,7 @@ end) :
             { completed_works: Transaction_snark_work.Stable.V1.t list
             ; user_commands: User_command.Stable.V1.t list
             ; coinbase: Ft.Stable.V1.t At_most_one.Stable.V1.t }
-          [@@deriving sexp, bin_io, version]
+          [@@deriving sexp, bin_io, version {unnumbered}]
         end
 
         include T
@@ -188,7 +188,7 @@ end) :
           type t =
             Pre_diff_with_at_most_two_coinbase.Stable.V1.t
             * Pre_diff_with_at_most_one_coinbase.Stable.V1.t option
-          [@@deriving sexp, bin_io, version]
+          [@@deriving sexp, bin_io, version {unnumbered}]
         end
 
         include T

--- a/src/lib/staged_ledger/transaction_snark_work.ml
+++ b/src/lib/staged_ledger/transaction_snark_work.ml
@@ -13,8 +13,7 @@ end) (Ledger_proof_statement : sig
   module Stable :
     sig
       module V1 : sig
-        type t
-        [@@deriving sexp, bin_io, hash, compare, yojson, version {unnumbered}]
+        type t [@@deriving sexp, bin_io, hash, compare, yojson, version]
       end
     end
     with type V1.t = t

--- a/src/lib/transaction_pool/transaction_pool.ml
+++ b/src/lib/transaction_pool/transaction_pool.ml
@@ -447,7 +447,8 @@ let%test_module _ =
           module Stable = struct
             module V1 = struct
               module T = struct
-                type t = int [@@deriving bin_io, version, sexp, yojson]
+                type t = int
+                [@@deriving bin_io, version {unnumbered}, sexp, yojson]
               end
 
               include T

--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -109,8 +109,6 @@ module Extend
   include Hashable.Make (T)
 
   (* TODO : actually version this type *)
-  let version = 1
-
   let __versioned__ = true
 
   include Bin_prot.Utils.Make_binable (struct

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -723,7 +723,7 @@ module type Staged_ledger_diff_intf = sig
     module Stable :
       sig
         module V1 : sig
-          type t [@@deriving sexp, bin_io, version {unnumbered}]
+          type t [@@deriving sexp, bin_io, version]
         end
       end
       with type V1.t = t


### PR DESCRIPTION
Get rid of "unused value version" warnings as much as possible.

- for versioned types with type parameters, `let version =` is not generated, because we don't register those types; you don't have to write `unnumbered` for these types to get rid of the warning
- in signatures, by default, `val version : int` is not generated, because the only code that needs the version number is the registration machinery; the option "numbered" allows generation of that declaration
- the option `for_tests` implies `asserted`, as before, and now also `unnumbered`

Running `make build` in this branch results in 0 such warnings.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
