### PR TITLE
Decrease in trust on TCP connection

### DIFF
--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -344,6 +344,12 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                   raise exn ))
             (Tcp.Where_to_listen.of_port config.me.Peer.communication_port)
             (fun client reader writer ->
+              let inet_addr = Socket.Address.Inet.addr client in
+              let%bind () =
+                Trust_system.(
+                  record t.trust_system t.logger inet_addr
+                    Actions.(Connected, None))
+              in
               let conn_map =
                 Option.value_map
                   ~default:(Hashtbl.create (module Uuid))

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -344,16 +344,16 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                   raise exn ))
             (Tcp.Where_to_listen.of_port config.me.Peer.communication_port)
             (fun client reader writer ->
-              let inet_addr = Socket.Address.Inet.addr client in
+              let client_inet_addr = Socket.Address.Inet.addr client in
               let%bind () =
                 Trust_system.(
-                  record t.trust_system t.logger inet_addr
+                  record t.trust_system t.logger client_inet_addr
                     Actions.(Connected, None))
               in
               let conn_map =
                 Option.value_map
                   ~default:(Hashtbl.create (module Uuid))
-                  (Hashtbl.find t.connections (Socket.Address.Inet.addr client))
+                  (Hashtbl.find t.connections client_inet_addr)
                   ~f:Fn.id
               in
               if
@@ -371,9 +371,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                 let conn_id = Uuid_unix.create () in
                 Hashtbl.add_exn conn_map ~key:conn_id
                   ~data:(Allowed (Ivar.create ())) ;
-                Hashtbl.set t.connections
-                  ~key:(Socket.Address.Inet.addr client)
-                  ~data:conn_map ;
+                Hashtbl.set t.connections ~key:client_inet_addr ~data:conn_map ;
                 let%map () =
                   Rpc.Connection.server_with_close reader writer
                     ~implementations
@@ -398,16 +396,13 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                           Deferred.unit ))
                 in
                 let conn_map =
-                  Hashtbl.find_exn t.connections
-                    (Socket.Address.Inet.addr client)
+                  Hashtbl.find_exn t.connections client_inet_addr
                 in
                 Hashtbl.remove conn_map conn_id ;
                 if Hashtbl.is_empty conn_map then
-                  Hashtbl.remove t.connections
-                  @@ Socket.Address.Inet.addr client
+                  Hashtbl.remove t.connections client_inet_addr
                 else
-                  Hashtbl.set t.connections
-                    ~key:(Socket.Address.Inet.addr client)
+                  Hashtbl.set t.connections ~key:client_inet_addr
                     ~data:conn_map )
         in
         t )

--- a/src/lib/trust_system/trust_system.ml
+++ b/src/lib/trust_system/trust_system.ml
@@ -11,6 +11,8 @@ module Actions = struct
     | Made_request
         (** Peer made a valid request. This causes a small decrease to mitigate
             DoS. *)
+    | Connected
+        (** Peer connected to TCP server. Very small decrease to mitigate DoS *)
     | Requested_unknown_item
         (** Peer requested something we don't know. They might be ahead of us or
           they might be malicious. *)
@@ -24,7 +26,11 @@ module Actions = struct
   let to_trust_response (action, _) =
     let open Peer_trust.Trust_response in
     (* FIXME figure out a good value for this *)
-    let request_increment = Peer_trust.max_rate 10. in
+    let fulfilled_increment = Peer_trust.max_rate 10. in
+    (* the summed decreases of a connection and request equals
+       the increase of a fulfilled request *)
+    let request_increment = 0.90 *. fulfilled_increment in
+    let connected_increment = 0.10 *. fulfilled_increment in
     match action with
     | Sent_bad_hash ->
         Insta_ban
@@ -32,10 +38,12 @@ module Actions = struct
         Insta_ban
     | Made_request ->
         Trust_decrease request_increment
+    | Connected ->
+        Trust_decrease connected_increment
     | Requested_unknown_item ->
         Trust_decrease (Peer_trust.max_rate 1.)
     | Fulfilled_request ->
-        (* trade 1:1 *) Trust_increase request_increment
+        Trust_increase fulfilled_increment
 
   let to_log : t -> string * (string, Yojson.Safe.json) List.Assoc.t =
    fun (action, extra_opt) ->


### PR DESCRIPTION
Each connection attempt to the TCP server results in a decrease in trust. That helps mitigate against DoS attacks. It also can lead to a ban if a node repeatedly makes a versioned RPC call with no common versions.

The decrease in trust of a connection and request equals the increase in trust of a fulfilled request. Before this PR, a request and fulfillment balanced one another.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
