### PR TITLE
Don't allow banned peers to connect

### DIFF
--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -356,7 +356,23 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                   (Hashtbl.find t.connections client_inet_addr)
                   ~f:Fn.id
               in
-              if
+              let is_client_banned =
+                let peer_status =
+                  Trust_system.Peer_trust.lookup t.trust_system
+                    client_inet_addr
+                in
+                match peer_status.banned with
+                | Banned_until _ ->
+                    true
+                | Unbanned ->
+                    false
+              in
+              if is_client_banned then (
+                Logger.error t.logger ~module_:__MODULE__ ~location:__LOC__
+                  "Disconnecting banned peer %s"
+                  (Socket.Address.Inet.to_string client) ;
+                Reader.close reader >>= fun _ -> Writer.close writer )
+              else if
                 Option.is_some t.max_concurrent_connections
                 && Hashtbl.length conn_map
                    >= Option.value_exn t.max_concurrent_connections

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -368,8 +368,8 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                     false
               in
               if is_client_banned then (
-                Logger.error t.logger ~module_:__MODULE__ ~location:__LOC__
-                  "Disconnecting banned peer %s"
+                Logger.info t.logger ~module_:__MODULE__ ~location:__LOC__
+                  "Rejecting connection from banned peer %s"
                   (Socket.Address.Inet.to_string client) ;
                 Reader.close reader >>= fun _ -> Writer.close writer )
               else if


### PR DESCRIPTION
Handler for TCP server doesn't allow connections from banned peers.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
