### PR TITLE
Trust increase when epoch ledger provided in postake

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -202,6 +202,7 @@ module type Proposer_intf = sig
 
   val run :
        logger:Logger.t
+    -> trust_system:Trust_system.t
     -> get_completed_work:(   completed_work_statement
                            -> completed_work_checked option)
     -> transaction_pool:transaction_pool
@@ -438,6 +439,7 @@ module Make (Inputs : Inputs_intf) = struct
         , unit Deferred.t )
         Writer.t
     ; logger: Logger.t
+    ; trust_system: Trust_system.t
     ; mutable seen_jobs: Work_selector.State.t
     ; receipt_chain_database: Coda_base.Receipt_chain_database.t
     ; staged_ledger_transition_backup_capacity: int
@@ -639,7 +641,8 @@ module Make (Inputs : Inputs_intf) = struct
 
   let start t =
     Option.iter t.propose_keypair ~f:(fun keypair ->
-        Proposer.run ~logger:t.logger ~transaction_pool:t.transaction_pool
+        Proposer.run ~logger:t.logger ~trust_system:t.trust_system
+          ~transaction_pool:t.transaction_pool
           ~get_completed_work:(Snark_pool.get_completed_work t.snark_pool)
           ~time_controller:t.time_controller ~keypair
           ~consensus_local_state:t.consensus_local_state
@@ -893,6 +896,7 @@ module Make (Inputs : Inputs_intf) = struct
                   Strict_pipe.Writer.to_linear_pipe external_transitions_writer
               ; verified_transitions= valid_transitions_for_api
               ; logger= config.logger
+              ; trust_system= config.trust_system
               ; seen_jobs= Work_selector.State.init
               ; staged_ledger_transition_backup_capacity=
                   config.staged_ledger_transition_backup_capacity

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -260,6 +260,7 @@ module type S = sig
     *)
   val sync_local_state :
        logger:Logger.t
+    -> trust_system:Trust_system.t
     -> local_state:Local_state.t
     -> random_peers:(int -> Network_peer.Peer.t list)
     -> query_peer:Network_peer.query_peer

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -298,9 +298,9 @@ module Make (Inputs : Inputs_intf) :
             in
             Some (protocol_state, internal_transition, witness) ) )
 
-  let run ~logger ~get_completed_work ~transaction_pool ~time_controller
-      ~keypair ~consensus_local_state ~frontier_reader ~transition_writer
-      ~random_peers ~query_peer =
+  let run ~logger ~trust_system ~get_completed_work ~transaction_pool
+      ~time_controller ~keypair ~consensus_local_state ~frontier_reader
+      ~transition_writer ~random_peers ~query_peer =
     trace_task "proposer" (fun () ->
         let log_bootstrap_mode () =
           Logger.info logger ~module_:__MODULE__ ~location:__LOC__
@@ -498,7 +498,7 @@ module Make (Inputs : Inputs_intf) :
                         (let%map res =
                            Consensus_mechanism.sync_local_state
                              ~local_state:consensus_local_state ~logger
-                             ~random_peers ~query_peer sync_jobs
+                             ~trust_system ~random_peers ~query_peer sync_jobs
                          in
                          ( match res with
                          | Ok () ->

--- a/src/lib/trust_system/trust_system.ml
+++ b/src/lib/trust_system/trust_system.ml
@@ -17,6 +17,7 @@ module Actions = struct
         (** Peer requested something we don't know. They might be ahead of us or
           they might be malicious. *)
     | Fulfilled_request  (** Peer fulfilled a request we made. *)
+    | Epoch_ledger_provided  (** Special case of request fulfillment *)
   [@@deriving show]
 
   (** The action they took, paired with a message and associated JSON metadata
@@ -31,6 +32,7 @@ module Actions = struct
        the increase of a fulfilled request *)
     let request_increment = 0.90 *. fulfilled_increment in
     let connected_increment = 0.10 *. fulfilled_increment in
+    let epoch_ledger_provided_increment = 10. *. fulfilled_increment in
     match action with
     | Sent_bad_hash ->
         Insta_ban
@@ -44,6 +46,8 @@ module Actions = struct
         Trust_decrease (Peer_trust.max_rate 1.)
     | Fulfilled_request ->
         Trust_increase fulfilled_increment
+    | Epoch_ledger_provided ->
+        Trust_increase epoch_ledger_provided_increment
 
   let to_log : t -> string * (string, Yojson.Safe.json) List.Assoc.t =
    fun (action, extra_opt) ->

--- a/src/protocols/coda_pow.ml
+++ b/src/protocols/coda_pow.ml
@@ -1647,6 +1647,7 @@ module type Consensus_mechanism_intf = sig
 
   val sync_local_state :
        logger:Logger.t
+    -> trust_system:Trust_system.t
     -> local_state:Local_state.t
     -> random_peers:(int -> Network_peer.Peer.t list)
     -> query_peer:Network_peer.query_peer


### PR DESCRIPTION
For postake, in `sync_local_state`, reward peers providing an epoch ledger. There's a new constructor, `Epoch_ledger_provided` for this purpose. Tentatively, that gives 10x the reward of `Fulfilled_request`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
