### PR TITLE
Fix version warnings; rename RPC modules to Master

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -332,8 +332,7 @@ module Epoch_ledger = struct
         module T = struct
           type ('ledger_hash, 'amount) t =
             {hash: 'ledger_hash; total_currency: 'amount}
-          [@@deriving
-            sexp, bin_io, eq, compare, hash, to_yojson, version {unnumbered}]
+          [@@deriving sexp, bin_io, eq, compare, hash, to_yojson, version]
         end
 
         include T
@@ -793,7 +792,8 @@ module Optional_state_hash = struct
     module V1 = struct
       module T = struct
         type t = Coda_base.State_hash.Stable.V1.t option
-        [@@deriving sexp, bin_io, eq, compare, hash, to_yojson, version]
+        [@@deriving
+          sexp, bin_io, eq, compare, hash, to_yojson, version {unnumbered}]
       end
 
       include T

--- a/src/lib/snark_worker_lib/rpcs.ml
+++ b/src/lib/snark_worker_lib/rpcs.ml
@@ -14,7 +14,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
   open Snark_work_lib
 
   module Get_work = struct
-    module T = struct
+    module Master = struct
       let name = "get_work"
 
       module T = struct
@@ -36,8 +36,8 @@ module Make (Inputs : Intf.Inputs_intf) = struct
       module Callee = T
     end
 
-    include T.T
-    module M = Versioned_rpc.Both_convert.Plain.Make (T)
+    include Master.T
+    module M = Versioned_rpc.Both_convert.Plain.Make (Master)
     include M
 
     module V1 = struct
@@ -71,7 +71,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
   end
 
   module Submit_work = struct
-    module T = struct
+    module Master = struct
       let name = "submit_work"
 
       module T = struct
@@ -93,8 +93,8 @@ module Make (Inputs : Intf.Inputs_intf) = struct
       module Callee = T
     end
 
-    include T.T
-    include Versioned_rpc.Both_convert.Plain.Make (T)
+    include Master.T
+    include Versioned_rpc.Both_convert.Plain.Make (Master)
 
     module V1 = struct
       module T = struct


### PR DESCRIPTION
remove an unneeded `unnumbered` from `deriving version`; add one that is needed

for snark worker RPCs, change module names to `Master`, as we did in `Coda_networking`

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
