### PR TITLE
Unsigned serialization tests

### DIFF
--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -47,29 +47,6 @@ module type F = functor
     end)
   -> S with type t = Unsigned.t
 
-module Make_bin_io (M : sig
-  type v
-
-  type t
-
-  val bin_t : t Bin_prot.Type_class.t
-
-  val there : v -> t
-
-  val back : t -> v
-end) =
-struct
-  let ( { Bin_prot.Type_class.reader= bin_reader_t
-        ; writer= bin_writer_t
-        ; shape= bin_shape_t } as bin_t ) =
-    Bin_prot.Type_class.cnv Fn.id M.there M.back M.bin_t
-
-  let {Bin_prot.Type_class.read= bin_read_t; vtag_read= __bin_read_t__} =
-    bin_reader_t
-
-  let {Bin_prot.Type_class.write= bin_write_t; size= bin_size_t} = bin_writer_t
-end
-
 module type Unsigned_intf = Unsigned.S
 
 module Extend
@@ -108,9 +85,6 @@ module Extend
   include T
   include Hashable.Make (T)
 
-  (* TODO : actually version this type *)
-  let __versioned__ = true
-
   include Bin_prot.Utils.Make_binable (struct
     module Binable = Signed
 
@@ -120,6 +94,12 @@ module Extend
 
     let of_binable = M.of_signed
   end)
+
+  (* Unsigned comes from an external library, so not actually versioned
+    we assert versioning here, and use tests to assure the serialization
+    doesn't change
+  *)
+  let __versioned__ = true
 
   include (Unsigned : Unsigned_intf with type t := t)
 
@@ -176,3 +156,27 @@ module UInt32 =
       let of_uint64 =
         Fn.compose Unsigned.UInt32.of_int64 Unsigned.UInt64.to_int64
     end)
+
+(* since we don't have real versioning, check that serialization don't change *)
+let%test_module "Unsigned serializations" =
+  ( module struct
+    let%test "uint32 serialization" =
+      let uint32 = UInt32.of_int 9775 in
+      let known_good_serialization = Bytes.of_string "\xFE\x2F\x26" in
+      let buff = Bin_prot.Common.create_buf 256 in
+      let len = UInt32.bin_write_t buff ~pos:0 uint32 in
+      let bytes = Bytes.create len in
+      Bin_prot.Common.blit_buf_bytes buff bytes ~len ;
+      Bytes.equal bytes known_good_serialization
+
+    let%test "uint64 serialization" =
+      let uint64 = UInt64.of_int64 191797697848L in
+      let known_good_serialization =
+        Bytes.of_string "\xFC\x38\x9D\x08\xA8\x2C\x00\x00\x00"
+      in
+      let buff = Bin_prot.Common.create_buf 256 in
+      let len = UInt64.bin_write_t buff ~pos:0 uint64 in
+      let bytes = Bytes.create len in
+      Bin_prot.Common.blit_buf_bytes buff bytes ~len ;
+      Bytes.equal bytes known_good_serialization
+  end )

--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -160,23 +160,23 @@ module UInt32 =
 (* since we don't have real versioning, check that serialization don't change *)
 let%test_module "Unsigned serializations" =
   ( module struct
-    let%test "uint32 serialization" =
-      let uint32 = UInt32.of_int 9775 in
-      let known_good_serialization = Bytes.of_string "\xFE\x2F\x26" in
+    let run_test (type t) (module M : Bin_prot.Binable.S with type t = t)
+        known_good_serialization (value : t) =
       let buff = Bin_prot.Common.create_buf 256 in
-      let len = UInt32.bin_write_t buff ~pos:0 uint32 in
+      let len = M.bin_write_t buff ~pos:0 value in
       let bytes = Bytes.create len in
       Bin_prot.Common.blit_buf_bytes buff bytes ~len ;
       Bytes.equal bytes known_good_serialization
+
+    let%test "uint32 serialization" =
+      let uint32 = UInt32.of_int 9775 in
+      let known_good_serialization = Bytes.of_string "\xFE\x2F\x26" in
+      run_test (module UInt32) known_good_serialization uint32
 
     let%test "uint64 serialization" =
       let uint64 = UInt64.of_int64 191797697848L in
       let known_good_serialization =
         Bytes.of_string "\xFC\x38\x9D\x08\xA8\x2C\x00\x00\x00"
       in
-      let buff = Bin_prot.Common.create_buf 256 in
-      let len = UInt64.bin_write_t buff ~pos:0 uint64 in
-      let bytes = Bytes.create len in
-      Bin_prot.Common.blit_buf_bytes buff bytes ~len ;
-      Bytes.equal bytes known_good_serialization
+      run_test (module UInt64) known_good_serialization uint64
   end )


### PR DESCRIPTION
Tying up a loose end for versioning.

`Unsigned` is the one place we still have a hand `let _versioned__ = true` declaration, because the whitelisting strategy we use for external modules won't work here: we're passing in the external module, rather than using it in a versioned type.

So we leave in that declaration, and add tests to verify the serializations haven't changed.

Also removed an unused functor, which was generating several compile warnings.

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
