### PR TITLE
Staged ledger, remove punish comment

### DIFF
--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -134,8 +134,6 @@ end = struct
             Error
               (Staged_ledger_error.Invalid_proof (proof, statement, prover)) )
 
-  (*TODO: Punish*)
-
   module M = struct
     include Monad.Ident
     module Or_error = Or_error


### PR DESCRIPTION
We added code to invoke the trust system on staged ledger errors in #2372, including the invalid proof error.

So the punish comment in `Staged_ledger` is no longer a `TODO`.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
