### PR TITLE
Wallet: Reduce dist package size

### DIFF
--- a/frontend/wallet/.gitignore
+++ b/frontend/wallet/.gitignore
@@ -9,6 +9,7 @@ settings.json
 /lib
 /bundle
 /dist
+app.js
 *.exe
 *.cmi
 *.cmx

--- a/frontend/wallet/package-lock.json
+++ b/frontend/wallet/package-lock.json
@@ -510,6 +510,12 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
@@ -519,6 +525,15 @@
       "version": "10.14.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.6.tgz",
       "integrity": "sha512-Fvm24+u85lGmV4hT5G++aht2C5I4Z4dYlWZIh62FAfFO/TfzXtPpoLI6I7AuBWkIFqZCnhFOoTT7RjjaIL5Fjg=="
+    },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -549,7 +564,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.6.tgz",
       "integrity": "sha512-QsaoUD2dpVpjENy8JFpQnXP9vyzoZPmAoKrE3S6HtSB7qzSebkJNnmdY4p004FQUSSiHXPueENpoeuUW/7a8Ig==",
-      "dev": true,
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.1"
@@ -558,14 +572,12 @@
         "mime-db": {
           "version": "1.40.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-          "dev": true
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
         },
         "mime-types": {
           "version": "2.1.24",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
           "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-          "dev": true,
           "requires": {
             "mime-db": "1.40.0"
           }
@@ -1377,7 +1389,7 @@
       }
     },
     "bs-electron": {
-      "version": "github:Schmavery/bs-electron#0988dedfa2f20ccb461ae9a81857b06f7e2fdd88",
+      "version": "github:Schmavery/bs-electron#094ddbfbd5f6b930a0fdc57892050385f26f0308",
       "from": "github:Schmavery/bs-electron",
       "requires": {
         "electron": "^4.0.4"
@@ -1477,11 +1489,16 @@
         }
       }
     },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==",
+      "dev": true
+    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1928,8 +1945,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2191,8 +2207,7 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -2735,6 +2750,12 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
+    "estree-walker": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+      "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -2966,17 +2987,6 @@
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
-      }
-    },
-    "express-graphql": {
-      "version": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
-      "from": "github:apis-guru/express-graphql#rootValue_dist",
-      "dev": true,
-      "requires": {
-        "accepts": "^1.3.0",
-        "content-type": "^1.0.2",
-        "http-errors": "^1.3.0",
-        "raw-body": "^2.1.0"
       }
     },
     "extend": {
@@ -3899,9 +3909,7 @@
         "core-js": "2.5.7",
         "cors": "2.8.4",
         "express": "4.16.3",
-        "express-graphql": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
         "faker": "4.1.0",
-        "graphql": "github:apis-guru/graphql-js#96b1ce3a0e578545dc3958f8b3457e9a535d73a9",
         "lodash": "4.17.10",
         "moment": "2.22.2",
         "node-fetch": "2.2.0",
@@ -3941,6 +3949,16 @@
             "xregexp": "4.0.0"
           }
         },
+        "express-graphql": {
+          "version": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
+          "from": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
+          "requires": {
+            "accepts": "^1.3.0",
+            "content-type": "^1.0.2",
+            "http-errors": "^1.3.0",
+            "raw-body": "^2.1.0"
+          }
+        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -3952,8 +3970,7 @@
         },
         "graphql": {
           "version": "github:apis-guru/graphql-js#96b1ce3a0e578545dc3958f8b3457e9a535d73a9",
-          "from": "github:apis-guru/graphql-js#directives-fork-dist",
-          "dev": true,
+          "from": "github:apis-guru/graphql-js#96b1ce3a0e578545dc3958f8b3457e9a535d73a9",
           "requires": {
             "iterall": "1.0.3"
           }
@@ -3961,8 +3978,7 @@
         "iterall": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.0.3.tgz",
-          "integrity": "sha1-4LMZWPg1ATwyP/CxCUOCmsaapLc=",
-          "dev": true
+          "integrity": "sha1-4LMZWPg1ATwyP/CxCUOCmsaapLc="
         },
         "locate-path": {
           "version": "3.0.0",
@@ -4173,7 +4189,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -4397,6 +4412,12 @@
         "global-dirs": "^0.1.0",
         "is-path-inside": "^1.0.0"
       }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
     },
     "is-npm": {
       "version": "1.0.0",
@@ -5609,6 +5630,15 @@
         "yallist": "^2.1.2"
       }
     },
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -5872,8 +5902,7 @@
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "neo-async": {
       "version": "2.6.0",
@@ -6529,7 +6558,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
       "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.3",
@@ -6541,7 +6569,6 @@
           "version": "0.4.23",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -6870,6 +6897,65 @@
         "glob": "^7.1.3"
       }
     },
+    "rollup": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.11.3.tgz",
+      "integrity": "sha512-81MR7alHcFKxgWzGfG7jSdv+JQxSOIOD/Fa3iNUmpzbd7p+V19e1l9uffqT8/7YAHgGOzmoPGN3Fx3L2ptOf5g==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.13.9",
+        "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.13.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.10.tgz",
+          "integrity": "sha512-leUNzbFTMX94TWaIKz8N15Chu55F9QSH+INKayQr5xpkasBQBRF3qQXfo3/dOnMU/dEIit+Y/SU8HyOjq++GwA==",
+          "dev": true
+        },
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-commonjs": {
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.3.4.tgz",
+      "integrity": "sha512-DTZOvRoiVIHHLFBCL4pFxOaJt8pagxsVldEXBOn6wl3/V21wVaj17HFfyzTsQUuou3sZL3lEJZVWKPFblJfI6w==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.10.0",
+        "rollup-pluginutils": "^2.6.0"
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.3.tgz",
+      "integrity": "sha512-r+WaesPzdGEynpLZLALFEDugA4ACa5zn7bc/+LVX4vAXQQ8IgDHv0xfsSvJ8tDXUtprfBtrDtRFg27ifKjcJTg==",
+      "dev": true,
+      "requires": {
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.10.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.6.0.tgz",
+      "integrity": "sha512-aGQwspEF8oPKvg37u3p7h0cYNwmJR1sCBMZGZ5b9qy8HGtETknqjzcxrDRrcAnJNXN18lBH4Q9vZYth/p4n8jQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
+      }
+    },
     "rsvp": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
@@ -7086,8 +7172,7 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -7298,6 +7383,12 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "dev": true
+    },
     "spawn-command": {
       "version": "0.0.2-1",
       "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
@@ -7399,8 +7490,7 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -7956,8 +8046,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -2,7 +2,7 @@
   "name": "coda-wallet",
   "version": "0.1.0",
   "description": "",
-  "main": "./lib/js/src/main/App.js",
+  "main": "./app.js",
   "dependencies": {
     "@glennsl/bs-jest": "^0.4.8",
     "@glennsl/bs-json": "^3.0.0",
@@ -19,32 +19,34 @@
     "electron-builder": "^20.39.0",
     "fastpack": "^0.8.4",
     "graphql-faker": "^1.9.0",
-    "node": "^8.15.0"
+    "node": "^8.15.0",
+    "rollup": "^1.11.3",
+    "rollup-plugin-commonjs": "^9.3.4",
+    "rollup-plugin-node-resolve": "^4.2.3"
   },
   "scripts": {
-    "start": "electron ./lib/js/src/main/App.js",
     "fake": "graphql-faker --port 8080 -- schema.graphql",
     "fake-inspector": "graphql-faker --open -- schema.graphql",
     "build": "bsb -make-world",
     "build-ci": "npm run query-fake && npm run build",
     "clean": "bsb -clean-world",
     "pack": "fpack --development ./lib/js/src/render/Index.js",
+    "pack-main": "rollup --config ./rollup.config.js",
     "query": "send-introspection-query http://localhost:8080/graphql",
     "query-fake": "concurrently --kill-others 'npm run fake' 'sleep 5 && npm run query'",
     "reformat": "bsrefmt --in-place src/**/*.re",
     "test": "npm run build && jest",
-    "dist": "npm run build && npm run pack && build",
+    "dist": "npm run build && npm run pack && npm run pack-main && build",
     "dev": "concurrently --kill-others 'bsb -make-world -w' 'fpack watch --development ./lib/js/src/render/Index.js' 'electron ./lib/js/src/main/App.js'"
   },
   "build": {
     "appId": "FOO.org.codaprotocol.prowallet",
     "files": [
-      "lib/**/*",
-      "node_modules/**/*",
+      "./app.js",
       "package.json"
     ],
     "extraResources": [
-      "bundle/**/*",
+      "bundle/*",
       "public/*"
     ],
     "compression": "store",

--- a/frontend/wallet/rollup.config.js
+++ b/frontend/wallet/rollup.config.js
@@ -1,11 +1,11 @@
-import resolve from 'rollup-plugin-node-resolve';
-import commonjs from 'rollup-plugin-commonjs';
+import resolve from "rollup-plugin-node-resolve";
+import commonjs from "rollup-plugin-commonjs";
 
 export default {
-  input: './lib/js/src/main/app.js',
+  input: "./lib/js/src/main/app.js",
   output: {
-    file: './app.js',
-    format: 'cjs'
+    file: "./app.js",
+    format: "cjs"
   },
   external: ["electron"],
   plugins: [

--- a/frontend/wallet/rollup.config.js
+++ b/frontend/wallet/rollup.config.js
@@ -1,0 +1,15 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+
+export default {
+  input: './lib/js/src/main/app.js',
+  output: {
+    file: './app.js',
+    format: 'cjs'
+  },
+  external: ["electron"],
+  plugins: [
+    resolve(),
+    commonjs()
+  ]
+};

--- a/frontend/wallet/src/main/ProjectRoot.re
+++ b/frontend/wallet/src/main/ProjectRoot.re
@@ -1,5 +1,3 @@
-open Tc;
-
 [@bs.module "electron"] [@bs.scope "app"] external isPackaged: bool = "";
 
 [@bs.module "electron"] [@bs.scope "app"]
@@ -32,12 +30,12 @@ let userData =
   if (isPackaged) {
     getPath(`UserData);
   } else {
-    Node_path.join2(Option.getExn([%bs.node __dirname]), "../../../..");
+    Node.Process.cwd();
   };
 
 let resource =
   if (isPackaged) {
     Filename.dirname(getAppPath());
   } else {
-    Node_path.join2(Option.getExn([%bs.node __dirname]), "../../../..");
+    Node.Process.cwd();
   };


### PR DESCRIPTION
This reduces the wallet dist package size from ~500mb to ~140mb by packing our main process js so that we don't need to include any of the node_modules.

Unfortunately this meant we needed another packer, because fastpack doesn't support packing nodejs packages. Rollup is pretty [light](https://bundlephobia.com/result?p=rollup@1.11.3) so I pulled that in for now. It's slower than fastpack but we only rely on it when building the dist.