### PR TITLE
TRIVIAL: reduce debug of cred info

### DIFF
--- a/scripts/getkeys.sh
+++ b/scripts/getkeys.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-set -exo pipefail
+set -eo pipefail
 
 # Get fixed set of PV keys (which needs to be updated when snark changes)
-
 if [ -z "$JSON_GCLOUD_CREDENTIALS" ]; then
     echo "WARNING: JSON_GCLOUD_CREDENTIALS not set, static PV keys not used"
     exit 0
@@ -10,9 +9,11 @@ fi
 
 # GC credentials
 echo $JSON_GCLOUD_CREDENTIALS > google_creds.json
-set -x
 /usr/bin/gcloud auth activate-service-account --key-file=google_creds.json
 /usr/bin/gcloud config set project $(cat google_creds.json | jq -r .project_id)
+
+# Debug output
+set -x
 
 # Get cached keys
 echo "------------------------------------------------------------"


### PR DESCRIPTION
Previously we were echoing too much in CI re creds for keys.
