### PR TITLE
Dist builds preload happy

### DIFF
--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -38,9 +38,11 @@
   },
   "build": {
     "appId": "FOO.org.codaprotocol.prowallet",
+    "asarUnpack": [
+      "lib"
+    ],
     "files": [
-      "./lib/**/*",
-      "!./lib/js/src/render/Preload.js",
+      "lib/**/*",
       "!node_modules/electron",
       "!node_modules/graphql_ppx",
       "!node_modules/bs-platform/lib",
@@ -48,7 +50,6 @@
       "package.json"
     ],
     "extraResources": [
-      "./lib/js/src/render/Preload.js",
       "bundle/**/*",
       "public/*"
     ],

--- a/frontend/wallet/src/common/Bindings.re
+++ b/frontend/wallet/src/common/Bindings.re
@@ -1,5 +1,17 @@
 open Tc;
 
+module Url = {
+  type t;
+  [@bs.new] external create: string => t = "URL";
+
+  module SearchParams = {
+    type t;
+    [@bs.send] external get: (t, string) => string = "";
+  };
+
+  [@bs.get] external searchParams: t => SearchParams.t = "";
+};
+
 module Navigator = {
   module Clipboard = {
     [@bs.val] [@bs.scope ("navigator", "clipboard")]

--- a/frontend/wallet/src/main/App.re
+++ b/frontend/wallet/src/main/App.re
@@ -41,6 +41,14 @@ let createTray = (_settingsOrError, dispatch, wallets) => {
     Menu.Item.[
       make(Separator, ()),
       make(
+        Label("Debug"),
+        ~click=
+          () =>
+            AppWindow.get({path: Route.Home, dispatch})
+            |> AppWindow.openDevTools,
+        (),
+      ),
+      make(
         Label("Send"),
         ~accelerator="CmdOrCtrl+S",
         ~click=() => AppWindow.deepLink({path: Route.Send, dispatch}),
@@ -109,3 +117,5 @@ let run = () =>
       AppWindow.deepLink({AppWindow.Input.path: Route.Home, dispatch});
     },
   );
+
+run();

--- a/frontend/wallet/src/main/AppWindow.re
+++ b/frontend/wallet/src/main/AppWindow.re
@@ -58,6 +58,8 @@ include Single.Make({
         window,
         "file://"
         ++ Filename.concat(ProjectRoot.resource, "public/index.html")
+        ++ "?settingsPath="
+        ++ Js.Global.encodeURI(ProjectRoot.settings)
         ++ "#"
         ++ Route.print(input.path),
       );

--- a/frontend/wallet/src/main/AppWindow.re
+++ b/frontend/wallet/src/main/AppWindow.re
@@ -45,8 +45,8 @@ include Single.Make({
               makeWebPreferences(
                 ~preload=
                   Filename.concat(
-                    [%bs.node __dirname] |> Option.getExn,
-                    "../render/Preload.js",
+                    [%bs.node __dirname] |> Option.getExn |> Filename.dirname,
+                    "render/Preload.js",
                   ),
                 ~nodeIntegration=true,
                 (),

--- a/frontend/wallet/src/main/ProjectRoot.re
+++ b/frontend/wallet/src/main/ProjectRoot.re
@@ -30,16 +30,15 @@ external getPath:
 
 let isJest = Js.Dict.get(env, "JEST_WORKER_ID") == Some("1");
 
-// TODO(bkase): Fix this by using IPC
 let userData =
-  if (!isJest && false /*isPackaged*/) {
+  if (!isJest && isPackaged) {
     getPath(`UserData);
   } else {
     Node.Process.cwd();
   };
 
 let resource =
-  if (!isJest && false /*isPackaged*/) {
+  if (!isJest && isPackaged) {
     Filename.dirname(getAppPath());
   } else {
     Node.Process.cwd();

--- a/frontend/wallet/src/render/Preload.re
+++ b/frontend/wallet/src/render/Preload.re
@@ -15,19 +15,27 @@ include Settings.Loader.Make(
           },
         );
 
+let settingsPath = {
+  let url = [%bs.raw "window.location.href"];
+  let searchParams = Bindings.Url.create(url) |> Bindings.Url.searchParams;
+
+  Bindings.Url.SearchParams.get(searchParams, "settingsPath")
+  |> Js.Global.decodeURI;
+};
+
 // TODO: Is exposing a writeFile to this particular path, still too large of an
 // attack vector? An adversary could send a super large settings payload for
 // example.
 let saveSettings: SettingsRenderer.saveSettings('a) =
   settings =>
     writeFileAsync(
-      ProjectRoot.settings,
+      settingsPath,
       Js.Json.stringify(Settings.Encode.t(settings)),
     )
     |> Task.onError(~f=e => Task.fail(`Error_saving_file(e)));
 
 let loadSettings: Settings.Intf(Result).loadSettings(unit, 'a) =
-  () => load(ProjectRoot.settings);
+  () => load(settingsPath);
 
 [%bs.raw "window.loadSettings = loadSettings"];
 [%bs.raw "window.saveSettings = saveSettings"];


### PR DESCRIPTION
Funnel project root settings path through a query parameter.

The dist builds are happy about preload.js, but fail because the file doesn't exist in `Application Support`.

No more hacking the bool to false in any case.

Made sure `make dev` still works as well.
