### PR TITLE
Clean up tray menu

### DIFF
--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -50,6 +50,7 @@
       "package.json"
     ],
     "extraResources": [
+      "node_modules/graphql-faker/dist/index.js",
       "bundle/**/*",
       "public/*"
     ],

--- a/frontend/wallet/src/main/App.re
+++ b/frontend/wallet/src/main/App.re
@@ -6,39 +6,15 @@ let apolloClient = GraphqlMain.createClient("http://localhost:8080/graphql");
 
 IpcLinkMain.start(apolloClient);
 
-let createTray = (_settingsOrError, dispatch, wallets) => {
+let createTray = dispatch => {
   let t = AppTray.get();
-  let prefixItems =
+  let trayItems =
     Menu.Item.[
       make(
         Label("Synced"),
         ~icon=Filename.concat(ProjectRoot.resource, "public/circle-16.png"),
         (),
       ),
-      make(Separator, ()),
-      make(Label("Wallets:"), ~enabled=false, ()),
-    ];
-  let codaSymbol = {js|□|js};
-  let walletItems =
-    List.map(
-      ~f=
-        wallet =>
-          Menu.Item.make(
-            Radio(
-              Printf.sprintf(
-                "    %s %s %d",
-                wallet##publicKey,
-                codaSymbol,
-                100,
-              ),
-            ),
-            (),
-          ),
-      Array.to_list(wallets),
-    );
-
-  let suffixItems =
-    Menu.Item.[
       make(Separator, ()),
       make(
         Label("Debug"),
@@ -48,23 +24,25 @@ let createTray = (_settingsOrError, dispatch, wallets) => {
             |> AppWindow.openDevTools,
         (),
       ),
+      make(Separator, ()),
       make(
-        Label("Send"),
-        ~accelerator="CmdOrCtrl+S",
-        ~click=() => AppWindow.deepLink({path: Route.Send, dispatch}),
+        Label("Open"),
+        ~accelerator="CmdOrCtrl+O",
+        ~click=() => AppWindow.deepLink({path: Route.Home, dispatch}),
         (),
       ),
-      make(Separator, ()),
-      make(Label("Request"), ~accelerator="CmdOrCtrl+R", ()),
-      make(Separator, ()),
-      make(Label("Settings:"), ~enabled=false, ()),
-      make(Checkbox("    Snark worker"), ()),
+      make(
+        Label("Settings"),
+        ~accelerator="CmdOrCtrl+,",
+        ~click=() => AppWindow.deepLink({path: Route.Home, dispatch}),
+        (),
+      ),
       make(Separator, ()),
       make(Label("Quit"), ~accelerator="CmdOrCtrl+Q", ~role="quit", ()),
     ];
 
   let menu = Menu.make();
-  List.iter(~f=Menu.append(menu), prefixItems @ walletItems @ suffixItems);
+  List.iter(~f=Menu.append(menu), trayItems);
 
   Tray.setContextMenu(t, menu);
 };
@@ -94,25 +72,13 @@ let run = () =>
       let dispatch = ref(_ => ());
       let store =
         Application.Store.create(
-          initialState, ~onNewState=(_last, curr: Application.State.t('a)) =>
-          createTray(curr.settingsOrError, dispatch^, curr.wallets)
+          initialState, ~onNewState=(_last, _curr: Application.State.t('a)) =>
+          createTray(dispatch^)
         );
       dispatch := Application.Store.apply(store);
       let dispatch = dispatch^;
 
-      ignore @@
-      Js.Global.setTimeout(
-        () => {
-          let q = TestQuery.query(apolloClient);
-          Task.perform(q, ~f=response =>
-            switch (response.data) {
-            | Some(d) => dispatch(Application.Action.WalletInfo(d##wallets))
-            | None => Js.log("Error getting wallets")
-            }
-          );
-        },
-        2000,
-      );
+      createTray(dispatch);
 
       AppWindow.deepLink({AppWindow.Input.path: Route.Home, dispatch});
     },

--- a/frontend/wallet/src/main/DaemonProcess.re
+++ b/frontend/wallet/src/main/DaemonProcess.re
@@ -4,8 +4,17 @@ let start = port => {
   print_endline("Starting graphql-faker");
   let p =
     ChildProcess.spawn(
-      "./node_modules/.bin/graphql-faker",
-      [|"--port", string_of_int(port), "--", "schema.graphql"|],
+      "node",
+      [|
+        Filename.concat(
+          ProjectRoot.resource,
+          "node_modules/graphql-faker/dist/index.js",
+        ),
+        "--port",
+        string_of_int(port),
+        "--",
+        "schema.graphql",
+      |],
     );
 
   ChildProcess.Process.onError(p, e =>


### PR DESCRIPTION
Removes wallet listing from tray menu, removes lag before the tray menu icon appears, fixes graphql-faker in the dist build.
The reducer isn't really used for anything now that we don't use any state in the menu, but I left it in because eventually we'll be subscribing to sync status.

![image](https://user-images.githubusercontent.com/2154522/57414318-78696f00-71ac-11e9-839b-e903fad5f159.png)
