### PR TITLE
Wallet: fix graphql-faker 500 error bug

### DIFF
--- a/frontend/wallet/package-lock.json
+++ b/frontend/wallet/package-lock.json
@@ -549,6 +549,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.6.tgz",
       "integrity": "sha512-QsaoUD2dpVpjENy8JFpQnXP9vyzoZPmAoKrE3S6HtSB7qzSebkJNnmdY4p004FQUSSiHXPueENpoeuUW/7a8Ig==",
+      "dev": true,
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.1"
@@ -557,12 +558,14 @@
         "mime-db": {
           "version": "1.40.0",
           "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+          "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.24",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
           "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+          "dev": true,
           "requires": {
             "mime-db": "1.40.0"
           }
@@ -1477,7 +1480,8 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -1924,7 +1928,8 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
@@ -2186,7 +2191,8 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
@@ -2960,6 +2966,17 @@
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         }
+      }
+    },
+    "express-graphql": {
+      "version": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
+      "from": "github:apis-guru/express-graphql#rootValue_dist",
+      "dev": true,
+      "requires": {
+        "accepts": "^1.3.0",
+        "content-type": "^1.0.2",
+        "http-errors": "^1.3.0",
+        "raw-body": "^2.1.0"
       }
     },
     "extend": {
@@ -3864,11 +3881,19 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "graphql": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
-      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+      "version": "github:apis-guru/graphql-js#96b1ce3a0e578545dc3958f8b3457e9a535d73a9",
+      "from": "github:apis-guru/graphql-js#directives-fork-dist",
+      "dev": true,
       "requires": {
-        "iterall": "^1.2.2"
+        "iterall": "1.0.3"
+      },
+      "dependencies": {
+        "iterall": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.0.3.tgz",
+          "integrity": "sha1-4LMZWPg1ATwyP/CxCUOCmsaapLc=",
+          "dev": true
+        }
       }
     },
     "graphql-faker": {
@@ -3882,7 +3907,9 @@
         "core-js": "2.5.7",
         "cors": "2.8.4",
         "express": "4.16.3",
+        "express-graphql": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
         "faker": "4.1.0",
+        "graphql": "github:apis-guru/graphql-js#96b1ce3a0e578545dc3958f8b3457e9a535d73a9",
         "lodash": "4.17.10",
         "moment": "2.22.2",
         "node-fetch": "2.2.0",
@@ -3922,16 +3949,6 @@
             "xregexp": "4.0.0"
           }
         },
-        "express-graphql": {
-          "version": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
-          "from": "github:apis-guru/express-graphql#90ff36c20d49e7cec0b64846d0481f75b93d4ae6",
-          "requires": {
-            "accepts": "^1.3.0",
-            "content-type": "^1.0.2",
-            "http-errors": "^1.3.0",
-            "raw-body": "^2.1.0"
-          }
-        },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -3940,18 +3957,6 @@
           "requires": {
             "locate-path": "^3.0.0"
           }
-        },
-        "graphql": {
-          "version": "github:apis-guru/graphql-js#96b1ce3a0e578545dc3958f8b3457e9a535d73a9",
-          "from": "github:apis-guru/graphql-js#96b1ce3a0e578545dc3958f8b3457e9a535d73a9",
-          "requires": {
-            "iterall": "1.0.3"
-          }
-        },
-        "iterall": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.0.3.tgz",
-          "integrity": "sha1-4LMZWPg1ATwyP/CxCUOCmsaapLc="
         },
         "locate-path": {
           "version": "3.0.0",
@@ -4162,6 +4167,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -5871,7 +5877,8 @@
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
     },
     "neo-async": {
       "version": "2.6.0",
@@ -6523,6 +6530,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
       "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.3",
@@ -6534,6 +6542,7 @@
           "version": "0.4.23",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+          "dev": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -6692,6 +6701,16 @@
         "graphql-tag": "2.10.0",
         "react-apollo": "2.3.2",
         "subscriptions-transport-ws": "^0.9.16"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "14.0.2",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
+          "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+          "requires": {
+            "iterall": "^1.2.2"
+          }
+        }
       }
     },
     "reason-react": {
@@ -7078,7 +7097,8 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -7390,7 +7410,8 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -7946,7 +7967,8 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -22,6 +22,9 @@
     "graphql-faker": "^1.9.0",
     "node": "^8.15.0"
   },
+  "resolutions": {
+    "graphql": "14.0.2"
+  },
   "scripts": {
     "fake": "graphql-faker --port 8080 -- schema.graphql",
     "fake-inspector": "graphql-faker --open -- schema.graphql",


### PR DESCRIPTION
Under certain circumstances, it seems that graphql-faker can get confused about which version of graphql to use, resulting in a 500 error
With the help of https://github.com/rogeriochaves/npm-force-resolutions, I attempted to enforce that it always uses 14.0.2. Seems to be helping on my machine.