### PR TITLE
Refactor TransactionsView to use CSS Grid

### DIFF
--- a/frontend/wallet/src/render/components/Header.re
+++ b/frontend/wallet/src/render/components/Header.re
@@ -29,7 +29,7 @@ module Styles = {
 
 [@react.component]
 let make = () =>
-  <div className=Styles.header>
+  <header className=Styles.header>
     <div
       style={ReactDOMRe.Style.make(~display="flex", ~alignItems="center", ())}>
       <div className=Theme.codaLogoCurrent />
@@ -41,23 +41,22 @@ let make = () =>
     <div
       style={ReactDOMRe.Style.make(
         ~fontWeight="500",
-        // ~height="1em",
-        ~color="#c49d41",
+        ~color="#479056",
         ~marginRight="10px",
         ~padding="0.25em",
         ~paddingLeft="2em",
         ~paddingRight="2em",
+        ~overflow="hidden",
         ~borderRadius="4px",
-        ~border="2px solid #60542c",
         ~background=
           {|repeating-linear-gradient(
                 to right,
                 transparent,
                 transparent 2px,
-                #60542c 2px,
-                #60542c 4px)|},
+                rgba(71, 144, 86, 0.3) 2px,
+                rgba(71, 144, 86, 0.3) 4px)|},
         (),
       )}>
-      {ReasonReact.string({j|Syncing|j})}
+      {ReasonReact.string({j|SYNCED 1.4s|j})}
     </div>
-  </div>;
+  </header>;

--- a/frontend/wallet/src/render/components/TransactionCell.re
+++ b/frontend/wallet/src/render/components/TransactionCell.re
@@ -1,5 +1,20 @@
 open Tc;
 
+module Styles = {
+  open Css;
+
+  let pill =
+    style([
+      display(`inlineFlex),
+      alignItems(`center),
+      justifyContent(`center),
+      height(`rem(1.5)),
+      padding2(~v=`px(0), ~h=`rem(0.5)),
+      borderRadius(`px(4)),
+      backgroundColor(lightgrey),
+    ]);
+};
+
 module Transaction = {
   module RewardDetails = {
     type t = {
@@ -143,8 +158,10 @@ module ActorName = {
   let make = (~value: ViewModel.Actor.t) => {
     switch (value) {
     | Key(key) =>
-      <span> {ReasonReact.string(PublicKey.toString(key))} </span>
-    | Unknown => <span />
+      <span className=Styles.pill>
+        {ReasonReact.string(PublicKey.toString(key))}
+      </span>
+    | Unknown => <span> {React.string("Unknown")} </span>
     | Minted =>
       <span className=Css.(style([backgroundColor(Theme.Colors.sage)]))>
         {ReasonReact.string("Minted")}
@@ -173,14 +190,13 @@ module TimeDisplay = {
 module Amount = {
   [@react.component]
   let make = (~decorated: bool, ~value: int) => {
-    <span>
+    <span className=Css.(style([alignSelf(`flexEnd)]))>
       <span
         className=Css.(
           style([
             Theme.Typeface.lucidaGrande,
             color(
-              value >= 0
-                ? Theme.Colors.serpentine : Theme.Colors.roseBud,
+              value >= 0 ? Theme.Colors.serpentine : Theme.Colors.roseBud,
             ),
           ])
         )>
@@ -196,7 +212,8 @@ module Amount = {
 
 module InfoSection = {
   [@react.component]
-  let make = (~expanded: bool, ~viewModel: ViewModel.t) => {
+  let make = (~viewModel: ViewModel.t) => {
+    let (expanded, setExpanded) = React.useState(() => false);
     let mainRow = message => {
       <div
         className=Css.(
@@ -207,37 +224,15 @@ module InfoSection = {
           ])
         )>
         <p> {ReasonReact.string(message)} </p>
-        <Amount decorated=false value={viewModel.amountDelta} />
       </div>;
     };
-    <div>
-      <div
-        className=Css.(style([display(`flex), justifyContent(`flexEnd)]))>
-        {expanded
-           ? <span> {ReasonReact.string({j|Collapse 🠻|j})} </span>
-           : (
-             switch (viewModel.info) {
-             | Memo(_, date)
-             | Empty(date)
-             | StakingReward(_, date) =>
-               <>
-                 {switch (viewModel.action) {
-                  | Transfer => <span />
-                  | Pending =>
-                    <span className=Css.(style([textTransform(`uppercase)]))>
-                      {ReasonReact.string("pending")}
-                    </span>
-                  | Failed =>
-                    <span className=Css.(style([textTransform(`uppercase)]))>
-                      {ReasonReact.string("failed")}
-                    </span>
-                  }}
-                 <TimeDisplay date />
-               </>
-             | MissingReceipts => <span />
-             }
-           )}
-      </div>
+    <div
+      onClick={_e =>
+        switch (viewModel.info) {
+        | StakingReward(_, _) => setExpanded(expanded => !expanded)
+        | _ => ()
+        }
+      }>
       {switch (viewModel.info) {
        | Memo(message, _) => mainRow(message)
        | Empty(_) => mainRow("")
@@ -271,51 +266,58 @@ module InfoSection = {
   };
 };
 
-// TODO: As suggested in https://github.com/CodaProtocol/coda/pull/2260 , we
-// should probably switch to CSS Grid
-//
-// We can represent one of these cells as a row in an HTML table in the
-// following manner:
-//
-// ┌────────┬────┬───────────┬─────────────────────────
-// │ Sender │ -> │ Recipient │ Info (including amount)
-//
-// The final column is info and amount in order to more easily support the
-// expanded view of the staking reward
+// These cells are returned as a fragment so that the parent container can
+// use a consistent grid layout to keep everything lined up.
 
 [@react.component]
 let make = (~transaction: Transaction.t, ~myWallets: list(PublicKey.t)) => {
-  let (expanded, setExpanded) = React.useState(() => false);
-
   let viewModel = ViewModel.ofTransaction(transaction, ~myWallets);
 
-  <tr
-    onClick={_e =>
-      switch (viewModel.info) {
-      | StakingReward(_, _) => setExpanded(expanded => !expanded)
-      | _ => ()
-      }
-    }>
-    <td className=Css.(style([verticalAlign(`baseline)]))>
+  <>
+    <span>
       <ActorName value={viewModel.sender} />
-    </td>
-    <td className=Css.(style([verticalAlign(`baseline)]))>
-      {ReasonReact.string(
-         switch (viewModel.action) {
-         | Transfer => "->"
-         | Pending => ">>"
-         | Failed => "x"
-         },
-       )}
-    </td>
-    <td className=Css.(style([verticalAlign(`baseline)]))>
-      <ActorName value={viewModel.recipient} />
-    </td>
-    <td
+      <div>
+        {ReasonReact.string(
+           switch (viewModel.action) {
+           | Transfer => " -> "
+           | Pending => " ... "
+           | Failed => " x "
+           },
+         )}
+        <ActorName value={viewModel.recipient} />
+      </div>
+    </span>
+    <span
       className=Css.(
         style([verticalAlign(`baseline), width(`percent(100.))])
       )>
-      <InfoSection expanded viewModel />
-    </td>
-  </tr>;
+      <InfoSection viewModel />
+    </span>
+    <span className=Css.(style([justifySelf(`flexEnd)]))>
+      <div
+        className=Css.(style([display(`flex), justifyContent(`flexEnd)]))>
+        {switch (viewModel.info) {
+         | Memo(_, date)
+         | Empty(date)
+         | StakingReward(_, date) =>
+           <>
+             {switch (viewModel.action) {
+              | Transfer => <span />
+              | Pending =>
+                <span className=Css.(style([textTransform(`uppercase)]))>
+                  {ReasonReact.string("pending")}
+                </span>
+              | Failed =>
+                <span className=Css.(style([textTransform(`uppercase)]))>
+                  {ReasonReact.string("failed")}
+                </span>
+              }}
+             <TimeDisplay date />
+           </>
+         | MissingReceipts => <span />
+         }}
+      </div>
+      <Amount decorated=false value={viewModel.amountDelta} />
+    </span>
+  </>;
 };

--- a/frontend/wallet/src/render/components/TransactionsView.re
+++ b/frontend/wallet/src/render/components/TransactionsView.re
@@ -1,125 +1,131 @@
 open Tc;
 
-[@react.component]
-let make = () => {
-  let myWallets = [PublicKey.ofStringExn("123456789")];
-  let otherKey = PublicKey.ofStringExn("BDK342322");
+module Styles = {
+  open Css;
 
-  <table className=Css.(style([overflow(`scroll)]))>
-    <tr>
-      <th className=Css.(style([textAlign(`left)]))>
-        {ReasonReact.string("Sender")}
-      </th>
-      <th />
-      <th className=Css.(style([textAlign(`left)]))>
-        {ReasonReact.string("Recipient")}
-      </th>
-      <th className=Css.(style([textAlign(`left)]))>
-        {ReasonReact.string("Info")}
-      </th>
-    </tr>
-    // Transaction Cells as in the mockup
-    <TransactionCell
-      transaction={
-        TransactionCell.Transaction.Unknown({
-          key: List.head(myWallets) |> Option.getExn,
-          amount: 2415,
-        })
-      }
-      myWallets
-    />
-    <TransactionCell
-      transaction={
-        TransactionCell.Transaction.Payment(
-          {
-            from: otherKey,
-            to_: List.head(myWallets) |> Option.getExn,
-            amount: 2415,
-            fee: 10,
-            memo: Some("Funds received memo"),
-            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
-            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
-          },
-          {
-            status: ConsensusState.Status.Included,
-            estimatedPercentConfirmed: 0.95,
-          },
-        )
-      }
-      myWallets
-    />
-    <TransactionCell
-      transaction={
-        TransactionCell.Transaction.Payment(
-          {
-            from: List.head(myWallets) |> Option.getExn,
-            to_: otherKey,
-            amount: 1540,
-            fee: 10,
-            memo: Some("Funds sent"),
-            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
-            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
-          },
-          {
-            status: ConsensusState.Status.Finalized,
-            estimatedPercentConfirmed: 0.95,
-          },
-        )
-      }
-      myWallets
-    />
-    <TransactionCell
-      transaction={
-        TransactionCell.Transaction.Minted({
-          key: List.head(myWallets) |> Option.getExn,
-          coinbase: 2000,
-          transactionFees: 858,
-          proofFees: 200,
-          delegationFees: 215,
-          includedAt: Js.Date.fromString("16 Apr 2019 21:46:00 PST"),
-        })
-      }
-      myWallets
-    />
-    <TransactionCell
-      transaction={
-        TransactionCell.Transaction.Payment(
-          {
-            from: otherKey,
-            to_: List.head(myWallets) |> Option.getExn,
-            amount: 1540,
-            fee: 10,
-            memo: Some("Remitance payment"),
-            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
-            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
-          },
-          {
-            status: ConsensusState.Status.Submitted,
-            estimatedPercentConfirmed: 0.0,
-          },
-        )
-      }
-      myWallets
-    />
-    <TransactionCell
-      transaction={
-        TransactionCell.Transaction.Payment(
-          {
-            from: otherKey,
-            to_: List.head(myWallets) |> Option.getExn,
-            amount: 2415,
-            fee: 10,
-            memo: Some("Order #: 2347B342"),
-            includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
-            submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
-          },
-          {
-            status: ConsensusState.Status.Failed,
-            estimatedPercentConfirmed: 0.0,
-          },
-        )
-      }
-      myWallets
-    />
-  </table>;
+  let container =
+    style([
+      height(`percent(100.)),
+    ]);
+
+  let row =
+    style([
+      display(`grid),
+      gridTemplateColumns([`rem(16.), `fr(1.), `px(200)]),
+      gridGap(Theme.Spacing.defaultSpacing),
+      alignItems(`center),
+      padding(`rem(1.)),
+      borderBottom(`px(1), `solid, Theme.Colors.borderColor),
+      lastChild([borderBottom(`px(0), `solid, white)]),
+    ]);
+
+  let headerRow =
+    style([
+      padding2(~v=`px(0), ~h=`rem(1.)),
+      textTransform(`uppercase),
+      height(`rem(2.)),
+    ]);
+
+  let body =
+    style([
+      width(`percent(100.)),
+      overflow(`auto),
+      maxHeight(`calc(`sub, `percent(100.), `rem(2.))),
+    ]);
 };
+
+let myWallets = [PublicKey.ofStringExn("123456789")];
+let otherKey = PublicKey.ofStringExn("BDK342322");
+
+let mockTransactions =
+  Array.fromList([
+    TransactionCell.Transaction.Payment(
+      {
+        from: otherKey,
+        to_: List.head(myWallets) |> Option.getExn,
+        amount: 2415,
+        fee: 10,
+        memo: Some("Order #: 2347B342"),
+        includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+        submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+      },
+      {status: ConsensusState.Status.Failed, estimatedPercentConfirmed: 0.0},
+    ),
+    TransactionCell.Transaction.Unknown({
+      key: List.head(myWallets) |> Option.getExn,
+      amount: 2415,
+    }),
+    TransactionCell.Transaction.Payment(
+      {
+        from: List.head(myWallets) |> Option.getExn,
+        to_: otherKey,
+        amount: 1540,
+        fee: 10,
+        memo: Some("Funds sent"),
+        includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+        submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+      },
+      {
+        status: ConsensusState.Status.Finalized,
+        estimatedPercentConfirmed: 0.95,
+      },
+    ),
+    TransactionCell.Transaction.Minted({
+      key: List.head(myWallets) |> Option.getExn,
+      coinbase: 2000,
+      transactionFees: 858,
+      proofFees: 200,
+      delegationFees: 215,
+      includedAt: Js.Date.fromString("16 Apr 2019 21:46:00 PST"),
+    }),
+    TransactionCell.Transaction.Payment(
+      {
+        from: otherKey,
+        to_: List.head(myWallets) |> Option.getExn,
+        amount: 1540,
+        fee: 10,
+        memo: Some("Remitance payment"),
+        includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+        submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+      },
+      {
+        status: ConsensusState.Status.Submitted,
+        estimatedPercentConfirmed: 0.0,
+      },
+    ),
+    TransactionCell.Transaction.Payment(
+      {
+        from: otherKey,
+        to_: List.head(myWallets) |> Option.getExn,
+        amount: 2415,
+        fee: 10,
+        memo: Some("Order #: 2347B342"),
+        includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
+        submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
+      },
+      {status: ConsensusState.Status.Failed, estimatedPercentConfirmed: 0.0},
+    ),
+  ]);
+
+[@react.component]
+let make = () =>
+  <div className=Styles.container>
+    <div className={Css.merge([Styles.row, Styles.headerRow])}>
+      <span> {ReasonReact.string("Sender")} </span>
+      <span> {ReasonReact.string("Memo")} </span>
+      <span className=Css.(style([textAlign(`right)]))>
+        {ReasonReact.string("Transaction")}
+      </span>
+    </div>
+    <div className=Styles.body>
+    {Array.map(
+       ~f=
+         transaction =>
+           <div className=Styles.row>
+             <TransactionCell transaction myWallets />
+           </div>,
+       mockTransactions,
+     )
+     |> React.array}
+     </div>
+  </div>;


### PR DESCRIPTION
<img width="914" alt="Screen Shot 2019-05-09 at 5 11 43 PM" src="https://user-images.githubusercontent.com/1709621/57494335-8a671280-727d-11e9-98be-4f6b9bf4c9a6.png">

**What changed**

Updates the `TransactionList` to use CSS Grids instead of `<table>`. Cleans up some styles as well.