### PR TITLE
Add diagram for high level daemon architecture

### DIFF
--- a/docs/res/daemon_architecture.dot
+++ b/docs/res/daemon_architecture.dot
@@ -1,0 +1,41 @@
+digraph deamon_architecture {
+  rankdir=LR;
+
+  {
+    rank=source;
+    node [shape=box,width=2];
+    Protocol [height=6];
+    API [height=3];
+  }
+
+  {Transition_router, Bootstrap_controller, Transition_frontier_controller};
+  {Transition_frontier, Transition_frontier_extensions, Transition_frontier_persistence};
+  {Proposer, Snark_worker};
+  {Snark_pool, Transaction_pool};
+  {Verifier, Prover};
+
+  Protocol
+    -> Transition_router
+    -> {Bootstrap_controller, Transition_frontier_controller}
+    -> Transition_frontier
+    -> Proposer;
+  Proposer -> Transition_frontier_controller [constraint=false];
+  Proposer -> Prover;
+  Transition_router -> Verifier;
+
+  subgraph cluster_Transition_frontier {
+    style=invis;
+    Transition_frontier -> Transition_frontier_extensions [dir=none,constraint=false];
+    Transition_frontier_extensions -> Transition_frontier_persistence;
+  }
+
+  Protocol -> {Snark_pool, Transaction_pool} -> Protocol;
+  Transition_frontier_extensions -> {Snark_pool, Transaction_pool} [constraint=false];
+
+  Transition_frontier -> Snark_worker;
+  Snark_worker -> Snark_pool [constraint=false];
+  Snark_pool -> Snark_worker;
+
+  Transition_frontier -> API [constraint=false];
+  API -> Transaction_pool;
+}

--- a/docs/res/daemon_architecture.dot.png
+++ b/docs/res/daemon_architecture.dot.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21a8c351cecc34267f5af3b720198694daf346ae10d5b89dfae3e67afcb7ad18
+size 130156


### PR DESCRIPTION
New diagram for the high level componetized architecture of our daemon. I will add some more detailed diagrams for some of the components and put together a single architecture markdown file as an entry point to all of these. In the diagram I made, the boxes on the left represent the external network interactions. There is a lot of whitespace on the bottom right hand side of the graph, but this is the best I was able to get the graph to look for now. I think it still looks pretty good for a computer generated graph.