### PR TITLE
Cleans up styles on transaction cells

### DIFF
--- a/frontend/wallet/src/render/Theme.re
+++ b/frontend/wallet/src/render/Theme.re
@@ -23,6 +23,8 @@ module Colors = {
   let slateAlpha = a => `rgba((81, 102, 121, a));
 
   let roseBud = `hex("a3536f");
+  let pendingOrange = `hex("967103");
+  let greenblack = `hex("2a3c2e");
 
   let serpentine = `hex("479056");
   let serpentineLight = `rgba((101, 144, 110, 0.2));

--- a/frontend/wallet/src/render/components/TransactionCell.re
+++ b/frontend/wallet/src/render/components/TransactionCell.re
@@ -216,6 +216,7 @@ module TimeDisplay = {
       merge([
         Theme.Text.Body.small,
         style([
+          color(Theme.Colors.greyish(0.5)),
           whiteSpace(`nowrap),
           overflow(`hidden),
           textOverflow(`ellipsis),
@@ -226,10 +227,7 @@ module TimeDisplay = {
 
   [@react.component]
   let make = (~date: Js.Date.t) => {
-    <span
-      className=Css.(
-        merge([Styles.time, style([color(Theme.Colors.greyish(0.5))])])
-      )>
+    <span className=Styles.time>
       {ReasonReact.string(Time.render(~date, ~now=Js.Date.make()))}
     </span>;
   };

--- a/frontend/wallet/src/render/components/TransactionCell.re
+++ b/frontend/wallet/src/render/components/TransactionCell.re
@@ -378,6 +378,9 @@ module TopLevelStyles = {
         width(`percent(100.)),
         marginTop(`rem(0.5)),
       ]);
+
+    let action =
+      merge([Theme.Text.Body.small, style([marginRight(`rem(1.0))])]);
   };
 };
 
@@ -417,11 +420,8 @@ let make = (~transaction: Transaction.t, ~myWallets: list(PublicKey.t)) => {
                 <span
                   className=Css.(
                     merge([
-                      Theme.Text.Body.small,
-                      style([
-                        marginRight(`rem(1.0)),
-                        color(Theme.Colors.pendingOrange),
-                      ]),
+                      TopLevelStyles.RightSide.action,
+                      style([color(Theme.Colors.pendingOrange)]),
                     ])
                   )>
                   {ReasonReact.string("Pending")}
@@ -430,11 +430,8 @@ let make = (~transaction: Transaction.t, ~myWallets: list(PublicKey.t)) => {
                 <span
                   className=Css.(
                     merge([
-                      Theme.Text.Body.small,
-                      style([
-                        marginRight(`rem(1.0)),
-                        color(Theme.Colors.roseBud),
-                      ]),
+                      TopLevelStyles.RightSide.action,
+                      style([color(Theme.Colors.roseBud)]),
                     ])
                   )>
                   {ReasonReact.string("Failed")}

--- a/frontend/wallet/src/render/components/TransactionsView.re
+++ b/frontend/wallet/src/render/components/TransactionsView.re
@@ -11,7 +11,8 @@ module Styles = {
       gridTemplateColumns([`rem(16.), `fr(1.), `px(200)]),
       gridGap(Theme.Spacing.defaultSpacing),
       alignItems(`flexStart),
-      padding(`rem(1.)),
+      marginLeft(`rem(0.25)),
+      padding2(~h=`rem(0.75), ~v=`zero),
       borderBottom(`px(1), `solid, Theme.Colors.borderColor),
       lastChild([borderBottom(`px(0), `solid, white)]),
     ]);
@@ -38,6 +39,10 @@ let otherKey = PublicKey.ofStringExn("BDK342322");
 
 let mockTransactions =
   Array.fromList([
+    TransactionCell.Transaction.Unknown({
+      key: List.head(myWallets) |> Option.getExn,
+      amount: 2415,
+    }),
     TransactionCell.Transaction.Payment(
       {
         from: otherKey,
@@ -50,10 +55,6 @@ let mockTransactions =
       },
       {status: ConsensusState.Status.Failed, estimatedPercentConfirmed: 0.0},
     ),
-    TransactionCell.Transaction.Unknown({
-      key: List.head(myWallets) |> Option.getExn,
-      amount: 2415,
-    }),
     TransactionCell.Transaction.Payment(
       {
         from: List.head(myWallets) |> Option.getExn,

--- a/frontend/wallet/src/render/components/TransactionsView.re
+++ b/frontend/wallet/src/render/components/TransactionsView.re
@@ -41,14 +41,14 @@ let mockTransactions =
   Array.fromList([
     TransactionCell.Transaction.Unknown({
       key: List.head(myWallets) |> Option.getExn,
-      amount: 2415,
+      amount: Int64.of_int(2415),
     }),
     TransactionCell.Transaction.Payment(
       {
         from: otherKey,
         to_: List.head(myWallets) |> Option.getExn,
-        amount: 2415,
-        fee: 10,
+        amount: Int64.of_int(2415),
+        fee: Int64.of_int(10),
         memo: Some("Order #: 2347B342"),
         includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
         submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
@@ -59,8 +59,8 @@ let mockTransactions =
       {
         from: List.head(myWallets) |> Option.getExn,
         to_: otherKey,
-        amount: 1540,
-        fee: 10,
+        amount: Int64.of_int(1540),
+        fee: Int64.of_int(10),
         memo: Some("Funds sent"),
         includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
         submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
@@ -72,18 +72,18 @@ let mockTransactions =
     ),
     TransactionCell.Transaction.Minted({
       key: List.head(myWallets) |> Option.getExn,
-      coinbase: 2000,
-      transactionFees: 858,
-      proofFees: 200,
-      delegationFees: 215,
+      coinbase: Int64.of_int(2000),
+      transactionFees: Int64.of_int(858),
+      proofFees: Int64.of_int(200),
+      delegationFees: Int64.of_int(215),
       includedAt: Js.Date.fromString("16 Apr 2019 21:46:00 PST"),
     }),
     TransactionCell.Transaction.Payment(
       {
         from: otherKey,
         to_: List.head(myWallets) |> Option.getExn,
-        amount: 1540,
-        fee: 10,
+        amount: Int64.of_int(1540),
+        fee: Int64.of_int(10),
         memo: Some("Remittance payment"),
         includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
         submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),
@@ -97,8 +97,8 @@ let mockTransactions =
       {
         from: otherKey,
         to_: List.head(myWallets) |> Option.getExn,
-        amount: 2415,
-        fee: 10,
+        amount: Int64.of_int(2415),
+        fee: Int64.of_int(10),
         memo: Some("Order #: 2347B342"),
         includedAt: Some(Js.Date.fromString("16 Apr 2019 21:46:00 PST")),
         submittedAt: Js.Date.fromString("15 Apr 2019 21:46:00 PST"),


### PR DESCRIPTION
Transaction cells mostly look like the spec now. Ignore my scrollbar thing, it's specific to my computer and we're not sure why it's happening.

Given that we may change the treatment on the unknown amount cell, I avoided special casing the alignment of that one for now.

<img width="866" alt="Screen Shot 2019-05-15 at 11 28 45 AM" src="https://user-images.githubusercontent.com/515445/57801920-ba913400-7709-11e9-97cc-1e576e0cb7f3.png">

