### PR TITLE
Fixed mismatching merkle root when starting daemon

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -773,7 +773,7 @@ module Make (Inputs : Inputs_intf) = struct
                         Ledger_db.create
                           ?directory_name:config.ledger_db_location ()
                       in
-                      Logger.info config.logger ~module_:__MODULE__
+                      Logger.debug config.logger ~module_:__MODULE__
                         ~location:__LOC__
                         !"Reading persistence data from %s"
                         transition_frontier_location ;

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -773,6 +773,10 @@ module Make (Inputs : Inputs_intf) = struct
                         Ledger_db.create
                           ?directory_name:config.ledger_db_location ()
                       in
+                      Logger.info config.logger ~module_:__MODULE__
+                        ~location:__LOC__
+                        !"Reading persistence data from %s"
+                        transition_frontier_location ;
                       let%map frontier =
                         Transition_frontier_persistence.deserialize
                           ~directory_name ~logger:config.logger

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -19,7 +19,8 @@
     global_signer_private_key
     non_zero_curve_point
     module_version
-    yojson)
+    yojson
+    staged_ledger_hash)
    (preprocessor_deps "../../config.mlh")
    (preprocess (pps ppx_base ppx_coda ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx -conditional))
    (synopsis "Consensus mechanisms"))

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -306,9 +306,9 @@ module type S = sig
     module Make_state_hooks
         (Blockchain_state : Protocols.Coda_pow.Blockchain_state_intf
                             with type staged_ledger_hash :=
-                                        Coda_base.Staged_ledger_hash.t
+                                        Staged_ledger_hash.t
                              and type staged_ledger_hash_var :=
-                                        Coda_base.Staged_ledger_hash.var
+                                        Staged_ledger_hash.var
                              and type frozen_ledger_hash :=
                                         Coda_base.Frozen_ledger_hash.t
                              and type frozen_ledger_hash_var :=

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2647,10 +2647,9 @@ module Hooks = struct
 
   module Make_state_hooks
       (Blockchain_state : Protocols.Coda_pow.Blockchain_state_intf
-                          with type staged_ledger_hash :=
-                                      Coda_base.Staged_ledger_hash.t
+                          with type staged_ledger_hash := Staged_ledger_hash.t
                            and type staged_ledger_hash_var :=
-                                      Coda_base.Staged_ledger_hash.var
+                                      Staged_ledger_hash.var
                            and type frozen_ledger_hash :=
                                       Coda_base.Frozen_ledger_hash.t
                            and type frozen_ledger_hash_var :=

--- a/src/lib/lite_compat/lite_compat.ml
+++ b/src/lib/lite_compat/lite_compat.ml
@@ -94,10 +94,10 @@ let frozen_ledger_hash (h : Coda_base.Frozen_ledger_hash.t) :
     Lite_base.Ledger_hash.t =
   digest (h :> Tick.Pedersen.Digest.t)
 
-let ledger_builder_hash (h : Coda_base.Staged_ledger_hash.t) =
+let ledger_builder_hash (h : Staged_ledger_hash.t) =
   { Lite_base.Staged_ledger_hash.ledger_hash=
-      ledger_hash (Coda_base.Staged_ledger_hash.ledger_hash h)
-  ; aux_hash= Coda_base.Staged_ledger_hash.(Aux_hash.to_bytes (aux_hash h)) }
+      ledger_hash (Staged_ledger_hash.ledger_hash h)
+  ; aux_hash= Staged_ledger_hash.(Aux_hash.to_bytes (aux_hash h)) }
 
 let blockchain_state
     ({staged_ledger_hash= lbh; snarked_ledger_hash= lh; timestamp} :

--- a/src/lib/staged_ledger_diff/dune
+++ b/src/lib/staged_ledger_diff/dune
@@ -1,5 +1,5 @@
 (library
   (name staged_ledger_diff)
   (public_name staged_ledger_diff)
-  (libraries core_kernel coda_base transaction_snark_work)
+  (libraries core_kernel coda_base transaction_snark_work staged_ledger_hash)
   (preprocess (pps ppx_jane ppx_coda ppx_deriving_yojson)))

--- a/src/lib/staged_ledger_hash/dune
+++ b/src/lib/staged_ledger_hash/dune
@@ -1,0 +1,5 @@
+(library
+  (name staged_ledger_hash)
+  (public_name staged_ledger_hash)
+  (preprocess (pps ppx_coda ppx_snarky ppx_jane ppx_deriving.std ppx_deriving_yojson))
+  (libraries core_kernel coda_base snark_params genesis_ledger bitstring_lib fold_lib tuple_lib with_hash))

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.ml
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.ml
@@ -1,4 +1,5 @@
 open Core
+open Coda_base
 open Fold_lib
 open Tuple_lib
 open Snark_params.Tick
@@ -45,7 +46,7 @@ module Aux_hash = struct
   end
 
   (* bin_io omitted *)
-  type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash, yojson]
+  type t = Stable.Latest.t [@@deriving sexp, compare, hash, yojson]
 
   let of_bytes = Fn.id
 
@@ -94,11 +95,7 @@ module Pending_coinbase_aux = struct
   end
 
   (* bin_io omitted *)
-  type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash, yojson]
-
-  let of_bytes = Fn.id
-
-  let to_bytes = Fn.id
+  type t = Stable.Latest.t [@@deriving sexp, compare, hash, yojson]
 
   let dummy : t = String.init length_in_bytes ~f:(fun _ -> '\000')
 end
@@ -131,12 +128,12 @@ module Non_snark = struct
   end
 
   (* bin_io omitted *)
-  type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash, yojson]
+  type t = Stable.Latest.t [@@deriving sexp, compare, hash, yojson]
 
   type value = t [@@deriving sexp, compare, hash, yojson]
 
   let dummy : t =
-    { ledger_hash= Ledger_hash.of_hash Field.zero
+    { ledger_hash= Ledger.merkle_root Genesis_ledger.t
     ; aux_hash= Aux_hash.dummy
     ; pending_coinbase_aux= Pending_coinbase_aux.dummy }
 
@@ -206,7 +203,7 @@ module Stable = struct
     type ('non_snark, 'pending_coinbase_hash) t =
           ('non_snark, 'pending_coinbase_hash) Stable.Latest.t =
       {non_snark: 'non_snark; pending_coinbase_hash: 'pending_coinbase_hash}
-    [@@deriving sexp, eq, compare, hash, yojson]
+    [@@deriving sexp, compare, hash, yojson]
   end
 
   module V1 = struct

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.mli
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.mli
@@ -1,4 +1,5 @@
 open Core
+open Coda_base
 open Fold_lib
 open Tuple_lib
 open Snark_params.Tick

--- a/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
@@ -225,14 +225,17 @@ let%test_module "Transition Frontier Persistence" =
       in
       test_deserialization max_length frontier
 
-    let%test "Serializing a frontier and then deserializing it  from genesis \
-              should give us the same transition_frontier" =
+    let%test_unit "Serializing a frontier and then deserializing it  from \
+                   genesis should give us the same transition_frontier" =
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;
       Thread_safe.block_on_async_exn
       @@ fun () ->
-      let%bind frontier = genesis_frontier ~logger in
-      test_deserialization (max_length / 2) frontier
+      Stubs.with_genesis_frontier ~logger ~f:(fun frontier ->
+          let%map is_serialization_correct =
+            test_deserialization (max_length / 2) frontier
+          in
+          assert is_serialization_correct )
 
     (* TODO: create a test where a batch of diffs are being applied, but the
        worker dies in the middle. The transition_frontier_database can be left

--- a/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
@@ -178,7 +178,7 @@ module Make (Inputs : Intf.Main_inputs) = struct
   let staged_ledger_hash transition =
     let open External_transition.Verified in
     let protocol_state = protocol_state transition in
-    Coda_base.Staged_ledger_hash.ledger_hash
+    Staged_ledger_hash.ledger_hash
       Protocol_state.(
         Blockchain_state.staged_ledger_hash @@ blockchain_state protocol_state)
 

--- a/src/staged_ledger_hash.opam
+++ b/src/staged_ledger_hash.opam
@@ -1,0 +1,5 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]


### PR DESCRIPTION
- Fixed it by computing the genesis ledger_hash correctly in
staged_ledger_hash

Made a failing test in test_transition_frontier_persistence for this fix

You can also verify this when starting the daemon. Then killing it. And then starting it again.

Checklist:

- [X] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

