### PR TITLE
we can peek at cache that is already consumed but not yet finalized

### DIFF
--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -150,7 +150,7 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
       if was_finalized t then raise (of_string msg)
 
     let peek (type a b) (t : (a, b) t) : a =
-      assert_not_consumed t "cannot peek at consumed Cached.t" ;
+      assert_not_finalized t "cannot peek at consumed Cached.t" ;
       value t
 
     let mark_transformed : type a b. (a, b) t -> unit = function

--- a/src/lib/cache_lib/impl.ml
+++ b/src/lib/cache_lib/impl.ml
@@ -150,7 +150,7 @@ module Make (Inputs : Inputs_intf) : Intf.Main.S = struct
       if was_finalized t then raise (of_string msg)
 
     let peek (type a b) (t : (a, b) t) : a =
-      assert_not_finalized t "cannot peek at consumed Cached.t" ;
+      assert_not_finalized t "cannot peek at finalized Cached.t" ;
       value t
 
     let mark_transformed : type a b. (a, b) t -> unit = function


### PR DESCRIPTION
A 1-line change in cache_lib. We should enable peek for consumed/transformed items. This would fix a bug in ledger breadcrumb_builder.ml
