### PR TITLE
Create One_or_two library

### DIFF
--- a/src/lib/one_or_two/dune
+++ b/src/lib/one_or_two/dune
@@ -1,0 +1,9 @@
+(library
+ (name one_or_two)
+ (public_name one_or_two)
+ (flags :standard -short-paths)
+ (library_flags -linkall)
+ (libraries core async module_version)
+ (preprocess
+  (pps ppx_base ppx_bin_prot ppx_coda ppx_deriving.std ppx_deriving_yojson ppx_let))
+ )

--- a/src/lib/one_or_two/intfs.ml
+++ b/src/lib/one_or_two/intfs.ml
@@ -1,0 +1,11 @@
+type 'a t = [`One of 'a | `Two of 'a * 'a]
+
+module type Monadic = sig
+  type 'a m
+
+  val sequence : 'a m t -> 'a t m
+
+  val map : 'a t -> f:('a -> 'b m) -> 'b t m
+
+  val fold : 'a t -> init:'accum -> f:('accum -> 'a -> 'accum m) -> 'accum m
+end

--- a/src/lib/one_or_two/one_or_two.ml
+++ b/src/lib/one_or_two/one_or_two.ml
@@ -1,0 +1,92 @@
+open Core
+open Async
+
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      type 'a t = [`One of 'a | `Two of 'a * 'a]
+      [@@deriving bin_io, equal, compare, hash, sexp, version, yojson]
+    end
+
+    include T
+  end
+
+  module Latest = V1
+end
+
+type 'a t = 'a Stable.V1.t [@@deriving compare, equal, hash, sexp, yojson]
+
+let length = function `One _ -> 1 | `Two _ -> 2
+
+let to_list = function `One a -> [a] | `Two (a, b) -> [a; b]
+
+let group_sequence : 'a Sequence.t -> 'a t Sequence.t =
+ fun seq ->
+  Sequence.unfold ~init:seq ~f:(fun seq' ->
+      match Sequence.next seq' with
+      | None ->
+          None
+      | Some (a, seq'') -> (
+        match Sequence.next seq'' with
+        | None ->
+            Some (`One a, Sequence.empty)
+        | Some (b, seq''') ->
+            Some (`Two (a, b), seq''') ) )
+
+let group_list : 'a list -> 'a t list =
+ fun xs -> xs |> Sequence.of_list |> group_sequence |> Sequence.to_list
+
+let zip_exn : 'a t -> 'b t -> ('a * 'b) t =
+ fun a b ->
+  match (a, b) with
+  | `One a1, `One b1 ->
+      `One (a1, b1)
+  | `Two (a1, a2), `Two (b1, b2) ->
+      `Two ((a1, b1), (a2, b2))
+  | _ ->
+      failwith "One_or_two.zip_exn mismatched"
+
+module Monadic (M : Monad.S) : Intfs.Monadic with type 'a m := 'a M.t = struct
+  let sequence : 'a M.t t -> 'a t M.t = function
+    | `One def ->
+        M.map def ~f:(fun x -> `One x)
+    | `Two (def1, def2) ->
+        let open M.Let_syntax in
+        let%bind a = def1 in
+        let%map b = def2 in
+        `Two (a, b)
+
+  let map : 'a t -> f:('a -> 'b M.t) -> 'b t M.t =
+   fun t ~f ->
+    sequence
+    @@ match t with `One a -> `One (f a) | `Two (a, b) -> `Two (f a, f b)
+
+  let fold :
+      'a t -> init:'accum -> f:('accum -> 'a -> 'accum M.t) -> 'accum M.t =
+   fun t ~init ~f ->
+    match t with
+    | `One a ->
+        f init a
+    | `Two (a, b) ->
+        M.bind (f init a) ~f:(fun x -> f x b)
+end
+
+module Ident = Monadic (Monad.Ident)
+module Deferred = Monadic (Deferred)
+module Option = Monadic (Option)
+module Or_error = Monadic (Or_error)
+
+let map = Ident.map
+
+let fold = Ident.fold
+
+let iter t ~f = match t with `One a -> f a | `Two (a, b) -> f a ; f b
+
+let fold_until ~init ~f ~finish t =
+  Container.fold_until ~fold ~init ~f ~finish t
+
+let gen inner_gen =
+  Quickcheck.Generator.(
+    union
+      [ map inner_gen ~f:(fun x -> `One x)
+      ; map (tuple2 inner_gen inner_gen) ~f:(fun pair -> `Two pair) ])

--- a/src/lib/one_or_two/one_or_two.ml
+++ b/src/lib/one_or_two/one_or_two.ml
@@ -21,17 +21,17 @@ let length = function `One _ -> 1 | `Two _ -> 2
 let to_list = function `One a -> [a] | `Two (a, b) -> [a; b]
 
 let group_sequence : 'a Sequence.t -> 'a t Sequence.t =
- fun seq ->
-  Sequence.unfold ~init:seq ~f:(fun seq' ->
-      match Sequence.next seq' with
+ fun to_group ->
+  Sequence.unfold ~init:to_group ~f:(fun acc ->
+      match Sequence.next acc with
       | None ->
           None
-      | Some (a, seq'') -> (
-        match Sequence.next seq'' with
+      | Some (a, rest_1) -> (
+        match Sequence.next rest_1 with
         | None ->
             Some (`One a, Sequence.empty)
-        | Some (b, seq''') ->
-            Some (`Two (a, b), seq''') ) )
+        | Some (b, rest_2) ->
+            Some (`Two (a, b), rest_2) ) )
 
 let group_list : 'a list -> 'a t list =
  fun xs -> xs |> Sequence.of_list |> group_sequence |> Sequence.to_list

--- a/src/lib/one_or_two/one_or_two.mli
+++ b/src/lib/one_or_two/one_or_two.mli
@@ -1,0 +1,46 @@
+(** Simple container of one of two values of a given type. *)
+open Core
+
+open Async
+
+module Stable : sig
+  module V1 : sig
+    type 'a t = 'a Intfs.t
+    [@@deriving bin_io, compare, equal, hash, sexp, version, yojson]
+  end
+
+  module Latest = V1
+end
+
+type 'a t = 'a Intfs.t [@@deriving compare, equal, hash, sexp, yojson]
+
+val length : 'a t -> int
+
+val to_list : 'a t -> 'a list
+
+val group_sequence : 'a Sequence.t -> 'a t Sequence.t
+
+val group_list : 'a list -> 'a t list
+
+val zip_exn : 'a t -> 'b t -> ('a * 'b) t
+
+val map : 'a t -> f:('a -> 'b) -> 'b t
+
+val iter : 'a t -> f:('a -> unit) -> unit
+
+val fold : 'a t -> init:'accum -> f:('accum -> 'a -> 'accum) -> 'accum
+
+val fold_until :
+     init:'b
+  -> f:('b -> 'a -> ('b, 'final) Continue_or_stop.t)
+  -> finish:('b -> 'final)
+  -> 'a t
+  -> 'final
+
+module Deferred : Intfs.Monadic with type 'a m := 'a Deferred.t
+
+module Option : Intfs.Monadic with type 'a m := 'a option
+
+module Or_error : Intfs.Monadic with type 'a m := 'a Or_error.t
+
+val gen : 'a Quickcheck.Generator.t -> 'a t Quickcheck.Generator.t

--- a/src/one_or_two.opam
+++ b/src/one_or_two.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
I wrote this for some refactoring of the transaction snark and snark work code, but since that work involves messing with a lot of signatures and the signatures are currently in flux I'm going to set it aside for a bit. Let's merge the library now.