### PR TITLE
Clean up some dead code/dependencies

### DIFF
--- a/src/app/cli/src/coda_inputs.ml
+++ b/src/app/cli/src/coda_inputs.ml
@@ -911,7 +911,6 @@ module Make_coda (Init : Init_intf) = struct
     include Make_inputs (Init) (Storage.Disk)
     module Genesis_ledger = Genesis_ledger
     module Ledger_proof_statement = Transaction_snark.Statement
-    module Snark_worker = Snark_worker_lib
     module Transaction_validator = Transaction_validator
     module Genesis_protocol_state = Genesis_protocol_state
     module Snark_transition = Snark_transition

--- a/src/lib/transaction_pool/dune
+++ b/src/lib/transaction_pool/dune
@@ -4,7 +4,7 @@
  (flags :standard -short-paths)
  (library_flags -linkall)
  (inline_tests)
- (libraries core core_kernel.fheap async async_extra coda_base envelope protocols module_version quickcheck_lib transition_frontier)
+ (libraries core async async_extra coda_base envelope protocols module_version quickcheck_lib transition_frontier)
  (preprocessor_deps "../../config.mlh")
  (preprocess
   (pps bisect_ppx ppx_assert ppx_base ppx_bin_prot ppx_coda ppx_custom_printf ppx_deriving.std ppx_deriving_yojson ppx_here ppx_inline_test ppx_let ppx_optcomp ppx_pipebang -conditional))


### PR DESCRIPTION
The `Snark_worker_lib` was removed at some point. I'm surprised OCaml lets you reference a module that doesn't actually exist but apparently it does. Nathan also added back a dependency on `core_kernel.fheap` in transaction pool when he did the validation refactor, but I removed all use of that with the rewrite.