### PR TITLE
Remove a bunch of dead .opam files

### DIFF
--- a/src/banlist_lib.opam
+++ b/src/banlist_lib.opam
@@ -1,6 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]
-

--- a/src/ccc.opam
+++ b/src/ccc.opam
@@ -1,6 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]
-

--- a/src/echo.opam
+++ b/src/echo.opam
@@ -1,6 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]
-

--- a/src/ledger_builder_controller.opam
+++ b/src/ledger_builder_controller.opam
@@ -1,6 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]
-

--- a/src/merkle_database.opam
+++ b/src/merkle_database.opam
@@ -1,6 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]
-

--- a/src/pending_coinbase_lib.opam
+++ b/src/pending_coinbase_lib.opam
@@ -1,6 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]
-

--- a/src/spawner.opam
+++ b/src/spawner.opam
@@ -1,5 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]

--- a/src/stdout.opam
+++ b/src/stdout.opam
@@ -1,6 +1,0 @@
-opam-version: "1.2"
-version: "0.1"
-build: [
-  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
-]
-


### PR DESCRIPTION
We had a bunch of dead .opam files laying around. Here's the bash incantation I used to find them:

`for x in src/*.opam; do if ! [ -d $(sed -E 's/src\/([[:alnum:]_]+)\.opam/src\/lib\/\1/' <<< $x) ]; then echo $x; fi; done`

It returns false positives for libraries that aren't in `src/lib/`.