### PR TITLE
make catchup pipes buffered

### DIFF
--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -101,10 +101,12 @@ module Make (Inputs : Inputs_intf) :
         (Buffered (`Capacity 30, `Overflow Crash))
     in
     let catchup_job_reader, catchup_job_writer =
-      Strict_pipe.create ~name:"catchup jobs" Synchronous
+      Strict_pipe.create ~name:"catchup jobs"
+        (Buffered (`Capacity 30, `Overflow Crash))
     in
     let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-      Strict_pipe.create ~name:"catchup breadcrumbs" Synchronous
+      Strict_pipe.create ~name:"catchup breadcrumbs"
+        (Buffered (`Capacity 30, `Overflow Crash))
     in
     let proposer_transition_reader_copy, proposer_transition_writer_copy =
       Strict_pipe.create ~name:"proposer transition copy" Synchronous

--- a/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
+++ b/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
@@ -65,10 +65,12 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;
       let catchup_job_reader, catchup_job_writer =
-        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__) Synchronous
+        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       let _catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__) Synchronous
+        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       Thread_safe.block_on_async_exn (fun () ->
           let open Deferred.Let_syntax in
@@ -127,10 +129,12 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
                    catchup scheduler should not create duplicate jobs" =
       let logger = Logger.null () in
       let _catchup_job_reader, catchup_job_writer =
-        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__) Synchronous
+        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__) Synchronous
+        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       let unprocessed_transition_cache =
         Unprocessed_transition_cache.create ~logger
@@ -224,10 +228,12 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
                    the missing node is received before the timeout expires, \
                    the timeout would be canceled" =
       let _catchup_job_reader, catchup_job_writer =
-        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__) Synchronous
+        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__) Synchronous
+        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       let unprocessed_transition_cache =
         Unprocessed_transition_cache.create ~logger

--- a/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
+++ b/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
@@ -35,10 +35,11 @@ let%test_module "Ledger catchup" =
         (me : Transition_frontier.t) transition expected_breadcrumbs =
       let catchup_job_reader, catchup_job_writer =
         Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
-          (Buffered (`Capacity 10, `Overflow Drop_head))
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__) Synchronous
+        Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
+          (Buffered (`Capacity 10, `Overflow Crash))
       in
       let unprocessed_transition_cache =
         Transition_handler.Unprocessed_transition_cache.create ~logger
@@ -182,10 +183,10 @@ let%test_module "Ledger catchup" =
       let logger = Logger.create () in
       let trust_system = Trust_system.null () in
       let catchup_job_reader, catchup_job_writer =
-        Strict_pipe.create (Buffered (`Capacity 10, `Overflow Drop_head))
+        Strict_pipe.create (Buffered (`Capacity 10, `Overflow Crash))
       in
       let _catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-        Strict_pipe.create Synchronous
+        Strict_pipe.create (Buffered (`Capacity 10, `Overflow Crash))
       in
       let unprocessed_transition_cache =
         Transition_handler.Unprocessed_transition_cache.create ~logger
@@ -261,10 +262,10 @@ let%test_module "Ledger catchup" =
       let logger = Logger.create () in
       let trust_system = Trust_system.null () in
       let catchup_job_reader, catchup_job_writer =
-        Strict_pipe.create (Buffered (`Capacity 10, `Overflow Drop_head))
+        Strict_pipe.create (Buffered (`Capacity 10, `Overflow Crash))
       in
       let catchup_breadcrumbs_reader, catchup_breadcrumbs_writer =
-        Strict_pipe.create Synchronous
+        Strict_pipe.create (Buffered (`Capacity 10, `Overflow Crash))
       in
       let unprocessed_transition_cache =
         Transition_handler.Unprocessed_transition_cache.create ~logger

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -84,7 +84,7 @@ module Make (Inputs : Inputs.S) = struct
         Hashtbl.iter parent_root_timeouts ~f:(fun timeout ->
             Time.Timeout.cancel time_controller timeout () ) ) ;
     let breadcrumb_builder_supervisor =
-      Capped_supervisor.create ~job_capacity:5
+      Capped_supervisor.create ~job_capacity:30
         (fun (initial_hash, transition_branches) ->
           match%map
             Breadcrumb_builder.build_subtrees_of_breadcrumbs ~logger ~verifier

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -164,8 +164,8 @@ module Make (Inputs : Inputs.S) :
              Cached.t
              Rose_tree.t
              list
-         , synchronous
-         , unit Deferred.t )
+         , crash buffered
+         , unit )
          Writer.t)
       ~(catchup_breadcrumbs_reader :
          (Transition_frontier.Breadcrumb.t, State_hash.t) Cached.t Rose_tree.t
@@ -174,8 +174,8 @@ module Make (Inputs : Inputs.S) :
       ~(catchup_breadcrumbs_writer :
          ( (Transition_frontier.Breadcrumb.t, State_hash.t) Cached.t Rose_tree.t
            list
-         , synchronous
-         , unit Deferred.t )
+         , crash buffered
+         , unit )
          Writer.t) ~processed_transition_writer =
     let catchup_scheduler =
       Catchup_scheduler.create ~logger ~verifier ~trust_system ~frontier

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -62,7 +62,7 @@ module Make (Inputs : Inputs_intf) = struct
   module Initial_validator = Initial_validator.Make (Inputs)
 
   let create_bufferred_pipe ?name () =
-    Strict_pipe.create ?name (Buffered (`Capacity 30, `Overflow Crash))
+    Strict_pipe.create ?name (Buffered (`Capacity 50, `Overflow Crash))
 
   let kill reader writer =
     Strict_pipe.Reader.clear reader ;

--- a/src/protocols/coda_transition_frontier.ml
+++ b/src/protocols/coda_transition_frontier.ml
@@ -471,8 +471,8 @@ module type Catchup_intf = sig
                                     Cached.t
                                     Rose_tree.t
                                     list
-                                  , Strict_pipe.synchronous
-                                  , unit Deferred.t )
+                                  , Strict_pipe.crash Strict_pipe.buffered
+                                  , unit )
                                   Strict_pipe.Writer.t
     -> unprocessed_transition_cache:unprocessed_transition_cache
     -> unit
@@ -592,8 +592,8 @@ module type Transition_handler_processor_intf = sig
                               Cached.t
                               Rose_tree.t
                               list
-                          , Strict_pipe.synchronous
-                          , unit Deferred.t )
+                          , Strict_pipe.crash Strict_pipe.buffered
+                          , unit )
                           Strict_pipe.Writer.t
     -> catchup_breadcrumbs_reader:( transition_frontier_breadcrumb
                                   , state_hash )
@@ -606,8 +606,8 @@ module type Transition_handler_processor_intf = sig
                                     Cached.t
                                     Rose_tree.t
                                     list
-                                  , Strict_pipe.synchronous
-                                  , unit Deferred.t )
+                                  , Strict_pipe.crash Strict_pipe.buffered
+                                  , unit )
                                   Strict_pipe.Writer.t
     -> processed_transition_writer:( ( external_transition_validated
                                      , state_hash )


### PR DESCRIPTION
This PR makes catchup pipes (catchup_job/catchup_breadcrumbs) buffered so that async jobs won't be blocked.
