### PR TITLE
Add public key to prover state; assert equality of delegate, pubkey

### DIFF
--- a/src/lib/coda_base/stake_proof.ml
+++ b/src/lib/coda_base/stake_proof.ml
@@ -6,7 +6,8 @@ module Stable = struct
       type t =
         { delegator: Account.Index.Stable.V1.t
         ; ledger: Sparse_ledger.Stable.V1.t
-        ; private_key: Signature_lib.Private_key.Stable.V1.t }
+        ; private_key: Signature_lib.Private_key.Stable.V1.t
+        ; public_key: Signature_lib.Public_key.Stable.V1.t }
       [@@deriving bin_io, sexp, version]
     end
 
@@ -19,5 +20,6 @@ end
 type t = Stable.Latest.t =
   { delegator: Account.Index.t
   ; ledger: Sparse_ledger.Stable.V1.t
-  ; private_key: Signature_lib.Private_key.t }
+  ; private_key: Signature_lib.Private_key.t
+  ; public_key: Signature_lib.Public_key.t }
 [@@deriving sexp]

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -744,6 +744,7 @@ module Data = struct
     type _ Snarky.Request.t +=
       | Winner_address : Coda_base.Account.Index.t Snarky.Request.t
       | Private_key : Scalar.value Snarky.Request.t
+      | Public_key : Public_key.t Snarky.Request.t
 
     let%snarkydef get_vrf_evaluation shifted ~ledger ~message =
       let open Coda_base in
@@ -751,12 +752,18 @@ module Data = struct
       let%bind private_key =
         request_witness Scalar.typ (As_prover.return Private_key)
       in
+      let%bind public_key =
+        request_witness Public_key.typ (As_prover.return Public_key)
+      in
       let winner_addr = message.Message.delegator in
       let%bind account =
         with_label __LOC__ (Frozen_ledger_hash.get ledger winner_addr)
       in
       let%bind delegate =
         with_label __LOC__ (Public_key.decompress_var account.delegate)
+      in
+      let%bind () =
+        with_label __LOC__ (Public_key.assert_equal public_key delegate)
       in
       let%map evaluation =
         with_label __LOC__
@@ -831,7 +838,7 @@ module Data = struct
           ; delegator= 0 }
     end
 
-    let check ~epoch ~slot ~seed ~private_key ~total_stake ~logger
+    let check ~epoch ~slot ~seed ~private_key ~public_key ~total_stake ~logger
         ~epoch_snapshot =
       let open Message in
       let open Local_state in
@@ -861,7 +868,10 @@ module Data = struct
                 return
                   (Some
                      { Proposal_data.stake_proof=
-                         {private_key; delegator; ledger= epoch_snapshot.ledger}
+                         { private_key
+                         ; public_key
+                         ; delegator
+                         ; ledger= epoch_snapshot.ledger }
                      ; vrf_result }) ) ;
           None )
   end
@@ -871,7 +881,8 @@ module Data = struct
       module V1 = struct
         module T = struct
           type t = Coda_base.State_hash.Stable.V1.t option
-          [@@deriving sexp, bin_io, eq, compare, hash, to_yojson, version]
+          [@@deriving
+            sexp, bin_io, eq, compare, hash, to_yojson, version {unnumbered}]
         end
 
         include T
@@ -880,7 +891,7 @@ module Data = struct
       module Latest = V1
     end
 
-    type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash, to_yojson]
+    type t = Stable.Latest.t [@@deriving sexp, compare, hash, to_yojson]
 
     type var = Coda_base.State_hash.var
 
@@ -948,7 +959,7 @@ module Data = struct
         ; start_checkpoint: 'start_checkpoint
         ; lock_checkpoint: 'lock_checkpoint
         ; length: 'length }
-      [@@deriving sexp, compare, eq, hash, to_yojson]
+      [@@deriving sexp, compare, hash, to_yojson]
     end
 
     type var =
@@ -1038,8 +1049,7 @@ module Data = struct
         end
 
         module Latest : sig
-          type t
-          [@@deriving sexp, bin_io, eq, compare, hash, to_yojson, version]
+          type t [@@deriving sexp, bin_io, compare, hash, to_yojson, version]
         end
       end
 
@@ -1089,7 +1099,7 @@ module Data = struct
           , Lock_checkpoint.Stable.Latest.t
           , Length.Stable.Latest.t )
           Poly.t
-        [@@deriving sexp, eq, compare, hash, to_yojson]
+        [@@deriving sexp, compare, hash, to_yojson]
       end
 
       let data_spec =
@@ -2017,7 +2027,7 @@ module Data = struct
 
     let precomputed_handler = Vrf.Precomputed.handler
 
-    let handler {delegator; ledger; private_key}
+    let handler {delegator; ledger; private_key; public_key}
         ~pending_coinbase:{ Coda_base.Pending_coinbase_witness.pending_coinbases
                           ; is_new_stack } : Snark_params.Tick.Handler.t =
       let ledger_handler = unstage (Coda_base.Sparse_ledger.handler ledger) in
@@ -2037,6 +2047,8 @@ module Data = struct
             respond (Provide delegator)
         | Vrf.Private_key ->
             respond (Provide private_key)
+        | Vrf.Public_key ->
+            respond (Provide public_key)
         | _ ->
             respond
               (Provide
@@ -2530,7 +2542,8 @@ module Hooks = struct
       in
       let proposal_data slot =
         Vrf.check ~epoch ~slot ~seed:epoch_data.seed ~epoch_snapshot
-          ~private_key:keypair.private_key ~total_stake ~logger
+          ~private_key:keypair.private_key ~public_key:keypair.public_key
+          ~total_stake ~logger
       in
       let rec find_winning_slot slot =
         if UInt32.of_int (Epoch.Slot.to_int slot) >= Constants.Epoch.size then
@@ -2824,8 +2837,10 @@ let%test_module "Proof of stake tests" =
       let pending_coinbases = Pending_coinbase.create () |> Or_error.ok_exn in
       let maybe_sk, account = Genesis_ledger.largest_account_exn () in
       let private_key = Option.value_exn maybe_sk in
-      let public_key = Account.public_key account in
-      let location = Ledger.Any_ledger.M.location_of_key ledger public_key in
+      let public_key_compressed = Account.public_key account in
+      let location =
+        Ledger.Any_ledger.M.location_of_key ledger public_key_compressed
+      in
       let delegator =
         Option.value_exn location |> Ledger.Any_ledger.M.Location.to_path_exn
         |> Ledger.Addr.to_int
@@ -2874,9 +2889,10 @@ let%test_module "Proof of stake tests" =
         let sparse_ledger =
           Sparse_ledger.of_ledger_index_subset_exn ledger indices
         in
+        let public_key = Public_key.decompress_exn public_key_compressed in
         let handler =
           Prover_state.handler
-            {delegator; ledger= sparse_ledger; private_key}
+            {delegator; ledger= sparse_ledger; private_key; public_key}
             ~pending_coinbase:
               {Pending_coinbase_witness.pending_coinbases; is_new_stack= true}
         in

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -822,6 +822,8 @@ module Data = struct
               respond (Provide 0)
           | Private_key ->
               respond (Provide sk)
+          | Public_key ->
+              respond (Provide (Public_key.decompress_exn pk))
           | _ ->
               respond
                 (Provide

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -67,6 +67,15 @@ include Comparable.Make_binable (Stable.Latest)
 
 type var = Tick.Field.Var.t * Tick.Field.Var.t
 
+let assert_equal var1 var2 =
+  let open Tick0.Checked.Let_syntax in
+  let open Tick.Field.Checked.Assert in
+  let v1_f1, v1_f2 = var1 in
+  let v2_f1, v2_f2 = var2 in
+  let%bind () = equal v1_f1 v2_f1 in
+  let%bind () = equal v1_f2 v2_f2 in
+  return ()
+
 let var_of_t (x, y) = (Tick.Field.Var.constant x, Tick.Field.Var.constant y)
 
 let typ : (var, t) Tick.Typ.t = Tick.Typ.(field * field)

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -25,6 +25,8 @@ val typ : (var, t) Typ.t
 
 val var_of_t : t -> var
 
+val assert_equal : var -> var -> (unit, 'a) Checked.t
+
 val of_private_key_exn : Private_key.t -> t
 
 module Compressed : sig


### PR DESCRIPTION
As a step in debugging the delegation integration test under development, add `public_key` to the prover state, and assert in the `Checked` world that this key and the delegate seen in VRF evaluation are the same.

This change probably won't allow the test to succeed, though.

Also changed some `deriving` clauses to remove warnings.