### PR TITLE
Various small fixes to graphql behavior

### DIFF
--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -214,40 +214,51 @@ module Make (Commands : Coda_commands.Intf) = struct
         obj "Wallet" ~doc:"An account record according to the daemon"
           ~fields:(fun _ ->
             [ pubkey_field ~resolve:(fun _ account ->
-                  Stringable.public_key account.Account.Poly.public_key )
+                  (* Hack: Account.Poly.t is only parameterized over 'pk once
+                   * and so in order for delegate to optional we must also make
+                   * account public_key optional even though it's always Some.
+                   * In an attempt to avoid a large refactoring, and also avoid
+                   * making a new record, we'll deal with a value_exn here and
+                   * be sad. *)
+                  Stringable.public_key
+                    ( account.Account.Poly.public_key
+                    |> Option.value_exn ?here:None ?error:None ?message:None )
+              )
             ; field "balance"
                 ~typ:(non_null AnnotatedBalance.obj)
                 ~doc:"A balance of Coda as a stringified uint64"
                 ~args:Arg.[]
                 ~resolve:(fun _ account -> account.Account.Poly.balance)
-            ; field "nonce" ~typ:(non_null string)
+            ; field "nonce" ~typ:string
                 ~doc:
                   "Nonces are natural numbers that increase each transaction. \
                    Stringified uint32"
                 ~args:Arg.[]
                 ~resolve:(fun _ account ->
-                  Account.Nonce.to_string account.Account.Poly.nonce )
-            ; field "receiptChainHash" ~typ:(non_null string)
+                  Option.map ~f:Account.Nonce.to_string
+                    account.Account.Poly.nonce )
+            ; field "receiptChainHash" ~typ:string
                 ~doc:"Top hash of the receipt chain merkle-list"
                 ~args:Arg.[]
                 ~resolve:(fun _ account ->
-                  Receipt.Chain_hash.to_string
+                  Option.map ~f:Receipt.Chain_hash.to_string
                     account.Account.Poly.receipt_chain_hash )
-            ; field "delegate" ~typ:(non_null string)
+            ; field "delegate" ~typ:string
                 ~doc:
-                  "The public key to which you are delegating (including the \
-                   empty key!)"
+                  "The public key to which you are delegating. Your own key \
+                   if you are delegating to yourself."
                 ~args:Arg.[]
                 ~resolve:(fun _ account ->
-                  Stringable.public_key account.Account.Poly.delegate )
-            ; field "votingFor" ~typ:(non_null string)
+                  Option.map ~f:Stringable.public_key
+                    account.Account.Poly.delegate )
+            ; field "votingFor" ~typ:string
                 ~doc:
                   "The previous epoch lock hash of the chain which you are \
                    voting for"
                 ~args:Arg.[]
                 ~resolve:(fun _ account ->
-                  Coda_base.State_hash.to_bytes account.Account.Poly.voting_for
-                  ) ] )
+                  Option.map ~f:Coda_base.State_hash.to_bytes
+                    account.Account.Poly.voting_for ) ] )
     end
 
     let snark_worker =
@@ -420,28 +431,73 @@ module Make (Commands : Coda_commands.Intf) = struct
     end
   end
 
-  let account_of_pk coda pk =
-    let account =
-      Program.best_ledger coda |> Participating_state.active
-      |> Option.bind ~f:(fun ledger ->
-             Ledger.location_of_key ledger pk
-             |> Option.bind ~f:(Ledger.get ledger) )
-    in
-    Option.map account
-      ~f:(fun { Account.Poly.public_key
-              ; nonce
-              ; balance
-              ; receipt_chain_hash
-              ; delegate
-              ; voting_for }
-         ->
+  module Partial_account = struct
+    let to_full_account
         { Account.Poly.public_key
         ; nonce
-        ; delegate
-        ; balance=
-            {Types.Wallet.AnnotatedBalance.total= balance; unknown= balance}
+        ; balance
         ; receipt_chain_hash
-        ; voting_for } )
+        ; delegate
+        ; voting_for } =
+      let open Option.Let_syntax in
+      let%bind public_key = public_key in
+      let%bind nonce = nonce in
+      let%bind receipt_chain_hash = receipt_chain_hash in
+      let%bind delegate = delegate in
+      let%map voting_for = voting_for in
+      { Account.Poly.public_key
+      ; nonce
+      ; balance
+      ; receipt_chain_hash
+      ; delegate
+      ; voting_for }
+
+    let of_full_account
+        { Account.Poly.public_key
+        ; nonce
+        ; balance
+        ; receipt_chain_hash
+        ; delegate
+        ; voting_for } =
+      { Account.Poly.public_key= Some public_key
+      ; nonce= Some nonce
+      ; balance
+      ; receipt_chain_hash= Some receipt_chain_hash
+      ; delegate= Some delegate
+      ; voting_for= Some voting_for }
+
+    let of_pk coda pk =
+      let account =
+        Program.best_ledger coda |> Participating_state.active
+        |> Option.bind ~f:(fun ledger ->
+               Ledger.location_of_key ledger pk
+               |> Option.bind ~f:(Ledger.get ledger) )
+      in
+      match account with
+      | Some
+          { Account.Poly.public_key
+          ; nonce
+          ; balance
+          ; receipt_chain_hash
+          ; delegate
+          ; voting_for } ->
+          { Account.Poly.public_key= Some public_key
+          ; nonce= Some nonce
+          ; delegate= Some delegate
+          ; balance=
+              {Types.Wallet.AnnotatedBalance.total= balance; unknown= balance}
+          ; receipt_chain_hash= Some receipt_chain_hash
+          ; voting_for= Some voting_for }
+      | None ->
+          { Account.Poly.public_key= Some pk
+          ; nonce= None
+          ; delegate= None
+          ; balance=
+              { Types.Wallet.AnnotatedBalance.total= Balance.zero
+              ; unknown= Balance.zero }
+          ; receipt_chain_hash= None
+          ; voting_for= None }
+  end
 
   module Arguments = struct
     let public_key ~name public_key =
@@ -468,13 +524,13 @@ module Make (Commands : Coda_commands.Intf) = struct
     let owned_wallets =
       field "ownedWallets"
         ~doc:
-          "Wallets for which the daemon knows the private key that are found \
-           in our ledger"
+          "Wallets for which the daemon knows the private key. If they are \
+           found in our ledger, all the fields will be non-null"
         ~typ:(non_null (list (non_null Types.Wallet.wallet)))
         ~args:Arg.[]
         ~resolve:(fun {ctx= coda; _} () ->
           Program.wallets coda |> Secrets.Wallets.pks
-          |> List.filter_map ~f:(fun pk -> account_of_pk coda pk) )
+          |> List.map ~f:(fun pk -> Partial_account.of_pk coda pk) )
 
     let wallet =
       result_field "wallet"
@@ -489,7 +545,9 @@ module Make (Commands : Coda_commands.Intf) = struct
         ~resolve:(fun {ctx= coda; _} () pk_string ->
           let open Result.Let_syntax in
           let%map pk = Arguments.public_key ~name:"publicKey" pk_string in
-          account_of_pk coda pk )
+          Partial_account.(
+            of_pk coda pk |> to_full_account |> Option.map ~f:of_full_account)
+          )
 
     let current_snark_worker =
       field "currentSnarkWorker" ~typ:Types.snark_worker
@@ -512,16 +570,17 @@ module Make (Commands : Coda_commands.Intf) = struct
         {Types.Pagination.Page_info.has_previous_page; has_next_page}
       in
       let total_count =
-        Option.value_exn
+        Option.value
           (Transaction_database.get_total_transactions transaction_database
              public_key)
+          ~default:0
       in
       { Types.Pagination.Connection.edges= queried_transactions
       ; page_info
       ; total_count }
 
     let user_command =
-      io_field "user_command"
+      io_field "userCommand"
         ~args:
           Arg.
             [ arg "filter" ~typ:(non_null Types.Input.user_command_filter_input)
@@ -668,7 +727,7 @@ module Make (Commands : Coda_commands.Intf) = struct
       let%bind sender = Arguments.public_key ~name:"from" from in
       let%bind sender_account =
         Result.of_option
-          (account_of_pk coda sender)
+          Partial_account.(of_pk coda sender |> to_full_account)
           ~error:"Couldn't find the account for specified `sender`."
       in
       let%bind fee =
@@ -729,7 +788,7 @@ module Make (Commands : Coda_commands.Intf) = struct
           build_user_command coda sender_account sender_kp memo body fee )
 
     let add_payment_receipt =
-      result_field "AddPaymentReceipt"
+      result_field "addPaymentReceipt"
         ~doc:"Add payment into transation database"
         ~args:
           Arg.[arg "input" ~typ:(non_null Types.Input.AddPaymentReceipt.typ)]

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -221,9 +221,7 @@ module Make (Commands : Coda_commands.Intf) = struct
                    * avoid making a new record, we'll deal with a value_exn here
                    * and be sad. *)
                   Stringable.public_key
-                    ( account.Account.Poly.public_key
-                    |> Option.value_exn ?here:None ?error:None ?message:None )
-              )
+                  @@ Option.value_exn account.Account.Poly.public_key )
             ; field "balance"
                 ~typ:(non_null AnnotatedBalance.obj)
                 ~doc:"A balance of Coda as a stringified uint64"
@@ -245,8 +243,9 @@ module Make (Commands : Coda_commands.Intf) = struct
                     account.Account.Poly.receipt_chain_hash )
             ; field "delegate" ~typ:string
                 ~doc:
-                  "The public key to which you are delegating. Your own key \
-                   if you are delegating to yourself."
+                  "The public key to which you are delegating. If you are not \
+                   delegating to anybody, than this would return your public \
+                   key."
                 ~args:Arg.[]
                 ~resolve:(fun _ account ->
                   Option.map ~f:Stringable.public_key

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -215,11 +215,11 @@ module Make (Commands : Coda_commands.Intf) = struct
           ~fields:(fun _ ->
             [ pubkey_field ~resolve:(fun _ account ->
                   (* Hack: Account.Poly.t is only parameterized over 'pk once
-                   * and so in order for delegate to optional we must also make
-                   * account public_key optional even though it's always Some.
-                   * In an attempt to avoid a large refactoring, and also avoid
-                   * making a new record, we'll deal with a value_exn here and
-                   * be sad. *)
+                   * and so, in order for delegate to be optional, we must also
+                   * make account public_key optional even though it's always
+                   * Some. In an attempt to avoid a large refactoring, and also
+                   * avoid making a new record, we'll deal with a value_exn here
+                   * and be sad. *)
                   Stringable.public_key
                     ( account.Account.Poly.public_key
                     |> Option.value_exn ?here:None ?error:None ?message:None )


### PR DESCRIPTION
1. ownedWallets now also returns accounts that aren't found in the best
ledger.
2. More consistent naming of graphql endpoints
3. userCommand query doesn't crash on public keys that don't exist

Tested via running graphiql on the daemon node.