### PR TITLE
Wallet: bundle fonts

### DIFF
--- a/frontend/wallet/.gitattributes
+++ b/frontend/wallet/.gitattributes
@@ -1,0 +1,5 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.woff filter=lfs diff=lfs merge=lfs -text
+*.woff2 filter=lfs diff=lfs merge=lfs -text
+*.ttf filter=lfs diff=lfs merge=lfs -text

--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -55,7 +55,7 @@
       "_build/",
       "node_modules/graphql-faker/dist/index.js",
       "bundle/**/*",
-      "public/*"
+      "public/**/*"
     ],
     "compression": "store",
     "dmg": {

--- a/frontend/wallet/public/fonts/IBMPlexSans-Medium-Latin1.woff
+++ b/frontend/wallet/public/fonts/IBMPlexSans-Medium-Latin1.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:017c992b53f6c13ec74110db7094efc73c921d00b1ee45ca18f0e6065e8c2bca
+size 22656

--- a/frontend/wallet/public/fonts/IBMPlexSans-Medium-Latin1.woff2
+++ b/frontend/wallet/public/fonts/IBMPlexSans-Medium-Latin1.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0c8ebe383ce65c702e6a6032212b97205d58393e6e53db89cc3eb3670e8e684
+size 17204

--- a/frontend/wallet/public/fonts/IBMPlexSans-Regular-Latin1.woff
+++ b/frontend/wallet/public/fonts/IBMPlexSans-Regular-Latin1.woff
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36f50919fa8757ed34edae584c69c4127c9fbb805d43eccf166e6dfa9eaa8f3a
+size 21920

--- a/frontend/wallet/public/fonts/IBMPlexSans-Regular-Latin1.woff2
+++ b/frontend/wallet/public/fonts/IBMPlexSans-Regular-Latin1.woff2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c307b8a6c94c602aa6bcb54ff46ef860f2dcd005eb17861fc25cec79bb8e4a7
+size 16668

--- a/frontend/wallet/public/fonts/OCR A Std Regular.ttf
+++ b/frontend/wallet/public/fonts/OCR A Std Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfa1012072cb55dcdcc1c8598b8bab005c1ff9beb2f5a30b630e702e03c6a0c0
+size 29460

--- a/frontend/wallet/public/index.html
+++ b/frontend/wallet/public/index.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,400,500" rel="stylesheet">
     <title>Coda Wallet</title>
   </head>
   <body style="margin: 0">

--- a/frontend/wallet/src/render/Theme.re
+++ b/frontend/wallet/src/render/Theme.re
@@ -51,6 +51,39 @@ module Colors = {
 };
 
 module Typeface = {
+  // fontFace has the sideEffect of loading the font
+  let _ = {
+    [
+      fontFace(
+        ~fontFamily="IBM Plex Sans",
+        ~src=[
+          `url("fonts/IBMPlexSans-Medium-Latin1.woff2"),
+          `url("fonts/IBMPlexSans-Medium-Latin1.woff"),
+        ],
+        ~fontStyle=`normal,
+        ~fontWeight=`medium,
+        (),
+      ),
+      fontFace(
+        ~fontFamily="IBM Plex Sans",
+        ~src=[
+          `url("fonts/IBMPlexSans-Regular-Latin1.woff2"),
+          `url("fonts/IBMPlexSans-Regular-Latin1.woff"),
+        ],
+        ~fontStyle=`normal,
+        ~fontWeight=`normal,
+        (),
+      ),
+      fontFace(
+        ~fontFamily="OCR A Std",
+        ~src=[`url("fonts/OCR A Std Regular.ttf")],
+        ~fontStyle=`normal,
+        ~fontWeight=`normal,
+        (),
+      ),
+    ];
+  };
+
   let lucidaGrande = fontFamily("LucidaGrande");
   let plex = fontFamily("IBM Plex Sans, Sans-Serif");
   let mono = fontFamily("OCR A Std, monospace");


### PR DESCRIPTION
Only bundles the sizes used in the Theme.re file. Doesn't bundle lucida grande because of https://superuser.com/a/486347, we should come up with another solution for this (fallback font or use something else).
Tested it on the dist build and it works there too.