### PR TITLE
Unify source of coinbase configuration

### DIFF
--- a/src/app/cli/src/transaction_snark_profiler.ml
+++ b/src/app/cli/src/transaction_snark_profiler.ml
@@ -64,7 +64,7 @@ let create_ledger_and_transactions num_transitions =
         Fee_transfer.One (Public_key.compress keys.(0).public_key, total_fee)
       in
       let coinbase =
-        Coinbase.create ~amount:Protocols.Coda_praos.coinbase_amount
+        Coinbase.create ~amount:Coda_compile_config.coinbase
           ~proposer:(Public_key.compress keys.(0).public_key)
           ~fee_transfer:None
         |> Or_error.ok_exn

--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -92,7 +92,7 @@ let gen =
   let open Quickcheck.Let_syntax in
   let%bind proposer = Public_key.Compressed.gen in
   let%bind amount =
-    Currency.Amount.(gen_incl zero Protocols.Coda_praos.coinbase_amount)
+    Currency.Amount.(gen_incl zero Coda_compile_config.coinbase)
   in
   let fee =
     Currency.Fee.gen_incl Currency.Fee.zero (Currency.Amount.to_fee amount)

--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -459,7 +459,7 @@ module T = struct
         (Merkle_tree.modify_req ~depth (Hash.var_to_hash_packed t) addr
            ~f:(fun stack ->
              let total_coinbase_amount =
-               Currency.Amount.var_of_t Protocols.Coda_praos.coinbase_amount
+               Currency.Amount.var_of_t Coda_compile_config.coinbase
              in
              let%bind rem_amount =
                Currency.Amount.Checked.sub total_coinbase_amount amount
@@ -783,7 +783,7 @@ let%test_unit "Checked_tree = Unchecked_tree" =
   let open Quickcheck in
   let pending_coinbases = create () |> Or_error.ok_exn in
   test ~trials:20 Coinbase.gen ~f:(fun coinbase ->
-      let max_coinbase_amount = Protocols.Coda_praos.coinbase_amount in
+      let max_coinbase_amount = Coda_compile_config.coinbase in
       let coinbase_data = Coinbase_data.of_coinbase coinbase in
       let coinbase2 =
         Coinbase.create
@@ -828,7 +828,7 @@ let%test_unit "push and pop multiple stacks" =
   let open Quickcheck in
   let pending_coinbases = ref (create () |> Or_error.ok_exn) in
   let queue_of_stacks = Queue.create ~capacity:(coinbase_stacks + 1) () in
-  let max_coinbase_amount = Protocols.Coda_praos.coinbase_amount in
+  let max_coinbase_amount = Coda_compile_config.coinbase in
   let coinbases_gen = Quickcheck.Generator.list Coinbase.gen in
   let add_new_stack t = function
     | [] ->

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -5,6 +5,11 @@
 "proof_level", proof_level]
 
 [%%inject
+"coinbase_int", coinbase]
+
+let coinbase = Currency.Amount.of_int coinbase_int
+
+[%%inject
 "scan_state_transaction_capacity_log_2", scan_state_transaction_capacity_log_2]
 
 [%%inject

--- a/src/lib/coda_compile_config/dune
+++ b/src/lib/coda_compile_config/dune
@@ -1,4 +1,5 @@
 (library
   (name coda_compile_config)
   (public_name coda_compile_config)
+  (libraries currency)
   (preprocess (pps ppx_base ppx_optcomp)))

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -606,7 +606,7 @@ end)
   *)
   let create_coinbase coinbase_parts proposer =
     let open Result.Let_syntax in
-    let coinbase = Protocols.Coda_praos.coinbase_amount in
+    let coinbase = Coda_compile_config.coinbase in
     let coinbase_or_error = function
       | Ok x ->
           Ok x
@@ -2861,7 +2861,7 @@ let%test_module "test" =
 
     let expected_ledger no_txns_included txns_sent old_ledger =
       old_ledger
-      + Currency.Amount.to_int Protocols.Coda_praos.coinbase_amount
+      + Currency.Amount.to_int Coda_compile_config.coinbase
       + List.sum
           (module Int)
           (List.take txns_sent no_txns_included)

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -281,7 +281,7 @@ end) :
     | At_most_two.Zero, At_most_one.Zero ->
         Currency.Amount.zero
     | _ ->
-        Protocols.Coda_praos.coinbase_amount
+        Coda_compile_config.coinbase
 end
 
 include Make (Transaction_snark_work)

--- a/src/protocols/coda_praos.ml
+++ b/src/protocols/coda_praos.ml
@@ -1,8 +1,6 @@
 open Core_kernel
 open Async_kernel
 
-let coinbase_amount = Currency.Amount.of_int 10
-
 module type Time_intf = sig
   module Stable : sig
     module V1 : sig


### PR DESCRIPTION
Found this recently during a refactor. I think this is indicative that we are missing some constraints with the integration between the transaction snark and the blockchain snark. We should review where a constraint that would prevent these two snarks on disagreeing would go.