### PR TITLE
Fix dead whitepaper link

### DIFF
--- a/frontend/website/src/Links.re
+++ b/frontend/website/src/Links.re
@@ -43,7 +43,8 @@ module Forms = {
 module Static = {
   let whitepaper = () => {
     name: ("Read the Coda Whitepaper", "coda-whitepaper"),
-    link: Cdn.url("/static/coda-whitepaper-05-10-2018-0.pdf"),
+    // Hardcoding to v2 as the pdf is no longer tracked in git
+    link: "https://cdn.codaprotocol.com/v2/static/coda-whitepaper-05-10-2018-0.pdf",
   };
 
   let snarkette = {


### PR DESCRIPTION
Already deployed. See codaprotocol.com and notice that the whitepaper link is no longer dead (points to v2 of cdn assets)