### PR TITLE
Wallet: Finish up initial settings pass

### DIFF
--- a/frontend/wallet/src/common/PublicKey.re
+++ b/frontend/wallet/src/common/PublicKey.re
@@ -6,10 +6,10 @@ let ofStringExn = s => s;
 let toString = s => s;
 
 let prettyPrint = s =>
-  if (String.length(s) < 16) {
+  if (String.length(s) < 17) {
     s;
   } else {
-    String.sub(s, 0, 6) ++ "..." ++ String.sub(s, String.length(s) - 5, 4);
+    String.sub(s, 0, 6) ++ ".." ++ String.sub(s, String.length(s) - 5, 5);
   };
 
 let equal = (a, b) => a === b;

--- a/frontend/wallet/src/render/Preload.re
+++ b/frontend/wallet/src/render/Preload.re
@@ -10,4 +10,10 @@ let downloadKey = (keyName, chunkCb, doneCb) =>
     doneCb,
   );
 
+[@bs.module "electron"] [@bs.scope "shell"] [@bs.val]
+external showItemInFolder: string => unit = "";
+
+let showItemInFolder = showItemInFolder;
+
 [%bs.raw "window.downloadKey = downloadKey"];
+[%bs.raw "window.showItemInFolder = showItemInFolder"];

--- a/frontend/wallet/src/render/Theme.re
+++ b/frontend/wallet/src/render/Theme.re
@@ -25,7 +25,9 @@ module Colors = {
   let slateAlpha = a => `rgba((81, 102, 121, a));
   let slate = slateAlpha(1.);
 
-  let roseBud = `hex("a3536f");
+  let roseBudAlpha = a => `rgba((163, 83, 112, a));
+  let roseBud = roseBudAlpha(1.);
+
   let pendingOrange = `hex("967103");
   let greenblack = `hex("2a3c2e");
 
@@ -61,7 +63,9 @@ module Colors = {
 
   // TODO: Rename
   let greyish = a => `rgba((51, 66, 79, a));
-  let teal = `hex("4782A0");
+
+  let tealAlpha = a => `rgba((71, 130, 160, a));
+  let teal = tealAlpha(1.0);
 };
 
 module Typeface = {
@@ -123,6 +127,14 @@ module Text = {
         lineHeight(`rem(1.5)),
       ]);
 
+    let mono =
+      style([
+        Typeface.mono,
+        fontWeight(`normal),
+        fontSize(`rem(0.9)),
+        lineHeight(`rem(1.4)),
+      ]);
+
     let small =
       style([
         Typeface.plex,
@@ -149,6 +161,15 @@ module Text = {
         fontSize(`rem(1.25)),
         lineHeight(`rem(1.5)),
         letterSpacing(`rem(-0.03125)),
+      ]);
+
+    let h6 =
+      style([
+        Typeface.plex,
+        fontWeight(`medium),
+        fontSize(`rem(0.75)),
+        lineHeight(`rem(1.0)),
+        letterSpacing(`rem(0.0875)),
       ]);
   };
 

--- a/frontend/wallet/src/render/components/AddWalletModal.re
+++ b/frontend/wallet/src/render/components/AddWalletModal.re
@@ -4,7 +4,7 @@ module Styles = {
   let container =
     style([
       margin(`auto),
-      width(`rem(22.)),
+      width(`rem(21.)),
       display(`flex),
       flexDirection(`column),
       alignItems(`center),

--- a/frontend/wallet/src/render/components/AddressPill.re
+++ b/frontend/wallet/src/render/components/AddressPill.re
@@ -23,13 +23,22 @@ module Styles = {
       bottom(`zero),
       left(`zero),
       display(`flex),
-      justifyContent(`spaceBetween), padding2(~v=`zero, ~h=`rem(0.5)),
+      justifyContent(`spaceBetween),
+      padding2(~v=`zero, ~h=`rem(0.5)),
       color(white),
     ]);
 
   let copyButton =
-    merge([Theme.Text.Body.regular, style([overflow(`hidden)])]);
-  let editButton = merge([Theme.Text.Body.regular, style([opacity(0.5)])]);
+    merge([
+      Theme.Text.Body.regular,
+      style([overflow(`hidden), opacity(0.9), hover([opacity(1.0)])]),
+    ]);
+
+  let editButton =
+    merge([
+      Theme.Text.Body.regular,
+      style([opacity(0.5), hover([opacity(0.8)])]),
+    ]);
 
   let editing =
     style([
@@ -90,6 +99,10 @@ let make = (~pubkey) => {
       AddressBook.set(~key=pubkey, ~name=ReactEvent.Form.target(e)##value),
     );
 
+  let handleClipboard = _ =>
+    ignore @@
+    Bindings.Navigator.Clipboard.writeText(PublicKey.toString(pubkey));
+
   <div
     className=Styles.container
     onClick={e => ReactEvent.Mouse.stopPropagation(e)}
@@ -112,7 +125,9 @@ let make = (~pubkey) => {
     {switch (hovered, editing) {
      | (true, false) =>
        <div className=Styles.hoverContainer>
-         <span className=Styles.copyButton> {React.string("Copy")} </span>
+         <span className=Styles.copyButton onClick=handleClipboard>
+           {React.string("Copy")}
+         </span>
          <span
            onClick={_ => setEditing(_ => true)} className=Styles.editButton>
            {React.string("Edit")}

--- a/frontend/wallet/src/render/components/Button.re
+++ b/frontend/wallet/src/render/components/Button.re
@@ -11,6 +11,7 @@ module Styles = {
     merge([
       Theme.Text.Body.regular,
       style([
+        userSelect(`none),
         display(`inlineFlex),
         alignItems(`center),
         justifyContent(`center),
@@ -68,6 +69,15 @@ module Styles = {
         hover([backgroundColor(Theme.Colors.slateAlpha(0.2))]),
       ]),
     ]);
+
+  let disabled =
+    merge([
+      base,
+      style([
+        backgroundColor(Theme.Colors.slateAlpha(0.05)),
+        color(Theme.Colors.midnightAlpha(0.5)),
+      ]),
+    ]);
 };
 
 [@react.component]
@@ -77,7 +87,7 @@ let make = (~label, ~onClick=?, ~style=Blue, ~disabled=false) =>
     ?onClick
     className={
       switch (style) {
-      | _ when disabled => Styles.gray
+      | _ when disabled => Styles.disabled
       | Blue => Styles.blue
       | Green => Styles.green
       | Red => Styles.red

--- a/frontend/wallet/src/render/components/Dropdown.re
+++ b/frontend/wallet/src/render/components/Dropdown.re
@@ -19,7 +19,7 @@ module Styles = {
       borderRadius(`rem(0.25)),
       borderBottomLeftRadius(isOpen ? `zero : `rem(0.25)),
       borderBottomRightRadius(isOpen ? `zero : `rem(0.25)),
-      focus([outlineStyle(`none), borderColor(black)]),
+      focus([outlineStyle(`none)]),
     ]);
 
   let label =

--- a/frontend/wallet/src/render/components/Dropdown.re
+++ b/frontend/wallet/src/render/components/Dropdown.re
@@ -19,15 +19,18 @@ module Styles = {
       borderRadius(`rem(0.25)),
       borderBottomLeftRadius(isOpen ? `zero : `rem(0.25)),
       borderBottomRightRadius(isOpen ? `zero : `rem(0.25)),
+      focus([outlineStyle(`none), borderColor(black)]),
     ]);
 
   let label =
     merge([
       Theme.Text.smallHeader,
       style([
+        userSelect(`none),
         textTransform(`uppercase),
         color(Theme.Colors.slateAlpha(0.7)),
         cursor(`default),
+        minWidth(`rem(2.5)),
       ]),
     ]);
 
@@ -56,6 +59,7 @@ module Styles = {
       borderBottomLeftRadius(`rem(0.25)),
       borderBottomRightRadius(`rem(0.25)),
       cursor(`default),
+      zIndex(1),
     ]);
 
   let item =
@@ -108,7 +112,7 @@ let make = (~onChange, ~value, ~label, ~options) => {
              <div
                key=label
                className=Styles.item
-               onClick={_e => onChange(Some(value))}>
+               onClick={_e => onChange(value)}>
                {React.string(label)}
              </div>,
          options,

--- a/frontend/wallet/src/render/components/Link.re
+++ b/frontend/wallet/src/render/components/Link.re
@@ -12,8 +12,17 @@ module Styles = {
         hover([color(Theme.Colors.hyperlinkAlpha(0.7))]),
       ]),
     ]);
+
+  let redLink =
+    merge([
+      link,
+      style([
+        color(Theme.Colors.roseBudAlpha(0.5)),
+        hover([color(Theme.Colors.roseBud)]),
+      ]),
+    ]);
 };
 
 [@react.component]
-let make = (~children, ~onClick=?) =>
-  <a className=Styles.link ?onClick> children </a>;
+let make = (~children, ~onClick=?, ~isRed=false) =>
+  <a className={isRed ? Styles.redLink : Styles.link} ?onClick> children </a>;

--- a/frontend/wallet/src/render/components/SendButton.re
+++ b/frontend/wallet/src/render/components/SendButton.re
@@ -134,7 +134,9 @@ let make = (~wallets, ~onSubmit) => {
                label="From"
                value=fromStr
                onChange={value =>
-                 setModalState(Option.map(~f=s => {...s, fromStr: value}))
+                 setModalState(
+                   Option.map(~f=s => {...s, fromStr: Some(value)}),
+                 )
                }
                options={
                  wallets
@@ -150,6 +152,7 @@ let make = (~wallets, ~onSubmit) => {
              spacer
              <TextField
                label="To"
+               mono=true
                onChange={value =>
                  setModalState(Option.map(~f=s => {...s, toStr: value}))
                }

--- a/frontend/wallet/src/render/components/SettingsPage.re
+++ b/frontend/wallet/src/render/components/SettingsPage.re
@@ -3,11 +3,34 @@ open Tc;
 module Styles = {
   open Css;
 
+  let headerContainer =
+    style([display(`flex), justifyContent(`spaceBetween)]);
+
+  let networkContainer = style([width(`rem(21.))]);
+
+  let customNetwork = style([display(`flex), alignItems(`center)]);
+
+  let versionText =
+    merge([
+      Theme.Text.Header.h6,
+      style([display(`flex), textTransform(`uppercase)]),
+    ]);
+
   let container =
     style([
       height(`percent(100.)),
       padding(`rem(2.)),
       backgroundColor(Theme.Colors.greyish(0.1)),
+    ]);
+
+  let label =
+    merge([
+      Theme.Text.Header.h3,
+      style([
+        margin2(~v=`rem(0.5), ~h=`zero),
+        color(Theme.Colors.midnight),
+        userSelect(`none),
+      ]),
     ]);
 
   let walletItemContainer =
@@ -25,10 +48,12 @@ module Styles = {
     merge([
       Theme.Text.Body.regular,
       style([
+        userSelect(`none),
         padding(`rem(0.5)),
         color(Theme.Colors.midnight),
         display(`flex),
         alignItems(`center),
+        hover([opacity(0.6)]),
       ]),
     ]);
 
@@ -68,7 +93,9 @@ module WalletItem = {
       <div className=Styles.walletName>
         {React.string(AddressBook.getWalletName(addressBook, publicKey))}
       </div>
-      <Pill> {React.string(PublicKey.prettyPrint(publicKey))} </Pill>
+      <span className=Theme.Text.Body.mono>
+        <Pill> {React.string(PublicKey.prettyPrint(publicKey))} </Pill>
+      </span>
       <Spacer width=5.0 />
       <span className=Styles.walletChevron>
         <Icon kind=Icon.EmptyChevronRight />
@@ -77,37 +104,118 @@ module WalletItem = {
   };
 };
 
+let doubleList = l => List.map(~f=x => (x, x), l);
+
+type networkOption =
+  | NetworkOption(string)
+  | Custom(string);
+
 [@react.component]
 let make = () => {
-  <div className=Styles.container>
-    <span className=Theme.Text.title> {React.string("Settings")} </span>
-    <Spacer height=1. />
-    <SettingsQuery>
-      {response =>
-         switch (response.result) {
-         | Loading => React.string("...")
-         | Error(err) => React.string(err##message)
-         | Data(data) =>
-           <>
-             <span className=Theme.Text.Body.regular>
-               {React.string("Wallet version: " ++ data##version)}
-             </span>
-             <div className=Styles.walletItemContainer>
-               {data##ownedWallets
-                |> Array.mapi(~f=(i, w) =>
-                     <>
-                       <WalletItem
-                         key={PublicKey.toString(w##publicKey)}
-                         publicKey=w##publicKey
-                       />
-                       {i < Array.length(data##ownedWallets) - 1
-                          ? <hr className=Styles.line /> : React.null}
-                     </>
-                   )
-                |> React.array}
+  // TODO: Get and save value from the settings
+  let (networkValue, setNetworkValue) =
+    React.useState(() => NetworkOption("testnet.codaprotocol.com"));
+
+  <SettingsQuery>
+    {response =>
+       switch (response.result) {
+       | Loading => React.string("...")
+       | Error(err) => React.string(err##message)
+       | Data(data) =>
+         let versionText =
+           String.slice(
+             data##version,
+             ~from=0,
+             ~to_=min(8, String.length(data##version)),
+           );
+         <div className=Styles.container>
+           <div className=Styles.headerContainer>
+             <div className=Styles.label> {React.string("Network")} </div>
+             <div className=Styles.versionText>
+               <span
+                 className=Css.(
+                   style([color(Theme.Colors.slateAlpha(0.3))])
+                 )>
+                 {React.string("Version:")}
+               </span>
+               <Spacer width=0.5 />
+               <span
+                 className=Css.(
+                   style([color(Theme.Colors.slateAlpha(0.7))])
+                 )>
+                 {React.string(versionText)}
+               </span>
              </div>
-           </>
-         }}
-    </SettingsQuery>
-  </div>;
+           </div>
+           <div className=Styles.networkContainer>
+             <Dropdown
+               value={
+                 switch (networkValue) {
+                 | NetworkOption(s) => Some(s)
+                 | Custom(_) => Some("CUSTOM")
+                 }
+               }
+               label="URL"
+               options={doubleList([
+                 "testnet.codaprotocol.com",
+                 "testnet2.codaprotocol.com",
+                 "testnet3.codaprotocol.com",
+                 "CUSTOM",
+               ])}
+               onChange={s =>
+                 switch (s) {
+                 | "CUSTOM" =>
+                   setNetworkValue(
+                     fun
+                     | NetworkOption(_) => Custom("")
+                     | x => x,
+                   )
+                 | s => setNetworkValue(_ => NetworkOption(s))
+                 }
+               }
+             />
+             {switch (networkValue) {
+              | Custom(v) =>
+                <>
+                  <Spacer height=0.5 />
+                  <div className=Styles.customNetwork>
+                    <Icon kind=Icon.BentArrow />
+                    <Spacer width=0.5 />
+                    <TextField
+                      value=v
+                      label="URL"
+                      placeholder="my.network.com"
+                      onChange={s => setNetworkValue(_ => Custom(s))}
+                      button={
+                        <TextField.Button
+                          text="Save"
+                          color=`Green
+                          onClick=ignore
+                        />
+                      }
+                    />
+                  </div>
+                </>
+              | _ => React.null
+              }}
+           </div>
+           <Spacer height=1. />
+           <div className=Styles.label> {React.string("Wallets")} </div>
+           <div className=Styles.walletItemContainer>
+             {data##ownedWallets
+              |> Array.mapi(~f=(i, w) =>
+                   <>
+                     <WalletItem
+                       key={PublicKey.toString(w##publicKey)}
+                       publicKey=w##publicKey
+                     />
+                     {i < Array.length(data##ownedWallets) - 1
+                        ? <hr className=Styles.line /> : React.null}
+                   </>
+                 )
+              |> React.array}
+           </div>
+         </div>;
+       }}
+  </SettingsQuery>;
 };

--- a/frontend/wallet/src/render/components/SettingsPage.re
+++ b/frontend/wallet/src/render/components/SettingsPage.re
@@ -49,19 +49,14 @@ module Styles = {
         display(`flex),
         alignItems(`center),
         hover([opacity(0.6)]),
+        borderBottom(`px(1), `solid, Theme.Colors.slateAlpha(0.5)),
+        lastChild([borderBottomWidth(`zero)]),
       ]),
     ]);
 
   let walletName = style([width(`rem(12.5))]);
 
-  let walletChevron = style([color(Theme.Colors.teal)]);
-
-  let line =
-    style([
-      border(`zero, `none, transparent),
-      borderTop(`px(1), `solid, Theme.Colors.slateAlpha(0.5)),
-      width(`percent(100.)),
-    ]);
+  let walletChevron = style([color(Theme.Colors.tealAlpha(0.5))]);
 };
 
 module SettingsQueryString = [%graphql
@@ -111,6 +106,31 @@ let make = () => {
   let (networkValue, setNetworkValue) =
     React.useState(() => NetworkOption("testnet.codaprotocol.com"));
 
+  let dropDownValue =
+    switch (networkValue) {
+    | NetworkOption(s) => Some(s)
+    | Custom(_) => Some("CUSTOM")
+    };
+
+  let dropDownOptions =
+    doubleList([
+      "testnet.codaprotocol.com",
+      "testnet2.codaprotocol.com",
+      "testnet3.codaprotocol.com",
+      "CUSTOM",
+    ]);
+
+  let dropdownHandler = s =>
+    switch (s) {
+    | "CUSTOM" =>
+      setNetworkValue(
+        fun
+        | NetworkOption(_) => Custom("")
+        | x => x,
+      )
+    | s => setNetworkValue(_ => NetworkOption(s))
+    };
+
   <SettingsQuery>
     {response =>
        switch (response.result) {
@@ -144,30 +164,10 @@ let make = () => {
            </div>
            <div className=Styles.networkContainer>
              <Dropdown
-               value={
-                 switch (networkValue) {
-                 | NetworkOption(s) => Some(s)
-                 | Custom(_) => Some("CUSTOM")
-                 }
-               }
+               value=dropDownValue
                label="URL"
-               options={doubleList([
-                 "testnet.codaprotocol.com",
-                 "testnet2.codaprotocol.com",
-                 "testnet3.codaprotocol.com",
-                 "CUSTOM",
-               ])}
-               onChange={s =>
-                 switch (s) {
-                 | "CUSTOM" =>
-                   setNetworkValue(
-                     fun
-                     | NetworkOption(_) => Custom("")
-                     | x => x,
-                   )
-                 | s => setNetworkValue(_ => NetworkOption(s))
-                 }
-               }
+               options=dropDownOptions
+               onChange=dropdownHandler
              />
              {switch (networkValue) {
               | Custom(v) =>
@@ -198,15 +198,11 @@ let make = () => {
            <div className=Styles.label> {React.string("Wallets")} </div>
            <div className=Styles.walletItemContainer>
              {data##ownedWallets
-              |> Array.mapi(~f=(i, w) =>
-                   <>
-                     <WalletItem
-                       key={PublicKey.toString(w##publicKey)}
-                       publicKey=w##publicKey
-                     />
-                     {i < Array.length(data##ownedWallets) - 1
-                        ? <hr className=Styles.line /> : React.null}
-                   </>
+              |> Array.map(~f=w =>
+                   <WalletItem
+                     key={PublicKey.toString(w##publicKey)}
+                     publicKey=w##publicKey
+                   />
                  )
               |> React.array}
            </div>

--- a/frontend/wallet/src/render/components/SettingsPage.re
+++ b/frontend/wallet/src/render/components/SettingsPage.re
@@ -16,12 +16,7 @@ module Styles = {
       style([display(`flex), textTransform(`uppercase)]),
     ]);
 
-  let container =
-    style([
-      height(`percent(100.)),
-      padding(`rem(2.)),
-      backgroundColor(Theme.Colors.greyish(0.1)),
-    ]);
+  let container = style([height(`percent(100.)), padding(`rem(2.))]);
 
   let label =
     merge([

--- a/frontend/wallet/src/render/components/TextField.re
+++ b/frontend/wallet/src/render/components/TextField.re
@@ -19,8 +19,10 @@ module Styles = {
     merge([
       Theme.Text.smallHeader,
       style([
+        userSelect(`none),
         textTransform(`uppercase),
         color(Theme.Colors.slateAlpha(0.7)),
+        minWidth(`rem(2.5)),
       ]),
     ]);
 
@@ -31,10 +33,25 @@ module Styles = {
       Theme.Text.Body.regular,
       style([
         placeholder([color(placeholderColor)]),
-        border(`zero, `solid, white),
+        border(`zero, `none, transparent),
         flexGrow(1.),
         padding(`zero),
         paddingBottom(`px(2)),
+        color(Theme.Colors.teal),
+        active([outline(`zero, `solid, white)]),
+        focus([outline(`zero, `solid, white)]),
+      ]),
+    ]);
+
+  let inputMono =
+    merge([
+      Theme.Text.Body.mono,
+      style([
+        placeholder([color(placeholderColor)]),
+        border(`zero, `none, transparent),
+        flexGrow(1.),
+        padding(`zero),
+        margin(`zero),
         color(Theme.Colors.teal),
         active([outline(`zero, `solid, white)]),
         focus([outline(`zero, `solid, white)]),
@@ -48,6 +65,71 @@ module Styles = {
       Theme.Typeface.lucidaGrande,
       color(active ? Theme.Colors.teal : placeholderColor),
     ]);
+
+  let baseButton =
+    merge([
+      Theme.Text.Body.regular,
+      style([
+        display(`inlineFlex),
+        alignItems(`center),
+        justifyContent(`center),
+        height(`rem(1.5)),
+        minWidth(`rem(3.5)),
+        padding2(~v=`zero, ~h=`rem(0.5)),
+        border(`px(0), `none, transparent),
+        borderRadius(`rem(0.25)),
+        active([outlineStyle(`none)]),
+        focus([outlineStyle(`none)]),
+        disabled([pointerEvents(`none)]),
+        marginRight(`rem(-0.25)),
+        marginLeft(`rem(0.25)),
+      ]),
+    ]);
+
+  let greenButton =
+    merge([
+      baseButton,
+      style([
+        backgroundColor(Theme.Colors.serpentine),
+        color(white),
+        hover([backgroundColor(Theme.Colors.jungle)]),
+      ]),
+    ]);
+
+  let blueButton =
+    merge([
+      baseButton,
+      style([
+        backgroundColor(Theme.Colors.hyperlinkAlpha(1.)),
+        color(white),
+        hover([backgroundColor(Theme.Colors.hyperlinkAlpha(0.7))]),
+      ]),
+    ]);
+
+  let tealButton =
+    merge([
+      baseButton,
+      style([
+        backgroundColor(Theme.Colors.teal),
+        color(white),
+        hover([backgroundColor(Theme.Colors.tealAlpha(0.7))]),
+      ]),
+    ]);
+};
+
+module Button = {
+  [@react.component]
+  let make = (~text, ~color, ~onClick) => {
+    let buttonStyle =
+      switch (color) {
+      | `Blue => Styles.blueButton
+      | `Teal => Styles.tealButton
+      | `Green => Styles.greenButton
+      };
+    <button className=buttonStyle onClick={_ => onClick()}>
+      {React.string(text)}
+    </button>;
+  };
 };
 
 module Currency = {
@@ -75,15 +157,24 @@ module Currency = {
 };
 
 [@react.component]
-let make = (~onChange, ~value, ~label, ~placeholder=?) =>
+let make =
+    (
+      ~onChange,
+      ~value,
+      ~label,
+      ~mono=false,
+      ~button=React.null,
+      ~placeholder=?,
+    ) =>
   <label className=Styles.container>
     <span className=Styles.label> {React.string(label ++ ":")} </span>
     <Spacer width=0.5 />
     <input
-      className=Styles.input
+      className={mono ? Styles.inputMono : Styles.input}
       type_="text"
       onChange={e => onChange(ReactEvent.Form.target(e)##value)}
       value
       ?placeholder
     />
+    button
   </label>;

--- a/frontend/wallet/src/render/components/TransactionCell.re
+++ b/frontend/wallet/src/render/components/TransactionCell.re
@@ -128,8 +128,7 @@ module ActorName = {
   [@react.component]
   let make = (~value: ViewModel.Actor.t) => {
     switch (value) {
-    | Key(key) =>
-      <AddressPill pubkey=key />
+    | Key(key) => <AddressPill pubkey=key />
     | Unknown =>
       <Pill>
         <span
@@ -341,6 +340,8 @@ module TopLevelStyles = {
       alignItems(`center),
     ]);
 
+  let icon = style([opacity(0.5)]);
+
   module RightSide = {
     let outerWrapper =
       style([
@@ -385,7 +386,10 @@ let make = (~transaction: Transaction.t) => {
       <ActorName value={viewModel.sender} />
       <div className=TopLevelStyles.Actors.mode>
         {switch (viewModel.action) {
-         | Transfer => <Icon kind=Icon.BentArrow />
+         | Transfer =>
+           <span className=TopLevelStyles.icon>
+             <Icon kind=Icon.BentArrow />
+           </span>
          | Pending => React.string("... ")
          | Failed => React.string("x ")
          }}

--- a/frontend/wallet/src/render/components/TransactionsView.re
+++ b/frontend/wallet/src/render/components/TransactionsView.re
@@ -32,6 +32,8 @@ module Styles = {
       overflow(`auto),
       maxHeight(`calc((`sub, `percent(100.), `rem(2.)))),
     ]);
+
+  let icon = style([opacity(0.5), height(`rem(1.5))]);
 };
 
 module Transactions = [%graphql
@@ -68,23 +70,25 @@ module Transactions = [%graphql
 ];
 module TransactionsQuery = ReasonApollo.CreateQuery(Transactions);
 
-let extractTransactions: Js.t('a) => array(TransactionCell.Transaction.t) = data => {
-  data##blocks##nodes
-  |> Array.map(~f=block => {
-       open TransactionCell.Transaction;
-       let userCommands =
-         block##transactions##userCommands
-         |> Array.map(~f=userCommand => UserCommand(userCommand));
-       let blockReward =
-         BlockReward({
-           date: block##protocolState##blockchainState##date,
-           creator: block##creator,
-           coinbase: block##transactions##coinbase,
-           feeTransfers: block##transactions##feeTransfer,
-         });
-       Array.append(userCommands, [|blockReward|]);
-     }) |> Array.concatenate;
-};
+let extractTransactions: Js.t('a) => array(TransactionCell.Transaction.t) =
+  data => {
+    data##blocks##nodes
+    |> Array.map(~f=block => {
+         open TransactionCell.Transaction;
+         let userCommands =
+           block##transactions##userCommands
+           |> Array.map(~f=userCommand => UserCommand(userCommand));
+         let blockReward =
+           BlockReward({
+             date: block##protocolState##blockchainState##date,
+             creator: block##creator,
+             coinbase: block##transactions##coinbase,
+             feeTransfers: block##transactions##feeTransfer,
+           });
+         Array.append(userCommands, [|blockReward|]);
+       })
+    |> Array.concatenate;
+  };
 
 [@react.component]
 let make = () => {
@@ -96,7 +100,11 @@ let make = () => {
         Theme.Text.smallHeader,
         Styles.headerRow,
       ])}>
-      <span> {ReasonReact.string("Sender")} </span>
+      <span className=Css.(style([display(`flex), alignItems(`center)]))>
+        {React.string("Sender")}
+        <span className=Styles.icon> <Icon kind=Icon.BentArrow /> </span>
+        {React.string("recipient")}
+      </span>
       <span> {ReasonReact.string("Memo")} </span>
       <span className=Css.(style([textAlign(`right)]))>
         {ReasonReact.string("Transaction")}


### PR DESCRIPTION
Some more work on settings that I wanted to get done.
- Fixed styling for the daemon version
- Added ability for textfields to have a button
- Copy is hooked up (could use an indicator that the copy happened, after the click)
- Open file is hooked up to the file explorer (right now it opens the location of the executable lol)
- Fixed several styling things
- Added some made-up hover styles to the wallet list selector in general settings -- in general it seems like we need to put some work into getting hover and focus styles for all the interactive elements (and active?)

![image](https://user-images.githubusercontent.com/2154522/58755014-0ecd3f80-8490-11e9-9135-b1342bb2afdb.png)
![image](https://user-images.githubusercontent.com/2154522/58755018-142a8a00-8490-11e9-8740-37d3e02e9f85.png)
![image](https://user-images.githubusercontent.com/2154522/58754913-b8133600-848e-11e9-9719-048fe82b4096.png)
