### PR TITLE
Added private key path to wallet type

### DIFF
--- a/frontend/wallet/schema.graphql
+++ b/frontend/wallet/schema.graphql
@@ -79,6 +79,7 @@ type Wallet {
   votingFor: String!
   balance: AnnotatedBalance!
   stakingActive: Boolean! # Actively staking. There is a lag between switching staking keys and them appearing here as you may be in the middle of a staking procedure with other keys.
+  privateKeyPath: String! @examples(values: ["/Users/o1labs/.coda_config/wallets/store/ASgu5t5hlbjC3DZYZ87tASbUX+mGXJUpp+uekWKwtxlJbHxGuedIAQAAAQ=="])
 }
 
 type NodeStatus {

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -272,35 +272,41 @@ module Make (Commands : Coda_commands.Intf) = struct
                   ~resolve:(fun _ (b : t) -> Stringable.balance b.unknown) ] )
       end
 
+      (** Hack: Account.Poly.t is only parameterized over 'pk once and so, in order for delegate to be optional, we must also make account public_key optional even though it's always Some. In an attempt to avoid a large refactoring, and also avoid making a new record, we'll deal with a value_exn here and be sad. *)
+      type t =
+        { account:
+            ( Public_key.Compressed.t option
+            , AnnotatedBalance.t
+            , Account.Nonce.t option
+            , Receipt.Chain_hash.t option
+            , State_hash.t option )
+            Account.Poly.t
+        ; is_actively_staking: bool
+        ; path: string }
+
       let wallet =
         obj "Wallet" ~doc:"An account record according to the daemon"
           ~fields:(fun _ ->
-            [ pubkey_field ~resolve:(fun _ (account, _) ->
-                  (* Hack: Account.Poly.t is only parameterized over 'pk once
-                           * and so, in order for delegate to be optional, we must also
-                           * make account public_key optional even though it's always
-                           * Some. In an attempt to avoid a large refactoring, and also
-                           * avoid making a new record, we'll deal with a value_exn here
-                           * and be sad. *)
+            [ pubkey_field ~resolve:(fun _ {account; _} ->
                   Stringable.public_key
                   @@ Option.value_exn account.Account.Poly.public_key )
             ; field "balance"
                 ~typ:(non_null AnnotatedBalance.obj)
                 ~doc:"A balance of Coda as a stringified uint64"
                 ~args:Arg.[]
-                ~resolve:(fun _ (account, _) -> account.Account.Poly.balance)
+                ~resolve:(fun _ {account; _} -> account.Account.Poly.balance)
             ; field "nonce" ~typ:string
                 ~doc:
                   "Nonces are natural numbers that increase each transaction. \
                    Stringified uint32"
                 ~args:Arg.[]
-                ~resolve:(fun _ (account, _) ->
+                ~resolve:(fun _ {account; _} ->
                   Option.map ~f:Account.Nonce.to_string
                     account.Account.Poly.nonce )
             ; field "receiptChainHash" ~typ:string
                 ~doc:"Top hash of the receipt chain merkle-list"
                 ~args:Arg.[]
-                ~resolve:(fun _ (account, _) ->
+                ~resolve:(fun _ {account; _} ->
                   Option.map ~f:Receipt.Chain_hash.to_string
                     account.Account.Poly.receipt_chain_hash )
             ; field "delegate" ~typ:string
@@ -309,7 +315,7 @@ module Make (Commands : Coda_commands.Intf) = struct
                    delegating to anybody, than this would return your public \
                    key."
                 ~args:Arg.[]
-                ~resolve:(fun _ (account, _) ->
+                ~resolve:(fun _ {account; _} ->
                   Option.map ~f:Stringable.public_key
                     account.Account.Poly.delegate )
             ; field "votingFor" ~typ:string
@@ -317,7 +323,7 @@ module Make (Commands : Coda_commands.Intf) = struct
                   "The previous epoch lock hash of the chain which you are \
                    voting for"
                 ~args:Arg.[]
-                ~resolve:(fun _ (account, _) ->
+                ~resolve:(fun _ {account; _} ->
                   Option.map ~f:Coda_base.State_hash.to_bytes
                     account.Account.Poly.voting_for )
             ; field "stakingActive" ~typ:(non_null bool)
@@ -326,7 +332,11 @@ module Make (Commands : Coda_commands.Intf) = struct
                    keys and them appearing here as you may be in the middle \
                    of a staking procedure with other keys."
                 ~args:Arg.[]
-                ~resolve:(fun _ (_, staking_active) -> staking_active) ] )
+                ~resolve:(fun _ {is_actively_staking; _} -> is_actively_staking)
+            ; field "privateKeyPath" ~typ:(non_null string)
+                ~doc:"The path of the private key for wallet"
+                ~args:Arg.[]
+                ~resolve:(fun _ {path; _} -> path) ] )
     end
 
     let snark_worker =
@@ -529,7 +539,7 @@ module Make (Commands : Coda_commands.Intf) = struct
 
         val get_database : Program.t -> Pagination_database.t
 
-        val filter_argument : string sexp_option Schema.Arg.arg_typ
+        val filter_argument : string option Schema.Arg.arg_typ
 
         val query_name : string
 
@@ -821,11 +831,14 @@ module Make (Commands : Coda_commands.Intf) = struct
         ~typ:(non_null (list (non_null Types.Wallet.wallet)))
         ~args:Arg.[]
         ~resolve:(fun {ctx= coda; _} () ->
+          let wallets = Program.wallets coda in
           let propose_public_keys = Program.propose_public_keys coda in
-          Program.wallets coda |> Secrets.Wallets.pks
+          wallets |> Secrets.Wallets.pks
           |> List.map ~f:(fun pk ->
-                 ( Partial_account.of_pk coda pk
-                 , Public_key.Compressed.Set.mem propose_public_keys pk ) ) )
+                 { Types.Wallet.account= Partial_account.of_pk coda pk
+                 ; is_actively_staking=
+                     Public_key.Compressed.Set.mem propose_public_keys pk
+                 ; path= Secrets.Wallets.get_path wallets pk } ) )
 
     let wallet =
       result_field "wallet"
@@ -847,8 +860,10 @@ module Make (Commands : Coda_commands.Intf) = struct
             Partial_account.(
               of_pk coda pk |> to_full_account |> Option.map ~f:of_full_account)
             ~f:(fun account ->
-              (account, Public_key.Compressed.Set.mem propose_public_keys pk)
-              ) )
+              { Types.Wallet.account
+              ; is_actively_staking=
+                  Public_key.Compressed.Set.mem propose_public_keys pk
+              ; path= Secrets.Wallets.get_path (Program.wallets coda) pk } ) )
 
     let current_snark_worker =
       field "currentSnarkWorker" ~typ:Types.snark_worker

--- a/src/lib/secrets/wallets.mli
+++ b/src/lib/secrets/wallets.mli
@@ -10,3 +10,5 @@ val generate_new : t -> Public_key.Compressed.t Deferred.t
 val pks : t -> Public_key.Compressed.t list
 
 val find : t -> needle:Public_key.Compressed.t -> Keypair.t option
+
+val get_path : t -> Public_key.Compressed.t -> string


### PR DESCRIPTION
Here are the commands showing that the private key path is correct.

# Add Wallet

## Input
```graphql
mutation {addWallet{publicKey}}
```
## Output
```graphql
{
  "data": {
    "addWallet": {
      "publicKey": "ASgu5t5hlbjC3DZYZ87tASbUX+mGXJUpp+uekWKwtxlJbHxGuedIAQAAAQ=="
    }
  }
}
```

# OwnedWallets

## Input

```graphql
{ownedWallets{publicKey, privateKeyPath}}
```

## Output
```
{
  "data": {
    "ownedWallets": [
      {
        "publicKey": "ASgu5t5hlbjC3DZYZ87tASbUX+mGXJUpp+uekWKwtxlJbHxGuedIAQAAAQ==",
        "privateKeyPath": "/Users/johnwu/.coda-config/wallets/store/ASgu5t5hlbjC3DZYZ87tASbUX+mGXJUpp+uekWKwtxlJbHxGuedIAQAAAQ=="
      }
    ]
  }
}

```


This is a valid path showing the public key:

```
ls /Users/johnwu/.coda-config/wallets/store/ASgu5t5hlbjC3DZYZ87tASbUX+mGXJUpp+uekWKwtxlJbHxGuedIAQAAAQ==
/Users/johnwu/.coda-config/wallets/store/ASgu5t5hlbjC3DZYZ87tASbUX+mGXJUpp+uekWKwtxlJbHxGuedIAQAAAQ==
```

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

