### PR TITLE
Log error when duplicate proposer, slot

### DIFF
--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -274,6 +274,8 @@ module type S = sig
     type t [@@deriving yojson, bin_io]
 
     val t : t
+
+    val network_delay_opt : t -> int option (* for postake, at least *)
   end
 
   module Data : sig
@@ -376,6 +378,9 @@ module type S = sig
       val to_lite : (Value.t -> Lite_base.Consensus_state.t) option
 
       val display : Value.t -> display
+
+      (* for postake, returns Some *)
+      val curr_epoch_and_slot_opt : Value.t -> (int * int) option
     end
 
     module Proposal_data : sig

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -274,8 +274,6 @@ module type S = sig
     type t [@@deriving yojson, bin_io]
 
     val t : t
-
-    val network_delay_opt : t -> int option (* for postake, at least *)
   end
 
   module Data : sig

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -270,6 +270,9 @@ module type S = sig
 
   module Constants : Constants_intf
 
+  (** from postake *)
+  val epoch_size : int
+
   module Configuration : sig
     type t [@@deriving yojson, bin_io]
 
@@ -377,8 +380,11 @@ module type S = sig
 
       val display : Value.t -> display
 
-      (* for postake, returns Some *)
-      val curr_epoch_and_slot_opt : Value.t -> (int * int) option
+      val network_delay : Configuration.t -> int
+
+      val curr_epoch : Value.t -> int
+
+      val curr_slot : Value.t -> int
     end
 
     module Proposal_data : sig

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -92,6 +92,8 @@ module Constants = struct
     Time.Span.of_ms (Int64.of_int (Int64.to_int Slot.duration_ms * delta))
 end
 
+let epoch_size = UInt32.to_int Constants.Epoch.size
+
 module Configuration = struct
   type t =
     { delta: int
@@ -2082,8 +2084,12 @@ module Data = struct
       ; curr_slot= Segment_id.to_int t.curr_slot
       ; total_currency= Amount.to_int t.total_currency }
 
-    let curr_epoch_and_slot_opt (t : Value.t) =
-      Some (Epoch.to_int t.curr_epoch, Epoch.Slot.to_int t.curr_slot)
+    let network_delay (config : Configuration.t) =
+      config.acceptable_network_delay
+
+    let curr_epoch (t : Value.t) = Epoch.to_int t.curr_epoch
+
+    let curr_slot (t : Value.t) = Epoch.Slot.to_int t.curr_slot
   end
 
   module Prover_state = struct

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -115,8 +115,6 @@ module Configuration = struct
     ; epoch_duration= Int64.to_int (Time.Span.to_ms Epoch.duration)
     ; acceptable_network_delay= Int64.to_int (Time.Span.to_ms delta_duration)
     }
-
-  let network_delay_opt t = Some t.acceptable_network_delay
 end
 
 module Data = struct

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -115,6 +115,8 @@ module Configuration = struct
     ; epoch_duration= Int64.to_int (Time.Span.to_ms Epoch.duration)
     ; acceptable_network_delay= Int64.to_int (Time.Span.to_ms delta_duration)
     }
+
+  let network_delay_opt t = Some t.acceptable_network_delay
 end
 
 module Data = struct
@@ -2081,6 +2083,9 @@ module Data = struct
       ; curr_epoch= Segment_id.to_int t.curr_epoch
       ; curr_slot= Segment_id.to_int t.curr_slot
       ; total_currency= Amount.to_int t.total_currency }
+
+    let curr_epoch_and_slot_opt (t : Value.t) =
+      Some (Epoch.to_int t.curr_epoch, Epoch.Slot.to_int t.curr_slot)
   end
 
   module Prover_state = struct

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -3,6 +3,7 @@ open Async_kernel
 open Pipe_lib.Strict_pipe
 open Coda_base
 open Coda_state
+open Signature_lib
 
 module Make (Inputs : Transition_frontier.Inputs_intf) = struct
   open Inputs
@@ -46,24 +47,73 @@ module Make (Inputs : Transition_frontier.Inputs_intf) = struct
              ( "off by $slot_diff slots"
              , [("slot_diff", `String (Int64.to_string slot_diff))] ))
 
+  module Duplicate_proposal_detector = struct
+    module T = struct
+      (* int is a slot *)
+      type t = Public_key.Compressed.Stable.V1.t * int
+      [@@deriving bin_io, sexp, hash, compare]
+    end
+
+    module Key = Hashable.Make_binable (T)
+
+    type t = {table: State_hash.t Key.Table.t; mutable latest_epoch: int}
+
+    let create () = {table= Key.Table.create (); latest_epoch= 0}
+
+    let check t logger external_transition_with_hash =
+      let external_transition = external_transition_with_hash.With_hash.data in
+      let protocol_state_hash = external_transition_with_hash.hash in
+      let open Consensus.Data.Consensus_state in
+      let consensus_state =
+        External_transition.consensus_state external_transition
+      in
+      match curr_epoch_and_slot_opt consensus_state with
+      | None ->
+          ()
+      | Some (epoch, slot) -> (
+          (* new epoch, flush table *)
+          (* TODO: can we see transitions from previous epochs *)
+          if epoch > t.latest_epoch then (
+            Key.Table.clear t.table ;
+            t.latest_epoch <- epoch ) ;
+          let proposer = External_transition.proposer external_transition in
+          let key = (proposer, slot) in
+          match Key.Table.find t.table key with
+          | None ->
+              Key.Table.add_exn t.table ~key ~data:protocol_state_hash
+          | Some hash ->
+              if not (State_hash.equal hash protocol_state_hash) then
+                Logger.error logger ~module_:__MODULE__ ~location:__LOC__
+                  !"Duplicate proposer and slot: proposer = %{sexp: \
+                    Public_key.Compressed.t}, slot = %i, previous protocol \
+                    state hash = %s, current protocol state hash = %s"
+                  proposer slot (State_hash.to_bytes hash)
+                  (State_hash.to_bytes protocol_state_hash) )
+  end
+
   let run ~logger ~trust_system ~verifier ~transition_reader
       ~valid_transition_writer =
     let open Deferred.Let_syntax in
+    let duplicate_checker = Duplicate_proposal_detector.create () in
     Reader.iter transition_reader ~f:(fun network_transition ->
         let `Transition transition_env, `Time_received time_received =
           network_transition
         in
-        let transition =
+        let transition_with_hash =
           Envelope.Incoming.data transition_env
           |> With_hash.of_data
                ~hash_data:
                  (Fn.compose Protocol_state.hash
                     External_transition.protocol_state)
         in
+        Duplicate_proposal_detector.check duplicate_checker logger
+          transition_with_hash ;
         let sender = Envelope.Incoming.sender transition_env in
         match%bind
           let open Deferred.Result.Let_syntax in
-          let transition = External_transition.Validation.wrap transition in
+          let transition =
+            External_transition.Validation.wrap transition_with_hash
+          in
           let%bind transition =
             ( Deferred.return
                 (External_transition.validate_time_received transition
@@ -82,15 +132,15 @@ module Make (Inputs : Transition_frontier.Inputs_intf) = struct
         | Error error ->
             let%map () =
               handle_validation_error ~logger ~trust_system ~sender
-                ~state_hash:(With_hash.hash transition)
+                ~state_hash:(With_hash.hash transition_with_hash)
                 error
             in
             Logger.warn logger ~module_:__MODULE__ ~location:__LOC__
               ~metadata:
                 [ ("peer", Envelope.Sender.to_yojson sender)
                 ; ( "transition"
-                  , External_transition.to_yojson (With_hash.data transition)
-                  ) ]
+                  , External_transition.to_yojson
+                      (With_hash.data transition_with_hash) ) ]
               !"Failed to validate transition from $peer" )
     |> don't_wait_for
 end

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -77,7 +77,6 @@ module Make (Inputs : Transition_frontier.Inputs_intf) = struct
 
     (* create dummy proposal to split map on *)
     let make_splitting_proposal (proposal : Proposals.t) : Proposals.t =
-      let roundup_div x y = (x / y) + if x mod y > 0 then 1 else 0 in
       let proposer = Public_key.Compressed.empty in
       if proposal.slot >= gc_width then
         (* within current epoch *)
@@ -85,7 +84,9 @@ module Make (Inputs : Transition_frontier.Inputs_intf) = struct
       else
         (* earlier epoch *)
         { epoch=
-            max 0 (proposal.epoch - roundup_div gc_width Consensus.epoch_size)
+            max 0
+              ( proposal.epoch - 1
+              - ((gc_width - proposal.slot) / Consensus.epoch_size) )
         ; slot=
             Consensus.epoch_size - 1
             - (gc_width mod Consensus.epoch_size)


### PR DESCRIPTION
Log an `error` message when we see an external transition with the same proposer and slot, but a different protocol state hash.

There's a table mapping proposers and slots to the hashes. It's flushed when we see a new epoch, so the table does not grow without bound. (Apparently, there's a smaller window of slots, but I worry about network lag so we might see transitions outside what we think the current window is.)

To achieve this, `Consensus` exports a function to get the epoch and slot (as an option), slightly tarnishing the consensus abstraction.

Closes #2467
