### PR TITLE
Coda_base, remove warn-error clause

### DIFF
--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -24,7 +24,7 @@ module type Basic = sig
   module Stable : sig
     module V1 : sig
       type nonrec t = t
-      [@@deriving bin_io, sexp, compare, eq, hash, yojson, version]
+      [@@deriving bin_io, sexp, compare, hash, yojson, version]
 
       include Hashable_binable with type t := t
 
@@ -83,7 +83,7 @@ struct
     module V1 = struct
       module T = struct
         type t = Pedersen.Digest.Stable.V1.t
-        [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
+        [@@deriving bin_io, sexp, compare, hash, yojson, version]
       end
 
       include T

--- a/src/lib/coda_base/data_hash.mli
+++ b/src/lib/coda_base/data_hash.mli
@@ -19,7 +19,7 @@ module type Basic = sig
   module Stable : sig
     module V1 : sig
       type nonrec t = t
-      [@@deriving bin_io, sexp, compare, eq, hash, yojson, version]
+      [@@deriving bin_io, sexp, compare, hash, yojson, version]
 
       include Hashable_binable with type t := t
 

--- a/src/lib/coda_base/dune
+++ b/src/lib/coda_base/dune
@@ -1,7 +1,6 @@
 (library
  (name coda_base)
  (public_name coda_base)
- (flags :standard -short-paths -warn-error -35-32-9-27-34-58-39)
  (inline_tests)
  (library_flags -linkall)
  (libraries

--- a/src/lib/coda_base/how_to_obtain_keys.ml
+++ b/src/lib/coda_base/how_to_obtain_keys.ml
@@ -25,5 +25,5 @@ let obtain_keys (type vk pk kp)
     | Generate_both ->
         let ks = f () in
         (Impl.Keypair.vk ks, Impl.Keypair.pk ks)
-    | Load_both {step} ->
+    | Load_both {step; _} ->
         Sexp.load_sexp_conv_exn step keypair_of_sexp )

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -16,8 +16,6 @@ module Ledger_inner = struct
   module Kvdb : Intf.Key_value_database = Rocksdb.Database
 
   module Storage_locations : Intf.Storage_locations = struct
-    let stack_db_file = "coda_stack_db"
-
     let key_value_db_dir = "coda_key_value_db"
   end
 

--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -103,7 +103,7 @@ end = struct
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  type t = Stable.Latest.t [@@deriving sexp, compare, eq]
+  type t = Stable.Latest.t [@@deriving sexp, compare]
 
   let ( > ), to_string, zero, to_int, of_int, equal =
     Int.(( > ), to_string, zero, to_int, of_int, equal)
@@ -367,8 +367,7 @@ module T = struct
       , set_exn
       , find_index_exn
       , add_path
-      , merkle_root
-      , iteri )]
+      , merkle_root )]
   end
 
   module Checked = struct

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -63,7 +63,7 @@ let of_any_ledger (ledger : Ledger.Any_ledger.witness) =
 
 let of_ledger_subset_exn (oledger : Ledger.t) keys =
   let ledger = Ledger.copy oledger in
-  let new_keys, sparse =
+  let _, sparse =
     List.fold keys
       ~f:(fun (new_keys, sl) key ->
         match Ledger.location_of_key ledger key with

--- a/src/lib/coda_base/timeout.ml
+++ b/src/lib/coda_base/timeout.ml
@@ -61,7 +61,7 @@ module Make (Time : Time_intf) : Timeout_intf(Time).S = struct
 
   let cancel _ {cancel; _} value = cancel value
 
-  let remaining_time {ctrl: _; deferred: _; cancel: _; start_time; span} =
+  let remaining_time {ctrl: _; start_time; span; _} =
     let current_time = Time.now ctrl in
     let time_elapsed = Time.diff current_time start_time in
     Time.Span.(span - time_elapsed)

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -186,9 +186,6 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
   let sub_amount balance amount =
     error_opt "insufficient funds" (Balance.sub_amount balance amount)
 
-  let add_fee amount fee =
-    error_opt "add_fee: overflow" (Amount.add_fee amount fee)
-
   let validate_nonces txn_nonce account_nonce =
     if Account.Nonce.equal account_nonce txn_nonce then Or_error.return ()
     else

--- a/src/lib/coda_base/transaction_validator.ml
+++ b/src/lib/coda_base/transaction_validator.ml
@@ -64,7 +64,7 @@ module Hashless_ledger = struct
     failwith "hashless_ledger: bug in transaction_logic, who is calling undo?"
 
   (* Without undo validating that the hashes match, Transaction_logic doesn't really care what this is. *)
-  let merkle_root t = Ledger_hash.empty_hash
+  let merkle_root _t = Ledger_hash.empty_hash
 
   let create l =
     {base= l; overlay= Hashtbl.create (module Public_key.Compressed)}
@@ -76,8 +76,6 @@ module Hashless_ledger = struct
 end
 
 include Transaction_logic.Make (Hashless_ledger)
-
-type ledger = Hashless_ledger.t
 
 let create = Hashless_ledger.create
 

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -14,7 +14,7 @@ module Poly = struct
       module T = struct
         type ('payload, 'pk, 'signature) t =
           {payload: 'payload; sender: 'pk; signature: 'signature}
-        [@@deriving bin_io, compare, eq, sexp, hash, yojson, version]
+        [@@deriving bin_io, compare, sexp, hash, yojson, version]
       end
 
       include T
@@ -26,7 +26,7 @@ module Poly = struct
   type ('payload, 'pk, 'signature) t =
         ('payload, 'pk, 'signature) Stable.Latest.t =
     {payload: 'payload; sender: 'pk; signature: 'signature}
-  [@@deriving eq, sexp, hash, yojson]
+  [@@deriving sexp, hash, yojson]
 end
 
 module Stable = struct
@@ -37,7 +37,7 @@ module Stable = struct
         , Public_key.Stable.V1.t
         , Signature.Stable.V1.t )
         Poly.Stable.V1.t
-      [@@deriving bin_io, compare, eq, sexp, hash, yojson, version]
+      [@@deriving bin_io, compare, sexp, hash, yojson, version]
     end
 
     include T
@@ -66,8 +66,6 @@ type t = Stable.Latest.t [@@deriving sexp, yojson, hash]
 let accounts_accessed = Stable.Latest.accounts_accessed
 
 include Comparable.Make (Stable.Latest)
-
-type value = t
 
 let payload Poly.{payload; _} = payload
 
@@ -104,13 +102,6 @@ module Gen = struct
         ~body
     in
     sign' sender payload
-
-  let gen ?(sign_type = `Fake) =
-    match sign_type with
-    | `Fake ->
-        gen_inner For_tests.fake_sign
-    | `Real ->
-        gen_inner sign
 
   let with_random_participants ~keys ~gen =
     let key_gen = Quickcheck_lib.gen_pair @@ Quickcheck_lib.of_array keys in

--- a/src/lib/coda_base/user_command.mli
+++ b/src/lib/coda_base/user_command.mli
@@ -7,7 +7,7 @@ module Poly : sig
     module V1 : sig
       type ('payload, 'pk, 'signature) t =
         {payload: 'payload; sender: 'pk; signature: 'signature}
-      [@@deriving bin_io, eq, sexp, hash, yojson]
+      [@@deriving bin_io, sexp, hash, yojson]
     end
 
     module Latest = V1
@@ -21,7 +21,7 @@ module Stable : sig
       , Public_key.Stable.V1.t
       , Signature.Stable.V1.t )
       Poly.Stable.V1.t
-    [@@deriving bin_io, eq, sexp, hash, yojson, version]
+    [@@deriving bin_io, sexp, hash, yojson, version]
 
     include Comparable.S with type t := t
 

--- a/src/lib/coda_base/user_command_intf.ml
+++ b/src/lib/coda_base/user_command_intf.ml
@@ -79,7 +79,7 @@ module type S = sig
       module V1 = Latest
     end
 
-    type t = Stable.Latest.t [@@deriving sexp, eq, yojson, compare, hash]
+    type t = Stable.Latest.t [@@deriving sexp, yojson, compare, hash]
 
     include Gen_intf with type t := t
 


### PR DESCRIPTION
Remove the dune `flags` clause containing `warn-error` in `Coda_base`. Fix the code to remove the resulting errors.

Most of the changes are simple. There are two dead-code removals, which we may want to keep. One is `gen` in `User_command`, the other is `add_fee` in `Transaction_logic`.