### PR TITLE
Merkle mask, remove warn-error

### DIFF
--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -1,7 +1,6 @@
 (library
  (name merkle_mask)
  (public_name merkle_mask)
- (flags :standard -short-paths -warn-error -6-27-9-58)
  (library_flags -linkall)
  (libraries core debug_assert bitstring integers immutable_array
    dyn_array merkle_ledger merkle_address yojson visualization)


### PR DESCRIPTION
Remove the `flags` clause in `Merkle_mask`, no errors result.