### PR TITLE
In cli, remove warn-error

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -83,7 +83,6 @@ let get_balance =
              printf "Failed to get balance %s\n" (Error.to_string_hum e) ))
 
 let get_public_keys =
-  let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let open Command.Param in
   let with_balances_flag =
@@ -104,7 +103,6 @@ let get_public_keys =
              Get_public_keys.rpc () port ))
 
 let prove_payment =
-  let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let open Command.Param in
   let open Cli_lib.Arg_type in
@@ -201,9 +199,7 @@ let get_nonce_cmd =
              exit 0 ))
 
 let status =
-  let open Deferred.Let_syntax in
   let open Daemon_rpcs in
-  let open Command.Param in
   let flag = Args.zip2 Cli_lib.Flag.json Cli_lib.Flag.performance in
   Command.async ~summary:"Get running daemon status"
     (Cli_lib.Background_daemon.init flag ~f:(fun port (json, performance) ->
@@ -214,7 +210,6 @@ let status =
            port ))
 
 let status_clear_hist =
-  let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let flag = Args.zip2 Cli_lib.Flag.json Cli_lib.Flag.performance in
   Command.async ~summary:"Clear histograms reported in status"
@@ -256,7 +251,7 @@ let batch_send_payments =
     with
     | Ok x ->
         return x
-    | Error e ->
+    | Error _ ->
         let sample_info () : Payment_info.t =
           let keypair = Keypair.create () in
           { Payment_info.receiver=
@@ -451,7 +446,6 @@ let constraint_system_digests =
 
 let snark_job_list =
   let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
   let open Command.Param in
   Command.async ~summary:"List of snark jobs in JSON format"
     (Cli_lib.Background_daemon.init (return ()) ~f:(fun port () ->
@@ -463,7 +457,6 @@ let snark_job_list =
 
 let start_tracing =
   let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
   let open Command.Param in
   Command.async ~summary:"Start async tracing to $config-directory/$pid.trace"
     (Cli_lib.Background_daemon.init (return ()) ~f:(fun port () ->
@@ -475,7 +468,6 @@ let start_tracing =
 
 let stop_tracing =
   let open Deferred.Let_syntax in
-  let open Daemon_rpcs in
   let open Command.Param in
   Command.async ~summary:"Stop async tracing"
     (Cli_lib.Background_daemon.init (return ()) ~f:(fun port () ->
@@ -489,7 +481,6 @@ module Visualization = struct
   let create_command (type rpc_response) ~name ~f
       (rpc : (string, rpc_response) Rpc.Rpc.t) =
     let open Deferred.Let_syntax in
-    let open Command.Param in
     Command.async
       ~summary:(sprintf !"Produce a visualization of the %s" name)
       (Cli_lib.Background_daemon.init

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -4,7 +4,6 @@
 open Core
 open Async
 open Coda_base
-open Blockchain_snark
 open Cli_lib
 open Coda_inputs
 open Signature_lib
@@ -106,9 +105,6 @@ let daemon logger =
                snark proof (default: %d)"
               (Currency.Fee.to_int Cli_lib.Fee.default_snark_worker))
          (optional txn_fee)
-     and sexp_logging =
-       flag "sexp-logging" no_arg
-         ~doc:"Use S-expressions in log output, instead of JSON"
      and enable_tracing =
        flag "tracing" no_arg ~doc:"Trace into $config-directory/$pid.trace"
      and limit_connections =
@@ -316,8 +312,6 @@ let daemon logger =
          let commit_id = commit_id
 
          let work_selection = work_selection
-
-         let max_concurrent_connections = max_concurrent_connections
        end in
        let%bind (module Init) = make_init (module Config0) in
        let module M = Coda_inputs.Make_coda (Init) in
@@ -382,7 +376,7 @@ let daemon logger =
        let transaction_database_dir = conf_dir ^/ "transaction" in
        let%bind () = Async.Unix.mkdir ~p:() transaction_database_dir in
        let transaction_database =
-         Auxiliary_database.Transaction_database.create logger
+         Auxiliary_database.Transaction_database.create ~logger
            transaction_database_dir
        in
        trace_database_initialization "transaction_database" __LOC__
@@ -392,7 +386,7 @@ let daemon logger =
        in
        let%bind () = Async.Unix.mkdir ~p:() external_transition_database_dir in
        let external_transition_database =
-         Auxiliary_database.External_transition_database.create logger
+         Auxiliary_database.External_transition_database.create ~logger
            external_transition_database_dir
        in
        let monitor = Async.Monitor.create ~name:"coda" () in

--- a/src/app/cli/src/coda_batch_payment_test.ml
+++ b/src/app/cli/src/coda_batch_payment_test.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 open Signature_lib
 
 let name = "coda-batch-payment-test"
@@ -37,5 +35,4 @@ let main () =
   Coda_worker_testnet.Api.teardown testnet
 
 let command =
-  let open Command.Let_syntax in
   Command.async ~summary:"Test batch payments" (Async.Command.Spec.return main)

--- a/src/app/cli/src/coda_block_production_test.ml
+++ b/src/app/cli/src/coda_block_production_test.ml
@@ -1,14 +1,12 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 
 let name = "coda-block-production-test"
 
 let main () =
   let logger = Logger.create () in
   let n = 1 in
-  let snark_work_public_keys i = None in
+  let snark_work_public_keys _ = None in
   let%bind testnet =
     Coda_worker_testnet.test logger n Option.some snark_work_public_keys
       Cli_lib.Arg_type.Seq ~max_concurrent_connections:None

--- a/src/app/cli/src/coda_bootstrap_test.ml
+++ b/src/app/cli/src/coda_bootstrap_test.ml
@@ -1,8 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
-open Coda_base
 open Signature_lib
 
 let name = "coda-bootstrap-test"
@@ -46,6 +43,5 @@ let main () =
   Coda_worker_testnet.Api.teardown testnet
 
 let command =
-  let open Command.Let_syntax in
   Command.async ~summary:"Test that triggers bootstrap once"
     (Command.Param.return main)

--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -1,12 +1,9 @@
 open Core
 open Async
-open Pipe_lib
 open Signature_lib
 open Coda_numbers
 open Coda_base
 open Coda_state
-open Coda_transition
-open O1trace
 
 module type Intf = sig
   module Program : Coda_inputs.Main_intf
@@ -92,7 +89,7 @@ struct
            collision should not happen." ;
         Core.exit 1
 
-  let is_valid_user_command t (txn : User_command.t) account_opt =
+  let is_valid_user_command _t (txn : User_command.t) account_opt =
     let remainder =
       let open Option.Let_syntax in
       let%bind account = account_opt

--- a/src/app/cli/src/coda_delegation_test.ml
+++ b/src/app/cli/src/coda_delegation_test.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 open Coda_base
 
 let name = "coda-delegation-test"
@@ -36,7 +34,7 @@ let main () =
   (* keep CI alive *)
   Deferred.don't_wait_for (print_heartbeat ()) ;
   (* dump account info to log *)
-  List.iteri Genesis_ledger.accounts (fun ndx ((_, acct) as record) ->
+  List.iteri Genesis_ledger.accounts ~f:(fun ndx ((_, acct) as record) ->
       let keypair = Genesis_ledger.keypair_of_account_record_exn record in
       Logger.info logger ~module_:__MODULE__ ~location:__LOC__
         !"Account: %i private key: %{sexp: Import.Private_key.t} public key: \
@@ -51,9 +49,7 @@ let main () =
     Genesis_ledger.keypair_of_account_record_exn delegator
   in
   (* zeroth account is delegatee *)
-  let ((_, delegatee_account) as delegatee) =
-    List.nth_exn Genesis_ledger.accounts 0
-  in
+  let _, delegatee_account = List.nth_exn Genesis_ledger.accounts 0 in
   let delegatee_pubkey = Account.public_key delegatee_account in
   let worker = testnet.workers.(0) in
   (* setup readers for proposals by delegator, delegatee *)
@@ -127,7 +123,6 @@ let main () =
   Coda_worker_testnet.Api.teardown testnet
 
 let command =
-  let open Command.Let_syntax in
   Command.async
     ~summary:
       "Test whether stake delegation from a high-balance account to a \

--- a/src/app/cli/src/coda_five_nodes_test.ml
+++ b/src/app/cli/src/coda_five_nodes_test.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 open Coda_base
 
 let name = "coda-five-nodes-test"
@@ -24,6 +22,5 @@ let main () =
   Coda_worker_testnet.Api.teardown testnet
 
 let command =
-  let open Command.Let_syntax in
   Command.async ~summary:"Test that five nodes work"
     (Command.Param.return main)

--- a/src/app/cli/src/coda_inputs.ml
+++ b/src/app/cli/src/coda_inputs.ml
@@ -8,9 +8,7 @@ open Coda_state
 open Coda_transition
 open Signature_lib
 open Blockchain_snark
-open Coda_numbers
 open Pipe_lib
-open O1trace
 
 module type Work_selector_F = functor
   (Inputs : Work_selector.Inputs.Inputs_intf)
@@ -254,8 +252,6 @@ let make_init (module Config : Config_intf) : (module Init_intf) Deferred.t =
   (module Init : Init_intf)
 
 module Make_inputs0 (Init : Init_intf) = struct
-  open Init
-
   let max_length = Consensus.Constants.k
 
   module Time_close_validator = struct

--- a/src/app/cli/src/coda_long_fork.ml
+++ b/src/app/cli/src/coda_long_fork.ml
@@ -1,8 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_run
-open Coda_base
 
 let name = "coda-long-fork"
 

--- a/src/app/cli/src/coda_peers_test.ml
+++ b/src/app/cli/src/coda_peers_test.ml
@@ -1,8 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
-open Coda_processes
 
 let name = "coda-peers-test"
 

--- a/src/app/cli/src/coda_process.ml
+++ b/src/app/cli/src/coda_process.ml
@@ -56,76 +56,76 @@ let disconnect (conn, proc, _) =
   let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
   ()
 
-let peers_exn (conn, _, _) =
+let peers_exn (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.peers ~arg:()
 
-let get_balance_exn (conn, _, _) pk =
+let get_balance_exn (conn, _proc, _) pk =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.get_balance
     ~arg:pk
 
-let get_nonce_exn (conn, _, _) pk =
+let get_nonce_exn (conn, _proc, _) pk =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.get_nonce
     ~arg:pk
 
-let root_length_exn (conn, _, _) =
+let root_length_exn (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.root_length
     ~arg:()
 
-let send_user_command_exn (conn, _, _) sk pk amount fee memo =
+let send_user_command_exn (conn, _proc, _) sk pk amount fee memo =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.send_user_command
     ~arg:(sk, pk, amount, fee, memo)
 
-let process_user_command_exn (conn, _, _) cmd =
+let process_user_command_exn (conn, _proc, _) cmd =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.process_user_command ~arg:cmd
 
-let prove_receipt_exn (conn, _, _) proving_receipt resulting_receipt =
+let prove_receipt_exn (conn, _proc, _) proving_receipt resulting_receipt =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.prove_receipt
     ~arg:(proving_receipt, resulting_receipt)
 
-let sync_status_exn (conn, _, _) =
+let sync_status_exn (conn, _proc, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.sync_status
       ~arg:()
   in
   Linear_pipe.wrap_reader r
 
-let verified_transitions_exn (conn, _, _) =
+let verified_transitions_exn (conn, _proc, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn
       ~f:Coda_worker.functions.verified_transitions ~arg:()
   in
   Linear_pipe.wrap_reader r
 
-let new_block_exn (conn, _, __) key =
+let new_block_exn (conn, _proc, __) key =
   let%map r =
     Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.new_block
       ~arg:key
   in
   Linear_pipe.wrap_reader r
 
-let root_diff_exn (conn, _, _) =
+let root_diff_exn (conn, _proc, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.root_diff
       ~arg:()
   in
   Linear_pipe.wrap_reader r
 
-let start_exn (conn, _, _) =
+let start_exn (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.start ~arg:()
 
-let new_user_command_exn (conn, _, _) pk =
+let new_user_command_exn (conn, _proc, _) pk =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.new_user_command
     ~arg:pk
 
-let get_all_user_commands_exn (conn, _, _) pk =
+let get_all_user_commands_exn (conn, _proc, _) pk =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.get_all_user_commands ~arg:pk
 
-let dump_tf (conn, _, _) =
+let dump_tf (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.dump_tf ~arg:()
 
-let best_path (conn, _, _) =
+let best_path (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.best_path
     ~arg:()

--- a/src/app/cli/src/coda_process.ml
+++ b/src/app/cli/src/coda_process.ml
@@ -3,9 +3,6 @@
 
 open Core
 open Async
-open Coda_worker
-open Coda_base
-open Coda_inputs
 open Pipe_lib
 
 type t = Coda_worker.Connection.t * Process.t * Coda_worker.Input.t
@@ -21,7 +18,7 @@ let spawn_exn (config : Coda_worker.Input.t) =
   File_system.dup_stderr process ;
   return (conn, process, config)
 
-let local_config ?proposal_interval ~peers ~addrs_and_ports ~acceptable_delay
+let local_config ?proposal_interval:_ ~peers ~addrs_and_ports ~acceptable_delay
     ~program_dir ~proposer ~snark_worker_config ~work_selection ~offset
     ~trace_dir ~max_concurrent_connections () =
   let conf_dir =
@@ -59,76 +56,76 @@ let disconnect (conn, proc, _) =
   let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
   ()
 
-let peers_exn (conn, proc, _) =
+let peers_exn (conn, _, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.peers ~arg:()
 
-let get_balance_exn (conn, proc, _) pk =
+let get_balance_exn (conn, _, _) pk =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.get_balance
     ~arg:pk
 
-let get_nonce_exn (conn, proc, _) pk =
+let get_nonce_exn (conn, _, _) pk =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.get_nonce
     ~arg:pk
 
-let root_length_exn (conn, proc, _) =
+let root_length_exn (conn, _, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.root_length
     ~arg:()
 
-let send_user_command_exn (conn, proc, _) sk pk amount fee memo =
+let send_user_command_exn (conn, _, _) sk pk amount fee memo =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.send_user_command
     ~arg:(sk, pk, amount, fee, memo)
 
-let process_user_command_exn (conn, proc, _) cmd =
+let process_user_command_exn (conn, _, _) cmd =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.process_user_command ~arg:cmd
 
-let prove_receipt_exn (conn, proc, _) proving_receipt resulting_receipt =
+let prove_receipt_exn (conn, _, _) proving_receipt resulting_receipt =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.prove_receipt
     ~arg:(proving_receipt, resulting_receipt)
 
-let sync_status_exn (conn, proc, _) =
+let sync_status_exn (conn, _, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.sync_status
       ~arg:()
   in
   Linear_pipe.wrap_reader r
 
-let verified_transitions_exn (conn, proc, _) =
+let verified_transitions_exn (conn, _, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn
       ~f:Coda_worker.functions.verified_transitions ~arg:()
   in
   Linear_pipe.wrap_reader r
 
-let new_block_exn (conn, proc, __) key =
+let new_block_exn (conn, _, __) key =
   let%map r =
     Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.new_block
       ~arg:key
   in
   Linear_pipe.wrap_reader r
 
-let root_diff_exn (conn, proc, _) =
+let root_diff_exn (conn, _, _) =
   let%map r =
     Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.root_diff
       ~arg:()
   in
   Linear_pipe.wrap_reader r
 
-let start_exn (conn, proc, _) =
+let start_exn (conn, _, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.start ~arg:()
 
-let new_user_command_exn (conn, proc, _) pk =
+let new_user_command_exn (conn, _, _) pk =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.new_user_command
     ~arg:pk
 
-let get_all_user_commands_exn (conn, proc, _) pk =
+let get_all_user_commands_exn (conn, _, _) pk =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.get_all_user_commands ~arg:pk
 
-let dump_tf (conn, proc, _) =
+let dump_tf (conn, _, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.dump_tf ~arg:()
 
-let best_path (conn, proc, _) =
+let best_path (conn, _, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.best_path
     ~arg:()

--- a/src/app/cli/src/coda_processes.ml
+++ b/src/app/cli/src/coda_processes.ml
@@ -3,8 +3,6 @@
 
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 
 let init () = Parallel.init_master ()
 

--- a/src/app/cli/src/coda_receipt_chain_test.ml
+++ b/src/app/cli/src/coda_receipt_chain_test.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 open Coda_base
 open Signature_lib
 
@@ -66,6 +64,5 @@ let main () =
   Deferred.List.iter workers ~f:Coda_process.disconnect
 
 let command =
-  let open Command.Let_syntax in
   Command.async ~summary:"Test that peers can prove sent payments"
     (Command.Param.return main)

--- a/src/app/cli/src/coda_restart_node_test.ml
+++ b/src/app/cli/src/coda_restart_node_test.ml
@@ -1,8 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
-open Coda_base
 open Signature_lib
 
 let name = "coda-restart-node-test"
@@ -29,6 +26,5 @@ let main () =
   Coda_worker_testnet.Api.teardown testnet
 
 let command =
-  let open Command.Let_syntax in
   Command.async ~summary:"Test of stopping, waiting, then starting a node"
     (Command.Param.return main)

--- a/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
+++ b/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 open Coda_base
 
 let name = "coda-restarts-and-txns-holy-grail"

--- a/src/app/cli/src/coda_run.ml
+++ b/src/app/cli/src/coda_run.ml
@@ -1,8 +1,6 @@
 open Core
 open Async
-open Pipe_lib
 open Signature_lib
-open Coda_numbers
 open Coda_base
 open Coda_transition
 open Coda_state
@@ -209,7 +207,7 @@ struct
               Server.create_expert
                 ~on_handler_error:
                   (`Call
-                    (fun net exn ->
+                    (fun _net exn ->
                       Logger.error logger ~module_:__MODULE__ ~location:__LOC__
                         "%s" (Exn.to_string_mach exn) ))
                 (Tcp.Where_to_listen.bind_to Localhost
@@ -242,7 +240,7 @@ struct
         Tcp.Server.create
           ~on_handler_error:
             (`Call
-              (fun net exn ->
+              (fun _net exn ->
                 Logger.error logger ~module_:__MODULE__ ~location:__LOC__ "%s"
                   (Exn.to_string_mach exn) ))
           where_to_listen
@@ -270,7 +268,6 @@ struct
     |> ignore
 
   let create_snark_worker ~public_key ~client_port ~shutdown_on_disconnect =
-    let open Snark_worker in
     let%map p =
       let our_binary = Sys.executable_name in
       Process.create_exn () ~prog:our_binary

--- a/src/app/cli/src/coda_shared_prefix_multiproposer_test.ml
+++ b/src/app/cli/src/coda_shared_prefix_multiproposer_test.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 open Signature_lib
 
 let name = "coda-shared-prefix-multiproposer-test"

--- a/src/app/cli/src/coda_shared_prefix_test.ml
+++ b/src/app/cli/src/coda_shared_prefix_test.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 
 let name = "coda-shared-prefix-test"
 
@@ -9,7 +7,7 @@ let main who_proposes () =
   let logger = Logger.create () in
   let n = 2 in
   let proposers i = if i = who_proposes then Some i else None in
-  let snark_work_public_keys i = None in
+  let snark_work_public_keys _ = None in
   let%bind testnet =
     Coda_worker_testnet.test logger n proposers snark_work_public_keys
       Cli_lib.Arg_type.Seq ~max_concurrent_connections:None

--- a/src/app/cli/src/coda_shared_state_test.ml
+++ b/src/app/cli/src/coda_shared_state_test.ml
@@ -1,8 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
-open Coda_base
 open Signature_lib
 
 let name = "coda-shared-state-test"
@@ -28,6 +25,5 @@ let main () =
   Coda_worker_testnet.Api.teardown testnet
 
 let command =
-  let open Command.Let_syntax in
   Command.async ~summary:"Test that workers share states"
     (Command.Param.return main)

--- a/src/app/cli/src/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/coda_transitive_peers_test.ml
@@ -1,11 +1,7 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 
 let name = "coda-transitive-peers-test"
-
-open Coda_processes
 
 let main () =
   let%bind program_dir = Unix.getcwd () in

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -574,8 +574,10 @@ module T = struct
                     Async.Pipe.map pipe ~f:(function
                       | Ok json ->
                           parse_sync_status_exn json
-                      | Error _ ->
-                          failwith "Receiving sync status error: " )
+                      | Error json ->
+                          failwith
+                            (sprintf "Receiving sync status error: %s"
+                               (Yojson.Basic.to_string json)) )
                 | _ ->
                     failwith "Expected to get a stream of sync updates" )
             | Error e ->

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -2,7 +2,6 @@ open Core
 open Async
 open Coda_base
 open Coda_state
-open Signature_lib
 open Coda_inputs
 open Signature_lib
 open Pipe_lib
@@ -316,9 +315,9 @@ module T = struct
         ; work_selection
         ; conf_dir
         ; trace_dir
-        ; program_dir
         ; peers
-        ; max_concurrent_connections } =
+        ; max_concurrent_connections
+        ; _ } =
       let logger =
         Logger.create
           ~metadata:
@@ -350,15 +349,9 @@ module T = struct
 
         let genesis_proof = Precomputed_values.base_proof
 
-        let transaction_capacity_log_2 = 3
-
-        let work_delay_factor = 2
-
         let commit_id = None
 
         let work_selection = work_selection
-
-        let max_concurrent_connections = max_concurrent_connections
       end in
       O1trace.trace_task "worker_main" (fun () ->
           let%bind (module Init) = make_init (module Config) in
@@ -581,7 +574,7 @@ module T = struct
                     Async.Pipe.map pipe ~f:(function
                       | Ok json ->
                           parse_sync_status_exn json
-                      | Error e ->
+                      | Error _ ->
                           failwith "Receiving sync status error: " )
                 | _ ->
                     failwith "Expected to get a stream of sync updates" )

--- a/src/app/cli/src/coda_worker_testnet.ml
+++ b/src/app/cli/src/coda_worker_testnet.ml
@@ -1,7 +1,5 @@
 open Core
 open Async
-open Coda_worker
-open Coda_inputs
 open Signature_lib
 open Coda_base
 open Pipe_lib
@@ -39,10 +37,13 @@ module Api = struct
           `On (`Synced user_cmds_under_inspection) )
     in
     let locks =
-      Array.init (Array.length workers) (fun _ -> (ref 0, Condition.create ()))
+      Array.init (Array.length workers) ~f:(fun _ ->
+          (ref 0, Condition.create ()) )
     in
-    let root_lengths = Array.init (Array.length workers) (fun _ -> 0) in
-    let restart_signals = Array.init (Array.length workers) (fun _ -> None) in
+    let root_lengths = Array.init (Array.length workers) ~f:(fun _ -> 0) in
+    let restart_signals =
+      Array.init (Array.length workers) ~f:(fun _ -> None)
+    in
     { workers
     ; configs
     ; start_writer
@@ -127,7 +128,7 @@ module Api = struct
     let%bind () = wait_for_no_rpcs () in
     Coda_process.disconnect t.workers.(i)
 
-  let run_user_command t i (sk : Private_key.t) (pk : Account.key) fee ~body =
+  let run_user_command t i (sk : Private_key.t) (_ : Account.key) fee ~body =
     let open Deferred.Option.Let_syntax in
     let worker = t.workers.(i) in
     let pk_of_sk = Public_key.of_private_key_exn sk |> Public_key.compress in
@@ -198,7 +199,7 @@ end
 let start_prefix_check logger workers events testnet ~acceptable_delay =
   let all_transitions_r, all_transitions_w = Linear_pipe.create () in
   let%map chains =
-    Deferred.Array.init (Array.length workers) (fun i ->
+    Deferred.Array.init (Array.length workers) ~f:(fun i ->
         Coda_process.best_path workers.(i) )
   in
   let check_chains (chains : State_hash.Stable.Latest.t list array) =
@@ -295,7 +296,7 @@ let start_prefix_check logger workers events testnet ~acceptable_delay =
 type user_cmd_status =
   {snapshots: int option array; passed_root: bool array; result: unit Ivar.t}
 
-let start_payment_check logger root_pipe workers (testnet : Api.t) =
+let start_payment_check logger root_pipe _workers (testnet : Api.t) =
   Linear_pipe.iter root_pipe ~f:(function
       | `Root
           ( worker_id
@@ -328,7 +329,7 @@ let start_payment_check logger root_pipe workers (testnet : Api.t) =
                     else () ) ;
               let earliest_user_cmd =
                 List.min_elt (Hashtbl.to_alist user_cmds_under_inspection)
-                  ~compare:(fun (user_cmd1, status1) (user_cmd2, status2) ->
+                  ~compare:(fun (_user_cmd1, status1) (_user_cmd2, status2) ->
                     Int.compare status1.expected_deadline
                       status2.expected_deadline )
               in
@@ -419,7 +420,7 @@ let test logger n proposers snark_work_public_keys work_selection
   let configs =
     Coda_processes.local_configs n ~proposal_interval ~program_dir ~proposers
       ~acceptable_delay
-      ~snark_worker_public_keys:(Some (List.init n snark_work_public_keys))
+      ~snark_worker_public_keys:(Some (List.init n ~f:snark_work_public_keys))
       ~work_selection
       ~trace_dir:(Unix.getenv "CODA_TRACING")
       ~max_concurrent_connections
@@ -552,7 +553,7 @@ end = struct
           let%map pipe = Api.new_user_command_and_subscribe testnet i pk in
           Option.value_exn pipe )
     in
-    Deferred.List.init ~how:`Sequential n ~f:(fun i ->
+    Deferred.List.init ~how:`Sequential n ~f:(fun _i ->
         let receiver_keypair = List.random_element_exn keypairs in
         let receiver_pk = receiver_keypair.public_key |> Public_key.compress in
         (* Everybody will be watching for a payment *)

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -17,6 +17,4 @@
   (pps ppx_deriving.eq ppx_deriving.make ppx_inline_test ppx_coda
     ppx_base ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson
   ))
- (flags -short-paths -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
  (modes native))

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -17,4 +17,6 @@
   (pps ppx_deriving.eq ppx_deriving.make ppx_inline_test ppx_coda
     ppx_base ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson
   ))
+ ; the -w list here should be the same as in src/dune
+ (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60)
  (modes native))

--- a/src/app/cli/src/find_ip.ml
+++ b/src/app/cli/src/find_ip.ml
@@ -17,7 +17,7 @@ let ip_service_result {uri; body_handler} =
 
 let find () =
   let handler acc elem =
-    match acc with None -> ip_service_result elem | Some x -> return acc
+    match acc with None -> ip_service_result elem | Some _ -> return acc
   in
   Deferred.List.fold services ~init:None ~f:handler
   >>| fun x ->

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -257,13 +257,13 @@ let run_test () : unit Deferred.t =
           amount balance_sheet fee =
         let payment = build_payment amount sender_sk receiver_pk fee in
         let new_balance_sheet =
-          Map.update balance_sheet sender_pk (fun v ->
+          Map.update balance_sheet sender_pk ~f:(fun v ->
               Option.value_exn
                 (Currency.Balance.sub_amount (Option.value_exn v)
                    (Option.value_exn (Currency.Amount.add_fee amount fee))) )
         in
         let new_balance_sheet' =
-          Map.update new_balance_sheet receiver_pk (fun v ->
+          Map.update new_balance_sheet receiver_pk ~f:(fun v ->
               Option.value_exn
                 (Currency.Balance.add_amount (Option.value_exn v) amount) )
         in
@@ -379,7 +379,6 @@ let run_test () : unit Deferred.t =
         test_duplicate_payments sender_keypair receiver_keypair )
 
 let command =
-  let open Core in
   let open Async in
   Command.async ~summary:"Full coda end-to-end test"
     (Command.Param.return run_test)

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -352,13 +352,14 @@ module Make (Commands : Coda_commands.Intf) = struct
           [ field "key" ~typ:(non_null string)
               ~doc:"Public key of current snark worker."
               ~args:Arg.[]
-              ~resolve:(fun {ctx= _; _} (key, _) -> Stringable.public_key key)
+              ~resolve:(fun (_ : Program.t resolve_info) (key, _) ->
+                Stringable.public_key key )
           ; field "fee" ~typ:(non_null string)
               ~doc:
                 "Fee that snark worker is charging to generate a snark proof \
                  (fee is uint64 and is coerced as a string)"
               ~args:Arg.[]
-              ~resolve:(fun {ctx= _; _} (_, fee) ->
+              ~resolve:(fun (_ : Program.t resolve_info) (_, fee) ->
                 Stringable.uint64 (Currency.Fee.to_uint64 fee) ) ] )
 
     module Payload = struct

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -824,7 +824,7 @@ module Make (Commands : Coda_commands.Intf) = struct
           in
           let transaction_pool = Program.transaction_pool coda in
           List.map
-            (Transaction_pool.all_from_user transaction_pool pk)
+            (Program.Inputs.Transaction_pool.all_from_user transaction_pool pk)
             ~f:User_command.forget_check )
 
     let sync_state =

--- a/src/app/cli/src/transaction_snark_profiler.ml
+++ b/src/app/cli/src/transaction_snark_profiler.ml
@@ -1,7 +1,6 @@
 open Core
 open Signature_lib
 open Coda_base
-open Snark_params
 
 let name = "transaction-snark-profiler"
 
@@ -13,7 +12,6 @@ module Sparse_ledger = struct
 end
 
 let create_ledger_and_transactions num_transitions =
-  let open Tick in
   let num_accounts = 4 in
   let ledger = Ledger.create () in
   let keys =
@@ -51,7 +49,8 @@ let create_ledger_and_transactions num_transitions =
   | `Count n ->
       let num_transactions = n - 2 in
       let transactions =
-        List.rev (List.init num_transactions (fun _ -> random_transaction ()))
+        List.rev
+          (List.init num_transactions ~f:(fun _ -> random_transaction ()))
       in
       let fee_transfer =
         let open Currency.Fee in
@@ -134,7 +133,7 @@ let profile (module T : Transaction_snark.S) sparse_ledger0
   in
   let rec merge_all serial_time proofs =
     match proofs with
-    | [x] ->
+    | [_] ->
         serial_time
     | _ ->
         let layer_time, new_proofs =
@@ -229,7 +228,7 @@ let run profiler num_transactions repeats preeval =
            | User_command t ->
                let t = (t :> User_command.t) in
                User_command.accounts_accessed t
-           | Coinbase {proposer; fee_transfer} ->
+           | Coinbase {proposer; fee_transfer; _} ->
                proposer :: Option.to_list (Option.map fee_transfer ~f:fst) ))
   in
   for i = 1 to repeats do

--- a/src/dune
+++ b/src/dune
@@ -26,6 +26,7 @@ let () =
     |> List.map chop_file_extension
   in
   let foreach ls ~f = List.map f ls |> String.concat "" in
+  (* the -w list here should be the same as in src/app/cli/src/dune *)
   let env_entry profile = "  ("^profile^" (flags (:standard -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60)))\n" in
 
 


### PR DESCRIPTION
Remove the `flags` clause in `app/cli/src/dune` and fixed the resulting errors.

Some concerns:
- the clause also had `-g`, which is useful when OCaml better supports gdb, maybe this should be global, and maybe just for some profiles
- `Coda_process.local_config` has an unused optional parameter `proposal_interval`, should that just be removed, or should it be used somehow
- `Client` had a variable `sexp_logging` that was unused, is that an oversight?
