### PR TITLE
Reformat, use src/dune warnings

### DIFF
--- a/src/app/reformat/dune
+++ b/src/app/reformat/dune
@@ -4,6 +4,6 @@
  (libraries core async)
  (preprocess
   (pps ppx_jane))
- (flags -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
+ ; the -w list here should be the same as in src/dune
+ (flags -g -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60)
  (modes native))

--- a/src/app/reformat/reformat.ml
+++ b/src/app/reformat/reformat.ml
@@ -28,7 +28,7 @@ let rec fold_over_files ~path ~process_path ~init ~f =
           return acc )
 
 let main dry_run check path =
-  let%bind all =
+  let%bind _all =
     fold_over_files ~path ~init:()
       ~process_path:(fun kind path ->
         match kind with

--- a/src/dune
+++ b/src/dune
@@ -26,7 +26,7 @@ let () =
     |> List.map chop_file_extension
   in
   let foreach ls ~f = List.map f ls |> String.concat "" in
-  (* the -w list here should be the same as in src/app/cli/src/dune *)
+  (* the -w list here should be the same as in src/app/cli/src/dune and src/app/reformat/dune *)
   let env_entry profile = "  ("^profile^" (flags (:standard -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60)))\n" in
 
 


### PR DESCRIPTION
In `app/reformat`, use the same warnings list as in `src/dune`. Fix the resulting error.