### PR TITLE
ocaml-rocksdb, warnings as errors

### DIFF
--- a/src/external/ocaml-rocksdb/dune
+++ b/src/external/ocaml-rocksdb/dune
@@ -4,7 +4,6 @@
     (no_dynlink)
     (modes native)
     (libraries ctypes ctypes.foreign)
-    (flags (:standard -warn-error -A))
     (modules (:standard \ rocks_linker_flags_gen rocks_test))
     (c_library_flags (:standard (:include flags.sexp)))
     (self_build_stubs_archive (rocksdb))


### PR DESCRIPTION
The `dune` file for ocaml-rocksdb had `-warn-error -A`, turning off all warnings-as-errors. This PR removes that, and fixes the few errors that appeared as a result.
