### PR TITLE
Wallet: Add pending transactions support [with headers]

### DIFF
--- a/frontend/wallet/schema.graphql
+++ b/frontend/wallet/schema.graphql
@@ -56,7 +56,7 @@ type Transactions {
 
 type Block {
   creator: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
-  stateHash: String!
+  stateHash: String! @examples(values: ["bd6c106462010ba158c428272bb30bd8", "36d14efca6de2774692605f910b852ddf9468418"])
   protocolState: ProtocolState!
   transactions: Transactions!
 }

--- a/frontend/wallet/src/render/components/Icon.re
+++ b/frontend/wallet/src/render/components/Icon.re
@@ -6,6 +6,7 @@ type kind =
   | Question
   | Warning
   | Info
+  | Dots
   | Success
   | Danger
   | BackArrow;
@@ -78,5 +79,11 @@ let make = (~kind) =>
          d="M10.9956 20L3 12L10.9956 4L13.3263 6.332L9.29034 10.3509H21V13.6491L9.29034 13.6491L13.3263 17.668L10.9956 20Z"
          strokeWidth="0"
        />
+     | Dots =>
+       <>
+         <rect x="16" y="10" width="4" height="4" rx="2" />
+         <rect x="10" y="10" width="4" height="4" rx="2" />
+         <rect x="4" y="10" width="4" height="4" rx="2" />
+       </>
      }}
   </svg>;

--- a/frontend/wallet/src/render/views/transactions/Transactions.re
+++ b/frontend/wallet/src/render/views/transactions/Transactions.re
@@ -68,29 +68,61 @@ module TransactionsQueryString = [%graphql
           lastCursor
         }
       }
+
+      pooledUserCommands(publicKey: $publicKey) {
+        to_: to @bsDecoder(fn: "Apollo.Decoders.publicKey")
+        from @bsDecoder(fn: "Apollo.Decoders.publicKey")
+        amount @bsDecoder(fn: "Apollo.Decoders.int64")
+        fee @bsDecoder(fn: "Apollo.Decoders.int64")
+        memo
+        isDelegation
+        date @bsDecoder(fn: "Apollo.Decoders.date")
+      }
     }
   |}
 ];
 module TransactionsQuery = ReasonApollo.CreateQuery(TransactionsQueryString);
 
-let extractTransactions: Js.t('a) => array(TransactionCell.Transaction.t) =
+/**
+  This function is getting pretty gnarly so here's an explaination.
+  We take in the GraphQL response object called `data`.
+  Next we extract the data from the response object, and put it into a
+  record of type `{ pending: [], blocks: [] }`.
+  Pending contains the pending userCommands, while transactions contains
+  an array of transactions per block.
+ */
+
+type extractedResponse = {
+  blocks: array(array(TransactionCell.Transaction.t)),
+  pending: array(TransactionCell.Transaction.t),
+};
+
+let extractTransactions: Js.t('a) => extractedResponse =
   data => {
-    data##blocks##nodes
-    |> Array.map(~f=block => {
-         open TransactionCell.Transaction;
-         let userCommands =
-           block##transactions##userCommands
-           |> Array.map(~f=userCommand => UserCommand(userCommand));
-         let blockReward =
-           BlockReward({
-             date: block##protocolState##blockchainState##date,
-             creator: block##creator,
-             coinbase: block##transactions##coinbase,
-             feeTransfers: block##transactions##feeTransfer,
-           });
-         Array.append(userCommands, [|blockReward|]);
-       })
-    |> Array.concatenate;
+    let blocks =
+      data##blocks##nodes
+      |> Array.map(~f=block => {
+           open TransactionCell.Transaction;
+           let userCommands =
+             block##transactions##userCommands
+             |> Array.map(~f=userCommand => UserCommand(userCommand));
+           let blockReward =
+             BlockReward({
+               date: block##protocolState##blockchainState##date,
+               creator: block##creator,
+               coinbase: block##transactions##coinbase,
+               feeTransfers: block##transactions##feeTransfer,
+             });
+           Array.append(userCommands, [|blockReward|]);
+         });
+
+    let pending =
+      data##pooledUserCommands
+      |> Array.map(~f=userCommand =>
+           TransactionCell.Transaction.UserCommand(userCommand)
+         );
+
+    { pending, blocks }
   };
 
 [@react.component]
@@ -140,17 +172,19 @@ let make = () => {
              | Loading => <Loader.Page> <Loader /> </Loader.Page>
              | Error(err) => React.string(err##message) /* TODO format this error message */
              | Data(data) =>
-               let transactions = extractTransactions(data);
-               switch (Array.length(transactions)) {
-               | 0 =>
+               let { blocks, pending } = extractTransactions(data);
+               let transactions = Array.concatenate(blocks);
+               switch ((Array.length(transactions), Array.length(pending))) {
+               | (0, 0) =>
                  <div className=Styles.alertContainer>
                    <Alert
                      kind=`Info
                      message="You don't have any coda in this wallet."
                    />
                  </div>
-               | _ =>
+               | (_, _) =>
                  <TransactionsList
+                   pending
                    transactions
                    onLoadMore={() => {
                      let moreTransactions =

--- a/frontend/wallet/src/render/views/transactions/TransactionsList.re
+++ b/frontend/wallet/src/render/views/transactions/TransactionsList.re
@@ -33,10 +33,19 @@ module Styles = {
 };
 
 [@react.component]
-let make = (~transactions, ~onLoadMore: unit => Js.Promise.t('a)) => {
+let make = (~transactions, ~pending, ~onLoadMore: unit => Js.Promise.t('a)) => {
   let (isFetchingMore, setFetchingMore) = React.useState(() => false);
 
   <div className=Styles.body>
+    {Array.mapi(
+       ~f=
+         (i, transaction) =>
+           <div className=Styles.row key={string_of_int(i)}>
+             <TransactionCell transaction pending=true />
+           </div>,
+       pending,
+     )
+     |> React.array}
     {Array.mapi(
        ~f=
          (i, transaction) =>

--- a/frontend/wallet/src/render/views/transactions/TransactionsList.re
+++ b/frontend/wallet/src/render/views/transactions/TransactionsList.re
@@ -21,7 +21,6 @@ module Styles = {
       alignItems(`center),
       color(Theme.Colors.slateAlpha(0.7)),
       backgroundColor(Theme.Colors.midnightAlpha(0.06)),
-      marginTop(`rem(1.5)),
     ]);
 
   let body =
@@ -33,10 +32,15 @@ module Styles = {
 };
 
 [@react.component]
-let make = (~transactions, ~pending, ~onLoadMore: unit => Js.Promise.t('a)) => {
+let make = (~blocks, ~pending, ~onLoadMore: unit => Js.Promise.t('a)) => {
   let (isFetchingMore, setFetchingMore) = React.useState(() => false);
 
   <div className=Styles.body>
+    <div className=Styles.sectionHeader>
+      <span className=Theme.Text.Header.h6>
+        {React.string("Pending Transactions")}
+      </span>
+    </div>
     {Array.mapi(
        ~f=
          (i, transaction) =>
@@ -46,13 +50,27 @@ let make = (~transactions, ~pending, ~onLoadMore: unit => Js.Promise.t('a)) => {
        pending,
      )
      |> React.array}
-    {Array.mapi(
+    {Array.map(
        ~f=
-         (i, transaction) =>
-           <div className=Styles.row key={string_of_int(i)}>
-             <TransactionCell transaction />
-           </div>,
-       transactions,
+         ((transactions, stateHash)) =>
+           <>
+             <Spacer height=1.5 />
+             <div className=Styles.sectionHeader>
+               <span className=Theme.Text.Header.h6>
+                 {React.string("Block " ++ stateHash)}
+               </span>
+             </div>
+             {Array.mapi(
+                ~f=
+                  (i, transaction) =>
+                    <div className=Styles.row key={string_of_int(i)}>
+                      <TransactionCell transaction />
+                    </div>,
+                transactions,
+              )
+              |> React.array}
+           </>,
+       blocks,
      )
      |> React.array}
     {!isFetchingMore


### PR DESCRIPTION
Adds pending transactions to Transactions, but this time, with section headers.
<img width="973" alt="Screen Shot 2019-06-07 at 3 55 39 PM" src="https://user-images.githubusercontent.com/1709621/59137498-04ea8700-893d-11e9-8177-f7e2e788a4cb.png">
