### PR TITLE
Remove warn-error from lib subdir dunes

### DIFF
--- a/src/lib/coda_base/gen/dune
+++ b/src/lib/coda_base/gen/dune
@@ -4,6 +4,4 @@
    crypto_params signature_lib yojson)
  (preprocess
   (pps ppx_jane ppxlib.metaquot ppxlib.runner))
- (flags -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
  (modes native))

--- a/src/lib/coda_base/gen/gen.ml
+++ b/src/lib/coda_base/gen/gen.ml
@@ -11,7 +11,6 @@ let seed = "Coda_sample_keypairs"
 let random_bool = Crs.create ~seed
 
 module Group = Curve_choice.Tick_backend.Inner_curve
-open Tuple_lib
 
 let bigint_of_bits bits =
   List.foldi bits ~init:Bigint.zero ~f:(fun i acc b ->

--- a/src/lib/crypto_params/gen/dune
+++ b/src/lib/crypto_params/gen/dune
@@ -4,6 +4,4 @@
    curve_choice chunk_table chunked_triples)
  (preprocess
   (pps ppx_jane ppxlib.metaquot ppxlib.runner))
- (flags -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
  (modes native))

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -6,7 +6,6 @@ open Asttypes
 open Parsetree
 open Longident
 open Core
-open Fold_lib
 open Chunked_triples
 
 let seed = "CodaPedersenParams"
@@ -15,7 +14,6 @@ let random_bool = Crs.create ~seed
 
 module Impl = Curve_choice.Tick0
 module Group = Curve_choice.Tick_backend.Inner_curve
-open Tuple_lib
 
 let bigint_of_bits bits =
   List.foldi bits ~init:Bigint.zero ~f:(fun i acc b ->
@@ -57,7 +55,7 @@ let max_input_size_in_bits = 20000
 let base_params =
   List.init
     (max_input_size_in_bits / (3 * scalar_size_in_triples))
-    ~f:(fun i -> Group.of_affine_coordinates (random_point ()))
+    ~f:(fun _i -> Group.of_affine_coordinates (random_point ()))
 
 let sixteen_times x =
   x |> Group.double |> Group.double |> Group.double |> Group.double

--- a/src/lib/dummy_values/gen_values/dune
+++ b/src/lib/dummy_values/gen_values/dune
@@ -3,6 +3,4 @@
  (libraries async core crypto_params snarky ppxlib)
  (preprocess
   (pps ppx_jane ppxlib.metaquot ppxlib.runner))
- (flags -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
  (modes native))

--- a/src/lib/dummy_values/gen_values/gen_values.ml
+++ b/src/lib/dummy_values/gen_values/gen_values.ml
@@ -36,8 +36,7 @@ struct
     let proof =
       let exposing = Data_spec.[Typ.field] in
       let main x =
-        let open Let_syntax in
-        let%bind z = Field.Checked.mul x x in
+        let%bind _z = Field.Checked.mul x x in
         Field.Checked.Assert.equal x x
       in
       let keypair = generate_keypair main ~exposing in
@@ -51,7 +50,7 @@ struct
       match M.curve with
       | Tick ->
           generate_keypair
-            Data_spec.[Boolean.typ]
+            ~exposing:Data_spec.[Boolean.typ]
             (fun b -> Boolean.Assert.is_true b)
       | Tock -> (
           (* Hack *)
@@ -61,12 +60,12 @@ struct
           match n with
           | 1 ->
               generate_keypair
-                Data_spec.[Boolean.typ]
+                ~exposing:Data_spec.[Boolean.typ]
                 (fun b1 -> Boolean.Assert.is_true b1)
           | 2 ->
               generate_keypair
-                Data_spec.[Boolean.typ; Boolean.typ]
-                (fun b1 b2 -> Boolean.Assert.is_true b1)
+                ~exposing:Data_spec.[Boolean.typ; Boolean.typ]
+                (fun b1 _b2 -> Boolean.Assert.is_true b1)
           | _ ->
               assert false )
     in
@@ -74,7 +73,7 @@ struct
     , Proving_key.to_string (Keypair.pk kp) )
 
   let structure ~loc =
-    let ident str = Loc.make loc (Longident.parse str) in
+    let ident str = Loc.make ~loc (Longident.parse str) in
     let ( ^. ) x y = x ^ "." ^ y in
     let module E = Ppxlib.Ast_builder.Make (struct
       let loc = loc

--- a/src/lib/precomputed_values/gen_values/dune
+++ b/src/lib/precomputed_values/gen_values/dune
@@ -6,6 +6,4 @@
  (preprocessor_deps ../../../config.mlh)
  (preprocess
   (pps ppx_jane ppxlib.metaquot ppxlib.runner))
- (flags -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
  (modes native))

--- a/src/lib/snark_keys/gen_keys/dune
+++ b/src/lib/snark_keys/gen_keys/dune
@@ -5,6 +5,4 @@
  (preprocessor_deps ../../../config.mlh)
  (preprocess
   (pps ppx_jane ppxlib.metaquot ppxlib.runner))
- (flags -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
  (modes native))

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -5,7 +5,6 @@ open Ppxlib
 open Asttypes
 open Parsetree
 open Longident
-open Signature_lib
 open Core
 
 module Blockchain_snark_keys = struct

--- a/src/lib/snark_keys/remove_snark_keys_trigger/clear_keys/clear_keys.ml
+++ b/src/lib/snark_keys/remove_snark_keys_trigger/clear_keys/clear_keys.ml
@@ -1,7 +1,7 @@
 open Core
 
 let () =
-  Out_channel.write_all "remove_keys_trigger.ml" "" ;
+  Out_channel.write_all "remove_keys_trigger.ml" ~data:"" ;
   let dir = Cache_dir.autogen_path in
   match Sys.is_directory dir with
   | `Yes ->

--- a/src/lib/snark_keys/remove_snark_keys_trigger/clear_keys/dune
+++ b/src/lib/snark_keys/remove_snark_keys_trigger/clear_keys/dune
@@ -3,6 +3,4 @@
  (libraries core async cache_dir snarky)
  (preprocess
   (pps ppx_jane))
- (flags -w -40 -g -warn-error
-   +3+4+6+8+9+10+11+12+14+16+20+21+23+24+26+27+29+32..39+56-58+59+60+61)
  (modes native))


### PR DESCRIPTION
Remove the `flags` clause containing `-warn-error` from `dune` files in subdirectories of libraries.

After this PR is merged, there should be no warnings when building the `coda` repo.