### PR TITLE
Close database after async fun finishes

### DIFF
--- a/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
@@ -89,7 +89,7 @@ let%test_module "Transition Frontier Persistence" =
       in
       Transition_frontier_persistence.with_database ~directory_name
         ~f:(fun transition_storage ->
-          check_transitions transition_storage breadcrumbs )
+          return @@ check_transitions transition_storage breadcrumbs )
 
     let test_linear_breadcrumbs =
       test_breadcrumbs ~gen_root_breadcrumb_builder:gen_linear_breadcrumbs
@@ -105,7 +105,7 @@ let%test_module "Transition Frontier Persistence" =
       Thread_safe.block_on_async_exn
       @@ fun () ->
       let directory_name = Uuid.to_string (Uuid_unix.create ()) in
-      let%map root, next_breadcrumb =
+      let%bind root, next_breadcrumb =
         with_persistence ~logger ~directory_name ~f:(fun (frontier, t) ->
             let create_breadcrumb =
               gen_breadcrumb ~logger ~trust_system
@@ -142,22 +142,28 @@ let%test_module "Transition Frontier Persistence" =
             (root, next_breadcrumb) )
       in
       Transition_frontier_persistence.with_database ~directory_name
-        ~f:(fun storage -> check_transitions storage [root; next_breadcrumb])
+        ~f:(fun storage ->
+          return @@ check_transitions storage [root; next_breadcrumb] )
 
     let%test_unit "Dump external transitions to disk" =
-      test_linear_breadcrumbs (max_length - 1)
+      Thread_safe.block_on_async_exn (fun () ->
+          test_linear_breadcrumbs (max_length - 1) )
 
     let%test_unit "Root changes multiple times" =
       Printexc.record_backtrace true ;
-      test_linear_breadcrumbs (2 * max_length)
+      Thread_safe.block_on_async_exn (fun () ->
+          test_linear_breadcrumbs (2 * max_length) )
 
     let%test_unit "Randomly generate a tree" =
-      test_tree_breadcrumbs (2 * max_length)
+      Thread_safe.block_on_async_exn (fun () ->
+          test_tree_breadcrumbs (2 * max_length) )
 
     let test_deserialization num_breadcrumbs frontier =
-      let directory_name = Some (Uuid.to_string (Uuid_unix.create ())) in
+      let directory_name = Uuid.to_string (Uuid_unix.create ()) in
       let frontier_reader, _ = Broadcast_pipe.create (Some frontier) in
-      let frontier_persistence = create_persistence ~directory_name in
+      let frontier_persistence =
+        create_persistence ~directory_name:(Some directory_name)
+      in
       let%bind breadcrumbs =
         generate_breadcrumbs ~gen_root_breadcrumb_builder:gen_tree_list
           frontier num_breadcrumbs
@@ -170,17 +176,14 @@ let%test_module "Transition Frontier Persistence" =
            frontier_reader frontier_persistence ;
       let%bind () = store_transitions frontier breadcrumbs in
       let%bind () =
-        Transition_frontier_persistence
-        .close_and_finish_copy_without_closing_worker frontier_persistence
+        Transition_frontier_persistence.close_and_finish_copy
+          frontier_persistence
       in
-      let%bind () = frontier_persistence.worker_thread in
       let%map deserialized_frontier =
-        Transition_frontier_persistence.read ~logger ~trust_system ~verifier:()
-          ~root_snarked_ledger
+        Transition_frontier_persistence.deserialize ~directory_name ~logger
+          ~trust_system ~verifier:() ~root_snarked_ledger
           ~consensus_local_state:
             (Transition_frontier.consensus_local_state frontier)
-          (Transition_frontier_persistence.Worker.For_tests.transition_storage
-             frontier_persistence.worker)
       in
       Transition_frontier.equal frontier deserialized_frontier
 

--- a/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
@@ -178,7 +178,7 @@ module Make (Inputs : Intf.Main_inputs) = struct
     let transition_storage =
       Transition_storage.create ~directory:directory_name
     in
-    let result = f transition_storage in
+    let%map result = f transition_storage in
     Transition_storage.close transition_storage ;
     result
 


### PR DESCRIPTION
In the TF persistence layer, `with_db` was not using the `Async` monad to obtain the result of the function passed to it, so that database operations could occur after the database had been closed, which resulted in `InvalidObject` exceptions in RocksDB. 

Also, a couple of little cleanups suggested by @johnwu are in this PR.