### PR TITLE
Group map parameters at compile time

### DIFF
--- a/src/lib/crypto_params/dune
+++ b/src/lib/crypto_params/dune
@@ -3,7 +3,7 @@
  (public_name crypto_params)
  (library_flags -linkall)
  (inline_tests)
- (libraries chunked_pedersen_lib snarky bignum_bigint curve_choice chunk_table tuple_lib)
+ (libraries chunked_pedersen_lib snarky bignum_bigint curve_choice chunk_table tuple_lib group_map)
  (preprocess
   (pps ppx_jane bisect_ppx -- -conditional))
  (synopsis "Cryptographic parameters"))

--- a/src/lib/crypto_params/gen/dune
+++ b/src/lib/crypto_params/gen/dune
@@ -1,6 +1,6 @@
 (executable
  (name gen)
- (libraries async core crs coda_digestif fold_lib snarky tuple_lib ppxlib
+ (libraries async core crs coda_digestif fold_lib snarky tuple_lib ppxlib group_map
    curve_choice chunk_table chunked_triples)
  (preprocess
   (pps ppx_jane ppxlib.metaquot ppxlib.runner))

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -96,6 +96,31 @@ let params_ast ~loc =
     (fun (g1, g2, g3, g4) -> (conv g1, conv g2, conv g3, conv g4))
     [%e earray]
 
+let group_map_params =
+  Group_map.Params.create
+    (module Curve_choice.Tick0.Field)
+    ~a:Curve_choice.Tick_backend.Inner_curve.Coefficients.a
+    ~b:Curve_choice.Tick_backend.Inner_curve.Coefficients.b
+
+let group_map_params_structure ~loc =
+  let module T = struct
+    type t = Curve_choice.Tick_backend.Field.t Group_map.Params.t
+    [@@deriving bin_io]
+  end in
+  let module E = Ppxlib.Ast_builder.Make (struct
+    let loc = loc
+  end) in
+  let open E in
+  [%str
+    let params =
+      let module T = struct
+        type t = Curve_choice.Tick_backend.Field.t Group_map.Params.t
+        [@@deriving bin_io]
+      end in
+      Binable.of_string
+        (module T)
+        [%e estring (Binable.to_string (module T) group_map_params)]]
+
 let params_structure ~loc =
   let module E = Ppxlib.Ast_builder.Make (struct
     let loc = loc
@@ -194,4 +219,5 @@ let generate_ml_file filename structure =
 let () =
   generate_ml_file "pedersen_params.ml" params_structure ;
   generate_ml_file "pedersen_chunk_table.ml" chunk_table_structure ;
+  generate_ml_file "group_map_params.ml" group_map_params_structure ;
   ignore (exit 0)


### PR DESCRIPTION
Generate the group map parameters at compile time. This must be merged before https://github.com/CodaProtocol/coda/pull/2556.