### PR TITLE
Static dune file

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,4 @@
   (action (copy config/config.mlh config.mlh)))
 
 (env
-  (_ (flags (:standard -w @a-4-29-40-41-42-44-45-48-58-59-60))))
+  (_ (flags (:standard -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60))))

--- a/src/dune
+++ b/src/dune
@@ -1,46 +1,8 @@
-(* -*- tuareg -*- *)
+(rule
+  (targets config.mlh)
+  (mode promote)
+  (deps config/config.mlh)
+  (action (copy config/config.mlh config.mlh)))
 
-let rec all_but_last = function
-  | [] -> raise (Invalid_argument "all_but_last: empty list")
-  | [x] -> []
-  | h :: t -> h :: all_but_last t
-
-let file_extension filename =
-  try List.hd (List.rev (String.split_on_char '.' filename)) with _ -> ""
-
-let chop_file_extension filename =
-  try String.concat "." (all_but_last (String.split_on_char '.' filename)) with _ -> filename
-
-let get_directory_contents ~blacklist_exts dirname =
-  assert (Sys.is_directory dirname);
-  Sys.readdir dirname
-  |> Array.to_list
-  |> List.filter (fun name ->
-      not (List.exists ((=) (file_extension name)) blacklist_exts))
-
-let () =
-  let blacklist_exts = ["un~"] in
-  let profiles =
-    get_directory_contents ~blacklist_exts "config"
-    |> List.filter (fun name -> file_extension name = "mlh")
-    |> List.map chop_file_extension
-  in
-  let foreach ls ~f = List.map f ls |> String.concat "" in
-  (* the -w list here should be the same as in src/app/cli/src/dune and src/app/reformat/dune *)
-  let env_entry profile = "  ("^profile^" (flags (:standard -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60)))\n" in
-
-
-  let dune_file = "\
-    (rule\n\
-   \  (targets config.mlh)\n\
-   \  (mode promote)\n\
-   \  (deps config/config.mlh)\n\
-   \  (action (copy config/config.mlh config.mlh)))\n\
-    (env\n"^foreach profiles ~f:env_entry^")"
-  in
-  (* uncomment for debugging
-    let ch = open_out "generated_dune_file" in
-    output_string ch dune_file;
-    close_out ch;
-  *)
-  Jbuild_plugin.V1.send dune_file
+(env
+  (_ (flags (:standard -w @a-4-29-40-41-42-44-45-48-58-59-60))))


### PR DESCRIPTION
Replace the ML file `src/dune`, which generated a `dune` file to pass to dune via a plugin feature, with a static file.

The generated file had an identical warnings list for each profile, plus some boilerplate. The static file uses a wildcard to represent all profiles, plus the same boilerplate.

The static file produces the same results.

Closes #2619.