### PR TITLE
Hack: disable min_length_of_epoch check in consensus.select

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2514,24 +2514,10 @@ module Hooks = struct
       |> Option.value
            ~default:
              ( "default case"
-             , "candidate virtual min-length is longer than existing virtual \
-                min-length"
+             , "candidate length is longer than existing length"
              , lazy
-                 (let newest_epoch =
-                    Epoch.max existing.curr_epoch candidate.curr_epoch
-                  in
-                  let virtual_min_length (s : Consensus_state.Value.t) =
-                    if Epoch.(succ s.curr_epoch < newest_epoch) then
-                      Length.zero (* There is a gap of an entire epoch *)
-                    else if Epoch.(succ s.curr_epoch = newest_epoch) then
-                      Length.(
-                        min s.min_length_of_epoch s.curr_epoch_data.length)
-                      (* Imagine the latest epoch was padded out with zeroes to reach the newest_epoch *)
-                    else s.min_length_of_epoch
-                  in
-                  Length.(
-                    virtual_min_length existing < virtual_min_length candidate))
-             )
+                 (* TODO: Undo this hack once the min_length_of_epoch bug is fixed *)
+                 Length.(existing.length < candidate.length) )
     in
     let choice = if Lazy.force should_take then `Take else `Keep in
     log_choice ~precondition_msg ~choice_msg choice ;

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2517,7 +2517,8 @@ module Hooks = struct
              ( "default case"
              , "candidate length is longer than existing length"
              , lazy
-                 (* TODO: Undo this hack once the min_length_of_epoch bug is fixed *)
+                 (* TODO: THIS IS INSECURE! See #2643.
+                    Undo this hack once the min_length_of_epoch bug is fixed *)
                  Length.(existing.length < candidate.length) )
     in
     let choice = if Lazy.force should_take then `Take else `Keep in


### PR DESCRIPTION
This is a hack to disable min_length_of_epoch check in consensus selection rule. See #2643 
