### PR TITLE
Hack: DO NOT propose until it sync'd with the network

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -36,10 +36,9 @@ let daemon logger =
     (let%map_open conf_dir =
        flag "config-directory" ~doc:"DIR Configuration directory"
          (optional string)
-     and is_genesis =
-       flag "is-genesis"
-         ~doc:"Indicating that we are start from genesis or not"
-         (optional bool)
+     and from_genesis =
+       flag "from-genesis"
+         ~doc:"Indicating that we are starting from genesis or not" no_arg
      and propose_key =
        flag "propose-key"
          ~doc:
@@ -412,12 +411,11 @@ let daemon logger =
        @@ fun () ->
        let%bind () = maybe_sleep 3. in
        let%bind () =
-         Option.fold is_genesis ~init:Deferred.unit ~f:(fun _ is_genesis ->
-             if is_genesis then Deferred.unit
-             else
-               after
-                 ( Consensus.Constants.block_window_duration_ms * 2
-                 |> Float.of_int |> Time.Span.of_ms ) )
+         if from_genesis then Deferred.unit
+         else
+           after
+             ( Consensus.Constants.block_window_duration_ms * 2
+             |> Float.of_int |> Time.Span.of_ms )
        in
        M.start coda ;
        let web_service = Web_pipe.get_service () in

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -37,7 +37,7 @@ let daemon logger =
        flag "config-directory" ~doc:"DIR Configuration directory"
          (optional string)
      and is_genesis =
-       flag "is_genesis"
+       flag "is-genesis"
          ~doc:"Indicating that we are start from genesis or not"
          (optional bool)
      and propose_key =

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -292,22 +292,14 @@ module Make (Inputs : Intf.Inputs) = struct
   end
 
   let start t =
-    (* TODO: remove this hack once #2642 is fixed *)
-    Logger.debug t.logger ~module_:__MODULE__ ~location:__LOC__
-      "Proposer blocked waiting for potential bootstrap" ;
-    upon
-      (after
-         ( Consensus.Constants.(block_window_duration_ms * 2)
-         |> Float.of_int |> Time_ns.Span.of_ms ))
-      (fun () ->
-        Proposer.run ~logger:t.logger ~verifier:t.verifier
-          ~trust_system:t.trust_system ~transaction_pool:t.transaction_pool
-          ~get_completed_work:(Snark_pool.get_completed_work t.snark_pool)
-          ~time_controller:t.time_controller
-          ~keypairs:(Agent.read_only t.propose_keypairs)
-          ~consensus_local_state:t.consensus_local_state
-          ~frontier_reader:t.transition_frontier
-          ~transition_writer:t.proposer_transition_writer )
+    Proposer.run ~logger:t.logger ~verifier:t.verifier
+      ~trust_system:t.trust_system ~transaction_pool:t.transaction_pool
+      ~get_completed_work:(Snark_pool.get_completed_work t.snark_pool)
+      ~time_controller:t.time_controller
+      ~keypairs:(Agent.read_only t.propose_keypairs)
+      ~consensus_local_state:t.consensus_local_state
+      ~frontier_reader:t.transition_frontier
+      ~transition_writer:t.proposer_transition_writer
 
   let create_genesis_frontier (config : Config.t) =
     let consensus_local_state = config.consensus_local_state in

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -292,9 +292,12 @@ module Make (Inputs : Intf.Inputs) = struct
   end
 
   let start t =
+    (* TODO: remove this hack once #2642 is fixed *)
+    Logger.debug t.logger ~module_:__MODULE__ ~location:__LOC__
+      "Proposer blocked waiting for potential bootstrap" ;
     upon
       (after
-         ( Consensus.Constants.(block_window_duration_ms * k)
+         ( Consensus.Constants.(block_window_duration_ms * 2)
          |> Float.of_int |> Time_ns.Span.of_ms ))
       (fun () ->
         Proposer.run ~logger:t.logger ~verifier:t.verifier


### PR DESCRIPTION
The proposer has trouble doing bootstrap, see #2642. This is a hack to make the proposer wait for `k` slots to make sure that it would be synced before trying to propose.

The proper change would require us to do some kind of bootstrap eagerly before start the proposer. I still need some time to think about the changes needed to be done.