### PR TITLE
Wallet: workaround for daemon crash on spawn

### DIFF
--- a/frontend/wallet/.gitignore
+++ b/frontend/wallet/.gitignore
@@ -14,4 +14,5 @@ app.js
 *.cmi
 *.cmx
 *.o
+*.log
 coda-daemon-macos.zip

--- a/frontend/wallet/__tests__/wallet_test.re
+++ b/frontend/wallet/__tests__/wallet_test.re
@@ -130,9 +130,14 @@ describe("Bindings", () =>
       "echo and get stdout",
       ~timeout=10,
       cb => {
-        let echoProcess = ChildProcess.spawn("echo", [|"hello"|]);
+        let echoProcess =
+          ChildProcess.spawn(
+            "echo",
+            [|"hello"|],
+            {"stdio": ChildProcess.pipe, "env": ChildProcess.Process.env},
+          );
         let stdout = ChildProcess.Process.stdoutGet(echoProcess);
-        ChildProcess.ReadablePipe.on(stdout, "data", data =>
+        Stream.Readable.on(stdout, "data", data =>
           cb(expect(Node.Buffer.toString(data)) |> toEqual("hello\n"))
         );
       },
@@ -141,7 +146,12 @@ describe("Bindings", () =>
       "kill sleep and get exit code",
       ~timeout=10,
       cb => {
-        let pauseProcess = ChildProcess.spawn("sleep", [|"10"|]);
+        let pauseProcess =
+          ChildProcess.spawn(
+            "sleep",
+            [|"10"|],
+            {"stdio": ChildProcess.ignore, "env": ChildProcess.Process.env},
+          );
         ChildProcess.Process.onExit(
           pauseProcess,
           fun
@@ -157,7 +167,11 @@ describe("Bindings", () =>
       ~timeout=10,
       cb => {
         let pauseProcess =
-          ChildProcess.spawn("this-program-doesn't-exist", [||]);
+          ChildProcess.spawn(
+            "this-program-doesn't-exist",
+            [||],
+            {"stdio": ChildProcess.ignore, "env": ChildProcess.Process.env},
+          );
         ChildProcess.Process.onError(pauseProcess, _ => cb(pass));
       },
     );

--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -36,7 +36,7 @@
     "query": "send-introspection-query http://localhost:8080/graphql",
     "query-fake": "concurrently --kill-others 'yarn run fake' 'sleep 5 && yarn run query' || true",
     "reformat": "bsrefmt --in-place $(find src -name '*.re' -or -name '*.rei' -print)",
-    "test": "yarn run build && jest",
+    "test": "yarn run build && jest lib/js/",
     "dist": "yarn run build && yarn run pack && build",
     "dev": "concurrently --kill-others 'bsb -make-world -w' 'fpack watch --development ./lib/js/src/render/Index.js' 'electron ./lib/js/src/main/App.js'"
   },

--- a/frontend/wallet/src/common/Bindings.re
+++ b/frontend/wallet/src/common/Bindings.re
@@ -54,12 +54,18 @@ module Navigator = {
   };
 };
 
-module ChildProcess = {
-  module ReadablePipe = {
+module Stream = {
+  module Readable = {
     type t;
     [@bs.send] external on: (t, string, Node.Buffer.t => unit) => unit = "";
   };
 
+  module Writable = {
+    type t;
+  };
+};
+
+module ChildProcess = {
   module Error = {
     [@bs.deriving abstract]
     type t = {
@@ -69,10 +75,12 @@ module ChildProcess = {
   };
 
   module Process = {
+    [@bs.val] [@bs.module "process"] external env: Js.Dict.t(string) = "";
+
     [@bs.deriving abstract]
     type t = {
-      stdout: ReadablePipe.t,
-      stderr: ReadablePipe.t,
+      stdout: Stream.Readable.t,
+      stderr: Stream.Readable.t,
     };
 
     [@bs.send] external kill: (t, string) => unit = "";
@@ -103,12 +111,44 @@ module ChildProcess = {
       );
     let onExitTask = t => Task.uncallbackifyValue(onExit(t));
   };
-  [@bs.val] [@bs.module "child_process"]
-  external spawn: (string, array(string)) => Process.t = "spawn";
+
+  type io;
+
+  /**
+    https://nodejs.org/api/child_process.html#child_process_options_stdio
+    The stdio parameter to spawn is a 3-element heterogenous list of some string
+    keywords and Streams (as well as some other cases not supported here).
+    This function lets us safely construct this parameter (with makeIOTriple).
+    */
+  let makeIO = (v): io =>
+    switch (v) {
+    | `Pipe => Obj.magic("pipe")
+    | `Inherit => Obj.magic("inherit")
+    | `Ignore => Obj.magic("ignore")
+    | `Stream((s: Stream.Writable.t)) => Obj.magic(s)
+    };
+
+  let makeIOTriple = (io1, io2, io3) => (
+    makeIO(io1),
+    makeIO(io2),
+    makeIO(io3),
+  );
+
+  let pipe = makeIOTriple(`Pipe, `Pipe, `Pipe);
+  let ignore = makeIOTriple(`Ignore, `Ignore, `Ignore);
 
   [@bs.val] [@bs.module "child_process"]
-  external spawnWithEnv:
-    (string, array(string), {. "env": Js.Dict.t(string)}) => Process.t =
+  external spawn:
+    (
+      string,
+      array(string),
+      {
+        .
+        "env": Js.Dict.t(string),
+        "stdio": (io, io, io),
+      }
+    ) =>
+    Process.t =
     "spawn";
 };
 
@@ -122,6 +162,9 @@ module Fs = {
     ) =>
     unit =
     "";
+
+  [@bs.val] [@bs.module "fs"]
+  external openSync: (string, string) => Stream.Writable.t = "";
 
   [@bs.val] [@bs.module "fs"]
   external writeFile:

--- a/frontend/wallet/src/main/DaemonProcess.re
+++ b/frontend/wallet/src/main/DaemonProcess.re
@@ -66,7 +66,7 @@ module Process = {
      */
 
     let log = Fs.openSync(command.logfileName ++ ".log", "w");
-    let p =
+    let process =
       ChildProcess.spawn(
         command.executable,
         command.args,
@@ -77,7 +77,7 @@ module Process = {
         },
       );
 
-    ChildProcess.Process.onError(p, e =>
+    ChildProcess.Process.onError(process, e =>
       prerr_endline(
         "Daemon process "
         ++ command.executable
@@ -89,7 +89,7 @@ module Process = {
     );
 
     ChildProcess.Process.onExit(
-      p,
+      process,
       fun
       | `Code(code) =>
         if (code != 0) {
@@ -115,7 +115,7 @@ module Process = {
         },
     );
 
-    p;
+    process;
   };
 };
 


### PR DESCRIPTION
Copied from comment in the PR:
>child_process.spawn communicates with processes using sockets.
     When the proposer process starts up in the daemon, stdout and stderr
     are accessed using a helper function from async_unix:
     https://github.com/janestreet/async_unix/blob/ff13d69c96f4b857737263910b3f6b08311b5dfc/src/writer0.ml#L1465
     This causes async_unix to attempt to infer the type of stdout/err
     using and check if it has SO_ACCEPTCONN set using getsockopt.
     This flag is not supported on Mac, so it crashes with "Protocol not available"
      As a workaround, we have to redirect all output to a file.
      If this issue is ever resolved or we stop using async_unix, this code can be simplified:
     https://github.com/janestreet/async_unix/issues/15

This bug is triggered by something in the proposer process. The multiple-proposer change (https://github.com/CodaProtocol/coda/pull/2567) surfaced the issue because it starts up the proposer process by default (though it would have been a problem as soon as we started up a proposer process, so it's not really a problem with that PR).