### PR TITLE
Wallet: Hook network to faker

### DIFF
--- a/frontend/wallet/src/common/Route.re
+++ b/frontend/wallet/src/common/Route.re
@@ -7,35 +7,25 @@
 //     before actions happen
 // (2) Other code depends on this property
 
-open Tc;
-
 type t =
-  | Send
-  | DeleteWallet // TODO: include wallet id in payload
-  | Home;
+  | Home
+  | Settings;
 
 module Decode = {
   let parse =
     fun
-    | "send" => Some(Send)
-    | "wallet/delete" => Some(DeleteWallet)
-    | "" => Some(Home)
+    | "/settings" => Some(Home)
+    | "/" => Some(Home)
     | _ => None;
 
-  let t = json =>
-    Json.Decode.string(json)
-    |> parse
-    |> Option.withDefault(
-         ~default=raise(Json.Decode.DecodeError("Path can't parse")),
-       );
+  let t = json => Json.Decode.string(json) |> parse;
 };
 
 module Encode = {
   let print =
     fun
-    | Send => "send"
-    | DeleteWallet => "wallet/delete"
-    | Home => "";
+    | Settings => "/settings"
+    | Home => "/";
 
   let t = t => Json.Encode.string(print(t));
 };

--- a/frontend/wallet/src/main/App.re
+++ b/frontend/wallet/src/main/App.re
@@ -19,14 +19,13 @@ let createTray = dispatch => {
       make(
         Label("Open"),
         ~accelerator="CmdOrCtrl+O",
-        ~click=
-          () => AppWindow.get({path: Route.Home, dispatch}) |> AppWindow.show,
+        ~click=() => AppWindow.deepLink({path: Route.Home, dispatch}),
         (),
       ),
       make(
         Label("Settings"),
         ~accelerator="CmdOrCtrl+,",
-        ~click=() => AppWindow.deepLink({path: Route.Home, dispatch}),
+        ~click=() => AppWindow.deepLink({path: Route.Settings, dispatch}),
         (),
       ),
       make(Separator, ()),

--- a/frontend/wallet/src/main/AppWindow.re
+++ b/frontend/wallet/src/main/AppWindow.re
@@ -91,5 +91,5 @@ let deepLink = input => {
   // route handling is idempotent so doesn't matter if we also send the message
   // if window already exists
   send(w, `Deep_link(Route.print(input.path)));
-  ();
+  show(w);
 };

--- a/frontend/wallet/src/render/CodaProcess.re
+++ b/frontend/wallet/src/render/CodaProcess.re
@@ -103,20 +103,16 @@ let reduce = (acc, action) => {
   };
 };
 
-// TODO: Use the version query as health check
-module Version = [%graphql {| query version { version } |}];
-module VersionQuery = ReasonApollo.CreateQuery(Version);
-
-[@react.component]
-let make = (~children) => {
+let useHook = () => {
   let (_state, dispatch) =
     Hooks.Reducer.useReducer(reduce, {State.args: [], mode: Stable});
 
   let () =
     React.useEffect0(() => {
+      let token = MainCommunication.listen();
       dispatch(Action.ForceStartCoda);
-      None;
+      Some(() => MainCommunication.stopListening(token));
     });
 
-  children(dispatch);
+  dispatch;
 };

--- a/frontend/wallet/src/render/ReactApp.re
+++ b/frontend/wallet/src/render/ReactApp.re
@@ -1,26 +1,17 @@
 [@react.component]
 let make = () => {
   let settingsValue = AddressBookProvider.createContext();
-
-  let () =
-    React.useEffect0(() => {
-      let token = MainCommunication.listen();
-      Some(() => MainCommunication.stopListening(token));
-    });
+  let dispatch = CodaProcess.useHook();
 
   <AddressBookProvider value=settingsValue>
-    <ReasonApollo.Provider client=Apollo.client>
-      <CodaProcess>
-        {_dispatch =>
-          {
-            <Window>
-              <Header />
-              <Main> <SideBar /> <Router /> </Main>
-              <Footer />
-            </Window>
-          }
-        }
-      </CodaProcess>
-    </ReasonApollo.Provider>
+    <ProcessDispatchProvider value=dispatch>
+      <ReasonApollo.Provider client=Apollo.client>
+        <Window>
+          <Header />
+          <Main> <SideBar /> <Router /> </Main>
+          <Footer />
+        </Window>
+      </ReasonApollo.Provider>
+    </ProcessDispatchProvider>
   </AddressBookProvider>;
 };

--- a/frontend/wallet/src/render/components/Dropdown.re
+++ b/frontend/wallet/src/render/components/Dropdown.re
@@ -52,7 +52,7 @@ module Styles = {
       top(`percent(100.)),
       left(`px(-1)),
       right(`px(-1)),
-      maxHeight(`calc(`add, `rem(10.), `px(2))),
+      maxHeight(`calc((`add, `rem(10.), `px(2)))),
       overflow(`scroll),
       background(white),
       border(`px(1), `solid, Theme.Colors.marineAlpha(0.3)),
@@ -85,7 +85,14 @@ module Styles = {
 };
 
 [@react.component]
-let make = (~onChange, ~value, ~label, ~options: list((string, React.element))) => {
+let make =
+    (
+      ~onChange,
+      ~value,
+      ~label,
+      ~disabled=false,
+      ~options: list((string, React.element)),
+    ) => {
   let (isOpen, setOpen) = React.useState(() => false);
   let toggleOpen = () => setOpen(isOpen => !isOpen);
 
@@ -99,11 +106,13 @@ let make = (~onChange, ~value, ~label, ~options: list((string, React.element))) 
     className={Styles.container(isOpen)}
     onClick={e => {
       ReactEvent.Mouse.stopPropagation(e);
-      toggleOpen();
+      if (!disabled) {
+        toggleOpen();
+      };
     }}>
     <span className=Styles.label> {React.string(label ++ ":")} </span>
     <Spacer width=0.5 />
-    <span className=Styles.value> {currentLabel} </span>
+    <span className=Styles.value> currentLabel </span>
     <Spacer width=0.5 />
     <span className=Styles.icon> <Icon kind=Icon.ChevronDown /> </span>
     <div className={isOpen ? Styles.options : Styles.hidden}>
@@ -114,13 +123,12 @@ let make = (~onChange, ~value, ~label, ~options: list((string, React.element))) 
                key=value
                className=Styles.item
                onClick={_e => onChange(value)}>
-               {label}
+               label
              </div>,
          options,
        )
        |> Array.fromList
-       |> React.array
-      }
+       |> React.array}
     </div>
   </div>;
 };

--- a/frontend/wallet/src/render/contexts/ProcessDispatchProvider.re
+++ b/frontend/wallet/src/render/contexts/ProcessDispatchProvider.re
@@ -1,0 +1,8 @@
+module ProcessDispatchContextType = {
+  type t = CodaProcess.Action.t => unit;
+
+  let initialContext = ignore;
+};
+
+type t = ProcessDispatchContextType.t;
+include ContextProvider.Make(ProcessDispatchContextType);

--- a/frontend/wallet/src/render/views/settings/NetworkDropdown.re
+++ b/frontend/wallet/src/render/views/settings/NetworkDropdown.re
@@ -1,0 +1,123 @@
+open Tc;
+module Styles = {
+  open Css;
+
+  let networkContainer = style([width(`rem(21.))]);
+
+  let customNetwork = style([display(`flex), alignItems(`center)]);
+};
+
+type networkOption =
+  | NetworkOption(string)
+  | Custom(string)
+  | Loading
+  | None;
+
+let listToOptions = l => List.map(~f=x => (x, React.string(x)), l);
+
+module NetworkQueryString = [%graphql {|
+    {
+      network
+    }
+  |}];
+
+module NetworkQuery = ReasonApollo.CreateQuery(NetworkQueryString);
+
+module InnerDropdown = {
+  [@react.component]
+  let make = (~network) => {
+    let (networkValue, setNetworkValue) =
+      React.useState(() =>
+        switch (
+          (network: ReasonApolloTypes.queryResponse(NetworkQueryString.t))
+        ) {
+        | Loading => Loading
+        | Error(_) => None
+        | Data(d) =>
+          switch (d##network) {
+          | Some("testnet.codaprotocol.com") =>
+            NetworkOption("testnet.codaprotocol.com")
+          | Some(s) => Custom(s)
+          | None => None
+          }
+        }
+      );
+
+    let customNetwork = "Custom network";
+    let loading = "Loading...";
+
+    let dropDownValue =
+      switch (networkValue) {
+      | NetworkOption(s) => Some(s)
+      | Custom(_) => Some(customNetwork)
+      | Loading => Some(loading)
+      | None => None
+      };
+
+    let isLoading = networkValue == Loading;
+
+    let dropDownOptions = ["testnet.codaprotocol.com", customNetwork];
+    let dropDownOptions =
+      isLoading ? [loading, ...dropDownOptions] : dropDownOptions;
+
+    let dispatchToMain = React.useContext(ProcessDispatchProvider.context);
+
+    let dropdownHandler = s =>
+      switch (s) {
+      | "Custom network" =>
+        setNetworkValue(
+          fun
+          | NetworkOption(_) => Custom("")
+          | x => x,
+        )
+      | s =>
+        dispatchToMain(CodaProcess.Action.ChangeArgs(["-peer", s]));
+        setNetworkValue(_ => NetworkOption(s));
+      };
+
+    <div className=Styles.networkContainer>
+      <Dropdown
+        value=dropDownValue
+        label="Network"
+        options={listToOptions(dropDownOptions)}
+        onChange=dropdownHandler
+        disabled=isLoading
+      />
+      {switch (networkValue) {
+       | Custom(v) =>
+         <>
+           <Spacer height=0.5 />
+           <div className=Styles.customNetwork>
+             <Icon kind=Icon.BentArrow />
+             <Spacer width=0.5 />
+             <TextField
+               value=v
+               label="URL"
+               placeholder="my.network.com"
+               onChange={s => setNetworkValue(_ => Custom(s))}
+               button={
+                 <TextField.Button
+                   text="Save"
+                   color=`Green
+                   onClick={_ =>
+                     dispatchToMain(
+                       CodaProcess.Action.ChangeArgs(["-peer", v]),
+                     )
+                   }
+                 />
+               }
+             />
+           </div>
+         </>
+       | _ => React.null
+       }}
+    </div>;
+  };
+};
+
+[@react.component]
+let make = () => {
+  <NetworkQuery partialRefetch=true>
+    {response => <InnerDropdown network={response.result} />}
+  </NetworkQuery>;
+};

--- a/frontend/wallet/src/render/views/settings/SettingsPage.re
+++ b/frontend/wallet/src/render/views/settings/SettingsPage.re
@@ -6,17 +6,17 @@ module Styles = {
   let headerContainer =
     style([display(`flex), justifyContent(`spaceBetween)]);
 
-  let networkContainer = style([width(`rem(21.))]);
-
-  let customNetwork = style([display(`flex), alignItems(`center)]);
-
   let versionText =
     merge([
       Theme.Text.Header.h6,
-      style([display(`flex), textTransform(`uppercase), paddingTop(`rem(0.5))]),
+      style([
+        display(`flex),
+        textTransform(`uppercase),
+        paddingTop(`rem(0.5)),
+      ]),
     ]);
 
-  let container = 
+  let container =
     style([
       height(`percent(100.)),
       padding(`rem(2.)),
@@ -38,7 +38,7 @@ module Styles = {
     style([
       display(`flex),
       flexDirection(`column),
-      backgroundColor(`rgba(255, 255, 255, 0.8)),
+      backgroundColor(`rgba((255, 255, 255, 0.8))),
       borderRadius(`px(6)),
       border(`px(1), `solid, Theme.Colors.slateAlpha(0.4)),
       width(`rem(28.)),
@@ -57,20 +57,15 @@ module Styles = {
         lastChild([borderBottomWidth(`zero)]),
         hover([
           backgroundColor(Theme.Colors.midnightAlpha(0.05)),
-          selector(
-            "> :last-child",
-            [color(Theme.Colors.hyperlink)],
-          ),
+          selector("> :last-child", [color(Theme.Colors.hyperlink)]),
         ]),
       ]),
     ]);
 
   let walletName = style([width(`rem(12.5))]);
 
-  let walletChevron = style([
-    display(`inlineFlex), 
-    color(Theme.Colors.tealAlpha(0.5)),
-  ]);
+  let walletChevron =
+    style([display(`inlineFlex), color(Theme.Colors.tealAlpha(0.5))]);
 };
 
 module SettingsQueryString = [%graphql
@@ -93,11 +88,8 @@ module WalletSettingsItem = {
     let route = "/settings/" ++ Js.Global.encodeURIComponent(keyStr);
     <div
       className=Styles.walletItem
-      onClick={_ => ReasonReact.Router.push(route)}
-    >
-      <div className=Styles.walletName>
-        <WalletName pubkey={publicKey} />
-      </div>
+      onClick={_ => ReasonReact.Router.push(route)}>
+      <div className=Styles.walletName> <WalletName pubkey=publicKey /> </div>
       <span className=Theme.Text.Body.mono>
         <Pill> {React.string(PublicKey.prettyPrint(publicKey))} </Pill>
       </span>
@@ -109,43 +101,8 @@ module WalletSettingsItem = {
   };
 };
 
-let doubleList = l => List.map(~f=x => (x, React.string(x)), l);
-
-type networkOption =
-  | NetworkOption(string)
-  | Custom(string);
-
 [@react.component]
 let make = () => {
-  // TODO: Get and save value from the settings
-  let (networkValue, setNetworkValue) =
-    React.useState(() => NetworkOption("testnet.codaprotocol.com"));
-
-  let dropDownValue =
-    switch (networkValue) {
-    | NetworkOption(s) => Some(s)
-    | Custom(_) => Some("Custom network")
-    };
-
-  let dropDownOptions =
-    doubleList([
-      "testnet.codaprotocol.com",
-      "testnet2.codaprotocol.com",
-      "testnet3.codaprotocol.com",
-      "Custom network",
-    ]);
-
-  let dropdownHandler = s =>
-    switch (s) {
-    | "Custom network" =>
-      setNetworkValue(
-        fun
-        | NetworkOption(_) => Custom("")
-        | x => x,
-      )
-    | s => setNetworkValue(_ => NetworkOption(s))
-    };
-
   <SettingsQuery>
     {response =>
        switch (response.result) {
@@ -160,7 +117,9 @@ let make = () => {
            );
          <div className=Styles.container>
            <div className=Styles.headerContainer>
-             <div className=Theme.Text.Header.h3>{React.string("Node Settings")}</div>
+             <div className=Theme.Text.Header.h3>
+               {React.string("Node Settings")}
+             </div>
              <div className=Styles.versionText>
                <span
                  className=Css.(
@@ -178,40 +137,11 @@ let make = () => {
              </div>
            </div>
            <Spacer height=1. />
-           <div className=Styles.networkContainer>
-             <Dropdown
-               value=dropDownValue
-               label="Network"
-               options=dropDownOptions
-               onChange=dropdownHandler
-             />
-             {switch (networkValue) {
-              | Custom(v) =>
-                <>
-                  <Spacer height=0.5 />
-                  <div className=Styles.customNetwork>
-                    <Icon kind=Icon.BentArrow />
-                    <Spacer width=0.5 />
-                    <TextField
-                      value=v
-                      label="URL"
-                      placeholder="my.network.com"
-                      onChange={s => setNetworkValue(_ => Custom(s))}
-                      button={
-                        <TextField.Button
-                          text="Save"
-                          color=`Green
-                          onClick=ignore
-                        />
-                      }
-                    />
-                  </div>
-                </>
-              | _ => React.null
-              }}
-           </div>
+           <NetworkDropdown />
            <Spacer height=1. />
-           <div className=Styles.label> {React.string("Wallet Settings")} </div>
+           <div className=Styles.label>
+             {React.string("Wallet Settings")}
+           </div>
            <Spacer height=0.5 />
            <div className=Styles.walletItemContainer>
              {data##ownedWallets


### PR DESCRIPTION
Another step towards connecting to the daemon.

Converts the coda dispatch reducer to a hook instead of a wrapper component and makes a context for the dispatch function.

Now setting the network in the UI restarts the coda daemon. This doesn't work 100% yet but at least exercises the restart code.
Next PR will make it a little possible to run everything against the daemon (optionally).

The network dropdown is somewhat messy, we should look into seeing what it would take to be able to change this from graphql before doing too much more work to patch it (as with the multi-proposers).

Also:
- Fix the deeplink from the taskbar menu