### PR TITLE
Swap in base58_check for base64 in most places

### DIFF
--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -88,7 +88,7 @@ let get_accounts t =
   Ledger.to_list ledger
 
 let string_of_public_key =
-  Fn.compose Public_key.Compressed.to_base64 Account.public_key
+  Fn.compose Public_key.Compressed.to_base58_check Account.public_key
 
 let get_public_keys t =
   let open Participating_state.Let_syntax in

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -1,7 +1,7 @@
 (executable
  (name coda)
  (public_name coda)
- (libraries base64 core debug_assert daemon_rpcs pipe_lib coda_networking
+ (libraries base64 base58_check core debug_assert daemon_rpcs pipe_lib coda_networking
    proposer gossip_net kademlia coda_lib coda_numbers coda_intf lite_lib
    lite_compat coda_base coda_state coda_transition test_util staged_ledger sparse_ledger_lib
    syncable_ledger blockchain_snark transaction_snark snarky

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -29,8 +29,8 @@ module Types = struct
   open Schema
 
   module Stringable = struct
-    (** base64 representation of public key that is compressed to make snark computation efficent *)
-    let public_key = Public_key.Compressed.to_base64
+    (** base58 representation of public key that is compressed to make snark computation efficent *)
+    let public_key = Public_key.Compressed.to_base58_check
 
     (** Unix form of time, which is the number of milliseconds that elapsed from January 1, 1970 *)
     let date = Time.to_string
@@ -45,17 +45,20 @@ module Types = struct
 
     let amount amount = uint64 @@ Currency.Amount.to_uint64 amount
 
-    module State_hash = Codable.Make_base64 (State_hash.Stable.V1)
+    module State_hash = Codable.Make_base58_check (State_hash.Stable.V1)
   end
 
   module Id = struct
-    (* The id of a user_command is base64 the seralized version of the user_command *)
+    let version_byte = '\x17'
+
+    (* The id of a user_command is.encode of the seralized version of the user_command *)
     let user_command user_command =
       let bigstring =
         Bin_prot.Utils.bin_dump Coda_base.User_command.Stable.V1.bin_t.writer
           user_command
       in
-      Base64.encode_exn @@ Bigstring.to_string bigstring
+      let payload = Bigstring.to_string bigstring in
+      Base58_check.encode ~version_byte ~payload
   end
 
   let uint64_arg name ~doc ~typ =
@@ -203,7 +206,7 @@ module Types = struct
         [ field "previousStateHash" ~typ:(non_null string)
             ~args:Arg.[]
             ~resolve:(fun _ t ->
-              Stringable.State_hash.to_base64 t.previous_state_hash )
+              Stringable.State_hash.to_base58_check t.previous_state_hash )
         ; field "blockchainState"
             ~typ:(non_null blockchain_state)
             ~args:Arg.[]
@@ -222,7 +225,7 @@ module Types = struct
         ; field "stateHash" ~typ:(non_null string)
             ~args:Arg.[]
             ~resolve:(fun _ {With_hash.hash; _} ->
-              Stringable.State_hash.to_base64 hash )
+              Stringable.State_hash.to_base58_check hash )
         ; field "protocolState" ~typ:(non_null protocol_state)
             ~args:Arg.[]
             ~resolve:(fun _ {With_hash.data; _} -> data.protocol_state)
@@ -394,7 +397,7 @@ module Types = struct
 
   module Arguments = struct
     let public_key ~name public_key =
-      result_of_exn Public_key.Compressed.of_base64_exn public_key
+      result_of_exn Public_key.Compressed.of_base58_check_exn public_key
         ~error:(sprintf !"%s address is not valid." name)
   end
 
@@ -471,7 +474,7 @@ module Types = struct
           ~fields:
             [ arg "payment"
                 ~doc:
-                  "Payment is the base64 version of a serialized payment (via \
+                  "Payment is the base58 version of a serialized payment (via \
                    Jane Street bin_prot)"
                 ~typ:(non_null string)
             ; (* TODO: create a formal method for verifying that the provided added_time is correct  *)
@@ -664,15 +667,17 @@ module Types = struct
           let serialize = Id.user_command
 
           let deserialize serialized_payment =
-            let serialized_transaction =
-              Base64.decode_exn serialized_payment
+            let vb, serialized_transaction =
+              Base58_check.decode_exn serialized_payment
             in
+            if not (Char.equal vb Id.version_byte) then
+              failwith "Cursor.deserialize: unexpected version byte" ;
             Coda_base.User_command.Stable.V1.bin_t.reader.read
               (Bigstring.of_string serialized_transaction)
               ~pos_ref:(ref 0)
 
           let doc =
-            "Cursor is the base64 version of a serialized user command (via \
+            "Cursor is the base58 version of a serialized user command (via \
              Jane Street bin_prot)"
         end
 
@@ -703,12 +708,12 @@ module Types = struct
         module Cursor = struct
           type t = State_hash.t
 
-          let serialize = Stringable.State_hash.to_base64
+          let serialize = Stringable.State_hash.to_base58_check
 
-          let deserialize = Stringable.State_hash.of_base64_exn
+          let deserialize = Stringable.State_hash.of_base58_check_exn
 
           let doc =
-            "Cursor is the base64 version of a serialized user command (via \
+            "Cursor is the base58 version of a serialized user command (via \
              Jane Street bin_prot)"
         end
 

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -49,9 +49,9 @@ module Types = struct
   end
 
   module Id = struct
-    let version_byte = '\x17'
+    let version_byte = Base58_check.Version_bytes.graphql
 
-    (* The id of a user_command is.encode of the seralized version of the user_command *)
+    (* The id of a user_command is the Base58Check encoding of the serialized version of the user_command *)
     let user_command user_command =
       let bigstring =
         Bin_prot.Utils.bin_dump Coda_base.User_command.Stable.V1.bin_t.writer

--- a/src/app/cli/src/web_pipe.ml
+++ b/src/app/cli/src/web_pipe.ml
@@ -20,9 +20,8 @@ module type Intf = sig
        Strict_pipe.Reader.t
 end
 
-let version_byte = '\x41'
-
 let to_base58 m x =
+  let version_byte = Base58_check.Version_bytes.web_pipe in
   Base58_check.encode ~version_byte ~payload:(Binable.to_string m x)
 
 module Storage (Bin : Binable.S) = struct
@@ -133,12 +132,10 @@ let run_service coda ~conf_dir ~logger =
           ~f:(fun _ ->
             Writer.save (path ^/ "chain")
               ~contents:
-                (Base58_check.encode ~version_byte
-                   ~payload:
-                     (Binable.to_string
-                        (module Lite_base.Lite_chain)
-                        (get_lite_chain coda
-                           [Public_key.compress keypair.public_key]))) )
+                (to_base58
+                   (module Lite_base.Lite_chain)
+                   (get_lite_chain coda [Public_key.compress keypair.public_key]))
+        )
         |> don't_wait_for
     | `S3 ->
         Logger.info logger ~module_:__MODULE__ ~location:__LOC__

--- a/src/app/mock_wallet_data/dune
+++ b/src/app/mock_wallet_data/dune
@@ -2,7 +2,7 @@
  (name mock_wallet_data)
  (public_name mock_wallet_data)
  (package mock_wallet_data)
- (libraries core async auxiliary_database coda_base secrets)
+ (libraries core async auxiliary_database coda_base secrets base58_check)
  (preprocess (pps ppx_jane))
  (modes native)
  )

--- a/src/app/mock_wallet_data/mock_wallet_data.ml
+++ b/src/app/mock_wallet_data/mock_wallet_data.ml
@@ -3,7 +3,8 @@ open Async
 
 let render_keys public_keys =
   String.concat ~sep:"\n"
-  @@ List.map public_keys ~f:Signature_lib.Public_key.Compressed.to_base64
+  @@ List.map public_keys
+       ~f:Signature_lib.Public_key.Compressed.to_base58_check
 
 let command =
   let open Command.Let_syntax in

--- a/src/lib/base58_check/base58_check.ml
+++ b/src/lib/base58_check/base58_check.ml
@@ -54,6 +54,8 @@ let decode_exn s =
   let version_byte = decoded.[0] in
   (version_byte, payload)
 
+module Version_bytes = Version_bytes
+
 let%test_module "empty string" =
   ( module struct
     let test_roundtrip version_byte payload =

--- a/src/lib/base58_check/base58_check.mli
+++ b/src/lib/base58_check/base58_check.mli
@@ -5,7 +5,7 @@ exception Invalid_base58_checksum
 exception Invalid_base58_check_length
 
 (** apply Base58Check algorithm to version byte and payload *)
-val base58_check : version_byte:char -> payload:string -> string
+val encode : version_byte:char -> payload:string -> string
 
 (** decode Base58Check result into version byte and payload; can raise the above exceptions *)
-val base58_check_decode_exn : string -> char * string
+val decode_exn : string -> char * string

--- a/src/lib/base58_check/base58_check.mli
+++ b/src/lib/base58_check/base58_check.mli
@@ -9,3 +9,5 @@ val encode : version_byte:char -> payload:string -> string
 
 (** decode Base58Check result into version byte and payload; can raise the above exceptions *)
 val decode_exn : string -> char * string
+
+module Version_bytes : module type of Version_bytes

--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -1,0 +1,27 @@
+(* version_bytes.ml -- version bytes for Base58Check encodings *)
+
+type t = char
+
+(* each of the following values should be distinct *)
+
+let graphql : t = '\x17'
+
+let web_pipe : t = '\x41'
+
+let data_hash : t = '\x37'
+
+let proof : t = '\x70'
+
+let signature : t = '\x9A'
+
+let non_zero_curve_point : t = '\xCD'
+
+let non_zero_curve_point_compressed : t = '\xCA'
+
+let random_oracle_base : t = '\x03'
+
+let private_key : t = '\x5A'
+
+let staged_ledger_hash_aux_hash : t = '\x0B'
+
+let staged_ledger_hash_pending_coinbase_aux : t = '\x81'

--- a/src/lib/cli_lib/arg_type.ml
+++ b/src/lib/cli_lib/arg_type.ml
@@ -10,9 +10,9 @@ let int16 =
 module Key_arg_type (Key : sig
   type t
 
-  val of_base64_exn : string -> t
+  val of_base58_check_exn : string -> t
 
-  val to_base64 : t -> string
+  val to_base58_check : t -> string
 
   val name : string
 
@@ -21,14 +21,14 @@ end) =
 struct
   let arg_type =
     Command.Arg_type.create (fun s ->
-        try Key.of_base64_exn s
+        try Key.of_base58_check_exn s
         with e ->
           failwithf
             "Couldn't read %s (Invalid key format) %s -- here's a sample one: \
              %s"
             Key.name
             (Error.to_string_hum (Error.of_exn e))
-            (Key.to_base64 (Key.random ()))
+            (Key.to_base58_check (Key.random ()))
             () )
 end
 

--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -26,6 +26,8 @@ module type Basic = sig
       type nonrec t = t
       [@@deriving bin_io, sexp, compare, hash, yojson, version]
 
+      val version_byte : char (* for base58_check *)
+
       include Hashable_binable with type t := t
 
       include Comparable.S with type t := t
@@ -87,6 +89,9 @@ struct
       end
 
       include T
+
+      let version_byte = '\x37'
+
       include Registration.Make_latest_version (T)
       include Hashable.Make_binable (T)
       include Comparable.Make (T)

--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -90,7 +90,7 @@ struct
 
       include T
 
-      let version_byte = '\x37'
+      let version_byte = Base58_check.Version_bytes.data_hash
 
       include Registration.Make_latest_version (T)
       include Hashable.Make_binable (T)

--- a/src/lib/coda_base/data_hash.mli
+++ b/src/lib/coda_base/data_hash.mli
@@ -21,6 +21,8 @@ module type Basic = sig
       type nonrec t = t
       [@@deriving bin_io, sexp, compare, hash, yojson, version]
 
+      val version_byte : char (* for base58_check *)
+
       include Hashable_binable with type t := t
 
       include Comparable.S with type t := t

--- a/src/lib/coda_base/gen/gen.ml
+++ b/src/lib/coda_base/gen/gen.ml
@@ -41,13 +41,13 @@ let expr ~loc =
       (List.map keypairs ~f:(fun {public_key; private_key} ->
            E.pexp_tuple
              [ estring
-                 (Public_key.Compressed.to_base64
+                 (Public_key.Compressed.to_base58_check
                     (Public_key.compress public_key))
-             ; estring (Private_key.to_base64 private_key) ] ))
+             ; estring (Private_key.to_base58_check private_key) ] ))
   in
   let%expr conv (pk, sk) =
-    ( Signature_lib.Public_key.Compressed.of_base64_exn pk
-    , Signature_lib.Private_key.of_base64_exn sk )
+    ( Signature_lib.Public_key.Compressed.of_base58_check_exn pk
+    , Signature_lib.Private_key.of_base58_check_exn sk )
   in
   Array.map conv [%e earray]
 
@@ -64,9 +64,10 @@ let json =
          `Assoc
            [ ( "public_key"
              , `String
-                 Public_key.(Compressed.to_base64 (compress kp.public_key)) )
-           ; ("private_key", `String (Private_key.to_base64 kp.private_key)) ]
-     ))
+                 Public_key.(
+                   Compressed.to_base58_check (compress kp.public_key)) )
+           ; ( "private_key"
+             , `String (Private_key.to_base58_check kp.private_key) ) ] ))
 
 let main () =
   Out_channel.with_file "sample_keypairs.ml" ~f:(fun ml_file ->

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -16,15 +16,20 @@ module Stable = struct
     include T
     include Sexpable.Of_stringable (T)
 
-    let to_yojson s = `String (Base64.encode_string (to_string s))
+    let version_byte = '\x70'
+
+    let to_yojson s =
+      `String (Base58_check.encode ~version_byte ~payload:(to_string s))
 
     let of_yojson = function
       | `String s -> (
-        match Base64.decode s with
-        | Ok s ->
-            Ok (of_string s)
-        | Error (`Msg e) ->
-            Error (sprintf "bad base64: %s" e) )
+        try
+          let vb, decoded = Base58_check.decode_exn s in
+          if Char.equal vb version_byte then Ok (of_string decoded)
+          else Error "of_yojson: unexpected version byte"
+        with exn ->
+          Error (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))
+        )
       | _ ->
           Error "expected `String"
 

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -16,7 +16,7 @@ module Stable = struct
     include T
     include Sexpable.Of_stringable (T)
 
-    let version_byte = '\x70'
+    let version_byte = Base58_check.Version_bytes.proof
 
     let to_yojson s =
       `String (Base58_check.encode ~version_byte ~payload:(to_string s))

--- a/src/lib/coda_base/signature.ml
+++ b/src/lib/coda_base/signature.ml
@@ -7,22 +7,21 @@ module Stable = struct
       type t = Snark_params.Tock.Field.t * Snark_params.Tock.Field.t
       [@@deriving sexp, eq, compare, hash, bin_io, version {asserted}]
 
+      let version_byte = '\x9A'
+
       (* TODO : version Field in snarky *)
     end
 
-    let to_base64 t = Binable.to_string (module T) t |> Base64.encode_string
-
-    let of_base64_exn s = Base64.decode_exn s |> Binable.of_string (module T)
-
     include T
+    include Codable.Make_base58_check (T)
     include Registration.Make_latest_version (T)
 
     include Codable.Make_of_string (struct
       type nonrec t = t
 
-      let to_string = to_base64
+      let to_string = to_base58_check
 
-      let of_string = of_base64_exn
+      let of_string = of_base58_check_exn
     end)
   end
 

--- a/src/lib/coda_base/signature.ml
+++ b/src/lib/coda_base/signature.ml
@@ -7,7 +7,7 @@ module Stable = struct
       type t = Snark_params.Tock.Field.t * Snark_params.Tock.Field.t
       [@@deriving sexp, eq, compare, hash, bin_io, version {asserted}]
 
-      let version_byte = '\x9A'
+      let version_byte = Base58_check.Version_bytes.signature
 
       (* TODO : version Field in snarky *)
     end

--- a/src/lib/coda_base/signature.mli
+++ b/src/lib/coda_base/signature.mli
@@ -20,8 +20,8 @@ open Snark_params.Tick
 
 type var = Inner_curve.Scalar.var * Inner_curve.Scalar.var
 
-val to_base64 : t -> string
+val to_base58_check : t -> string
 
-val of_base64_exn : string -> t
+val of_base58_check_exn : string -> t
 
 val dummy : t

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -95,3 +95,20 @@ struct
 
   include Make_of_string (String_ops)
 end
+
+module Make_base58_check (T : sig
+  type t [@@deriving bin_io]
+
+  val version_byte : char
+end) =
+struct
+  let to_base58_check t =
+    let payload = Binable.to_string (module T) t in
+    Base58_check.encode ~version_byte:T.version_byte ~payload
+
+  let of_base58_check_exn s =
+    let version_byte, decoded = Base58_check.decode_exn s in
+    if not (Char.equal version_byte T.version_byte) then
+      failwith "of.encode_exn: unexpected version byte" ;
+    Binable.of_string (module T) decoded
+end

--- a/src/lib/codable/dune
+++ b/src/lib/codable/dune
@@ -3,6 +3,6 @@
   (public_name codable)
   (library_flags (-linkall))
   (inline_tests)
-  (libraries core_kernel ppx_deriving_yojson.runtime yojson base64)
+  (libraries core_kernel ppx_deriving_yojson.runtime yojson base64 base58_check)
   (preprocess (pps ppx_jane ppx_deriving_yojson bisect_ppx -conditional))
   (synopsis "Extension of Yojson to make it easy for a type to derive yojson"))

--- a/src/lib/genesis_ledger/functor.ml
+++ b/src/lib/genesis_ledger/functor.ml
@@ -3,9 +3,9 @@ open Coda_base
 open Signature_lib
 open Currency
 
-let pk = Public_key.Compressed.of_base64_exn
+let pk = Public_key.Compressed.of_base58_check_exn
 
-let sk = Private_key.of_base64_exn
+let sk = Private_key.of_base58_check_exn
 
 module type Base_intf = sig
   val accounts : (Private_key.t option * Account.t) list

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -188,7 +188,7 @@ module Key = struct
 
   type t = Stable.Latest.t [@@deriving sexp, compare, hash]
 
-  let to_string = Signature_lib.Public_key.Compressed.to_base64
+  let to_string = Signature_lib.Public_key.Compressed.to_base58_check
 
   let gen = Account.key_gen
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -9,7 +9,7 @@ module Stable = struct
       type t = Tick.Field.t * Tick.Field.t
       [@@deriving bin_io, sexp, eq, compare, hash, version {asserted}]
 
-      let version_byte = '\xCD'
+      let version_byte = Base58_check.Version_bytes.non_zero_curve_point
     end
 
     include T
@@ -106,7 +106,8 @@ module Compressed = struct
         type t = (Field.t, bool) Poly.Stable.V1.t
         [@@deriving bin_io, sexp, eq, compare, hash, version {asserted}]
 
-        let version_byte = '\xCA'
+        let version_byte =
+          Base58_check.Version_bytes.non_zero_curve_point_compressed
       end
 
       include T

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -8,6 +8,8 @@ module Stable = struct
     module T = struct
       type t = Tick.Field.t * Tick.Field.t
       [@@deriving bin_io, sexp, eq, compare, hash, version {asserted}]
+
+      let version_byte = '\xCD'
     end
 
     include T
@@ -26,6 +28,7 @@ module Stable = struct
       bs
 
     include Codable.Make_base64 (T)
+    include Codable.Make_base58_check (T)
   end
 
   module Latest = V1
@@ -102,6 +105,8 @@ module Compressed = struct
       module T = struct
         type t = (Field.t, bool) Poly.Stable.V1.t
         [@@deriving bin_io, sexp, eq, compare, hash, version {asserted}]
+
+        let version_byte = '\xCA'
       end
 
       include T
@@ -127,6 +132,7 @@ module Compressed = struct
   include Comparable.Make_binable (Stable.Latest)
   include Hashable.Make_binable (Stable.Latest)
   include Codable.Make_base64 (Stable.Latest)
+  include Codable.Make_base58_check (Stable.Latest)
 
   let compress (x, y) : t = {x; is_odd= parity y}
 

--- a/src/lib/random_oracle_base/dune
+++ b/src/lib/random_oracle_base/dune
@@ -9,6 +9,6 @@
     tuple_lib
     blake2
     coda_digestif
-    base64 
+    base58_check
     module_version
     ))

--- a/src/lib/random_oracle_base/random_oracle_base.ml
+++ b/src/lib/random_oracle_base/random_oracle_base.ml
@@ -24,7 +24,7 @@ module Digest = struct
 
       include T
 
-      let version_byte = '\x03'
+      let version_byte = Base58_check.Version_bytes.random_oracle_base
 
       let to_yojson s = `String (Base58_check.encode ~version_byte ~payload:s)
 

--- a/src/lib/secrets/keypair.ml
+++ b/src/lib/secrets/keypair.ml
@@ -19,7 +19,7 @@ let write_exn {Keypair.private_key; public_key} ~(privkey_path : string)
     Private_key.to_bigstring private_key |> Bigstring.to_bytes
   in
   let pubkey_string =
-    Public_key.Compressed.to_base64 (Public_key.compress public_key)
+    Public_key.Compressed.to_base58_check (Public_key.compress public_key)
   in
   match%bind
     Secret_file.write ~path:privkey_path ~mkdir:true ~plaintext:privkey_bytes

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -12,7 +12,7 @@ let password = lazy (Deferred.Or_error.return (Bytes.of_string ""))
 let get_path {path; _} public_key =
   let pubkey_str =
     (* TODO: Do we need to version this? *)
-    Public_key.Compressed.to_base64 public_key
+    Public_key.Compressed.to_base58_check public_key
     |> String.tr ~target:'/' ~replacement:'x'
   in
   path ^/ pubkey_str

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -31,7 +31,7 @@ let of_bigstring_exn = Binable.of_bigstring (module Stable.Latest)
 
 let to_bigstring = Binable.to_bigstring (module Stable.Latest)
 
-let version_byte = '\x5A'
+let version_byte = Base58_check.Version_bytes.private_key
 
 let to_base58_check t =
   let payload = to_bigstring t |> Bigstring.to_string in

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -31,7 +31,14 @@ let of_bigstring_exn = Binable.of_bigstring (module Stable.Latest)
 
 let to_bigstring = Binable.to_bigstring (module Stable.Latest)
 
-let to_base64 t = to_bigstring t |> Bigstring.to_string |> Base64.encode_string
+let version_byte = '\x5A'
 
-let of_base64_exn s =
-  Base64.decode_exn s |> Bigstring.of_string |> of_bigstring_exn
+let to_base58_check t =
+  let payload = to_bigstring t |> Bigstring.to_string in
+  Base58_check.encode ~version_byte ~payload
+
+let of_base58_check_exn s =
+  let vb, decoded = Base58_check.decode_exn s in
+  if not (Char.equal vb version_byte) then
+    failwith "of.encode_exn: unexpected version byte" ;
+  decoded |> Bigstring.of_string |> of_bigstring_exn

--- a/src/lib/signature_lib/public_key.ml
+++ b/src/lib/signature_lib/public_key.ml
@@ -3,9 +3,10 @@ include Non_zero_curve_point
 include Codable.Make_of_string (struct
   type nonrec t = t
 
-  let to_string t = Compressed.to_base64 (compress t)
+  let to_string t = Compressed.to_base58_check (compress t)
 
-  let of_string string = decompress_exn (Compressed.of_base64_exn string)
+  let of_string string =
+    Compressed.of_base58_check_exn string |> decompress_exn
 end)
 
 let of_private_key_exn p =

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -84,6 +84,10 @@ module Compressed : sig
 
   val to_string : t -> string
 
+  val to_base58_check : t -> string
+
+  val of_base58_check_exn : string -> t
+
   module Checked : sig
     val equal : var -> var -> (Boolean.var, _) Checked.t
 

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -159,7 +159,7 @@ module Make (Inputs : Intf.Inputs_intf) :
 
   let arguments ~public_key ~daemon_address ~shutdown_on_disconnect =
     [ "-public-key"
-    ; Public_key.Compressed.to_base64 public_key
+    ; Public_key.Compressed.to_base58_check public_key
     ; "-daemon-address"
     ; Host_and_port.to_string daemon_address
     ; "-shutdown-on-disconnect"

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.ml
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.ml
@@ -16,7 +16,8 @@ module Aux_hash = struct
       module T = struct
         type t = string [@@deriving bin_io, sexp, eq, compare, hash, version]
 
-        let version_byte = '\x57'
+        let version_byte =
+          Base58_check.Version_bytes.staged_ledger_hash_aux_hash
 
         let to_yojson s =
           `String (Base58_check.encode ~version_byte ~payload:s)
@@ -71,7 +72,8 @@ module Pending_coinbase_aux = struct
       module T = struct
         type t = string [@@deriving bin_io, sexp, eq, compare, hash, version]
 
-        let version_byte = '\x81'
+        let version_byte =
+          Base58_check.Version_bytes.staged_ledger_hash_pending_coinbase_aux
 
         let to_yojson s =
           `String (Base58_check.encode ~version_byte ~payload:s)

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.ml
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.ml
@@ -16,15 +16,21 @@ module Aux_hash = struct
       module T = struct
         type t = string [@@deriving bin_io, sexp, eq, compare, hash, version]
 
-        let to_yojson s = `String (Base64.encode_string s)
+        let version_byte = '\x57'
+
+        let to_yojson s =
+          `String (Base58_check.encode ~version_byte ~payload:s)
 
         let of_yojson = function
           | `String s -> (
-            match Base64.decode s with
-            | Ok s ->
-                Ok s
-            | Error (`Msg e) ->
-                Error (sprintf "bad base64: %s" e) )
+            try
+              let vb, decoded = Base58_check.decode_exn s in
+              if Char.equal vb version_byte then Ok decoded
+              else Error "of_yojson: unexpected version byte"
+            with exn ->
+              Error
+                (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))
+            )
           | _ ->
               Error "expected `String"
       end
@@ -65,15 +71,21 @@ module Pending_coinbase_aux = struct
       module T = struct
         type t = string [@@deriving bin_io, sexp, eq, compare, hash, version]
 
-        let to_yojson s = `String (Base64.encode_string s)
+        let version_byte = '\x81'
+
+        let to_yojson s =
+          `String (Base58_check.encode ~version_byte ~payload:s)
 
         let of_yojson = function
           | `String s -> (
-            match Base64.decode s with
-            | Ok s ->
-                Ok s
-            | Error (`Msg e) ->
-                Error (sprintf "bad base64: %s" e) )
+            try
+              let vb, decoded = Base58_check.decode_exn s in
+              if Char.equal vb version_byte then Ok decoded
+              else Error "of_yojson: unexpected version byte"
+            with exn ->
+              Error
+                (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))
+            )
           | _ ->
               Error "expected `String"
       end


### PR DESCRIPTION
Swap in base58_check in most places that base64 was being used. Didn't do it for lite client, can do that if this PR is OK. 

Tagged this PR as WIP to see if CI passes.

Renamed `Base58_check.base58_check` to `Base58_check.encode` and `Base58_check.base58_check_decode_exn` to `Base58_check.decode_exn`.
