### PR TITLE
Support tracking pre-existing propose sks

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -29,6 +29,13 @@ let daemon logger =
      and from_genesis =
        flag "from-genesis"
          ~doc:"Indicating that we are starting from genesis or not" no_arg
+     and unsafe_track_propose_key =
+       flag "unsafe-track-propose-key"
+         ~doc:
+           "Your private key will be copied to the inernal wallets folder \
+            stripped of its password if it is given using the `propose-key` \
+            flag. (default:don't copy a passwordless copy of the privatekey)"
+         no_arg
      and propose_key =
        flag "propose-key"
          ~doc:
@@ -269,7 +276,27 @@ let daemon logger =
                 `propose-public-key`" ;
              exit 11
          | Some sk_file, None ->
-             Secrets.Keypair.Terminal_stdin.read_exn sk_file >>| Option.some
+             let%bind keypair =
+               Secrets.Keypair.Terminal_stdin.read_exn sk_file
+             in
+             let%map () =
+               (* If we wish to track the propose key *)
+               if unsafe_track_propose_key then
+                 let pk = Public_key.compress keypair.public_key in
+                 let%bind wallets =
+                   Secrets.Wallets.load ~logger
+                     ~disk_location:wallets_disk_location
+                 in
+                 (* Either we already are tracking it *)
+                 match Secrets.Wallets.find wallets ~needle:pk with
+                 | Some _ ->
+                     Deferred.unit
+                 | None ->
+                     (* Or we import it *)
+                     Secrets.Wallets.import_keypair wallets keypair >>| ignore
+               else Deferred.unit
+             in
+             Some keypair
          | None, Some wallet_pk -> (
              match%bind
                Secrets.Wallets.load ~logger

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -32,9 +32,9 @@ let daemon logger =
      and unsafe_track_propose_key =
        flag "unsafe-track-propose-key"
          ~doc:
-           "Your private key will be copied to the inernal wallets folder \
+           "Your private key will be copied to the internal wallets folder \
             stripped of its password if it is given using the `propose-key` \
-            flag. (default:don't copy a passwordless copy of the privatekey)"
+            flag. (default:don't copy the private key)"
          no_arg
      and propose_key =
        flag "propose-key"

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -48,7 +48,7 @@ let load ~logger ~disk_location : t Deferred.t =
   in
   {cache; path}
 
-(** Effectfully generates a new private key file for the given keypair *)
+(** Generates a new private key file for the given keypair *)
 let import_keypair t keypair : Public_key.Compressed.t Deferred.t =
   let privkey_path =
     get_path t (Public_key.compress keypair.Keypair.public_key)
@@ -59,7 +59,7 @@ let import_keypair t keypair : Public_key.Compressed.t Deferred.t =
   Public_key.Compressed.Table.add_exn t.cache ~key:pk ~data:keypair ;
   pk
 
-(** Effectfully generates a new private key file and a keypair *)
+(** Generates a new private key file and a keypair *)
 let generate_new t : Public_key.Compressed.t Deferred.t =
   let keypair = Keypair.create () in
   import_keypair t keypair

--- a/src/lib/secrets/wallets.mli
+++ b/src/lib/secrets/wallets.mli
@@ -5,6 +5,8 @@ type t
 
 val load : logger:Logger.t -> disk_location:string -> t Deferred.t
 
+val import_keypair : t -> Keypair.t -> Public_key.Compressed.t Deferred.t
+
 val generate_new : t -> Public_key.Compressed.t Deferred.t
 
 val pks : t -> Public_key.Compressed.t list


### PR DESCRIPTION
Only occurs when `-unsafe-track-propose-key` is passed as this is an
unsafe operation that currently strips the passwords from private keys.

Reuses existing key generation code, so not too large of a change.