### PR TITLE
Add get-trust-status facility to client

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -64,11 +64,10 @@ let get_balance =
   let open Deferred.Let_syntax in
   let address_flag =
     flag "address"
-      ~doc:
-        "PUBLICKEY Public-key address of which you want to check the balance"
+      ~doc:"PUBLICKEY Public-key for which you want to check the balance"
       (required Cli_lib.Arg_type.public_key)
   in
-  Command.async ~summary:"Get balance associated with an address"
+  Command.async ~summary:"Get balance associated with a public key"
     (Cli_lib.Background_daemon.init address_flag ~f:(fun port address ->
          match%map
            dispatch Daemon_rpcs.Get_balance.rpc
@@ -81,6 +80,41 @@ let get_balance =
              printf "No account found at that public_key (zero balance)\n"
          | Error e ->
              printf "Failed to get balance %s\n" (Error.to_string_hum e) ))
+
+let get_trust_status =
+  let open Command.Param in
+  let open Deferred.Let_syntax in
+  let address_flag =
+    flag "ip-address"
+      ~doc:
+        "An IPv4 or IPv6 address for which you want to query the trust status"
+      (required Cli_lib.Arg_type.ip_address)
+  in
+  let json_flag = Cli_lib.Flag.json in
+  let flags = Args.zip2 address_flag json_flag in
+  Command.async ~summary:"Get the trust status associated with an IP address"
+    (Cli_lib.Background_daemon.init flags ~f:(fun port (ip_address, json) ->
+         match%map
+           dispatch Daemon_rpcs.Get_trust_status.rpc ip_address port
+         with
+         | Ok status ->
+             if json then
+               printf "%s\n"
+                 (Yojson.Safe.to_string
+                    (Trust_system.Peer_status.to_yojson status))
+             else
+               let ban_status =
+                 match status.banned with
+                 | Unbanned ->
+                     "Unbanned"
+                 | Banned_until tm ->
+                     sprintf "Banned_until %s"
+                       (Time.to_string_abs tm ~zone:Time.Zone.utc)
+               in
+               printf "%0.04f, %s\n" status.trust ban_status
+         | Error e ->
+             printf "Failed to get trust status %s\n" (Error.to_string_hum e)
+     ))
 
 let get_public_keys =
   let open Daemon_rpcs in
@@ -525,6 +559,7 @@ let command =
   Command.group ~summary:"Lightweight client commands"
     [ ("get-balance", get_balance)
     ; ("get-public-keys", get_public_keys)
+    ; ("get-trust-status", get_trust_status)
     ; ("prove-payment", prove_payment)
     ; ("verify-payment", verify_payment)
     ; ("get-nonce", get_nonce_cmd)

--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -87,7 +87,8 @@ let get_trust_status =
   let address_flag =
     flag "ip-address"
       ~doc:
-        "An IPv4 or IPv6 address for which you want to query the trust status"
+        "IP An IPv4 or IPv6 address for which you want to query the trust \
+         status"
       (required Cli_lib.Arg_type.ip_address)
   in
   let json_flag = Cli_lib.Flag.json in

--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -122,6 +122,11 @@ let get_balance t (addr : Public_key.Compressed.t) =
   let%map account = get_account t addr in
   account.Account.Poly.balance
 
+let get_trust_status t (ip_address : Unix.Inet_addr.Blocking_sexp.t) =
+  let config = Coda_lib.config t in
+  let trust_system = config.trust_system in
+  Trust_system.lookup trust_system ip_address
+
 module Receipt_chain_hash = struct
   (* Receipt.Chain_hash does not have bin_io *)
   include Receipt.Chain_hash.Stable.V1

--- a/src/app/cli/src/coda_run.ml
+++ b/src/app/cli/src/coda_run.ml
@@ -108,6 +108,8 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port ~coda
           return
             ( Coda_commands.get_balance coda pk
             |> Participating_state.active_exn ) )
+    ; implement Daemon_rpcs.Get_trust_status.rpc (fun () ip_address ->
+          return (Coda_commands.get_trust_status coda ip_address) )
     ; implement Daemon_rpcs.Verify_proof.rpc (fun () (pk, tx, proof) ->
           return
             ( Coda_commands.verify_payment coda pk tx proof

--- a/src/lib/cli_lib/arg_type.ml
+++ b/src/lib/cli_lib/arg_type.ml
@@ -67,6 +67,9 @@ let txn_nonce =
   let open Coda_base in
   Command.Arg_type.map Command.Param.string ~f:Account.Nonce.of_string
 
+let ip_address =
+  Command.Arg_type.map Command.Param.string ~f:Unix.Inet_addr.of_string
+
 type work_selection_method = Sequence | Random [@@deriving bin_io]
 
 let work_selection_method_val = function

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -317,6 +317,17 @@ module Get_balance = struct
     Rpc.Rpc.create ~name:"Get_balance" ~version:0 ~bin_query ~bin_response
 end
 
+module Get_trust_status = struct
+  type query = Unix.Inet_addr.Blocking_sexp.t [@@deriving bin_io]
+
+  type response = Trust_system.Peer_status.Stable.Latest.t [@@deriving bin_io]
+
+  type error = unit [@@deriving bin_io]
+
+  let rpc : (query, response) Rpc.Rpc.t =
+    Rpc.Rpc.create ~name:"Get_trust_score" ~version:0 ~bin_query ~bin_response
+end
+
 module Verify_proof = struct
   type query =
     Public_key.Compressed.Stable.Latest.t

--- a/src/lib/trust_system/banned_status.ml
+++ b/src/lib/trust_system/banned_status.ml
@@ -1,3 +1,33 @@
-open Core
+open Core_kernel
 
-type t = Unbanned | Banned_until of Time.t
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      (* TODO: there's no Time.Stable.Vn, how to version this? *)
+      type t = Unbanned | Banned_until of Time.t
+      [@@deriving bin_io, version {asserted}]
+    end
+
+    include T
+
+    let to_yojson = function
+      | Unbanned ->
+          `String "Unbanned"
+      | Banned_until tm ->
+          `Assoc
+            [ ( "Banned_until"
+              , `String (Time.to_string_abs tm ~zone:Time.Zone.utc) ) ]
+
+    let of_yojson = function
+      | `String "Unbanned" ->
+          Ok Unbanned
+      | `Assoc [("Banned_until", `String s)] ->
+          Ok (Banned_until (Time.of_string s))
+      | _ ->
+          Error "Banned_status.of_yojson: unexpected JSON"
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t = Unbanned | Banned_until of Time.t

--- a/src/lib/trust_system/peer_status.ml
+++ b/src/lib/trust_system/peer_status.ml
@@ -1,1 +1,17 @@
-type t = {trust: float; banned: Banned_status.t}
+open Core_kernel
+
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      type t = {trust: float; banned: Banned_status.Stable.V1.t}
+      [@@deriving bin_io, yojson, version]
+    end
+
+    include T
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t = {trust: float; banned: Banned_status.Stable.V1.t}
+[@@deriving yojson]


### PR DESCRIPTION
Plain text output:
```
coda.exe client get-trust-status -ip-address 192.168.1.1
0.0000, Unbanned
```
JSON:
```
coda.exe client get-trust-status -ip-address 192.168.1.1 -json
{"trust":0.0,"banned":"Unbanned"}
```
Since `Trust_system.Peer_status.t` needs `bin_io` to support this, that becomes a versioned type. But there's an issue versioning `Banned_status.t`, because `Time.t` in `Core` is not versioned, so versioning there is asserted for now. There is a `Time.Stable.some-other-type.V2.t`, which we can probably use, but the version ppx will need changes to handle that.

Partially implements #2658.

