### PR TITLE
Fix coda_version gen.sh when using git worktree

### DIFF
--- a/src/lib/coda_version/gen.sh
+++ b/src/lib/coda_version/gen.sh
@@ -1,16 +1,12 @@
 #!/bin/sh
+set -e
 
 if [ -n "$CODA_COMMIT_SHA1" ]; then
   # pull from env var if set
   id="$CODA_COMMIT_SHA1"
 else
-  # otherwise, query from git repository
-  # we are nested five directories deep (_build/<context>/src/lib/coda_version)
-  cd ../../../../..
-  if [ ! -d .git ]; then echo 'Error: git repository not found'; exit 1; fi
   id=$(git rev-parse --verify HEAD)
   if [ -n "$(git diff --stat)" ]; then id="[DIRTY]$id"; fi
-  cd -
 fi
 
-echo "let commit_id = \"$id\"" > $1
+echo "let commit_id = \"$id\"" > "$1"

--- a/src/lib/coda_version/gen.sh
+++ b/src/lib/coda_version/gen.sh
@@ -5,8 +5,13 @@ if [ -n "$CODA_COMMIT_SHA1" ]; then
   # pull from env var if set
   id="$CODA_COMMIT_SHA1"
 else
+  # otherwise, query from git repository
+  # we are nested five directories deep (_build/<context>/src/lib/coda_version)
+  cd ../../../../..
+  if [ ! -e .git ]; then echo 'Error: git repository not found'; exit 1; fi
   id=$(git rev-parse --verify HEAD)
   if [ -n "$(git diff --stat)" ]; then id="[DIRTY]$id"; fi
+  cd -
 fi
 
 echo "let commit_id = \"$id\"" > "$1"


### PR DESCRIPTION
`.git` is not a directory if you're using worktrees, so the script would fail. We rely on the exit status of `git rev-parse` to fail when not in a git repo in the new version. `set -e` makes non-zero exits inside `$(foo)` cause the script to fail. Also fixed possible issue if `$1` has spaces.