### PR TITLE
Purge uncaught exns in GraphQL layer

### DIFF
--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -10,11 +10,12 @@ let result_of_exn f v ~error = try Ok (f v) with _ -> Error error
 
 let result_of_or_error ?error v =
   Result.map_error v ~f:(fun internal_error ->
+      let str_error = Error.to_string_hum internal_error in
       match error with
       | None ->
-          Error.to_string_hum internal_error
+          str_error
       | Some error ->
-          sprintf "%s (%s)" error (Error.to_string_hum internal_error) )
+          sprintf "%s (%s)" error str_error )
 
 let result_field ~resolve =
   Schema.io_field ~resolve:(fun resolve_info src inputs ->
@@ -888,7 +889,7 @@ module Types = struct
           let deserialize ?error data =
             result_of_or_error
               (Stringable.State_hash.of_base58_check data)
-              ~error:(Option.value error ~default:"Invalid cursor data")
+              ~error:(Option.value error ~default:"Invalid state hash data")
 
           let doc =
             "Cursor is the base58 version of a serialized user command (via \

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -8,6 +8,14 @@ open Auxiliary_database
 
 let result_of_exn f v ~error = try Ok (f v) with _ -> Error error
 
+let result_of_or_error ?error v =
+  Result.map_error v ~f:(fun internal_error ->
+      match error with
+      | None ->
+          Error.to_string_hum internal_error
+      | Some error ->
+          sprintf "%s (%s)" error (Error.to_string_hum internal_error) )
+
 let result_field ~resolve =
   Schema.io_field ~resolve:(fun resolve_info src inputs ->
       Deferred.return @@ resolve resolve_info src inputs )
@@ -537,7 +545,8 @@ module Types = struct
 
   module Arguments = struct
     let public_key ~name public_key =
-      result_of_exn Public_key.Compressed.of_base58_check_exn public_key
+      result_of_or_error
+        (Public_key.Compressed.of_base58_check public_key)
         ~error:(sprintf !"%s address is not valid." name)
 
     let ip_address ~name ip_addr =
@@ -681,7 +690,7 @@ module Types = struct
 
         val serialize : t -> string
 
-        val deserialize : string -> t
+        val deserialize : ?error:string -> string -> (t, string) result
 
         val doc : string
       end
@@ -769,6 +778,14 @@ module Types = struct
                 @@ Arguments.public_key ~name:"publicKey" public_key
               in
               let database = get_database coda in
+              let resolve_cursor = function
+                | None ->
+                    Ok None
+                | Some data ->
+                    let open Result.Let_syntax in
+                    let%map decoded = Cursor.deserialize data in
+                    Some decoded
+              in
               let%map queried_nodes, has_earlier_page, has_later_page =
                 Deferred.return
                 @@
@@ -778,16 +795,15 @@ module Types = struct
                       "Illegal query: first and last must not be non-null \
                        value at the same time"
                 | num_to_query, cursor, None, _ ->
-                    Ok
-                      (Pagination_database.get_earlier_values database
-                         public_key
-                         (Option.map ~f:Cursor.deserialize cursor)
-                         num_to_query)
+                    let open Result.Let_syntax in
+                    let%map cursor = resolve_cursor cursor in
+                    Pagination_database.get_earlier_values database public_key
+                      cursor num_to_query
                 | None, _, num_to_query, cursor ->
-                    Ok
-                      (Pagination_database.get_later_values database public_key
-                         (Option.map ~f:Cursor.deserialize cursor)
-                         num_to_query)
+                    let open Result.Let_syntax in
+                    let%map cursor = resolve_cursor cursor in
+                    Pagination_database.get_later_values database public_key
+                      cursor num_to_query
               in
               ( ( List.map queried_nodes ~f:(fun node ->
                       {Edge.node; cursor= Cursor.serialize @@ to_cursor node}
@@ -814,15 +830,26 @@ module Types = struct
 
           let serialize = Id.user_command
 
-          let deserialize serialized_payment =
-            let vb, serialized_transaction =
-              Base58_check.decode_exn serialized_payment
+          let deserialize ?error serialized_payment =
+            let open Result.Let_syntax in
+            let%bind vb, serialized_transaction =
+              result_of_or_error
+                (Base58_check.decode serialized_payment)
+                ~error:(Option.value error ~default:"Invalid cursor")
             in
             if not (Char.equal vb Id.version_byte) then
-              failwith "Cursor.deserialize: unexpected version byte" ;
-            Coda_base.User_command.Stable.V1.bin_t.reader.read
-              (Bigstring.of_string serialized_transaction)
-              ~pos_ref:(ref 0)
+              let details = "Cursor.deserialize: unexpected version byte" in
+              Error
+                ( match error with
+                | None ->
+                    details
+                | Some e ->
+                    sprintf "%s (%s)" e details )
+            else
+              Ok
+                (Coda_base.User_command.Stable.V1.bin_t.reader.read
+                   (Bigstring.of_string serialized_transaction)
+                   ~pos_ref:(ref 0))
 
           let doc =
             "Cursor is the base58 version of a serialized user command (via \
@@ -858,7 +885,10 @@ module Types = struct
 
           let serialize = Stringable.State_hash.to_base58_check
 
-          let deserialize = Stringable.State_hash.of_base58_check_exn
+          let deserialize ?error data =
+            result_of_or_error
+              (Stringable.State_hash.of_base58_check data)
+              ~error:(Option.value error ~default:"Invalid cursor data")
 
           let doc =
             "Cursor is the base58 version of a serialized user command (via \
@@ -1133,8 +1163,8 @@ module Mutations = struct
             ~error:"Invalid `time` provided"
         in
         let%map payment =
-          result_of_exn Types.Pagination.User_command.Inputs.Cursor.deserialize
-            payment ~error:"Invaid `payment` provided"
+          Types.Pagination.User_command.Inputs.Cursor.deserialize
+            ~error:"Invaid `payment` provided" payment
         in
         let transaction_database = Coda_lib.transaction_database coda in
         Transaction_database.add transaction_database payment added_time ;

--- a/src/lib/base58_check/base58_check.ml
+++ b/src/lib/base58_check/base58_check.ml
@@ -1,6 +1,6 @@
 (* base58_check.ml : implement Base58Check algorithm
    see: https://www.oreilly.com/library/view/mastering-bitcoin-2nd/9781491954379/ch04.html#base58
- *)
+*)
 
 open Core_kernel
 
@@ -53,6 +53,15 @@ let decode_exn s =
   then raise Invalid_base58_checksum ;
   let version_byte = decoded.[0] in
   (version_byte, payload)
+
+let decode s =
+  try Ok (decode_exn s) with
+  | B58.Invalid_base58_character ->
+      Or_error.error_string "Invalid base58 character"
+  | Invalid_base58_check_length ->
+      Or_error.error_string "Invalid base58 check length"
+  | Invalid_base58_checksum ->
+      Or_error.error_string "Invalid base58 checksum"
 
 module Version_bytes = Version_bytes
 

--- a/src/lib/base58_check/base58_check.mli
+++ b/src/lib/base58_check/base58_check.mli
@@ -1,3 +1,5 @@
+open Core_kernel
+
 (* base58_check.mli -- implementation of Base58Check algorithm *)
 
 exception Invalid_base58_checksum
@@ -7,7 +9,11 @@ exception Invalid_base58_check_length
 (** apply Base58Check algorithm to version byte and payload *)
 val encode : version_byte:char -> payload:string -> string
 
-(** decode Base58Check result into version byte and payload; can raise the above exceptions *)
+(** decode Base58Check result into version byte and payload; can raise the above
+ * exceptions and a B58.Invalid_base58_character *)
 val decode_exn : string -> char * string
+
+(** decode Base58Check result into version byte and payload *)
+val decode : string -> (char * string) Or_error.t
 
 module Version_bytes : module type of Version_bytes

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -110,7 +110,7 @@ struct
     let open Or_error.Let_syntax in
     let%bind version_byte, decoded = Base58_check.decode s in
     if not (Char.equal version_byte T.version_byte) then
-      Or_error.error_string "of.encode_exn: unexpected version byte"
+      Or_error.error_string "of_base58_check: unexpected version byte"
     else Ok (Binable.of_string (module T) decoded)
 
   let of_base58_check_exn s = of_base58_check s |> Or_error.ok_exn

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -106,9 +106,12 @@ struct
     let payload = Binable.to_string (module T) t in
     Base58_check.encode ~version_byte:T.version_byte ~payload
 
-  let of_base58_check_exn s =
-    let version_byte, decoded = Base58_check.decode_exn s in
+  let of_base58_check s =
+    let open Or_error.Let_syntax in
+    let%bind version_byte, decoded = Base58_check.decode s in
     if not (Char.equal version_byte T.version_byte) then
-      failwith "of.encode_exn: unexpected version byte" ;
-    Binable.of_string (module T) decoded
+      Or_error.error_string "of.encode_exn: unexpected version byte"
+    else Ok (Binable.of_string (module T) decoded)
+
+  let of_base58_check_exn s = of_base58_check s |> Or_error.ok_exn
 end

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -88,6 +88,8 @@ module Compressed : sig
 
   val of_base58_check_exn : string -> t
 
+  val of_base58_check : string -> t Or_error.t
+
   module Checked : sig
     val equal : var -> var -> (Boolean.var, _) Checked.t
 


### PR DESCRIPTION
Mainly acheived via exposing a safe Base58_check.decode and using that
in the graphql layer as much as possible.

Tested with the following query (which used to crash the backend)

```
{
  blocks(after:"", filter:{relatedTo:"8QnLW56B6DaMYMcqgSWhPWf2DDmoFDYHStgZ4NEz2N9nEwnNs4SUJgPsUdGcgvjwsu"}){
    totalCount
  }
}
```

We now get an error message (that could be improved to report on which field the error occurred in, but that can be done as part of a larger error cleanup later)

```
{
  "errors": [
    {
      "message": "Invalid cursor data (Invalid base58 check length)",
      "path": [
        "blocks"
      ]
    }
  ],
  "data": null
}
``` 