### PR TITLE
Pass version byte to base58 decode

### DIFF
--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -848,24 +848,16 @@ module Types = struct
 
           let deserialize ?error serialized_payment =
             let open Result.Let_syntax in
-            let%bind vb, serialized_transaction =
+            let%bind serialized_transaction =
               result_of_or_error
-                (Base58_check.decode serialized_payment)
+                (Base58_check.decode ~version_byte:Id.version_byte
+                   serialized_payment)
                 ~error:(Option.value error ~default:"Invalid cursor")
             in
-            if not (Char.equal vb Id.version_byte) then
-              let details = "Cursor.deserialize: unexpected version byte" in
-              Error
-                ( match error with
-                | None ->
-                    details
-                | Some e ->
-                    sprintf "%s (%s)" e details )
-            else
-              Ok
-                (Coda_base.User_command.Stable.V1.bin_t.reader.read
-                   (Bigstring.of_string serialized_transaction)
-                   ~pos_ref:(ref 0))
+            Ok
+              (Coda_base.User_command.Stable.V1.bin_t.reader.read
+                 (Bigstring.of_string serialized_transaction)
+                 ~pos_ref:(ref 0))
 
           let doc =
             "Cursor is the base58 version of a serialized user command (via \

--- a/src/lib/base58_check/base58_check.ml
+++ b/src/lib/base58_check/base58_check.ml
@@ -6,6 +6,8 @@ open Core_kernel
 
 exception Invalid_base58_checksum
 
+exception Invalid_base58_version_byte
+
 exception Invalid_base58_check_length
 
 (* same as Bitcoin alphabet *)
@@ -34,7 +36,7 @@ let encode ~(version_byte : char) ~(payload : string) =
   let bytes = version_string ^ payload ^ checksum |> Bytes.of_string in
   B58.encode coda_alphabet bytes |> Bytes.to_string
 
-let decode_exn s =
+let decode_exn ~(version_byte : char) s =
   let bytes = Bytes.of_string s in
   let decoded = B58.decode coda_alphabet bytes |> Bytes.to_string in
   let len = String.length decoded in
@@ -51,17 +53,20 @@ let decode_exn s =
   in
   if not (String.equal checksum (compute_checksum ~version_string ~payload))
   then raise Invalid_base58_checksum ;
-  let version_byte = decoded.[0] in
-  (version_byte, payload)
+  if not (Char.equal decoded.[0] version_byte) then
+    raise Invalid_base58_version_byte ;
+  payload
 
-let decode s =
-  try Ok (decode_exn s) with
+let decode ~(version_byte : char) s =
+  try Ok (decode_exn ~version_byte s) with
   | B58.Invalid_base58_character ->
       Or_error.error_string "Invalid base58 character"
   | Invalid_base58_check_length ->
       Or_error.error_string "Invalid base58 check length"
   | Invalid_base58_checksum ->
       Or_error.error_string "Invalid base58 checksum"
+  | Invalid_base58_version_byte ->
+      Or_error.error_string "Invalid base58 version byte"
 
 module Version_bytes = Version_bytes
 
@@ -69,8 +74,8 @@ let%test_module "empty string" =
   ( module struct
     let test_roundtrip version_byte payload =
       let encoded = encode ~version_byte ~payload in
-      let version_byte', payload' = decode_exn encoded in
-      String.equal payload payload' && Char.equal version_byte version_byte'
+      let payload' = decode_exn ~version_byte encoded in
+      String.equal payload payload'
 
     let%test "empty_string" = test_roundtrip '\x57' ""
 
@@ -85,9 +90,9 @@ let%test_module "empty string" =
 
     let%test "invalid checksum" =
       try
+        let version_byte = '\xAC' in
         let encoded =
-          encode ~version_byte:'\xAC'
-            ~payload:"Bluer than velvet were her eyes"
+          encode ~version_byte ~payload:"Bluer than velvet were her eyes"
         in
         let bytes = Bytes.of_string encoded in
         let len = Bytes.length bytes in
@@ -99,13 +104,13 @@ let%test_module "empty string" =
         in
         Bytes.set bytes (len - 1) new_last_ch ;
         let encoded_bad_checksum = Bytes.to_string bytes in
-        let _version_byte, _payload = decode_exn encoded_bad_checksum in
+        let _payload = decode_exn ~version_byte encoded_bad_checksum in
         false
       with Invalid_base58_checksum -> true
 
     let%test "invalid length" =
       try
-        let _version_byte, _payload = decode_exn "abcd" in
+        let _payload = decode_exn ~version_byte:'\x53' "abcd" in
         false
       with Invalid_base58_check_length -> true
   end )

--- a/src/lib/base58_check/base58_check.mli
+++ b/src/lib/base58_check/base58_check.mli
@@ -4,16 +4,18 @@ open Core_kernel
 
 exception Invalid_base58_checksum
 
+exception Invalid_base58_version_byte
+
 exception Invalid_base58_check_length
 
 (** apply Base58Check algorithm to version byte and payload *)
 val encode : version_byte:char -> payload:string -> string
 
-(** decode Base58Check result into version byte and payload; can raise the above
+(** decode Base58Check result into payload; can raise the above
  * exceptions and a B58.Invalid_base58_character *)
-val decode_exn : string -> char * string
+val decode_exn : version_byte:char -> string -> string
 
-(** decode Base58Check result into version byte and payload *)
-val decode : string -> (char * string) Or_error.t
+(** decode Base58Check result into payload *)
+val decode : version_byte:char -> string -> string Or_error.t
 
 module Version_bytes : module type of Version_bytes

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -24,9 +24,8 @@ module Stable = struct
     let of_yojson = function
       | `String s -> (
         try
-          let vb, decoded = Base58_check.decode_exn s in
-          if Char.equal vb version_byte then Ok (of_string decoded)
-          else Error "of_yojson: unexpected version byte"
+          let decoded = Base58_check.decode_exn ~version_byte s in
+          Ok (of_string decoded)
         with exn ->
           Error (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))
         )

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -108,10 +108,8 @@ struct
 
   let of_base58_check s =
     let open Or_error.Let_syntax in
-    let%bind version_byte, decoded = Base58_check.decode s in
-    if not (Char.equal version_byte T.version_byte) then
-      Or_error.error_string "of_base58_check: unexpected version byte"
-    else Ok (Binable.of_string (module T) decoded)
+    let%bind decoded = Base58_check.decode ~version_byte:T.version_byte s in
+    Ok (Binable.of_string (module T) decoded)
 
   let of_base58_check_exn s = of_base58_check s |> Or_error.ok_exn
 end

--- a/src/lib/random_oracle_base/random_oracle_base.ml
+++ b/src/lib/random_oracle_base/random_oracle_base.ml
@@ -30,10 +30,7 @@ module Digest = struct
 
       let of_yojson = function
         | `String s -> (
-          try
-            let vb, decoded = Base58_check.decode_exn s in
-            if Char.equal vb version_byte then Ok decoded
-            else Error "of_yojson: unexpected version byte"
+          try Ok (Base58_check.decode_exn ~version_byte s)
           with exn ->
             Error
               (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn)) )

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -38,7 +38,5 @@ let to_base58_check t =
   Base58_check.encode ~version_byte ~payload
 
 let of_base58_check_exn s =
-  let vb, decoded = Base58_check.decode_exn s in
-  if not (Char.equal vb version_byte) then
-    failwith "of.encode_exn: unexpected version byte" ;
+  let decoded = Base58_check.decode_exn ~version_byte s in
   decoded |> Bigstring.of_string |> of_bigstring_exn

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.ml
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.ml
@@ -24,10 +24,7 @@ module Aux_hash = struct
 
         let of_yojson = function
           | `String s -> (
-            try
-              let vb, decoded = Base58_check.decode_exn s in
-              if Char.equal vb version_byte then Ok decoded
-              else Error "of_yojson: unexpected version byte"
+            try Ok (Base58_check.decode_exn ~version_byte s)
             with exn ->
               Error
                 (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))
@@ -80,10 +77,7 @@ module Pending_coinbase_aux = struct
 
         let of_yojson = function
           | `String s -> (
-            try
-              let vb, decoded = Base58_check.decode_exn s in
-              if Char.equal vb version_byte then Ok decoded
-              else Error "of_yojson: unexpected version byte"
+            try Ok (Base58_check.decode_exn ~version_byte s)
             with exn ->
               Error
                 (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))


### PR DESCRIPTION
Instead of returning the version byte when decoding a Base58Check string, pass the version byte to the decoder, which checks that the byte is valid. That saves callers the responsibility of verifying the version byte. 

Add an exception `Invalid_base58_version_byte`, which the decoder raises if the byte doesn't match the decoded version byte.