### PR TITLE
Arbitrary 32-byte contents in memos

### DIFF
--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -1115,7 +1115,7 @@ module Mutations = struct
     let%map memo =
       Option.value_map maybe_memo ~default:(Ok User_command_memo.dummy)
         ~f:(fun memo ->
-          result_of_exn User_command_memo.create_exn memo
+          result_of_exn User_command_memo.create_by_digesting_string_exn memo
             ~error:"Invalid `memo` provided." )
     in
     (sender_account, sender_kp, memo, receiver, fee)

--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -25,3 +25,5 @@ let private_key : t = '\x5A'
 let staged_ledger_hash_aux_hash : t = '\x0B'
 
 let staged_ledger_hash_pending_coinbase_aux : t = '\x81'
+
+let user_command_memo : t = '\xA2'

--- a/src/lib/coda_base/dune
+++ b/src/lib/coda_base/dune
@@ -9,7 +9,8 @@
     linked_tree
     hash_prefixes
     syncable_ledger
-    base64
+    base58_check
+    fold_lib
     signature_lib
     test_util
     random_oracle

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -98,7 +98,7 @@ module Gen = struct
     let%map body = create_body receiver in
     let payload : Payload.t =
       Payload.create ~fee ~nonce
-        ~memo:(User_command_memo.create_exn memo)
+        ~memo:(User_command_memo.create_by_digesting_string_exn memo)
         ~body
     in
     sign' sender payload

--- a/src/lib/coda_base/user_command_memo.ml
+++ b/src/lib/coda_base/user_command_memo.ml
@@ -28,7 +28,7 @@ type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash]
 [%%define_locally
 Stable.Latest.(to_yojson, of_yojson, to_string, of_string)]
 
-exception Too_long_user_memo_length
+exception Too_long_user_memo_input
 
 exception Too_long_digestible_string
 
@@ -51,6 +51,11 @@ let digest_length = Random_oracle.Digest.length_in_bytes
 
 let digest_length_byte = Char.of_int_exn digest_length
 
+(* +2 for tag and length bytes *)
+let memo_length = digest_length + 2
+
+let max_input_length = digest_length
+
 let tag (memo : t) = memo.[tag_index]
 
 let length memo = Char.to_int memo.[length_index]
@@ -58,16 +63,16 @@ let length memo = Char.to_int memo.[length_index]
 let is_digest memo = Char.equal (tag memo) digest_tag
 
 let is_valid memo =
-  Int.equal (String.length memo) (digest_length + 2)
+  Int.(String.length memo = memo_length)
   &&
-  let memo_len = length memo in
-  if is_digest memo then Int.equal memo_len digest_length
+  let length = length memo in
+  if is_digest memo then Int.(length = digest_length)
   else
     Char.equal (tag memo) bytes_tag
-    && Int.(memo_len <= digest_length)
+    && Int.(length <= digest_length)
     &&
     let padded =
-      String.sub memo ~pos:(memo_len + 2) ~len:(digest_length - memo_len)
+      String.sub memo ~pos:(length + 2) ~len:(digest_length - length)
     in
     String.for_all padded ~f:(Char.equal '\x00')
 
@@ -75,9 +80,9 @@ let create_by_digesting_string_exn s =
   if Int.(String.length s > max_digestible_string_length) then
     raise Too_long_digestible_string ;
   let digest = (Random_oracle.digest_string s :> t) in
-  String.init (digest_length + 2) ~f:(fun ndx ->
-      if Int.equal ndx tag_index then digest_tag
-      else if Int.equal ndx length_index then digest_length_byte
+  String.init memo_length ~f:(fun ndx ->
+      if Int.(ndx = tag_index) then digest_tag
+      else if Int.(ndx = length_index) then digest_length_byte
       else digest.[ndx - 2] )
 
 let create_by_digesting_string (s : string) =
@@ -96,35 +101,35 @@ end
 let create_from_value_exn (type t) (module M : Memoable with type t = t)
     (value : t) =
   let len = M.length value in
-  if not Int.(len <= digest_length) then raise Too_long_user_memo_length ;
-  String.init (digest_length + 2) ~f:(fun ndx ->
-      if Int.equal ndx tag_index then bytes_tag
-      else if Int.equal ndx length_index then Char.of_int_exn len
-      else if Int.(ndx <= len + 2) then M.get value (ndx - 2)
+  if Int.(len > max_input_length) then raise Too_long_user_memo_input ;
+  String.init memo_length ~f:(fun ndx ->
+      if Int.(ndx = tag_index) then bytes_tag
+      else if Int.(ndx = length_index) then Char.of_int_exn len
+      else if Int.(ndx < len + 2) then M.get value (ndx - 2)
       else '\x00' )
 
 let create_from_bytes_exn bytes = create_from_value_exn (module Bytes) bytes
 
 let create_from_bytes bytes =
   try Ok (create_from_bytes_exn bytes)
-  with Too_long_user_memo_length ->
+  with Too_long_user_memo_input ->
     Or_error.error_string
-      (sprintf "create_from_bytes: length exceeds %d" digest_length)
+      (sprintf "create_from_bytes: length exceeds %d" max_input_length)
 
 let create_from_string_exn s = create_from_value_exn (module String) s
 
 let create_from_string s =
   try Ok (create_from_string_exn s)
-  with Too_long_user_memo_length ->
+  with Too_long_user_memo_input ->
     Or_error.error_string
-      (sprintf "create_from_string: length exceeds %d" digest_length)
+      (sprintf "create_from_string: length exceeds %d" max_input_length)
 
 let dummy = (create_by_digesting_string_exn "" :> t)
 
 module Boolean = Tick0.Boolean
 module Typ = Tick0.Typ
 
-(* the code below is much the same as in Random_oracle.Digest; tag and length bytes 
+(* the code below is much the same as in Random_oracle.Digest; tag and length bytes
    make it a little different
  *)
 
@@ -137,13 +142,13 @@ module Checked = struct
     Fold_lib.Fold.(to_list (group3 ~default:Boolean.false_ (of_array t)))
 
   let constant unchecked =
-    assert (Int.(String.length (unchecked :> string) = digest_length + 2)) ;
+    assert (Int.(String.length (unchecked :> string) = memo_length)) ;
     Array.map
       (Blake2.string_to_bits (unchecked :> string))
       ~f:Boolean.var_of_value
 end
 
-let length_in_bits = 8 * digest_length
+let length_in_bits = 8 * memo_length
 
 let length_in_triples = (length_in_bits + 2) / 3
 
@@ -163,6 +168,37 @@ let fold t = Fold_lib.Fold.group3 ~default:false (fold_bits t)
 
 let typ : (Checked.t, t) Typ.t =
   Typ.transport
-    (Typ.array ~length:Blake2.digest_size_in_bits Boolean.typ)
+    (Typ.array ~length:length_in_bits Boolean.typ)
     ~there:(fun (t : t) -> Blake2.string_to_bits (t :> string))
     ~back:(fun bs -> of_string (Blake2.bits_to_string bs))
+
+let%test_module "user_command_memo" =
+  ( module struct
+    let data memo = String.sub memo ~pos:(length_index + 1) ~len:(length memo)
+
+    let%test "digest string" =
+      let s = "this is a string" in
+      let memo = create_by_digesting_string_exn s in
+      is_valid memo
+
+    let%test "digest too-long string" =
+      let s =
+        String.init (max_digestible_string_length + 1) ~f:(fun _ -> '\xFF')
+      in
+      try
+        let _ = create_by_digesting_string_exn s in
+        false
+      with Too_long_digestible_string -> true
+
+    let%test "memo from string" =
+      let s = "time and tide wait for no one" in
+      let memo = create_from_string_exn s in
+      is_valid memo && String.equal s (data memo)
+
+    let%test "memo from too-long string" =
+      let s = String.init (max_input_length + 1) ~f:(fun _ -> '\xFF') in
+      try
+        let _ = create_from_string_exn s in
+        false
+      with Too_long_user_memo_input -> true
+  end )

--- a/src/lib/coda_base/user_command_memo.ml
+++ b/src/lib/coda_base/user_command_memo.ml
@@ -1,21 +1,99 @@
 open Core
-include Random_oracle.Digest
+open Crypto_params
 
-(*TODO Currently sha-ing a string. Actual data in the memo needs to be decided *)
-let max_size_in_bytes = 1000
+module Stable = struct
+  module V1 = struct
+    module T = struct
+      open Base58_check
 
-let create_exn s =
-  let max_size = 1000 in
-  if Int.(String.length s > max_size_in_bytes) then
-    failwithf !"Memo data too long. Max size = %d" max_size ()
-  else Random_oracle.digest_string s
+      type t = string
+      [@@deriving bin_io, sexp, eq, compare, hash, version {unnumbered}]
 
-let dummy = create_exn ""
+      let version_byte = Version_bytes.user_command_memo
 
-include Codable.Make_of_string (struct
-  type nonrec t = t
+      let to_string (memo : t) : string = encode ~version_byte ~payload:memo
 
-  let to_string (memo : t) = Base64.encode_string (memo :> string)
+      let of_string (s : string) : t = decode_exn ~version_byte s
+    end
 
-  let of_string = Fn.compose of_string Base64.decode_exn
-end)
+    include T
+    include Codable.Make_of_string (T)
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t [@@deriving sexp, eq, compare, hash]
+
+[%%define_locally
+Stable.Latest.(to_yojson, of_yojson, to_string, of_string)]
+
+exception Invalid_user_memo_length
+
+exception Too_long_digestible_string
+
+let max_digestible_string_length = 1000
+
+[%%define_locally
+Random_oracle.Digest.(length_in_bytes, length_in_triples)]
+
+let create_by_digesting_string_exn s =
+  if Int.(String.length s > max_digestible_string_length) then
+    raise Too_long_digestible_string ;
+  (Random_oracle.digest_string s :> t)
+
+let create_from_bytes32_exn bytes : t =
+  if not (Int.equal (Bytes.length bytes) length_in_bytes) then
+    raise Invalid_user_memo_length ;
+  Bytes.to_string bytes
+
+let create_from_string32_exn s : t =
+  if not (Int.equal (String.length s) length_in_bytes) then
+    raise Invalid_user_memo_length ;
+  s
+
+let dummy = (create_by_digesting_string_exn "" :> t)
+
+module Boolean = Tick0.Boolean
+module Typ = Tick0.Typ
+
+(* the code below is much the same as in Random_oracle.Digest
+   we can't just use the values there, because Random_oracle.Digest.t is private;
+   we could reverse the dependency by having Random_oracle.Digest use this
+   code, but that seems fragile
+ *)
+
+module Checked = struct
+  type unchecked = t
+
+  type t = Boolean.var array
+
+  let to_triples t =
+    Fold_lib.Fold.(to_list (group3 ~default:Boolean.false_ (of_array t)))
+
+  let constant unchecked =
+    assert (Int.(String.length (unchecked :> string) = length_in_bytes)) ;
+    Array.map
+      (Blake2.string_to_bits (unchecked :> string))
+      ~f:Boolean.var_of_value
+end
+
+let fold_bits t =
+  { Fold_lib.Fold.fold=
+      (fun ~init ~f ->
+        let n = 8 * String.length t in
+        let rec go acc i =
+          if i = n then acc
+          else
+            let b = (Char.to_int t.[i / 8] lsr (i mod 8)) land 1 = 1 in
+            go (f acc b) (i + 1)
+        in
+        go init 0 ) }
+
+let fold t = Fold_lib.Fold.group3 ~default:false (fold_bits t)
+
+let typ : (Checked.t, t) Typ.t =
+  Typ.transport
+    (Typ.array ~length:Blake2.digest_size_in_bits Boolean.typ)
+    ~there:(fun (t : t) -> Blake2.string_to_bits (t :> string))
+    ~back:(fun bs -> of_string (Blake2.bits_to_string bs))

--- a/src/lib/coda_base/user_command_memo.mli
+++ b/src/lib/coda_base/user_command_memo.mli
@@ -1,8 +1,9 @@
+open Core
 open Snark_params
 open Tick
 open Tuple_lib
 
-exception Invalid_user_memo_length
+exception Too_long_user_memo_length
 
 exception Too_long_digestible_string
 
@@ -33,6 +34,12 @@ val to_string : t -> string
 
 val of_string : string -> t
 
+(** is the memo a digest *)
+val is_digest : t -> bool
+
+(** is the memo well-formed *)
+val is_valid : t -> bool
+
 val max_digestible_string_length : int
 
 (** create a memo by digesting a string; raises [Too_long_digestible_string] if 
@@ -40,15 +47,30 @@ val max_digestible_string_length : int
  *)
 val create_by_digesting_string_exn : string -> t
 
-(** create a memo from bytes of length exactly 32;
-    raise [Invalid_user_memo_length] for any other length 
+(** create a memo by digesting a string; returns error if
+    length exceeds [max_digestible_string_length]
  *)
-val create_from_bytes32_exn : bytes -> t
+val create_by_digesting_string : string -> t Or_error.t
 
-(** create a memo from a string of length exactly 32;
-    raise [Invalid_user_memo_length] for any other length 
+(** create a memo from bytes of length up to 32;
+    raise [Too_long_user_memo_length] if length is greater
  *)
-val create_from_string32_exn : string -> t
+val create_from_bytes_exn : bytes -> t
+
+(** create a memo from bytes of length up to 32; returns
+    error is length is greater
+ *)
+val create_from_bytes : bytes -> t Or_error.t
+
+(** create a memo from a string of length up to 32;
+    raise [Too_long_user_memo_length] if length is greater
+ *)
+val create_from_string_exn : string -> t
+
+(** create a memo from a string of length up to 32;
+    returns error if length is greater
+ *)
+val create_from_string : string -> t Or_error.t
 
 (** convert a memo to a fold of boolean triples 
  *)

--- a/src/lib/coda_base/user_command_memo.mli
+++ b/src/lib/coda_base/user_command_memo.mli
@@ -1,16 +1,20 @@
-open Core
 open Snark_params
 open Tick
-open Fold_lib
 open Tuple_lib
+
+exception Invalid_user_memo_length
+
+exception Too_long_digestible_string
 
 type t [@@deriving sexp, eq, compare, hash, yojson]
 
 module Stable : sig
   module V1 : sig
     type nonrec t = t
-    [@@deriving sexp, bin_io, eq, compare, hash, yojson, version]
+    [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
   end
+
+  module Latest = V1
 end
 
 module Checked : sig
@@ -23,16 +27,36 @@ module Checked : sig
   val constant : unchecked -> t
 end
 
-val typ : (Checked.t, t) Typ.t
-
-val fold : t -> bool Triple.t Fold.t
-
-val length_in_triples : int
-
 val dummy : t
 
-val max_size_in_bytes : int
-
-val create_exn : string -> t
-
 val to_string : t -> string
+
+val of_string : string -> t
+
+val max_digestible_string_length : int
+
+(** create a memo by digesting a string; raises [Too_long_digestible_string] if 
+    length exceeds [max_digestible_string_length]
+ *)
+val create_by_digesting_string_exn : string -> t
+
+(** create a memo from bytes of length exactly 32;
+    raise [Invalid_user_memo_length] for any other length 
+ *)
+val create_from_bytes32_exn : bytes -> t
+
+(** create a memo from a string of length exactly 32;
+    raise [Invalid_user_memo_length] for any other length 
+ *)
+val create_from_string32_exn : string -> t
+
+(** convert a memo to a fold of boolean triples 
+ *)
+val fold : t -> bool Tuple_lib.Triple.t Fold_lib.Fold.t
+
+(** number of triples to represent a memo
+ *)
+val length_in_triples : int
+
+(** typ representation *)
+val typ : (Checked.t, t) Curve_choice.Tick0.Typ.t

--- a/src/lib/coda_base/user_command_memo.mli
+++ b/src/lib/coda_base/user_command_memo.mli
@@ -3,7 +3,7 @@ open Snark_params
 open Tick
 open Tuple_lib
 
-exception Too_long_user_memo_length
+exception Too_long_user_memo_input
 
 exception Too_long_digestible_string
 
@@ -40,9 +40,13 @@ val is_digest : t -> bool
 (** is the memo well-formed *)
 val is_valid : t -> bool
 
+(** bound on length of strings to digest *)
 val max_digestible_string_length : int
 
-(** create a memo by digesting a string; raises [Too_long_digestible_string] if 
+(** bound on length of strings or bytes in memo *)
+val max_input_length : int
+
+(** create a memo by digesting a string; raises [Too_long_digestible_string] if
     length exceeds [max_digestible_string_length]
  *)
 val create_by_digesting_string_exn : string -> t
@@ -52,27 +56,27 @@ val create_by_digesting_string_exn : string -> t
  *)
 val create_by_digesting_string : string -> t Or_error.t
 
-(** create a memo from bytes of length up to 32;
-    raise [Too_long_user_memo_length] if length is greater
+(** create a memo from bytes of length up to max_input_length;
+    raise [Too_long_user_memo_input] if length is greater
  *)
 val create_from_bytes_exn : bytes -> t
 
-(** create a memo from bytes of length up to 32; returns
+(** create a memo from bytes of length up to max_input_length; returns
     error is length is greater
  *)
 val create_from_bytes : bytes -> t Or_error.t
 
-(** create a memo from a string of length up to 32;
-    raise [Too_long_user_memo_length] if length is greater
+(** create a memo from a string of length up to max_input_length;
+    raise [Too_long_user_memo_input] if length is greater
  *)
 val create_from_string_exn : string -> t
 
-(** create a memo from a string of length up to 32;
+(** create a memo from a string of length up to max_input_length;
     returns error if length is greater
  *)
 val create_from_string : string -> t Or_error.t
 
-(** convert a memo to a fold of boolean triples 
+(** convert a memo to a fold of boolean triples
  *)
 val fold : t -> bool Tuple_lib.Triple.t Fold_lib.Fold.t
 

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -67,9 +67,14 @@ module Common = struct
     let%map fee = Currency.Fee.gen
     and nonce = Account_nonce.gen
     and memo =
-      String.gen_with_length Memo.max_digestible_string_length
-        Char.quickcheck_generator
-      >>| Memo.create_by_digesting_string_exn
+      let%bind is_digest = Bool.quickcheck_generator in
+      if is_digest then
+        String.gen_with_length Memo.max_digestible_string_length
+          Char.quickcheck_generator
+        >>| Memo.create_by_digesting_string_exn
+      else
+        String.gen_with_length Memo.max_input_length Char.quickcheck_generator
+        >>| Memo.create_from_string_exn
     in
     Poly.{fee; nonce; memo}
 

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -67,8 +67,9 @@ module Common = struct
     let%map fee = Currency.Fee.gen
     and nonce = Account_nonce.gen
     and memo =
-      String.gen_with_length Memo.max_size_in_bytes Char.quickcheck_generator
-      >>| Memo.create_exn
+      String.gen_with_length Memo.max_digestible_string_length
+        Char.quickcheck_generator
+      >>| Memo.create_by_digesting_string_exn
     in
     Poly.{fee; nonce; memo}
 

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -766,7 +766,7 @@ let%test_module _ =
             in
             let cmd_payload =
               User_command.Payload.create ~fee ~nonce
-                ~memo:(User_command_memo.create_exn memo)
+                ~memo:(User_command_memo.create_by_digesting_string_exn memo)
                 ~body:
                   (User_command.Payload.Body.Payment
                      {receiver= receiver_pk; amount})

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -682,7 +682,7 @@ let%test_module _ =
       @@ User_command.sign test_keys.(sender_idx)
            (User_command_payload.create ~fee:(Currency.Fee.of_int fee)
               ~nonce:(Account.Nonce.of_int nonce)
-              ~memo:(User_command_memo.create_exn "foo")
+              ~memo:(User_command_memo.create_by_digesting_string_exn "foo")
               ~body:
                 (User_command_payload.Body.Payment
                    { receiver=

--- a/src/lib/random_oracle/random_oracle.ml
+++ b/src/lib/random_oracle/random_oracle.ml
@@ -15,9 +15,11 @@ module Digest = struct
     let to_triples t =
       Fold_lib.Fold.(to_list (group3 ~default:Boolean.false_ (of_array t)))
 
-    let constant (s : unchecked) =
-      assert (Int.(String.length (s :> string) = length_in_bytes)) ;
-      Array.map (Blake2.string_to_bits (s :> string)) ~f:Boolean.var_of_value
+    let constant (unchecked : unchecked) =
+      assert (Int.(String.length (unchecked :> string) = length_in_bytes)) ;
+      Array.map
+        (Blake2.string_to_bits (unchecked :> string))
+        ~f:Boolean.var_of_value
   end
 
   let to_bits (t : t) = Blake2.string_to_bits (t :> string)

--- a/src/lib/random_oracle_base/random_oracle_base.ml
+++ b/src/lib/random_oracle_base/random_oracle_base.ml
@@ -4,18 +4,6 @@ open Module_version
 module Digest = struct
   open Fold_lib
 
-  let fold_bits s =
-    { Fold.fold=
-        (fun ~init ~f ->
-          let n = 8 * String.length s in
-          let rec go acc i =
-            if i = n then acc
-            else
-              let b = (Char.to_int s.[i / 8] lsr (i mod 8)) land 1 = 1 in
-              go (f acc b) (i + 1)
-          in
-          go init 0 ) }
-
   module Stable = struct
     module V1 = struct
       module T = struct
@@ -52,6 +40,18 @@ module Digest = struct
     module Registrar = Registration.Make (Module_decl)
     module Registered_V1 = Registrar.Register (V1)
   end
+
+  let fold_bits s =
+    { Fold.fold=
+        (fun ~init ~f ->
+          let n = 8 * String.length s in
+          let rec go acc i =
+            if i = n then acc
+            else
+              let b = (Char.to_int s.[i / 8] lsr (i mod 8)) land 1 = 1 in
+              go (f acc b) (i + 1)
+          in
+          go init 0 ) }
 
   let to_bits = Blake2.string_to_bits
 

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1631,9 +1631,9 @@ let%test_module "transaction_snark" =
                 user_command wallets 1 0 8
                   (Fee.of_int (Random.int 20))
                   Account.Nonce.zero
-                  (User_command_memo.create_exn
+                  (User_command_memo.create_by_digesting_string_exn
                      (Test_util.arbitrary_string
-                        ~len:User_command_memo.max_size_in_bytes))
+                        ~len:User_command_memo.max_digestible_string_length))
               in
               let target =
                 Ledger.merkle_root_after_user_command_exn ledger t1
@@ -1665,17 +1665,17 @@ let%test_module "transaction_snark" =
                 user_command wallets 0 1 8
                   (Fee.of_int (Random.int 20))
                   Account.Nonce.zero
-                  (User_command_memo.create_exn
+                  (User_command_memo.create_by_digesting_string_exn
                      (Test_util.arbitrary_string
-                        ~len:User_command_memo.max_size_in_bytes))
+                        ~len:User_command_memo.max_digestible_string_length))
               in
               let t2 =
                 user_command wallets 1 2 3
                   (Fee.of_int (Random.int 20))
                   Account.Nonce.zero
-                  (User_command_memo.create_exn
+                  (User_command_memo.create_by_digesting_string_exn
                      (Test_util.arbitrary_string
-                        ~len:User_command_memo.max_size_in_bytes))
+                        ~len:User_command_memo.max_digestible_string_length))
               in
               let pending_coinbase_stack_state =
                 Pending_coinbase_stack_state.Stable.Latest.


### PR DESCRIPTION
Allow arbitrary 32-byte strings in user command memos. Can still pass an arbitrary string (up to a max length) to digest.

Can use a `bytes` or `string` to create a memo, the length is checked. 

Length violations raise exceptions.

Perhaps problematic: some code from `Random_oracle.Digest` can't be used directly, so there's a modicum of copied code. There could be a functor to factor out that small amount of commonality, but I'm hesistant to introduce more functors.

Update: the code is different enough that it can't really be shared by functorization.

Closes #2660
Closes #2701