### PR TITLE
make should_bootstrap ask consensus first

### DIFF
--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -466,6 +466,7 @@ module type S = sig
     val should_bootstrap :
          existing:Consensus_state.Value.t
       -> candidate:Consensus_state.Value.t
+      -> logger:Logger.t
       -> bool
 
     (** Data needed to synchronize the local state. *)

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2650,10 +2650,14 @@ module Hooks = struct
     let length = Length.to_int in
     length candidate - length existing > (2 * Constants.k) + Constants.delta
 
-  let should_bootstrap ~existing ~candidate =
-    should_bootstrap_len
-      ~existing:(Consensus_state.length existing)
-      ~candidate:(Consensus_state.length candidate)
+  let should_bootstrap ~existing ~candidate ~logger =
+    match select ~existing ~candidate ~logger with
+    | `Keep ->
+        false
+    | `Take ->
+        should_bootstrap_len
+          ~existing:(Consensus_state.length existing)
+          ~candidate:(Consensus_state.length candidate)
 
   let%test "should_bootstrap is sane" =
     (* Even when consensus constants are of prod sizes, candidate should still trigger a bootstrap *)

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -56,7 +56,10 @@ module Make (Inputs : Inputs_intf) = struct
     Consensus.Hooks.should_bootstrap
       ~existing:(Protocol_state.consensus_state root_state)
       ~candidate:(Protocol_state.consensus_state new_state)
-      ~logger
+      ~logger:
+        (Logger.extend logger
+           [ ( "selection_context"
+             , `String "Transition_router.is_transition_for_bootstrap" ) ])
 
   let get_root_state frontier =
     Transition_frontier.root frontier


### PR DESCRIPTION
`should_bootstrap` function should always consult consensus first; otherwise, malicious user can trigger bootstrapping on arbitrary nodes by sending out fake transitions with a large `blockchain_count`.

Close #2696
