### PR TITLE
CLI command snark-hashes in internal group

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -494,7 +494,22 @@ let ensure_testnet_id_still_good _ = Deferred.unit
 
 [%%endif]
 
-let internal_commands = [(Snark_worker.Intf.command_name, Snark_worker.command)]
+let snark_hashes =
+  let open Command.Let_syntax in
+  Command.basic ~summary:"List hashes of proving and verification keys"
+    [%map_open
+      let json = Cli_lib.Flag.json in
+      let print = Core.printf "%s\n%!" in
+      fun () ->
+        if json then
+          print
+            (Yojson.Safe.to_string
+               (Snark_keys.key_hashes_to_yojson Snark_keys.key_hashes))
+        else List.iter Snark_keys.key_hashes ~f:print]
+
+let internal_commands =
+  [ (Snark_worker.Intf.command_name, Snark_worker.command)
+  ; ("snark-hashes", snark_hashes) ]
 
 let coda_commands logger =
   [ (Parallel.worker_command_name, Parallel.worker_command)

--- a/src/lib/snark_keys/dune
+++ b/src/lib/snark_keys/dune
@@ -3,7 +3,7 @@
  (public_name snark_keys)
  (libraries async transaction_snark dummy_values blockchain_snark core)
  (preprocess
-  (pps ppx_jane ppxlib.runner)))
+  (pps ppx_jane ppxlib.runner ppx_deriving_yojson)))
 
 (rule
  (targets snark_keys.ml)

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -9,6 +9,15 @@ open Core
 
 module Blockchain_snark_keys = struct
   module Proving = struct
+    let key_location ~loc bc_location =
+      let module E = Ppxlib.Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      let open E in
+      estring
+        (Blockchain_snark.Blockchain_transition.Keys.Proving.Location.to_string
+           bc_location)
+
     let load_expr ~loc bc_location bc_checksum =
       let module E = Ppxlib.Ast_builder.Make (struct
         let loc = loc
@@ -19,10 +28,7 @@ module Blockchain_snark_keys = struct
         Blockchain_snark.Blockchain_transition.Keys.Proving.load
           (Blockchain_snark.Blockchain_transition.Keys.Proving.Location
            .of_string
-             [%e
-               estring
-                 (Blockchain_snark.Blockchain_transition.Keys.Proving.Location
-                  .to_string bc_location)])
+             [%e key_location ~loc bc_location])
         >>| fun (keys, checksum) ->
         assert (
           String.equal (Md5_lib.to_hex checksum)
@@ -31,6 +37,15 @@ module Blockchain_snark_keys = struct
   end
 
   module Verification = struct
+    let key_location ~loc bc_location =
+      let module E = Ppxlib.Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      let open E in
+      estring
+        (Blockchain_snark.Blockchain_transition.Keys.Verification.Location
+         .to_string bc_location)
+
     let load_expr ~loc bc_location bc_checksum =
       let module E = Ppxlib.Ast_builder.Make (struct
         let loc = loc
@@ -41,11 +56,7 @@ module Blockchain_snark_keys = struct
         Blockchain_snark.Blockchain_transition.Keys.Verification.load
           (Blockchain_snark.Blockchain_transition.Keys.Verification.Location
            .of_string
-             [%e
-               estring
-                 (Blockchain_snark.Blockchain_transition.Keys.Verification
-                  .Location
-                  .to_string bc_location)])
+             [%e key_location ~loc bc_location])
         >>| fun (keys, checksum) ->
         assert (
           String.equal (Md5_lib.to_hex checksum)
@@ -56,6 +67,13 @@ end
 
 module Transaction_snark_keys = struct
   module Proving = struct
+    let key_location ~loc t_location =
+      let module E = Ppxlib.Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      let open E in
+      estring (Transaction_snark.Keys.Proving.Location.to_string t_location)
+
     let load_expr ~loc t_location t_checksum =
       let module E = Ppxlib.Ast_builder.Make (struct
         let loc = loc
@@ -65,9 +83,7 @@ module Transaction_snark_keys = struct
         let open Async.Deferred in
         Transaction_snark.Keys.Proving.load
           (Transaction_snark.Keys.Proving.Location.of_string
-             [%e
-               estring
-                 (Transaction_snark.Keys.Proving.Location.to_string t_location)])
+             [%e key_location ~loc t_location])
         >>| fun (keys, checksum) ->
         assert (
           String.equal (Md5_lib.to_hex checksum)
@@ -76,6 +92,14 @@ module Transaction_snark_keys = struct
   end
 
   module Verification = struct
+    let key_location ~loc t_location =
+      let module E = Ppxlib.Ast_builder.Make (struct
+        let loc = loc
+      end) in
+      let open E in
+      estring
+        (Transaction_snark.Keys.Verification.Location.to_string t_location)
+
     let load_expr ~loc t_location t_checksum =
       let module E = Ppxlib.Ast_builder.Make (struct
         let loc = loc
@@ -85,10 +109,7 @@ module Transaction_snark_keys = struct
         let open Async.Deferred in
         Transaction_snark.Keys.Verification.load
           (Transaction_snark.Keys.Verification.Location.of_string
-             [%e
-               estring
-                 (Transaction_snark.Keys.Verification.Location.to_string
-                    t_location)])
+             [%e key_location ~loc t_location])
         >>| fun (keys, checksum) ->
         assert (
           String.equal (Md5_lib.to_hex checksum)
@@ -136,6 +157,20 @@ let loc = Ppxlib.Location.none
 [%%if
 proof_level = "full"]
 
+let location_expr key_location =
+  let module E = Ppxlib.Ast_builder.Make (struct
+    let loc = loc
+  end) in
+  let open E in
+  [%expr
+    let open Async.Deferred in
+    Transaction_snark.Keys.Verification.load
+      (Transaction_snark.Keys.Verification.Location.of_string
+         [%e
+           estring
+             (Transaction_snark.Keys.Verification.Location.to_string
+                key_location)])]
+
 let gen_keys () =
   let%bind tx_keys_location, tx_keys, tx_keys_checksum =
     Transaction_snark.Keys.cached ()
@@ -150,27 +185,45 @@ let gen_keys () =
   let%map bc_keys_location, _bc_keys, bc_keys_checksum = M.Keys.cached () in
   ( Blockchain_snark_keys.Proving.load_expr ~loc bc_keys_location.proving
       bc_keys_checksum.proving
+  , Blockchain_snark_keys.Proving.key_location ~loc bc_keys_location.proving
   , Blockchain_snark_keys.Verification.load_expr ~loc
       bc_keys_location.verification bc_keys_checksum.verification
+  , Blockchain_snark_keys.Verification.key_location ~loc
+      bc_keys_location.verification
   , Transaction_snark_keys.Proving.load_expr ~loc tx_keys_location.proving
       tx_keys_checksum.proving
+  , Transaction_snark_keys.Proving.key_location ~loc tx_keys_location.proving
   , Transaction_snark_keys.Verification.load_expr ~loc
-      tx_keys_location.verification tx_keys_checksum.verification )
+      tx_keys_location.verification tx_keys_checksum.verification
+  , Transaction_snark_keys.Verification.key_location ~loc
+      tx_keys_location.verification )
 
 [%%else]
 
 let gen_keys () =
+  let dummy_loc = [%expr "dummy-location"] in
   return
     ( Dummy.Blockchain_keys.Proving.expr ~loc
+    , dummy_loc
     , Dummy.Blockchain_keys.Verification.expr ~loc
+    , dummy_loc
     , Dummy.Transaction_keys.Proving.expr ~loc
-    , Dummy.Transaction_keys.Verification.expr ~loc )
+    , dummy_loc
+    , Dummy.Transaction_keys.Verification.expr ~loc
+    , dummy_loc )
 
 [%%endif]
 
 let main () =
   (*   let%bind blockchain_expr, transaction_expr = *)
-  let%bind bc_proving, bc_verification, tx_proving, tx_verification =
+  let%bind ( bc_proving
+           , bc_proving_loc
+           , bc_verification
+           , bc_verification_loc
+           , tx_proving
+           , tx_proving_loc
+           , tx_verification
+           , tx_verification_loc ) =
     gen_keys ()
   in
   let fmt =
@@ -179,13 +232,53 @@ let main () =
   Pprintast.top_phrase fmt
     (Ptop_def
        [%str
+         open Core_kernel
+
          let blockchain_proving () = [%e bc_proving]
 
          let blockchain_verification () = [%e bc_verification]
 
          let transaction_proving () = [%e tx_proving]
 
-         let transaction_verification () = [%e tx_verification]]) ;
+         let transaction_verification () = [%e tx_verification]
+
+         type key_hashes = string list [@@deriving to_yojson]
+
+         let key_locations =
+           [ ("blockchain_proving", [%e bc_proving_loc])
+           ; ("blockchain_verification", [%e bc_verification_loc])
+           ; ("transaction_proving", [%e tx_proving_loc])
+           ; ("transaction_verification", [%e tx_verification_loc]) ]
+
+         let rec location_sexp_to_hashes = function
+           | Sexp.Atom s
+             when List.mem
+                    ["base"; "merge"; "step"; "wrap"]
+                    s ~equal:String.equal ->
+               []
+           | Sexp.Atom s -> (
+               let fn = Filename.basename s in
+               match String.split fn ~on:'_' with
+               | hash :: _ ->
+                   [hash]
+               | _ ->
+                   failwith "location_sexp_to_hashes: unexpected filename" )
+           | Sexp.List sexps ->
+               List.(concat (map sexps ~f:location_sexp_to_hashes))
+
+         let location_to_hashes (loc : string) =
+           match Sexp.parse loc with
+           | Done (sexp, _) ->
+               location_sexp_to_hashes sexp
+           | _ ->
+               []
+
+         let key_hashes =
+           let locations =
+             List.map key_locations ~f:(fun (_name, loc) -> loc)
+           in
+           let hashes = List.(concat (map locations ~f:location_to_hashes)) in
+           List.dedup_and_sort hashes ~compare:String.compare]) ;
   exit 0
 
 let () =


### PR DESCRIPTION
New CLI command `internal snark-hashes [-json]`.

Lists the unique hex strings/hashes that appear in the proving, verification key filenames for the blockchain and transactions.

This PR partly addresses #1492 (nothing to do with Columbus or Isabella, I believe).

Text output:
```
coda.exe internal snark-hashes
1fcfafce88045da8edb21ca60f16364e
5cb02d2fce6f6865d9459434c8279373
791dd47158e4dad32059f8b6d5fef4e8
d54a391ecc01065ad98c490ec10fe56c
d7cee32fe1dccee1745b0c8cc6bbd3b8
```
JSON:
```
coda.exe internal snark-hashes -json
["1fcfafce88045da8edb21ca60f16364e","5cb02d2fce6f6865d9459434c8279373","791dd47158e4dad32059f8b6d5fef4e8","d54a391ecc01065ad98c490ec10fe56c","d7cee32fe1dccee1745b0c8cc6bbd3b8"]
```
There's meaningful output only at full proof level. Otherwise, the list of hashes is empty.

