### PR TITLE
Bump maximum read size

### DIFF
--- a/src/lib/storage/disk.ml
+++ b/src/lib/storage/disk.ml
@@ -17,7 +17,7 @@ let load_with_checksum (type a) (c : a Controller.t) location =
   | `Yes -> (
       match%map
         Reader.load_bin_prot
-          ~max_len:(1000 * 1024 * 1024)
+          ~max_len:(5 * 512 * 1024 * 1024 (* 2.5 GB *))
           location
           (bin_reader_t String.bin_reader_t)
       with


### PR DESCRIPTION
This increases the maximum file size we will read from disk to 2.5GB. The largest key I've seen generated is 1.1GB, so this gives us plenty of headroom.

Digging into the source of `load_bin_prot`, it is only used to throw an error when a file over that size is met, so this shouldn't be an issue (as long as the user has enough RAM).

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
