### PR TITLE
Link core files in directory for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,9 +256,9 @@ jobs:
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Run unit tests
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && dune build --profile=test_postake_snarkless -j8 && dune runtest --profile=test_postake_snarkless -j8'
+                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && dune build --profile=test_postake_snarkless -j8 && (dune runtest --profile=test_postake_snarkless -j8 || (./scripts/link-coredumps.sh && false))'
             - store_artifacts:
-                path: core*
+                path: core_dumps
     test-unit--dev:
         resource_class: large
         docker:
@@ -269,9 +269,9 @@ jobs:
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Run unit tests
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && dune build --profile=dev -j8 && dune runtest --profile=dev -j8'
+                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && dune build --profile=dev -j8 && (dune runtest --profile=dev -j8 || (./scripts/link-coredumps.sh && false))'
             - store_artifacts:
-                path: core*
+                path: core_dumps
     test--fake_hash:
         resource_class: large
         docker:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -189,9 +189,9 @@ jobs:
             - run: git submodule sync && git submodule update --init --recursive
             - run:
                   name: Run unit tests
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && dune build --profile={{profile}} -j8 && dune runtest --profile={{profile}} -j8'
+                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && dune build --profile={{profile}} -j8 && (dune runtest --profile={{profile}} -j8 || (./scripts/link-coredumps.sh && false))'
             - store_artifacts:
-                path: core*
+                path: core_dumps
     {%- endfor %}
 
     {%- for profile in test_permutations.keys() | sort %}

--- a/scripts/link-coredumps.sh
+++ b/scripts/link-coredumps.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# link core files for CI to help debug test failures
+
+CORE_DIR=core_dumps
+
+mkdir $CORE_DIR
+
+for file in `find . -name "core.[0-9]*.*"` ;
+  do ln -s "`pwd`/$file" $CORE_DIR/ ;
+done


### PR DESCRIPTION
There was an entry in the Circle config file to create artifacts from core files, but it didn't work. First, the core files were not generated in the git root directory, and second, the regexp syntax `core*` doesn't seem to be supported.

Circle does support creating artifacts by giving a directory name, as we were already doing for `test_logs`. If the unit tests fail, a new script `link-coredump.sh` is run, which creates the directory `core_dumps`, and puts in symlinks to each generated core file. Those files are apparently named `core.PID.something`.

The `&& false` in the config entry makes sure that if the unit test fails, the result is still a failure after running that script.

Tested by creating a unit test that segfaults (via `Obj.magic`), and verifying that the artifact is created.

Note: not sure of the regexp syntax in the script, even though it gives the desired result. In `core.[0-9]*.*`, replacing the first star with a `+` doesn't seem to work, even though we want a nonempty sequence of digits (for the PID). Suggestions welcome.
