### PR TITLE
Remove prev_hash field from staged ledger diff

### DIFF
--- a/src/lib/coda_intf/staged_ledger_intf.ml
+++ b/src/lib/coda_intf/staged_ledger_intf.ml
@@ -136,19 +136,13 @@ module type Staged_ledger_diff_generalized_intf = sig
       with type V1.t = t
   end
 
-  type t =
-    { diff: Diff.t
-    ; prev_hash: staged_ledger_hash
-    ; creator: compressed_public_key }
+  type t = {diff: Diff.t; creator: compressed_public_key}
   [@@deriving sexp, fields]
 
   module Stable :
     sig
       module V1 : sig
-        type t =
-          { diff: Diff.t
-          ; prev_hash: staged_ledger_hash
-          ; creator: compressed_public_key }
+        type t = {diff: Diff.t; creator: compressed_public_key}
         [@@deriving sexp, bin_io, version]
       end
 
@@ -174,11 +168,7 @@ module type Staged_ledger_diff_generalized_intf = sig
       * pre_diff_with_at_most_one_coinbase option
     [@@deriving sexp]
 
-    type t =
-      { diff: diff
-      ; prev_hash: staged_ledger_hash
-      ; creator: compressed_public_key }
-    [@@deriving sexp]
+    type t = {diff: diff; creator: compressed_public_key} [@@deriving sexp]
 
     val user_commands : t -> user_command_with_valid_signature list
   end
@@ -460,7 +450,6 @@ module type Staged_ledger_generalized_intf = sig
 
   module Staged_ledger_error : sig
     type t =
-      | Bad_prev_hash of staged_ledger_hash * staged_ledger_hash
       | Non_zero_fee_excess of Scan_state.Space_partition.t * transaction list
       | Invalid_proof of
           ledger_proof * transaction_snark_statement * compressed_public_key

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -306,11 +306,6 @@ let create_genesis_frontier (config : Config.t) ~verifier =
           ; user_commands= []
           ; coinbase= Staged_ledger_diff.At_most_two.Zero }
         , None )
-    ; prev_hash=
-        Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
-          (Staged_ledger_hash.Aux_hash.of_bytes "")
-          (Ledger.merkle_root Genesis_ledger.t)
-          pending_coinbases
     ; creator= Account.public_key (snd (List.hd_exn Genesis_ledger.accounts))
     }
   in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -48,7 +48,6 @@ struct
 
   module Staged_ledger_error = struct
     type t =
-      | Bad_prev_hash of Staged_ledger_hash.t * Staged_ledger_hash.t
       | Non_zero_fee_excess of
           Scan_state.Space_partition.t * Transaction.t list
       | Invalid_proof of
@@ -60,11 +59,6 @@ struct
     [@@deriving sexp]
 
     let to_string = function
-      | Bad_prev_hash (h1, h2) ->
-          Format.asprintf
-            !"bad prev_hash: Expected %{sexp: Staged_ledger_hash.t}, got \
-              %{sexp: Staged_ledger_hash.t} \n"
-            h1 h2
       | Non_zero_fee_excess (partition, txns) ->
           Format.asprintf
             !"Fee excess is non-zero for the transactions: %{sexp: \
@@ -744,14 +738,6 @@ struct
       ( Int.min (Scan_state.free_space t.scan_state) max_throughput
       , List.length jobs )
     in
-    let%bind () =
-      let curr_hash = hash t in
-      if Staged_ledger_hash.equal sl_diff.prev_hash (hash t) then return ()
-      else
-        Deferred.return
-          (Error
-             (Staged_ledger_error.Bad_prev_hash (curr_hash, sl_diff.prev_hash)))
-    in
     let new_mask = Inputs.Ledger.Mask.create () in
     let new_ledger = Inputs.Ledger.register_mask t.ledger new_mask in
     let scan_state' = Scan_state.copy t.scan_state in
@@ -1337,7 +1323,6 @@ struct
       ~(get_completed_work :
             Transaction_snark_work.Statement.t
          -> Transaction_snark_work.Checked.t option) =
-    let curr_hash = hash t in
     O1trace.trace_event "curr_hash" ;
     let validating_ledger = Transaction_validator.create t.ledger in
     O1trace.trace_event "done mask" ;
@@ -1395,9 +1380,7 @@ struct
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__
       "Block stats: Proofs ready for purchase: %d" proof_count ;
     trace_event "prediffs done" ;
-    { Staged_ledger_diff.With_valid_signatures_and_proofs.diff
-    ; creator= self
-    ; prev_hash= curr_hash }
+    {Staged_ledger_diff.With_valid_signatures_and_proofs.diff; creator= self}
 
   module For_tests = struct
     let snarked_ledger = snarked_ledger
@@ -2299,10 +2282,7 @@ let%test_module "test" =
         module Stable = struct
           module V1 = struct
             module T = struct
-              type t =
-                { diff: Diff.Stable.V1.t
-                ; prev_hash: staged_ledger_hash
-                ; creator: public_key }
+              type t = {diff: Diff.Stable.V1.t; creator: public_key}
               [@@deriving sexp, bin_io, version {for_test}]
             end
 
@@ -2312,10 +2292,7 @@ let%test_module "test" =
           module Latest = V1
         end
 
-        type t = Stable.Latest.t =
-          { diff: Diff.Stable.V1.t
-          ; prev_hash: staged_ledger_hash
-          ; creator: public_key }
+        type t = Stable.Latest.t = {diff: Diff.Stable.V1.t; creator: public_key}
         [@@deriving sexp, yojson, fields]
 
         module With_valid_signatures_and_proofs = struct
@@ -2336,9 +2313,7 @@ let%test_module "test" =
             * pre_diff_with_at_most_one_coinbase option
           [@@deriving sexp, yojson]
 
-          type t =
-            {diff: diff; prev_hash: staged_ledger_hash; creator: public_key}
-          [@@deriving sexp, yojson]
+          type t = {diff: diff; creator: public_key} [@@deriving sexp, yojson]
 
           let user_commands t =
             (fst t.diff).user_commands
@@ -2371,7 +2346,6 @@ let%test_module "test" =
           { diff=
               ( forget_pre_diff_with_at_most_two (fst t.diff)
               , Option.map (snd t.diff) ~f:forget_pre_diff_with_at_most_one )
-          ; prev_hash= t.prev_hash
           ; creator= t.creator }
 
         let user_commands (t : t) =
@@ -2631,14 +2605,13 @@ let%test_module "test" =
       let g = Int.gen_incl 1 p in
       let initial_ledger = ref 0 in
       let sl = ref (Sl.create_exn ~ledger:initial_ledger) in
-      let create_diff_with_non_zero_fee_excess prev_hash txns completed_works
+      let create_diff_with_non_zero_fee_excess txns completed_works
           (partition : Sl.Scan_state.Space_partition.t) : Staged_ledger_diff.t
           =
         match partition.second with
         | None ->
             { diff=
                 ({completed_works; user_commands= txns; coinbase= Zero}, None)
-            ; prev_hash
             ; creator= "C" }
         | Some _ ->
             let diff : Staged_ledger_diff.Diff.t =
@@ -2650,7 +2623,7 @@ let%test_module "test" =
                   ; user_commands= List.drop txns partition.first
                   ; coinbase= Zero } )
             in
-            {diff; prev_hash; creator= "C"}
+            {diff; creator= "C"}
       in
       Quickcheck.test g ~trials:50 ~f:(fun i ->
           Async.Thread_safe.block_on_async_exn (fun () ->
@@ -2673,9 +2646,8 @@ let%test_module "test" =
                       ; prover= "P" } )
                   work
               in
-              let hash = Sl.hash !sl in
               let diff =
-                create_diff_with_non_zero_fee_excess hash txns
+                create_diff_with_non_zero_fee_excess txns
                   (Sequence.to_list work_done)
                   partitions
               in

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -176,9 +176,7 @@ struct
     module V1 = struct
       module T = struct
         type t =
-          { diff: Diff.Stable.V1.t
-          ; prev_hash: Staged_ledger_hash.Stable.V1.t
-          ; creator: Public_key.Compressed.Stable.V1.t }
+          {diff: Diff.Stable.V1.t; creator: Public_key.Compressed.Stable.V1.t}
         [@@deriving sexp, bin_io, version]
       end
 
@@ -199,9 +197,7 @@ struct
   end
 
   type t = Stable.Latest.t =
-    { diff: Diff.Stable.V1.t
-    ; prev_hash: Staged_ledger_hash.Stable.V1.t
-    ; creator: Public_key.Compressed.Stable.V1.t }
+    {diff: Diff.Stable.V1.t; creator: Public_key.Compressed.Stable.V1.t}
   [@@deriving sexp, fields]
 
   module With_valid_signatures_and_proofs = struct
@@ -222,11 +218,7 @@ struct
       * pre_diff_with_at_most_one_coinbase option
     [@@deriving sexp]
 
-    type t =
-      { diff: diff
-      ; prev_hash: Staged_ledger_hash.t
-      ; creator: Public_key.Compressed.t }
-    [@@deriving sexp]
+    type t = {diff: diff; creator: Public_key.Compressed.t} [@@deriving sexp]
 
     let user_commands t =
       (fst t.diff).user_commands
@@ -255,7 +247,6 @@ struct
     { diff=
         ( forget_pre_diff_with_at_most_two (fst t.diff)
         , Option.map (snd t.diff) ~f:forget_pre_diff_with_at_most_one )
-    ; prev_hash= t.prev_hash
     ; creator= t.creator }
 
   let user_commands (t : t) =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -127,7 +127,7 @@ module Make (Inputs : Inputs_intf) :
                           make_actions Sent_invalid_proof
                       | Pre_diff (Bad_signature _) ->
                           make_actions Sent_invalid_signature
-                      | Pre_diff _ | Bad_prev_hash _ | Non_zero_fee_excess _ ->
+                      | Pre_diff _ | Non_zero_fee_excess _ ->
                           make_actions Gossiped_invalid_transition
                       | Unexpected _ ->
                           failwith

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -328,7 +328,6 @@ struct
             ; user_commands= []
             ; coinbase= Staged_ledger_diff.At_most_two.Zero }
           , None )
-      ; prev_hash= Staged_ledger_hash.genesis
       ; creator }
     in
     (* the genesis transition is assumed to be valid *)


### PR DESCRIPTION
Remove the `prev_hash` field from the type `Staged_ledger_diff.t` (and versioned version of that type).

Closes #2671.