### PR TITLE
Remove open of module with bin_io functions

### DIFF
--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -81,10 +81,12 @@ module Make
     module Registered_V1 = Registrar.Register (V1)
   end
 
-  open Stable.Latest
-
   (* bin_io omitted *)
-  type t = Stable.Latest.t [@@deriving sexp]
+  type t = Stable.Latest.t =
+    { protocol_state: Protocol_state.Value.Stable.V1.t
+    ; protocol_state_proof: Proof.Stable.V1.t sexp_opaque
+    ; staged_ledger_diff: Staged_ledger_diff.t }
+  [@@deriving sexp]
 
   type external_transition = t
 


### PR DESCRIPTION
There was an `open Stable.Latest` in `External_transitions`. That put all the `bin_io` functions in scope, which isn't supposed to happen for non-versioned types that are used in RPC.

