### PR TITLE
Base58_check, pass version_byte once in functor

### DIFF
--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -113,17 +113,18 @@ module Types = struct
     module State_hash = Codable.Make_base58_check (State_hash.Stable.V1)
   end
 
-  module Id = struct
+  module Base58_check = Base58_check.Make (struct
     let version_byte = Base58_check.Version_bytes.graphql
+  end)
 
+  module Id = struct
     (* The id of a user_command is the Base58Check encoding of the serialized version of the user_command *)
     let user_command user_command =
       let bigstring =
         Bin_prot.Utils.bin_dump Coda_base.User_command.Stable.V1.bin_t.writer
           user_command
       in
-      let payload = Bigstring.to_string bigstring in
-      Base58_check.encode ~version_byte ~payload
+      Base58_check.encode (Bigstring.to_string bigstring)
   end
 
   let uint64_arg name ~doc ~typ =
@@ -850,8 +851,7 @@ module Types = struct
             let open Result.Let_syntax in
             let%bind serialized_transaction =
               result_of_or_error
-                (Base58_check.decode ~version_byte:Id.version_byte
-                   serialized_payment)
+                (Base58_check.decode serialized_payment)
                 ~error:(Option.value error ~default:"Invalid cursor")
             in
             Ok

--- a/src/app/cli/src/web_pipe.ml
+++ b/src/app/cli/src/web_pipe.ml
@@ -20,9 +20,11 @@ module type Intf = sig
        Strict_pipe.Reader.t
 end
 
-let to_base58 m x =
-  let version_byte = Base58_check.Version_bytes.web_pipe in
-  Base58_check.encode ~version_byte ~payload:(Binable.to_string m x)
+module Base58_check = Base58_check.Make (struct
+  let version_byte = Base58_check.Version_bytes.web_pipe
+end)
+
+let to_base58 m x = Base58_check.encode (Binable.to_string m x)
 
 module Storage (Bin : Binable.S) = struct
   let store location data =

--- a/src/lib/base58_check/base58_check.ml
+++ b/src/lib/base58_check/base58_check.ml
@@ -6,7 +6,7 @@ open Core_kernel
 
 exception Invalid_base58_checksum
 
-exception Invalid_base58_version_byte
+exception Invalid_base58_version_byte of char
 
 exception Invalid_base58_check_length
 
@@ -19,81 +19,93 @@ let version_len = 1
 
 let checksum_len = 4
 
-let compute_checksum ~version_string ~payload =
-  (* double-hash using SHA256 *)
-  let open Digestif.SHA256 in
-  let ctx0 = init () in
-  let ctx1 = feed_string ctx0 version_string in
-  let ctx2 = feed_string ctx1 payload in
-  let first_hash = get ctx2 |> to_raw_string in
-  let ctx3 = feed_string ctx0 first_hash in
-  let second_hash = get ctx3 |> to_raw_string in
-  second_hash |> String.sub ~pos:0 ~len:checksum_len
+module Make (M : sig
+  val version_byte : char
+end) =
+struct
+  let version_byte = M.version_byte
 
-let encode ~(version_byte : char) ~(payload : string) =
-  let version_string = String.make 1 version_byte in
-  let checksum = compute_checksum ~version_string ~payload in
-  let bytes = version_string ^ payload ^ checksum |> Bytes.of_string in
-  B58.encode coda_alphabet bytes |> Bytes.to_string
+  let version_string = String.make 1 version_byte
 
-let decode_exn ~(version_byte : char) s =
-  let bytes = Bytes.of_string s in
-  let decoded = B58.decode coda_alphabet bytes |> Bytes.to_string in
-  let len = String.length decoded in
-  (* input must be at least as long as the version byte and checksum *)
-  if len < version_len + checksum_len then raise Invalid_base58_check_length ;
-  let version_string = String.sub decoded ~pos:0 ~len:version_len in
-  let checksum =
-    String.sub decoded
-      ~pos:(String.length decoded - checksum_len)
-      ~len:checksum_len
-  in
-  let payload =
-    String.sub decoded ~pos:1 ~len:(len - version_len - checksum_len)
-  in
-  if not (String.equal checksum (compute_checksum ~version_string ~payload))
-  then raise Invalid_base58_checksum ;
-  if not (Char.equal decoded.[0] version_byte) then
-    raise Invalid_base58_version_byte ;
-  payload
+  let compute_checksum payload =
+    (* double-hash using SHA256 *)
+    let open Digestif.SHA256 in
+    let ctx0 = init () in
+    let ctx1 = feed_string ctx0 version_string in
+    let ctx2 = feed_string ctx1 payload in
+    let first_hash = get ctx2 |> to_raw_string in
+    let ctx3 = feed_string ctx0 first_hash in
+    let second_hash = get ctx3 |> to_raw_string in
+    second_hash |> String.sub ~pos:0 ~len:checksum_len
 
-let decode ~(version_byte : char) s =
-  try Ok (decode_exn ~version_byte s) with
-  | B58.Invalid_base58_character ->
-      Or_error.error_string "Invalid base58 character"
-  | Invalid_base58_check_length ->
-      Or_error.error_string "Invalid base58 check length"
-  | Invalid_base58_checksum ->
-      Or_error.error_string "Invalid base58 checksum"
-  | Invalid_base58_version_byte ->
-      Or_error.error_string "Invalid base58 version byte"
+  let encode payload =
+    let checksum = compute_checksum payload in
+    let bytes = version_string ^ payload ^ checksum |> Bytes.of_string in
+    B58.encode coda_alphabet bytes |> Bytes.to_string
+
+  let decode_exn s =
+    let bytes = Bytes.of_string s in
+    let decoded = B58.decode coda_alphabet bytes |> Bytes.to_string in
+    let len = String.length decoded in
+    (* input must be at least as long as the version byte and checksum *)
+    if len < version_len + checksum_len then raise Invalid_base58_check_length ;
+    let checksum =
+      String.sub decoded
+        ~pos:(String.length decoded - checksum_len)
+        ~len:checksum_len
+    in
+    let payload =
+      String.sub decoded ~pos:1 ~len:(len - version_len - checksum_len)
+    in
+    if not (String.equal checksum (compute_checksum payload)) then
+      raise Invalid_base58_checksum ;
+    if not (Char.equal decoded.[0] version_byte) then
+      raise (Invalid_base58_version_byte decoded.[0]) ;
+    payload
+
+  let decode s =
+    try Ok (decode_exn s) with
+    | B58.Invalid_base58_character ->
+        Or_error.error_string "Invalid base58 character"
+    | Invalid_base58_check_length ->
+        Or_error.error_string "Invalid base58 check length"
+    | Invalid_base58_checksum ->
+        Or_error.error_string "Invalid base58 checksum"
+    | Invalid_base58_version_byte ch ->
+        Or_error.error_string
+          (sprintf "Invalid base58 version byte \\x%02X, expected \\x%02X"
+             (Char.to_int ch) (Char.to_int version_byte))
+end
 
 module Version_bytes = Version_bytes
 
 let%test_module "empty string" =
   ( module struct
-    let test_roundtrip version_byte payload =
-      let encoded = encode ~version_byte ~payload in
-      let payload' = decode_exn ~version_byte encoded in
+    module Base58_check = Make (struct
+      let version_byte = '\x53'
+    end)
+
+    open Base58_check
+
+    let test_roundtrip payload =
+      let encoded = encode payload in
+      let payload' = decode_exn encoded in
       String.equal payload payload'
 
-    let%test "empty_string" = test_roundtrip '\x57' ""
+    let%test "empty_string" = test_roundtrip ""
 
     let%test "nonempty_string" =
-      test_roundtrip '\x31' "Somewhere, over the rainbow, way up high"
+      test_roundtrip "Somewhere, over the rainbow, way up high"
 
     let%test "longer_string" =
-      test_roundtrip '\xFE'
+      test_roundtrip
         "Someday, I wish upon a star, wake up where the clouds are far behind \
          me, where trouble melts like lemon drops, High above the chimney \
          top, that's where you'll find me"
 
     let%test "invalid checksum" =
       try
-        let version_byte = '\xAC' in
-        let encoded =
-          encode ~version_byte ~payload:"Bluer than velvet were her eyes"
-        in
+        let encoded = encode "Bluer than velvet were her eyes" in
         let bytes = Bytes.of_string encoded in
         let len = Bytes.length bytes in
         let last_ch = Bytes.get bytes (len - 1) in
@@ -104,13 +116,13 @@ let%test_module "empty string" =
         in
         Bytes.set bytes (len - 1) new_last_ch ;
         let encoded_bad_checksum = Bytes.to_string bytes in
-        let _payload = decode_exn ~version_byte encoded_bad_checksum in
+        let _payload = decode_exn encoded_bad_checksum in
         false
       with Invalid_base58_checksum -> true
 
     let%test "invalid length" =
       try
-        let _payload = decode_exn ~version_byte:'\x53' "abcd" in
+        let _payload = decode_exn "abcd" in
         false
       with Invalid_base58_check_length -> true
   end )

--- a/src/lib/base58_check/base58_check.ml
+++ b/src/lib/base58_check/base58_check.ml
@@ -79,7 +79,7 @@ end
 
 module Version_bytes = Version_bytes
 
-let%test_module "empty string" =
+let%test_module "base58check tests" =
   ( module struct
     module Base58_check = Make (struct
       let version_byte = '\x53'

--- a/src/lib/base58_check/base58_check.mli
+++ b/src/lib/base58_check/base58_check.mli
@@ -4,18 +4,22 @@ open Core_kernel
 
 exception Invalid_base58_checksum
 
-exception Invalid_base58_version_byte
+exception Invalid_base58_version_byte of char
 
 exception Invalid_base58_check_length
 
-(** apply Base58Check algorithm to version byte and payload *)
-val encode : version_byte:char -> payload:string -> string
+module Make (M : sig
+  val version_byte : char
+end) : sig
+  (** apply Base58Check algorithm to version byte and payload *)
+  val encode : string -> string
 
-(** decode Base58Check result into payload; can raise the above
- * exceptions and a B58.Invalid_base58_character *)
-val decode_exn : version_byte:char -> string -> string
+  (** decode Base58Check result into payload; can raise the above
+   * exceptions and a B58.Invalid_base58_character *)
+  val decode_exn : string -> string
 
-(** decode Base58Check result into payload *)
-val decode : version_byte:char -> string -> string Or_error.t
+  (** decode Base58Check result into payload *)
+  val decode : string -> string Or_error.t
+end
 
 module Version_bytes : module type of Version_bytes

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -11,20 +11,20 @@ module Stable = struct
       let to_string = Binable.to_string (module Tock_backend.Proof)
 
       let of_string = Binable.of_string (module Tock_backend.Proof)
+
+      let version_byte = Base58_check.Version_bytes.proof
     end
 
     include T
     include Sexpable.Of_stringable (T)
+    module Base58_check = Base58_check.Make (T)
 
-    let version_byte = Base58_check.Version_bytes.proof
-
-    let to_yojson s =
-      `String (Base58_check.encode ~version_byte ~payload:(to_string s))
+    let to_yojson s = `String (Base58_check.encode (to_string s))
 
     let of_yojson = function
       | `String s -> (
         try
-          let decoded = Base58_check.decode_exn ~version_byte s in
+          let decoded = Base58_check.decode_exn s in
           Ok (of_string decoded)
         with exn ->
           Error (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))

--- a/src/lib/coda_base/user_command_memo.ml
+++ b/src/lib/coda_base/user_command_memo.ml
@@ -4,16 +4,16 @@ open Crypto_params
 module Stable = struct
   module V1 = struct
     module T = struct
-      open Base58_check
+      module Base58_check = Base58_check.Make (struct
+        let version_byte = Base58_check.Version_bytes.user_command_memo
+      end)
 
       type t = string
       [@@deriving bin_io, sexp, eq, compare, hash, version {unnumbered}]
 
-      let version_byte = Version_bytes.user_command_memo
+      let to_string (memo : t) : string = Base58_check.encode memo
 
-      let to_string (memo : t) : string = encode ~version_byte ~payload:memo
-
-      let of_string (s : string) : t = decode_exn ~version_byte s
+      let of_string (s : string) : t = Base58_check.decode_exn s
     end
 
     include T

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -102,13 +102,13 @@ module Make_base58_check (T : sig
   val version_byte : char
 end) =
 struct
-  let to_base58_check t =
-    let payload = Binable.to_string (module T) t in
-    Base58_check.encode ~version_byte:T.version_byte ~payload
+  module Base58_check = Base58_check.Make (T)
+
+  let to_base58_check t = Base58_check.encode (Binable.to_string (module T) t)
 
   let of_base58_check s =
     let open Or_error.Let_syntax in
-    let%bind decoded = Base58_check.decode ~version_byte:T.version_byte s in
+    let%bind decoded = Base58_check.decode s in
     Ok (Binable.of_string (module T) decoded)
 
   let of_base58_check_exn s = of_base58_check s |> Or_error.ok_exn

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -113,6 +113,7 @@ module Compressed = struct
       include T
       include Registration.Make_latest_version (T)
       include Codable.Make_base64 (T)
+      include Codable.Make_base58_check (T)
     end
 
     module Latest = V1

--- a/src/lib/random_oracle_base/random_oracle_base.ml
+++ b/src/lib/random_oracle_base/random_oracle_base.ml
@@ -12,13 +12,15 @@ module Digest = struct
 
       include T
 
-      let version_byte = Base58_check.Version_bytes.random_oracle_base
+      module Base58_check = Base58_check.Make (struct
+        let version_byte = Base58_check.Version_bytes.random_oracle_base
+      end)
 
-      let to_yojson s = `String (Base58_check.encode ~version_byte ~payload:s)
+      let to_yojson s = `String (Base58_check.encode s)
 
       let of_yojson = function
         | `String s -> (
-          try Ok (Base58_check.decode_exn ~version_byte s)
+          try Ok (Base58_check.decode_exn s)
           with exn ->
             Error
               (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn)) )

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -31,12 +31,13 @@ let of_bigstring_exn = Binable.of_bigstring (module Stable.Latest)
 
 let to_bigstring = Binable.to_bigstring (module Stable.Latest)
 
-let version_byte = Base58_check.Version_bytes.private_key
+module Base58_check = Base58_check.Make (struct
+  let version_byte = Base58_check.Version_bytes.private_key
+end)
 
 let to_base58_check t =
-  let payload = to_bigstring t |> Bigstring.to_string in
-  Base58_check.encode ~version_byte ~payload
+  Base58_check.encode (to_bigstring t |> Bigstring.to_string)
 
 let of_base58_check_exn s =
-  let decoded = Base58_check.decode_exn ~version_byte s in
+  let decoded = Base58_check.decode_exn s in
   decoded |> Bigstring.of_string |> of_bigstring_exn

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.ml
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.ml
@@ -16,15 +16,16 @@ module Aux_hash = struct
       module T = struct
         type t = string [@@deriving bin_io, sexp, eq, compare, hash, version]
 
-        let version_byte =
-          Base58_check.Version_bytes.staged_ledger_hash_aux_hash
+        module Base58_check = Base58_check.Make (struct
+          let version_byte =
+            Base58_check.Version_bytes.staged_ledger_hash_aux_hash
+        end)
 
-        let to_yojson s =
-          `String (Base58_check.encode ~version_byte ~payload:s)
+        let to_yojson s = `String (Base58_check.encode s)
 
         let of_yojson = function
           | `String s -> (
-            try Ok (Base58_check.decode_exn ~version_byte s)
+            try Ok (Base58_check.decode_exn s)
             with exn ->
               Error
                 (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))
@@ -69,15 +70,16 @@ module Pending_coinbase_aux = struct
       module T = struct
         type t = string [@@deriving bin_io, sexp, eq, compare, hash, version]
 
-        let version_byte =
-          Base58_check.Version_bytes.staged_ledger_hash_pending_coinbase_aux
+        module Base58_check = Base58_check.Make (struct
+          let version_byte =
+            Base58_check.Version_bytes.staged_ledger_hash_pending_coinbase_aux
+        end)
 
-        let to_yojson s =
-          `String (Base58_check.encode ~version_byte ~payload:s)
+        let to_yojson s = `String (Base58_check.encode s)
 
         let of_yojson = function
           | `String s -> (
-            try Ok (Base58_check.decode_exn ~version_byte s)
+            try Ok (Base58_check.decode_exn s)
             with exn ->
               Error
                 (sprintf "of_yojson, bad Base58Check: %s" (Exn.to_string exn))


### PR DESCRIPTION
Instead of passing a `version_byte` for each encode/decode, pass that once to a functor, use when needed. 

Also, no need to label arguments for encode/decode any longer, since there's no danger of mixing up arguments; there's just the string to be encoded or decoded. That simplifies the API.

When raising an exception for an invalid version byte, show the actual and expected byte as hex numbers.

Closes #2752.
