### PR TITLE
Remove remaining uses of base64

### DIFF
--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -1,7 +1,7 @@
 (executable
  (name coda)
  (public_name coda)
- (libraries base64 base58_check core debug_assert daemon_rpcs pipe_lib coda_networking
+ (libraries base58_check core debug_assert daemon_rpcs pipe_lib coda_networking
    proposer gossip_net kademlia coda_lib coda_numbers coda_intf lite_lib
    lite_compat coda_base coda_state coda_transition test_util staged_ledger sparse_ledger_lib
    syncable_ledger blockchain_snark transaction_snark snarky

--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -30,6 +30,8 @@ let user_command_memo : t = '\xA2'
 
 let lite_params : t = '\x21'
 
+let lite_precomputed : t = '\xBC'
+
 let receipt_chain_hash : t = '\x9D'
 
 let secret_box_byteswr : t = '\x02'

--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -27,3 +27,9 @@ let staged_ledger_hash_aux_hash : t = '\x0B'
 let staged_ledger_hash_pending_coinbase_aux : t = '\x81'
 
 let user_command_memo : t = '\xA2'
+
+let lite_params : t = '\x21'
+
+let receipt_chain_hash : t = '\x9D'
+
+let secret_box_byteswr : t = '\x02'

--- a/src/lib/coda_base/receipt.ml
+++ b/src/lib/coda_base/receipt.ml
@@ -5,11 +5,15 @@ open Fold_lib
 module Chain_hash = struct
   include Data_hash.Make_full_size ()
 
+  module Base58_check = Base58_check.Make (struct
+    let version_byte = Base58_check.Version_bytes.receipt_chain_hash
+  end)
+
   let to_string t =
-    Binable.to_string (module Stable.Latest) t |> Base64.encode_string
+    Binable.to_string (module Stable.Latest) t |> Base58_check.encode
 
   let of_string s =
-    Base64.decode_exn s |> Binable.of_string (module Stable.Latest)
+    Base58_check.decode_exn s |> Binable.of_string (module Stable.Latest)
 
   include Codable.Make_of_string (struct
     type nonrec t = t

--- a/src/lib/coda_base/signature.ml
+++ b/src/lib/coda_base/signature.ml
@@ -15,14 +15,6 @@ module Stable = struct
     include T
     include Codable.Make_base58_check (T)
     include Registration.Make_latest_version (T)
-
-    include Codable.Make_of_string (struct
-      type nonrec t = t
-
-      let to_string = to_base58_check
-
-      let of_string = of_base58_check_exn
-    end)
   end
 
   module Latest = V1

--- a/src/lib/codable/codable.ml
+++ b/src/lib/codable/codable.ml
@@ -77,25 +77,6 @@ Make (struct
   let decode = Iso.of_string
 end)
 
-module Make_base64 (T : sig
-  type t [@@deriving bin_io]
-end) =
-struct
-  let to_base64 t = Binable.to_string (module T) t |> Base64.encode_string
-
-  let of_base64_exn s = Base64.decode_exn s |> Binable.of_string (module T)
-
-  module String_ops = struct
-    type t = T.t
-
-    let to_string = to_base64
-
-    let of_string = of_base64_exn
-  end
-
-  include Make_of_string (String_ops)
-end
-
 module Make_base58_check (T : sig
   type t [@@deriving bin_io]
 
@@ -112,4 +93,14 @@ struct
     Ok (Binable.of_string (module T) decoded)
 
   let of_base58_check_exn s = of_base58_check s |> Or_error.ok_exn
+
+  module String_ops = struct
+    type t = T.t
+
+    let to_string = to_base58_check
+
+    let of_string = of_base58_check_exn
+  end
+
+  include Make_of_string (String_ops)
 end

--- a/src/lib/codable/dune
+++ b/src/lib/codable/dune
@@ -3,6 +3,6 @@
   (public_name codable)
   (library_flags (-linkall))
   (inline_tests)
-  (libraries core_kernel ppx_deriving_yojson.runtime yojson base64 base58_check)
+  (libraries core_kernel ppx_deriving_yojson.runtime yojson base58_check)
   (preprocess (pps ppx_jane ppx_deriving_yojson bisect_ppx -conditional))
   (synopsis "Extension of Yojson to make it easy for a type to derive yojson"))

--- a/src/lib/lite_curve_choice/dune
+++ b/src/lib/lite_curve_choice/dune
@@ -3,4 +3,4 @@
   (public_name lite_curve_choice)
   (preprocess (pps ppx_jane ppx_deriving.eq ppx_coda))
   (libraries
-    snarkette core_kernel base64))
+    snarkette core_kernel))

--- a/src/lib/lite_params/dune
+++ b/src/lib/lite_params/dune
@@ -2,7 +2,7 @@
   (name lite_params)
   (public_name lite_params)
   (preprocess (pps ppx_jane ppx_deriving.eq ppx_coda))
-  (libraries pedersen_lib lite_curve_choice snarkette core_kernel base64))
+  (libraries pedersen_lib base58_check lite_curve_choice snarkette core_kernel))
 
 (rule
   (targets pedersen_params.ml)

--- a/src/lib/lite_params/gen/dune
+++ b/src/lib/lite_params/gen/dune
@@ -2,6 +2,7 @@
   (name gen)
   (libraries
      async
+     base58_check
      core
      crypto_params
      snarky

--- a/src/lib/lite_precomputed_values/gen/gen.ml
+++ b/src/lib/lite_precomputed_values/gen/gen.ml
@@ -48,7 +48,7 @@ let wrap_vk ~loc =
   [%expr
     Core_kernel.Binable.of_string
       (module Lite_params.Tock.Groth_maller.Verification_key)
-      (Base64.decode_exn [%e estring vk_base64])]
+      (Base58_check.decode_exn [%e estring vk_base58])]
 
 let protocol_state (s : Protocol_state.Value.t) : Lite_base.Protocol_state.t =
   let consensus_state =
@@ -90,7 +90,7 @@ let genesis ~loc =
       (Base58_check.decode_exn
          [%e
            estring
-             (Base64.encode_string
+             (Base58_check.encode
                 (Binable.to_string (module Lite_base.Lite_chain) chain))])]
 
 open Async

--- a/src/lib/lite_precomputed_values/gen/gen.ml
+++ b/src/lib/lite_precomputed_values/gen/gen.ml
@@ -104,6 +104,10 @@ let main () =
   let%bind wrap_vk_expr = wrap_vk ~loc in
   let structure =
     [%str
+      module Base58_check = Base58_check.Make (struct
+        let version_byte = Base58_check.Version_bytes.lite_precomputed
+      end)
+
       let wrap_vk = [%e wrap_vk_expr]
 
       let genesis_chain = [%e genesis ~loc]]

--- a/src/lib/non_zero_curve_point/dune
+++ b/src/lib/non_zero_curve_point/dune
@@ -3,6 +3,6 @@
  (public_name non_zero_curve_point)
  (flags :standard -short-paths)
  (library_flags -linkall)
- (libraries core_kernel snark_params fold_lib base64 codable module_version)
+ (libraries core_kernel snark_params fold_lib codable module_version)
  (preprocess
   (pps ppx_snarky ppx_coda ppx_jane ppx_deriving.eq)))

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -27,7 +27,6 @@ module Stable = struct
       let _ = Bigstring.write_bin_prot bs bin_writer_t elem in
       bs
 
-    include Codable.Make_base64 (T)
     include Codable.Make_base58_check (T)
   end
 
@@ -112,7 +111,6 @@ module Compressed = struct
 
       include T
       include Registration.Make_latest_version (T)
-      include Codable.Make_base64 (T)
       include Codable.Make_base58_check (T)
     end
 
@@ -133,12 +131,11 @@ module Compressed = struct
 
   include Comparable.Make_binable (Stable.Latest)
   include Hashable.Make_binable (Stable.Latest)
-  include Codable.Make_base64 (Stable.Latest)
   include Codable.Make_base58_check (Stable.Latest)
 
   let compress (x, y) : t = {x; is_odd= parity y}
 
-  let to_string = to_base64
+  let to_string = to_base58_check
 
   let empty = Poly.{x= Field.zero; is_odd= false}
 

--- a/src/lib/random_oracle/dune
+++ b/src/lib/random_oracle/dune
@@ -8,5 +8,4 @@
     snarky
     snarky_blake2
     random_oracle_base
-    crypto_params
-    base64 ))
+    crypto_params))

--- a/src/lib/secrets/secret_box.ml
+++ b/src/lib/secrets/secret_box.ml
@@ -4,11 +4,15 @@ open Sodium
 module BytesWr = struct
   include Bytes
 
-  let to_yojson t = `String (Bytes.to_string t |> Base64.encode_string)
+  module Base58_check = Base58_check.Make (struct
+    let version_byte = Base58_check.Version_bytes.secret_box_byteswr
+  end)
+
+  let to_yojson t = `String (Bytes.to_string t |> Base58_check.encode)
 
   let of_yojson = function
     | `String s ->
-        Ok (Base64.decode_exn s |> Bytes.of_string)
+        Ok (Base58_check.decode_exn s |> Bytes.of_string)
     | _ ->
         Error "Bytes.of_yojson needs a string"
 end

--- a/src/lib/signature_lib/dune
+++ b/src/lib/signature_lib/dune
@@ -2,7 +2,7 @@
  (name signature_lib)
  (public_name signature_lib)
  (library_flags -linkall)
- (libraries snarky base64 snark_params core non_zero_curve_point yojson)
+ (libraries snarky snark_params core non_zero_curve_point yojson)
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_snarky ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))

--- a/src/lib/signature_lib/public_key.mli
+++ b/src/lib/signature_lib/public_key.mli
@@ -78,10 +78,6 @@ module Compressed : sig
 
   val var_to_triples : var -> (Boolean.var Triple.t list, _) Checked.t
 
-  val of_base64_exn : string -> t
-
-  val to_base64 : t -> string
-
   val to_string : t -> string
 
   val to_base58_check : t -> string

--- a/src/opam.export
+++ b/src/opam.export
@@ -51,7 +51,6 @@ installed: [
   "base-threads.base"
   "base-unix.base"
   "base58.0.1.0"
-  "base64.3.2.0"
   "base_bigstring.v0.12.0"
   "base_quickcheck.v0.12.0"
   "bignum.v0.12.0"


### PR DESCRIPTION
The few remaining uses of `Base64` are replaced by `Base58_check`.

Closes #2690.
