### PR TITLE
Build snarky into the docker instance

### DIFF
--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -69,6 +69,9 @@ RUN sudo rm -rf /async_kernel/.git && cd /async_kernel && yes | opam pin add .
 ADD /src/external/coda_base58 /coda_base58
 RUN sudo rm -rf /coda_base58/.git && cd /coda_base58 && yes | opam pin add .
 
+# Source copy of snarky's coda branch
+RUN SNARKY_PERFORMANCE=on opam pin add https://github.com/o1-labs/snarky.git#coda
+
 # Get coda-kademlia from packages repo
 RUN sudo apt-get install --yes apt-transport-https ca-certificates && \
       echo "deb [trusted=yes] https://packages.o1test.net unstable main" | sudo tee -a /etc/apt/sources.list.d/coda.list && \

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -69,14 +69,14 @@ RUN sudo rm -rf /async_kernel/.git && cd /async_kernel && yes | opam pin add .
 ADD /src/external/coda_base58 /coda_base58
 RUN sudo rm -rf /coda_base58/.git && cd /coda_base58 && yes | opam pin add .
 
-# Source copy of snarky's coda branch
-RUN SNARKY_PERFORMANCE=on opam pin add https://github.com/o1-labs/snarky.git#coda
-
 # Get coda-kademlia from packages repo
 RUN sudo apt-get install --yes apt-transport-https ca-certificates && \
       echo "deb [trusted=yes] https://packages.o1test.net unstable main" | sudo tee -a /etc/apt/sources.list.d/coda.list && \
       sudo apt-get update && \
       sudo apt-get install --yes coda-kademlia
+
+# Source copy of snarky's coda branch
+RUN SNARKY_PERFORMANCE=on opam pin add https://github.com/o1-labs/snarky.git#coda
 
 # The Ocaml images are set to London time for reason. UTC makes reading the logs
 # easier.


### PR DESCRIPTION
This PR builds snarky into the docker instance with `PERFORMANCE=on`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: