### PR TITLE
Add 'advanced' subsection to coda cli

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -646,23 +646,26 @@ let command =
   Command.group ~summary:"Lightweight client commands"
     [ ("get-balance", get_balance)
     ; ("get-public-keys", get_public_keys)
-    ; ("get-trust-status", get_trust_status)
-    ; ("get-trust-status-all", get_trust_status_all)
-    ; ("reset-trust-status", reset_trust_status)
     ; ("prove-payment", prove_payment)
     ; ("verify-payment", verify_payment)
     ; ("get-nonce", get_nonce_cmd)
     ; ("send-payment", send_payment)
     ; ("delegate-stake", delegate_stake)
     ; ("stop-daemon", stop_daemon)
-    ; ("batch-send-payments", batch_send_payments)
     ; ("status", status)
+    ; ("generate-keypair", generate_keypair) ]
+
+let advanced =
+  Command.group ~summary:"Advanced client commands"
+    [ ("get-trust-status", get_trust_status)
+    ; ("get-trust-status-all", get_trust_status_all)
+    ; ("reset-trust-status", reset_trust_status)
+    ; ("batch-send-payments", batch_send_payments)
     ; ("status-clear-hist", status_clear_hist)
     ; ("wrap-key", wrap_key)
     ; ("dump-keypair", dump_keypair)
     ; ("dump-ledger", dump_ledger)
     ; ("constraint-system-digests", constraint_system_digests)
-    ; ("generate-keypair", generate_keypair)
     ; ("start-tracing", start_tracing)
     ; ("stop-tracing", stop_tracing)
     ; ("snark-job-list", snark_job_list)

--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -215,21 +215,22 @@ let get_public_keys =
              (module Cli_lib.Render.String_list_formatter)
              Get_public_keys.rpc () port ))
 
-let prove_payment =
+let generate_receipt =
   let open Daemon_rpcs in
   let open Command.Param in
   let open Cli_lib.Arg_type in
   let receipt_hash_flag =
     flag "receipt-chain-hash"
       ~doc:
-        "RECEIPTHASH Receipt-chain-hash of the payment that you want to prove"
+        "RECEIPTHASH Receipt-chain-hash of the payment that you want to\n\
+        \        generate a receipt for"
       (required receipt_chain_hash)
   in
   let address_flag =
     flag "address" ~doc:"PUBLICKEY Public-key address of sender"
       (required public_key_compressed)
   in
-  Command.async ~summary:"Generate a proof of a sent payment"
+  Command.async ~summary:"Generate a receipt for a sent payment"
     (Cli_lib.Background_daemon.init (Args.zip2 receipt_hash_flag address_flag)
        ~f:(fun port (receipt_chain_hash, pk) ->
          dispatch_with_message Prove_receipt.rpc (receipt_chain_hash, pk) port
@@ -240,14 +241,14 @@ let read_json filepath =
   let%map json_contents = Reader.file_contents filepath in
   Yojson.Safe.from_string json_contents
 
-let verify_payment =
+let verify_receipt =
   let open Deferred.Let_syntax in
   let open Daemon_rpcs in
   let open Command.Param in
   let open Cli_lib.Arg_type in
   let proof_path_flag =
     flag "proof-path"
-      ~doc:"PROOFFILE File to read json version of payment proof"
+      ~doc:"PROOFFILE File to read json version of payment receipt"
       (required string)
   in
   let payment_path_flag =
@@ -259,7 +260,7 @@ let verify_payment =
     flag "address" ~doc:"PUBLICKEY Public-key address of sender"
       (required public_key_compressed)
   in
-  Command.async ~summary:"Verify a proof of a sent payment"
+  Command.async ~summary:"Verify a receipt of a sent payment"
     (Cli_lib.Background_daemon.init
        (Args.zip3 payment_path_flag proof_path_flag address_flag)
        ~f:(fun port (payment_path, proof_path, pk) ->
@@ -644,21 +645,22 @@ end
 
 let command =
   Command.group ~summary:"Lightweight client commands"
+    ~preserve_subcommand_order:()
     [ ("get-balance", get_balance)
-    ; ("get-public-keys", get_public_keys)
-    ; ("prove-payment", prove_payment)
-    ; ("verify-payment", verify_payment)
-    ; ("get-nonce", get_nonce_cmd)
     ; ("send-payment", send_payment)
+    ; ("generate-keypair", generate_keypair)
     ; ("delegate-stake", delegate_stake)
+    ; ("generate-receipt", generate_receipt)
+    ; ("verify-receipt", verify_receipt)
     ; ("stop-daemon", stop_daemon)
-    ; ("status", status)
-    ; ("generate-keypair", generate_keypair) ]
+    ; ("status", status) ]
 
 let advanced =
   Command.group ~summary:"Advanced client commands"
-    [ ("get-trust-status", get_trust_status)
+    [ ("get-nonce", get_nonce_cmd)
+    ; ("get-trust-status", get_trust_status)
     ; ("get-trust-status-all", get_trust_status_all)
+    ; ("get-public-keys", get_public_keys)
     ; ("reset-trust-status", reset_trust_status)
     ; ("batch-send-payments", batch_send_payments)
     ; ("status-clear-hist", status_clear_hist)

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -574,11 +574,11 @@ let internal_commands =
   ; ("snark-hashes", snark_hashes) ]
 
 let coda_commands logger =
-  [ (Parallel.worker_command_name, Parallel.worker_command)
-  ; ("internal", Command.group ~summary:"Internal commands" internal_commands)
+  [ ("client", Client.command)
   ; ("daemon", daemon logger)
-  ; ("client", Client.command)
   ; ("advanced", Client.advanced)
+  ; ("internal", Command.group ~summary:"Internal commands" internal_commands)
+  ; (Parallel.worker_command_name, Parallel.worker_command)
   ; ("transaction-snark-profiler", Transaction_snark_profiler.command) ]
 
 [%%if
@@ -623,5 +623,7 @@ let () =
   don't_wait_for (ensure_testnet_id_still_good logger) ;
   (* Turn on snark debugging in prod for now *)
   Snarky.Snark.set_eval_constraints true ;
-  Command.run (Command.group ~summary:"Coda" (coda_commands logger)) ;
+  Command.run
+    (Command.group ~summary:"Coda" ~preserve_subcommand_order:()
+       (coda_commands logger)) ;
   Core.exit 0

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -578,6 +578,7 @@ let coda_commands logger =
   ; ("internal", Command.group ~summary:"Internal commands" internal_commands)
   ; ("daemon", daemon logger)
   ; ("client", Client.command)
+  ; ("advanced", Client.advanced)
   ; ("transaction-snark-profiler", Transaction_snark_profiler.command) ]
 
 [%%if


### PR DESCRIPTION
Trying to simplify exploration/discoverability of cli by hiding some lesser-used commands under an "advanced" section.

```
$ coda.exe -help
Coda

  coda.exe SUBCOMMAND

=== subcommands ===

  daemon                      Coda daemon
  client                      Lightweight client commands
  advanced                    Advanced client commands
  internal                    Internal commands
  parallel-worker             internal use only
  transaction-snark-profiler  transaction snark profiler
  integration-tests           Integration tests
  version                     print version information
  help                        explain a given subcommand (perhaps recursively)

$ coda.exe client -help
Lightweight client commands

  coda.exe client SUBCOMMAND

=== subcommands ===

  get-balance       Get balance associated with a public key
  send-payment      Send payment to an address
  generate-keypair  Generate a new public-key/private-key pair
  delegate-stake    Change the address to which you're delegating your coda
  generate-receipt  Generate a receipt for a sent payment
  verify-receipt    Verify a receipt of a sent payment
  stop-daemon       Stop the daemon
  status            Get running daemon status
  help              explain a given subcommand (perhaps recursively)

$ coda.exe advanced -help
Advanced client commands

  coda.exe advanced SUBCOMMAND

=== subcommands ===

  batch-send-payments        Send multiple payments from a file
  constraint-system-digests  Print MD5 digest of each SNARK constraint
  dump-keypair               Print out a keypair from a private key file
  dump-ledger                Print the ledger with given merkle root as a sexp
  get-nonce                  Get the current nonce for an account
  get-public-keys            Get public keys
  get-trust-status           Get the trust status associated with an IP address
  get-trust-status-all       Get trust statuses for all peers known to the trust
                             system
  reset-trust-status         Reset the trust status associated with an IP
                             address
  snark-job-list             List of snark jobs in JSON format
  start-tracing              Start async tracing to $config-directory/$pid.trace
  status-clear-hist          Clear histograms reported in status
  stop-tracing               Stop async tracing
  visualization              Visualize data structures special to Coda
  wrap-key                   Wrap a private key into a private key file
  help                       explain a given subcommand (perhaps recursively)
```