### PR TITLE
Add vrf eval benchmarks

### DIFF
--- a/src/app/benchmarks/dune
+++ b/src/app/benchmarks/dune
@@ -1,7 +1,7 @@
 (executable
  (name main)
  (public_name main)
- (libraries core_bench.inline_benchmarks coda_base signature_lib)
+ (libraries core_bench.inline_benchmarks vrf_lib_tests)
  ; the -w list here should be the same as in src/dune
  (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60)
  (modes native))

--- a/src/app/benchmarks/main.ml
+++ b/src/app/benchmarks/main.ml
@@ -7,7 +7,7 @@
 
 open Core_kernel
 
-let available_libraries = ["snark_params"]
+let available_libraries = ["snark_params"; "vrf_lib_tests"]
 
 let run_benchmarks_in_lib libname =
   Core.printf "Running inline tests in library \"%s\"\n%!" libname ;

--- a/src/lib/vrf_lib/dune
+++ b/src/lib/vrf_lib/dune
@@ -5,15 +5,17 @@
  (library_flags -linkall)
  (libraries core snarky snarky_curves test_util)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
  (modules integrated standalone)
  (synopsis "VRF instantiation"))
 
 (library
- (name tests)
+ (name vrf_lib_tests)
+ (public_name vrf_lib_tests)
+ (library_flags -linkall)
  (inline_tests)
  (libraries core snarky snarky_curves test_util signature_lib snark_params
    vrf_lib coda_base random_oracle fold_lib)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
  (modules integrated_test))

--- a/src/vrf_lib_tests.opam
+++ b/src/vrf_lib_tests.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
Add benchmarks for vrf unchecked and checked evaluation.

Sample output:
```
┌──────────────────────────────────────────────────────────────────────┬──────────────┬──────────────┬────────────┬────────────┬────────────┐
│ Name                                                                 │     Time/Run │      mWd/Run │   mjWd/Run │   Prom/Run │ Percentage │
├──────────────────────────────────────────────────────────────────────┼──────────────┼──────────────┼────────────┼────────────┼────────────┤
│ [lib/vrf_lib/integrated_test.ml:vrf bench module] vrf eval unchecked │     942.07us │     184.80kw │     4.51kw │     4.22kw │      0.15% │
│ [lib/vrf_lib/integrated_test.ml:vrf bench module] vrf eval checked   │ 622_379.92us │ 203_510.31kw │ 7_308.66kw │ 7_307.85kw │    100.00% │
└──────────────────────────────────────────────────────────────────────┴──────────────┴──────────────┴────────────┴────────────┴────────────┘
```
Not sure how useful these benchmarks are, in fact.