### PR TITLE
Base58check rep of ledger hash, use it in client status

### DIFF
--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -264,7 +264,7 @@ let get_status ~flag t =
     let open Participating_state.Let_syntax in
     let%bind ledger = Coda_lib.best_ledger t in
     let ledger_merkle_root =
-      Ledger.merkle_root ledger |> [%sexp_of: Ledger_hash.t] |> Sexp.to_string
+      Ledger.merkle_root ledger |> Ledger_hash.to_string
     in
     let num_accounts = Ledger.num_accounts ledger in
     let%bind state = Coda_lib.best_protocol_state t in

--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -35,3 +35,5 @@ let lite_precomputed : t = '\xBC'
 let receipt_chain_hash : t = '\x9D'
 
 let secret_box_byteswr : t = '\x02'
+
+let ledger_hash : t = '\x63'

--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -42,6 +42,18 @@ let depth = Snark_params.ledger_depth
 
 include Data_hash.Make_full_size ()
 
+module T = struct
+  type t = Stable.Latest.t [@@deriving bin_io]
+
+  let version_byte = Base58_check.Version_bytes.ledger_hash
+end
+
+module Base58_check = Codable.Make_base58_check (T)
+
+let to_string t = Base58_check.String_ops.to_string t
+
+let of_string s = Base58_check.String_ops.of_string s
+
 let merge ~height (h1 : t) (h2 : t) =
   let open Tick.Pedersen in
   State.digest

--- a/src/lib/coda_base/ledger_hash_intf.ml
+++ b/src/lib/coda_base/ledger_hash_intf.ml
@@ -18,6 +18,11 @@ module type S = sig
 
   val merge : height:int -> t -> t -> t
 
+  (** string representation of hash is Base58Check of bin_io representation *)
+  val to_string : t -> string
+
+  val of_string : string -> t
+
   val empty_hash : t
 
   val of_digest : Pedersen.Digest.t -> t


### PR DESCRIPTION
Add `to_string`, `of_string` to `Ledger_hash`, using `Codable.Make_base58_check`.

Use `to_string` in `client status`.

Closes #2771. Or maybe there are other places where we want this base58 representation?