### PR TITLE
Lazy generated data

### DIFF
--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -28,8 +28,6 @@ let staged_ledger_hash_pending_coinbase_aux : t = '\x81'
 
 let user_command_memo : t = '\xA2'
 
-let lite_params : t = '\x21'
-
 let lite_precomputed : t = '\xBC'
 
 let receipt_chain_hash : t = '\x9D'

--- a/src/lib/coda_base/gen/gen.ml
+++ b/src/lib/coda_base/gen/gen.ml
@@ -41,13 +41,21 @@ let expr ~loc =
       (List.map keypairs ~f:(fun {public_key; private_key} ->
            E.pexp_tuple
              [ estring
-                 (Public_key.Compressed.to_base58_check
+                 (Binable.to_string
+                    (module Public_key.Compressed.Stable.Latest)
                     (Public_key.compress public_key))
-             ; estring (Private_key.to_base58_check private_key) ] ))
+             ; estring
+                 (Binable.to_string
+                    (module Private_key.Stable.Latest)
+                    private_key) ] ))
   in
   let%expr conv (pk, sk) =
-    ( Signature_lib.Public_key.Compressed.of_base58_check_exn pk
-    , Signature_lib.Private_key.of_base58_check_exn sk )
+    ( Core_kernel.Binable.of_string
+        (module Signature_lib.Public_key.Compressed.Stable.Latest)
+        pk
+    , Core_kernel.Binable.of_string
+        (module Signature_lib.Private_key.Stable.Latest)
+        sk )
   in
   Array.map conv [%e earray]
 
@@ -56,7 +64,7 @@ let structure ~loc =
     let loc = loc
   end) in
   let open E in
-  [%str let keypairs = [%e expr ~loc]]
+  [%str let keypairs = lazy [%e expr ~loc]]
 
 let json =
   `List

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -857,8 +857,10 @@ module Data = struct
     let eval = T.eval
 
     module Precomputed = struct
+      let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs
+
       let handler : Snark_params.Tick.Handler.t =
-        let pk, sk = Coda_base.Sample_keypairs.keypairs.(0) in
+        let pk, sk = keypairs.(0) in
         let dummy_sparse_ledger =
           Coda_base.Sparse_ledger.of_ledger_subset_exn Genesis_ledger.t [pk]
         in
@@ -895,7 +897,7 @@ module Data = struct
                       request))
 
       let vrf_output =
-        let _, sk = Coda_base.Sample_keypairs.keypairs.(0) in
+        let _, sk = keypairs.(0) in
         eval ~private_key:sk
           { Message.epoch= Epoch.zero
           ; slot= Epoch.Slot.zero

--- a/src/lib/genesis_ledger/release_ledger.ml
+++ b/src/lib/genesis_ledger/release_ledger.ml
@@ -8,8 +8,7 @@ include Make (struct
     let high_balances = List.init 1 ~f:(Fn.const 10_000_000) in
     let low_balances = List.init 17 ~f:(Fn.const 1_000) in
     let balances = high_balances @ low_balances in
+    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     List.mapi balances ~f:(fun i b ->
-        { balance= b
-        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
-        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
+        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
 end)

--- a/src/lib/genesis_ledger/test_delegation_ledger.ml
+++ b/src/lib/genesis_ledger/test_delegation_ledger.ml
@@ -5,8 +5,7 @@ include Make (struct
   let accounts =
     (* zeroth account becomes delegatee; first account is a placeholder; second account is delegator *)
     let balances = [0; 0; 5_000_000] in
+    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     List.mapi balances ~f:(fun i b ->
-        { balance= b
-        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
-        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
+        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
 end)

--- a/src/lib/genesis_ledger/test_five_even_stakes.ml
+++ b/src/lib/genesis_ledger/test_five_even_stakes.ml
@@ -4,11 +4,10 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
+    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     let balances =
       [1_000_000; 1_000_000; 1_000_000; 1_000_000; 1_000_000; 1_000]
     in
     List.mapi balances ~f:(fun i b ->
-        { balance= b
-        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
-        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
+        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
 end)

--- a/src/lib/genesis_ledger/test_ledger.ml
+++ b/src/lib/genesis_ledger/test_ledger.ml
@@ -23,7 +23,8 @@ include Make (struct
       ; 1_000
       ; 1_000 ]
     in
+    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     List.mapi balances ~f:(fun i b ->
-        let pk, sk = Coda_base.Sample_keypairs.keypairs.(i) in
+        let pk, sk = keypairs.(i) in
         {pk; sk; balance= b} )
 end)

--- a/src/lib/genesis_ledger/test_split_two_stakes_ledger.ml
+++ b/src/lib/genesis_ledger/test_split_two_stakes_ledger.ml
@@ -7,8 +7,7 @@ include Make (struct
     let high_balances = List.init 2 ~f:(Fn.const 5_000_000) in
     let low_balances = List.init 16 ~f:(Fn.const 1_000) in
     let balances = high_balances @ low_balances in
+    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     List.mapi balances ~f:(fun i b ->
-        { balance= b
-        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
-        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
+        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
 end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -7,8 +7,7 @@ include Make (struct
     let high_balances = List.init 5 ~f:(Fn.const 5_000_000) in
     let low_balances = List.init 13 ~f:(Fn.const 1_000) in
     let balances = high_balances @ low_balances in
+    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     List.mapi balances ~f:(fun i b ->
-        { balance= b
-        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
-        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
+        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
 end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
@@ -7,8 +7,7 @@ include Make (struct
     let high_balances = List.init 50 ~f:(Fn.const 5_000_000) in
     let low_balances = List.init 10 ~f:(Fn.const 1_000) in
     let balances = high_balances @ low_balances in
+    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
     List.mapi balances ~f:(fun i b ->
-        { balance= b
-        ; pk= fst Coda_base.Sample_keypairs.keypairs.(i)
-        ; sk= snd Coda_base.Sample_keypairs.keypairs.(i) } )
+        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
 end)

--- a/src/lib/lite_lib/account.ml
+++ b/src/lib/lite_lib/account.ml
@@ -3,7 +3,8 @@ include Lite_base.Account
 
 let digest t =
   Lite_base.Pedersen.digest_fold
-    (Lite_base.Pedersen.State.salt Lite_params.pedersen_params
+    (Lite_base.Pedersen.State.salt
+       (Lazy.force Lite_params.pedersen_params)
        (Hash_prefixes.account :> string))
     (fold t)
 
@@ -15,7 +16,7 @@ module Membership_proof = struct
       (Merkle_path.implied_root proof
          Pedersen.(
            digest_fold
-             (State.create Lite_params.pedersen_params)
+             (State.create (Lazy.force Lite_params.pedersen_params))
              (fold account)))
       root
 end

--- a/src/lib/lite_lib/merkle_path.ml
+++ b/src/lib/lite_lib/merkle_path.ml
@@ -10,7 +10,8 @@ type t = elem list [@@deriving bin_io]
 let merge ~height h1 h2 =
   let open Pedersen in
   digest_fold
-    (State.salt Lite_params.pedersen_params
+    (State.salt
+       (Lazy.force Lite_params.pedersen_params)
        (Hash_prefixes.merkle_tree height :> string))
     Fold.(Digest.fold h1 +> Digest.fold h2)
 

--- a/src/lib/lite_params/dune
+++ b/src/lib/lite_params/dune
@@ -2,7 +2,7 @@
   (name lite_params)
   (public_name lite_params)
   (preprocess (pps ppx_jane ppx_deriving.eq ppx_coda))
-  (libraries pedersen_lib base58_check lite_curve_choice snarkette core_kernel))
+  (libraries pedersen_lib lite_curve_choice snarkette core_kernel))
 
 (rule
   (targets pedersen_params.ml)

--- a/src/lib/lite_params/gen/dune
+++ b/src/lib/lite_params/gen/dune
@@ -2,7 +2,6 @@
   (name gen)
   (libraries
      async
-     base58_check
      core
      crypto_params
      snarky

--- a/src/lib/lite_params/gen/gen.ml
+++ b/src/lib/lite_params/gen/gen.ml
@@ -17,10 +17,6 @@ let key_generation = false
 
 [%%endif]
 
-module Base58_check = Base58_check.Make (struct
-  let version_byte = Base58_check.Version_bytes.lite_params
-end)
-
 let pedersen_params ~loc =
   let module E = Ppxlib.Ast_builder.Make (struct
     let loc = loc
@@ -49,12 +45,7 @@ let main () =
   in
   let loc = Ppxlib.Location.none in
   let structure =
-    [%str
-      module Base58_check = Base58_check.Make (struct
-        let version_byte = Base58_check.Version_bytes.lite_params
-      end)
-
-      let pedersen_params = [%e pedersen_params ~loc]]
+    [%str let pedersen_params = lazy [%e pedersen_params ~loc]]
   in
   Pprintast.top_phrase fmt (Ptop_def structure) ;
   exit 0

--- a/src/lib/lite_precomputed_values/dune
+++ b/src/lib/lite_precomputed_values/dune
@@ -2,7 +2,7 @@
   (name lite_precomputed_values)
   (public_name lite_precomputed_values)
   (preprocess (pps ppx_jane ppx_deriving.eq ppx_coda))
-  (libraries lite_base snarkette core_kernel base64))
+  (libraries lite_base snarkette core_kernel base58_check))
 
 (rule
   (targets lite_precomputed_values.ml)


### PR DESCRIPTION
Make `pedersen_params` and `sample_keypairs` lazy, because they're deserialized from strings.

Also, for `sample_keypairs`, remove the base58 encoding/decoding, which isn't needed.