### PR TITLE
Lazy pedersen params

### DIFF
--- a/src/lib/chunked_pedersen_lib/pedersen_inputs_intf.ml
+++ b/src/lib/chunked_pedersen_lib/pedersen_inputs_intf.ml
@@ -27,7 +27,7 @@ module type S = sig
     val negate : t -> t
   end
 
-  val params : Curve.t Tuple_lib.Quadruple.t array
+  val params : Curve.t Tuple_lib.Quadruple.t array Lazy.t
 
   val chunk_table : Curve.t array array Lazy.t
 end

--- a/src/lib/crypto_params/dune
+++ b/src/lib/crypto_params/dune
@@ -3,7 +3,7 @@
  (public_name crypto_params)
  (library_flags -linkall)
  (inline_tests)
- (libraries chunked_pedersen_lib snarky bignum_bigint curve_choice chunk_table tuple_lib group_map)
+ (libraries core chunked_pedersen_lib snarky bignum_bigint curve_choice chunk_table tuple_lib group_map)
  (preprocess
   (pps ppx_jane bisect_ppx -- -conditional))
  (synopsis "Cryptographic parameters"))

--- a/src/lib/crypto_params/gen/gen.ml
+++ b/src/lib/crypto_params/gen/gen.ml
@@ -93,9 +93,8 @@ let params_ast ~loc =
     Tick_backend.Inner_curve.of_affine
       (Tick0.Field.of_string x, Tick0.Field.of_string y)
   in
-  Array.map
-    (fun (g1, g2, g3, g4) -> (conv g1, conv g2, conv g3, conv g4))
-    [%e earray]
+  Core_kernel.Array.map [%e earray] ~f:(fun (g1, g2, g3, g4) ->
+      (conv g1, conv g2, conv g3, conv g4) )
 
 let group_map_params =
   Group_map.Params.create
@@ -129,7 +128,7 @@ let params_structure ~loc =
   let open E in
   [%str open Curve_choice
 
-        let params = [%e params_ast ~loc]]
+        let params = lazy [%e params_ast ~loc]]
 
 (* for the reversed chunk with value n, compute its curve value
    start is the starting parameter position of the chunk, based

--- a/src/lib/lite_params/gen/gen.ml
+++ b/src/lib/lite_params/gen/gen.ml
@@ -22,7 +22,7 @@ let pedersen_params ~loc =
     let loc = loc
   end) in
   let open E in
-  let arr = Crypto_params.Pedersen_params.params in
+  let arr = Lazy.force Crypto_params.Pedersen_params.params in
   let arr_expr =
     List.init (Array.length arr) ~f:(fun i ->
         let g, _, _, _ = arr.(i) in


### PR DESCRIPTION
Make the Pedersen params in `Crypto_params` lazy, with the eventual goal of pre-computing all hashes at startup.

Currently, on @psteckler's home machine, `coda client -help` takes a little under 2 seconds. About 0.2 seconds is the params deserialization, another 1.7 is hashing/digesting which makes use of the params.