### PR TITLE
Staged hash in status is base58

### DIFF
--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -268,9 +268,7 @@ let get_status ~flag t =
     in
     let num_accounts = Ledger.num_accounts ledger in
     let%bind state = Coda_lib.best_protocol_state t in
-    let state_hash =
-      Protocol_state.hash state |> [%sexp_of: State_hash.t] |> Sexp.to_string
-    in
+    let state_hash = Protocol_state.hash state |> State_hash.to_string in
     let consensus_state = state |> Protocol_state.consensus_state in
     let blockchain_length =
       Length.to_int

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -110,7 +110,7 @@ module Types = struct
 
     let amount amount = uint64 @@ Currency.Amount.to_uint64 amount
 
-    module State_hash = Codable.Make_base58_check (State_hash.Stable.V1)
+    module State_hash = State_hash
   end
 
   module Base58_check = Base58_check.Make (struct

--- a/src/lib/coda_base/state_hash.ml
+++ b/src/lib/coda_base/state_hash.ml
@@ -1,3 +1,11 @@
 include Data_hash.Make_full_size ()
 
+module Base58_check = Codable.Make_base58_check (Stable.Latest)
+
+[%%define_locally
+Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
+
+[%%define_locally
+Base58_check.String_ops.(to_string, of_string)]
+
 let zero = Snark_params.Tick.Pedersen.zero_hash

--- a/src/lib/coda_base/state_hash.mli
+++ b/src/lib/coda_base/state_hash.mli
@@ -1,3 +1,18 @@
 include Data_hash.Full_size
 
+(** string encoding (Base58Check) *)
+val to_string : t -> string
+
+(** string (Base58Check) decoding *)
+val of_string : string -> t
+
+(** explicit Base58Check encoding *)
+val to_base58_check : t -> string
+
+(** Base58Check decoding *)
+val of_base58_check : string -> t Base.Or_error.t
+
+(** Base58Check decoding *)
+val of_base58_check_exn : string -> t
+
 val zero : Crypto_params.Tick0.field


### PR DESCRIPTION
We recently changed the Merkle root in `client status` to be Base58.

This PR changes the `Staged Hash` in that command to also be Base58 (it's been in decimal up to now, as was the Merkle root in the old days). 
