### PR TITLE
[FIX] changed deb versioning scheme

### DIFF
--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -7,14 +7,12 @@ cd $SCRIPTPATH/../src/_build
 PROJECT="coda-$(echo "$DUNE_PROFILE" | tr _ -)"
 DATE=$(date +%Y-%m-%d)
 GITHASH=$(git rev-parse --short=8 HEAD)
+GITBRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!' )
 
-# Identify CI builds by build number
 set +u
-if [ -z "$CIRCLE_BUILD_NUM" ]; then
-    VERSION="0.1.${DATE}-${GITHASH}"
-else
-    VERSION="0.1.${CIRCLE_BUILD_NUM}-CI"
-fi
+# Identify All Artifacts by Branch and Git Hash
+
+VERSION="0.0.1-${GITBRANCH}-${GITHASH}"
 
 BUILDDIR="${PROJECT}_${VERSION}"
 


### PR DESCRIPTION
Updated deb versioning scheme from: `VERSION="0.1.${CIRCLE_BUILD_NUM}-CI"` to `VERSION="0.0.1-${GITBRANCH}-${GITHASH}"`