### PR TITLE
turned on time_offsets

### DIFF
--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -7,7 +7,7 @@
 [%%import "config/proof_level/full.mlh"]
 [%%import "config/txpool_size.mlh"]
 
-[%%define time_offsets false]
+[%%define time_offsets true]
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 


### PR DESCRIPTION
Enabled `time_offsets` on the `testnet_postake_medium_curves` profile. 

CC: @nholland94 @bkase 