### PR TITLE
Consensus human time now respects time offsets

### DIFF
--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -225,7 +225,9 @@ let get_status ~flag t =
   let run_snark_worker = Option.is_some (Coda_lib.snark_worker_key t) in
   let propose_pubkeys = Coda_lib.propose_public_keys t in
   let consensus_mechanism = Consensus.name in
-  let consensus_time_now = Consensus.time_hum (Core_kernel.Time.now ()) in
+  let consensus_time_now =
+    Consensus.time_hum (Block_time.now (Coda_lib.config t).time_controller)
+  in
   let consensus_configuration = Consensus.Configuration.t in
   let r = Perf_histograms.report in
   let histograms =

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -266,7 +266,7 @@ module type S = sig
     * This is mostly useful for PoStake and other consensus mechanisms that have their own
     * notions of time.
   *)
-  val time_hum : Time.t -> string
+  val time_hum : Coda_base.Block_time.t -> string
 
   module Constants : Constants_intf
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -233,8 +233,8 @@ module Data = struct
     end
 
     let slot_start_time (epoch : t) (slot : Slot.t) =
-      Time.add (start_time epoch)
-        (Time.Span.of_ms
+      Coda_base.Block_time.add (start_time epoch)
+        (Coda_base.Block_time.Span.of_ms
            Int64.Infix.(int64_of_uint32 slot * Constants.Slot.duration_ms))
 
     (*
@@ -244,7 +244,7 @@ module Data = struct
 
     let epoch_and_slot_of_time_exn tm : t * Slot.t =
       let epoch = of_time_exn tm in
-      let time_since_epoch = Time.diff tm (start_time epoch) in
+      let time_since_epoch = Coda_base.Block_time.diff tm (start_time epoch) in
       let slot =
         uint32_of_int64
         @@ Int64.Infix.(
@@ -2557,7 +2557,8 @@ module Hooks = struct
       "Checking for next proposal..." ;
     let curr_epoch, curr_slot =
       Epoch.epoch_and_slot_of_time_exn
-        (Time.of_span_since_epoch (Time.Span.of_ms now))
+        (Coda_base.Block_time.of_span_since_epoch
+           (Coda_base.Block_time.Span.of_ms now))
     in
     let epoch, slot =
       if
@@ -2859,8 +2860,8 @@ module Hooks = struct
   end
 end
 
-let time_hum (now : Core_kernel.Time.t) =
-  let epoch, slot = Data.Epoch.epoch_and_slot_of_time_exn (Time.of_time now) in
+let time_hum (now : Coda_base.Block_time.t) =
+  let epoch, slot = Data.Epoch.epoch_and_slot_of_time_exn now in
   Printf.sprintf "%d:%d" (Data.Epoch.to_int epoch)
     (Data.Epoch.Slot.to_int slot)
 


### PR DESCRIPTION
The consensus human friendly time we were displaying on `client status` was not respecting time offsets (due to it using `Core.Time` instead of `Coda_base.Block_time`). This PR fixes that by replacing uses of `Core.Time`.