### PR TITLE
Check for open external ports before starting net

### DIFF
--- a/src/app/cli/src/async_udp.ml
+++ b/src/app/cli/src/async_udp.ml
@@ -1,0 +1,332 @@
+(* Taken from https://github.com/janestreet/async_extra/blob/master/async_udp/src/async_udp.ml which we cannot find in our current version of async extra *)
+open! Core
+open! Async
+open! Int.Replace_polymorphic_compare
+
+type write_buffer = (read_write, Iobuf.seek) Iobuf.t
+
+let default_capacity = 1472
+
+let default_retry = 12
+
+module Config = struct
+  type t =
+    {capacity: int; init: write_buffer; stop: unit Deferred.t; max_ready: int}
+  [@@deriving fields]
+
+  let create ?(capacity = default_capacity)
+      ?(init = Iobuf.create ~len:capacity) ?(stop = Deferred.never ())
+      ?(max_ready = default_retry) () =
+    {capacity; init; stop; max_ready}
+end
+
+let fail iobuf message a sexp_of_a =
+  (* Render buffers immediately, before we have a chance to change them. *)
+  failwiths message
+    (a, [%sexp_of: (_, _) Iobuf.Hexdump.t option] iobuf)
+    (Tuple.T2.sexp_of_t sexp_of_a ident)
+
+(* Don't use [Or_error.map] to extract any of the [send] functions.  The natural usage
+   results in partially applied functions! *)
+
+let sendto_sync () =
+  match Iobuf.sendto_nonblocking_no_sigpipe () with
+  | Error _ as e ->
+      e
+  | Ok sendto ->
+      Ok
+        (fun fd buf addr ->
+          Fd.with_file_descr_exn fd ~nonblocking:true (fun desc ->
+              sendto buf desc (Unix.Socket.Address.to_sockaddr addr) ) )
+
+let send_sync () =
+  match Iobuf.send_nonblocking_no_sigpipe () with
+  | Error _ as e ->
+      e
+  | Ok send ->
+      Ok
+        (fun fd buf ->
+          Fd.with_file_descr_exn fd ~nonblocking:true (fun desc ->
+              send buf desc ) )
+
+(** [ready_iter fd ~stop ~max_ready ~f] iterates [f] over [fd], handling [EINTR] by
+    retrying immediately (at most [max_ready] times in a row) and [EWOULDBLOCK]/[EAGAIN]
+    by retrying when ready.  Iteration is terminated when [fd] closes, [stop] fills, or
+    [f] returns [User_stopped].
+
+    [ready_iter] may fill [stop] itself.
+
+    By design, this function will not return to the Async scheduler until [fd] is no
+    longer ready to transfer data or [f] has succeeded [max_ready] consecutive times. To
+    avoid starvation, use [stop] or [User_stopped] and/or choose [max_ready] carefully to
+    allow other Async jobs to run.
+
+    @raise Unix.Unix_error on errors other than [EINTR] and [EWOULDBLOCK]/[EAGAIN]. *)
+module Ready_iter = struct
+  module Ok = struct
+    type t = Poll_again | User_stopped
+    [@@deriving sexp_of, enumerate, compare]
+
+    let of_int_exn = function
+      | 0 ->
+          Poll_again
+      | 1 ->
+          User_stopped
+      | i ->
+          failwithf "invalid ready iter ok %d" i ()
+
+    let to_int = function Poll_again -> 0 | User_stopped -> 1
+  end
+
+  include Unix.Syscall_result.Make (Ok) ()
+
+  let poll_again = create_ok Poll_again
+
+  let user_stopped = create_ok User_stopped
+end
+
+let ready_iter fd ~stop ~max_ready ~f read_or_write ~syscall_name =
+  let rec inner_loop i file_descr : Ready_iter.Ok.t =
+    if i < max_ready && Ivar.is_empty stop && Fd.is_open fd then
+      match f file_descr |> Ready_iter.to_result (* doesn't allocate *) with
+      | Ok Poll_again | Error EINTR ->
+          inner_loop (i + 1) file_descr
+      | Ok User_stopped ->
+          User_stopped
+      | Error (EWOULDBLOCK | EAGAIN) ->
+          Poll_again
+      (* This looks extreme but serves the purpose of effectively terminating the
+         [interruptible_every_ready_iter] job and the [ready_iter] loop. *)
+      | Error e ->
+          raise (Unix.Unix_error (e, syscall_name, ""))
+    else Poll_again
+  in
+  (* [Fd.with_file_descr] is for [Raw_fd.set_nonblock_if_necessary].
+     [with_file_descr_deferred] would be the more natural choice, but it doesn't call
+     [set_nonblock_if_necessary]. *)
+  match
+    Fd.with_file_descr ~nonblocking:true fd (fun file_descr ->
+        Fd.interruptible_every_ready_to fd read_or_write
+          ~interrupt:(Ivar.read stop)
+          (fun file_descr ->
+            match inner_loop 0 file_descr with
+            | Poll_again ->
+                ()
+            | User_stopped ->
+                Ivar.fill_if_empty stop () )
+          file_descr )
+  with
+  (* Avoid one ivar creation and wait immediately by returning the result from
+     [Fd.interruptible_every_ready_to] directly. *)
+  | `Ok deferred ->
+      deferred
+  | `Already_closed ->
+      return `Closed
+  | `Error e ->
+      raise e
+
+let sendto () =
+  match Iobuf.sendto_nonblocking_no_sigpipe () with
+  | Error _ as e ->
+      e
+  | Ok sendto ->
+      Ok
+        (fun fd buf addr ->
+          let addr = Unix.Socket.Address.to_sockaddr addr in
+          let stop = Ivar.create () in
+          ready_iter fd ~max_ready:default_retry ~stop `Write
+            ~syscall_name:"sendto" ~f:(fun file_descr ->
+              match
+                Unix.Syscall_result.Unit.to_result (sendto buf file_descr addr)
+              with
+              | Ok () ->
+                  Ready_iter.user_stopped
+              | Error e ->
+                  Ready_iter.create_error e )
+          >>= function
+          | `Interrupted ->
+              Deferred.unit
+          | (`Bad_fd | `Closed | `Unsupported) as error ->
+              fail (Some buf) "Udp.sendto" (error, addr)
+                [%sexp_of:
+                  [`Bad_fd | `Closed | `Unsupported] * Core.Unix.sockaddr] )
+
+let send () =
+  match Iobuf.send_nonblocking_no_sigpipe () with
+  | Error _ as e ->
+      e
+  | Ok send ->
+      Ok
+        (fun fd buf ->
+          let stop = Ivar.create () in
+          ready_iter fd ~max_ready:default_retry ~stop `Write
+            ~syscall_name:"send" ~f:(fun file_descr ->
+              match
+                Unix.Syscall_result.Unit.to_result (send buf file_descr)
+              with
+              | Ok () ->
+                  Ready_iter.user_stopped
+              | Error e ->
+                  Ready_iter.create_error e )
+          >>= function
+          | `Interrupted ->
+              Deferred.unit
+          | (`Bad_fd | `Closed | `Unsupported) as error ->
+              fail (Some buf) "Udp.send" error
+                [%sexp_of: [`Bad_fd | `Closed | `Unsupported]] )
+
+let bind ?ifname addr =
+  let socket = Socket.create Socket.Type.udp in
+  let is_multicast a =
+    Unix.Cidr.does_match Unix.Cidr.multicast (Socket.Address.Inet.addr a)
+  in
+  ( if is_multicast addr then
+    try
+      (* We do not treat [mcast_join] as a blocking operation because it only instructs
+       the kernel to send an IGMP message, which the kernel handles asynchronously. *)
+      Core.Unix.mcast_join ?ifname
+        (Fd.file_descr_exn (Socket.fd socket))
+        (Socket.Address.to_sockaddr addr)
+    with exn ->
+      raise_s
+        [%message
+          "Async_udp.bind unable to join multicast group"
+            (addr : Socket.Address.Inet.t)
+            (ifname : string option)
+            (exn : Exn.t)] ) ;
+  Socket.bind_inet socket addr
+
+let bind_any () =
+  let bind_addr = Socket.Address.Inet.create_bind_any ~port:0 in
+  let socket = Socket.create Socket.Type.udp in
+  (* When bind() is called with a port number of zero, a non-conflicting local port
+     address is chosen (i.e., an ephemeral port).  In almost all cases where we use
+     this, we want a unique port, and hence prevent reuseaddr. *)
+  try Socket.bind_inet socket ~reuseaddr:false bind_addr
+  with bind_exn ->
+    let socket_fd = Socket.fd socket in
+    don't_wait_for
+      (* Errors from [close] are generally harmless, so we ignore them *)
+      (Monitor.handle_errors
+         (fun () -> Fd.close socket_fd)
+         (fun (_ : exn) -> ())) ;
+    raise bind_exn
+
+module Loop_result = struct
+  type t = Closed | Stopped [@@deriving sexp_of, compare]
+
+  let of_fd_interruptible_every_ready_to_result_exn buf function_name x
+      sexp_of_x result =
+    match result with
+    | (`Bad_fd | `Unsupported) as error ->
+        fail buf function_name (error, x)
+          [%sexp_of: [`Bad_fd | `Unsupported] * x]
+    | `Closed ->
+        Closed
+    | `Interrupted ->
+        Stopped
+end
+
+let recvfrom_loop_with_buffer_replacement ?(config = Config.create ()) fd f =
+  let stop = Ivar.create () in
+  Config.stop config >>> Ivar.fill_if_empty stop ;
+  let buf = ref (Config.init config) in
+  ready_iter ~stop ~max_ready:config.max_ready fd `Read
+    ~syscall_name:"recvfrom" ~f:(fun file_descr ->
+      match Iobuf.recvfrom_assume_fd_is_nonblocking !buf file_descr with
+      | exception Unix.Unix_error (e, _, _) ->
+          Ready_iter.create_error e
+      | ADDR_UNIX dom ->
+          fail (Some !buf) "Unix domain socket addresses not supported" dom
+            [%sexp_of: string]
+      | ADDR_INET (host, port) ->
+          Iobuf.flip_lo !buf ;
+          buf := f !buf (`Inet (host, port)) ;
+          Iobuf.reset !buf ;
+          Ready_iter.poll_again )
+  >>| Loop_result.of_fd_interruptible_every_ready_to_result_exn (Some !buf)
+        "recvfrom_loop_without_buffer_replacement" fd [%sexp_of: Fd.t]
+
+let recvfrom_loop ?config fd f =
+  recvfrom_loop_with_buffer_replacement ?config fd (fun b a -> f b a ; b)
+
+(* We don't care about the address, so read instead of recvfrom. *)
+let read_loop_with_buffer_replacement ?(config = Config.create ()) fd f =
+  let stop = Ivar.create () in
+  Config.stop config >>> Ivar.fill_if_empty stop ;
+  let buf = ref (Config.init config) in
+  ready_iter ~stop ~max_ready:config.max_ready fd `Read ~syscall_name:"read"
+    ~f:(fun file_descr ->
+      let result = Iobuf.read_assume_fd_is_nonblocking !buf file_descr in
+      if Unix.Syscall_result.Unit.is_ok result then (
+        Iobuf.flip_lo !buf ;
+        buf := f !buf ;
+        Iobuf.reset !buf ;
+        Ready_iter.poll_again )
+      else Unix.Syscall_result.Unit.reinterpret_error_exn result )
+  >>| Loop_result.of_fd_interruptible_every_ready_to_result_exn (Some !buf)
+        "read_loop_with_buffer_replacement" fd [%sexp_of: Fd.t]
+
+let read_loop ?config fd f =
+  read_loop_with_buffer_replacement ?config fd (fun b -> f b ; b)
+
+(* Too small a [max_count] here negates the value of [recvmmsg], while too large risks
+   starvation of other ready file descriptors.  32 was chosen empirically to stay below
+   ~64kb of data, assuming a standard Ethernet MTU. *)
+let default_recvmmsg_loop_max_count = 32
+
+let recvmmsg_loop =
+  let create_buffers ~max_count config =
+    let len = Config.capacity config in
+    if len <= 2048 then
+      let bstr = Bigstring.create (2048 * max_count) in
+      Array.init max_count ~f:(fun index ->
+          Iobuf.of_bigstring ~pos:(index * 2048) ~len bstr )
+    else
+      Array.init max_count ~f:(function
+        | 0 ->
+            Config.init config
+        | _ ->
+            Iobuf.create ~len:(Iobuf.length (Config.init config)) )
+  in
+  match Iobuf.recvmmsg_assume_fd_is_nonblocking with
+  | Error _ as e ->
+      e
+  | Ok recvmmsg ->
+      Ok
+        (fun ?(config = Config.create ())
+             ?(max_count = default_recvmmsg_loop_max_count)
+             ?(on_wouldblock = fun () -> ()) fd f ->
+          let bufs = create_buffers ~max_count config in
+          let context = Iobuf.Recvmmsg_context.create bufs in
+          let stop = Ivar.create () in
+          Config.stop config >>> Ivar.fill_if_empty stop ;
+          ready_iter ~stop ~max_ready:config.max_ready fd `Read
+            ~syscall_name:"recvmmsg" ~f:(fun file_descr ->
+              let result = recvmmsg file_descr context in
+              if Unix.Syscall_result.Int.is_ok result then
+                let count = Unix.Syscall_result.Int.ok_exn result in
+                if count > Array.length bufs then
+                  failwithf
+                    "Unexpected result from \
+                     Iobuf.recvmmsg_assume_fd_is_nonblocking: count (%d) > \
+                     Array.length bufs (%d)"
+                    count (Array.length bufs) ()
+                else (
+                  (* [recvmmsg_assume_fd_is_nonblocking] implicitly calls [flip_lo]
+                   before and [reset] after the call, so we mustn't. *)
+                  f bufs ~count ;
+                  Ready_iter.poll_again )
+              else (
+                ( match Unix.Syscall_result.Int.error_exn result with
+                | EWOULDBLOCK | EAGAIN ->
+                    on_wouldblock ()
+                | _ ->
+                    () ) ;
+                Unix.Syscall_result.Int.reinterpret_error_exn result ) )
+          >>| Loop_result.of_fd_interruptible_every_ready_to_result_exn None
+                "recvmmsg_loop" fd [%sexp_of: Fd.t] )
+
+module Private = struct
+  module Ready_iter = Ready_iter
+end

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -15,7 +15,7 @@
  (preprocessor_deps ../../../config.mlh)
  (preprocess
   (pps ppx_deriving.eq ppx_deriving.make ppx_inline_test ppx_coda
-    ppx_base ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson
+    ppx_base ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_sexp_message
   ))
  ; the -w list here should be the same as in src/dune
  (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60)

--- a/src/app/cli/src/port_open.ml
+++ b/src/app/cli/src/port_open.ml
@@ -1,0 +1,143 @@
+open Core
+open Async
+module Udp = Async_udp
+
+let check_udp ip ~port_to_use ~port_to_check ~logger =
+  let code = string_of_int (Random.int 1_000_000) ^ "\n" in
+  let server_deferred =
+    let addr =
+      Socket.Address.Inet.create Unix.Inet_addr.bind_any ~port:port_to_check
+    in
+    let socket = Udp.bind addr in
+    let socket_fd = Socket.fd socket in
+    let die_ivar : unit Ivar.t = Ivar.create () in
+    let stop =
+      Deferred.any [Async.after (Time.Span.of_sec 1.0); Ivar.read die_ivar]
+    in
+    let config = Udp.Config.create ~stop () in
+    (* listen for the request *)
+    let%map loop_result =
+      Udp.recvfrom_loop ~config socket_fd (fun buf addr ->
+          match
+            Iobuf.fill_bin_prot buf [%bin_type_class: string].writer code
+          with
+          | Ok () -> (
+            (* fire the response *)
+            match Udp.sendto () with
+            | Ok f ->
+                let reply = f socket_fd buf addr in
+                Deferred.upon reply (fun () -> Ivar.fill_if_empty die_ivar ()) ;
+                don't_wait_for reply
+            | Error e ->
+                Logger.error logger ~module_:__MODULE__ ~location:__LOC__ "%s"
+                  (Error.to_string_mach e) ;
+                Ivar.fill_if_empty die_ivar () )
+          | Error e ->
+              Logger.error logger ~module_:__MODULE__ ~location:__LOC__ "%s"
+                (Error.to_string_mach e) ;
+              Ivar.fill_if_empty die_ivar () )
+    in
+    Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
+      "Udp (serverside) loop result: %s"
+      (Udp.Loop_result.sexp_of_t loop_result |> Sexp.to_string_hum)
+  in
+  let client_deferred =
+    let addr =
+      Socket.Address.Inet.create Unix.Inet_addr.bind_any ~port:port_to_use
+    in
+    let socket = Udp.bind addr in
+    let socket_fd = Socket.fd socket in
+    let result :
+        (unit, [> `Timeout | `Bad_code | `Io_error of Error.t]) Result.t Ivar.t
+        =
+      Ivar.create ()
+    in
+    let stop =
+      Deferred.any
+        [Async.after (Time.Span.of_sec 1.0); Ivar.read result >>| ignore]
+    in
+    let config = Udp.Config.create ~stop () in
+    (* listen for the response *)
+    ( don't_wait_for
+    @@ let%map loop_result =
+         Udp.recvfrom_loop ~config socket_fd (fun buf _addr ->
+             match
+               Iobuf.consume_bin_prot buf [%bin_type_class: string].reader
+             with
+             | Ok code' ->
+                 if String.equal code' code then
+                   Ivar.fill result (Result.return ())
+                 else Ivar.fill result (Error `Bad_code)
+             | Error e ->
+                 Logger.error logger ~module_:__MODULE__ ~location:__LOC__ "%s"
+                   (Error.to_string_mach e) ;
+                 Ivar.fill result (Error (`Io_error e)) )
+       in
+       Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
+         "Udp (clientside) loop result: %s"
+         (Udp.Loop_result.sexp_of_t loop_result |> Sexp.to_string_hum) ) ;
+    (* fire the send *)
+    ( don't_wait_for
+    @@
+    match Udp.sendto () with
+    | Ok f ->
+        let buf = Iobuf.create ~len:(String.length code + 1) in
+        let addr = Socket.Address.Inet.create ip ~port:port_to_check in
+        f socket_fd buf addr
+    | Error e ->
+        Logger.error logger ~module_:__MODULE__ ~location:__LOC__ "%s"
+          (Error.to_string_mach e) ;
+        Ivar.fill result (Error (`Io_error e)) ;
+        Deferred.return () ) ;
+    Ivar.read result
+  in
+  don't_wait_for server_deferred ;
+  Deferred.any
+    [ client_deferred
+    ; (Async.after (Time.Span.of_sec 2.0) >>| fun () -> Error `Timeout) ]
+
+let check_tcp ip ~port ~logger =
+  let code = string_of_int (Random.int 1_000_000) ^ "\n" in
+  let die_ivar : unit Ivar.t = Ivar.create () in
+  let server_deferred =
+    Tcp.Server.create
+      ~on_handler_error:
+        (`Call
+          (fun _net exn ->
+            Logger.error logger ~module_:__MODULE__ ~location:__LOC__ "%s"
+              (Exn.to_string_mach exn) ;
+            Ivar.fill_if_empty die_ivar () ))
+      (Tcp.Where_to_listen.bind_to All_addresses (On_port port))
+      (fun _address _reader writer ->
+        Writer.write writer code ;
+        let%map () = Writer.close writer in
+        Ivar.fill_if_empty die_ivar () )
+  in
+  let%bind server = server_deferred in
+  don't_wait_for @@ (Ivar.read die_ivar >>= fun () -> Tcp.Server.close server) ;
+  let client_deferred :
+      ( unit
+      , [> `Io_error of Error.t | `Timeout | `Bad_code | `Eof] )
+      Deferred.Result.t =
+    let%map result_or_error =
+      Monitor.try_with_or_error (fun () ->
+          Tcp.with_connection ~timeout:(Time.Span.of_sec 1.0)
+            (Tcp.Where_to_connect.of_inet_address
+               (Socket.Address.Inet.create ip ~port))
+            (fun _socket reader _writer ->
+              match%map Reader.read_line reader with
+              | `Eof ->
+                  Error `Eof
+              | `Ok str ->
+                  if String.equal str code then Result.return ()
+                  else Error `Bad_code ) )
+    in
+    (* recover (which should be a combinator in Core, if you ask me) *)
+    match result_or_error with Ok v -> v | Error e -> Error (`Io_error e)
+  in
+  Deferred.any
+    [ client_deferred
+    ; ( Async.after (Time.Span.of_sec 2.0)
+      >>| fun () ->
+      Ivar.fill_if_empty die_ivar () ;
+      Error `Timeout ) ]

--- a/src/lib/command_line_tests/command_line_tests.ml
+++ b/src/lib/command_line_tests/command_line_tests.ml
@@ -22,6 +22,7 @@ let%test_module "Command line tests" =
       Process.run_exn ~prog:coda_exe
         ~args:
           [ "daemon"
+          ; "-no-check-open-ports"
           ; "-background"
           ; "-client-port"
           ; sprintf "%d" port
@@ -48,7 +49,7 @@ let%test_module "Command line tests" =
 
     let test_background_daemon () =
       let port = 1337 in
-      let client_delay = 40. in
+      let client_delay = 10. in
       let config_dir = create_config_directory () in
       Monitor.protect
         ~finally:(fun () -> remove_config_directory config_dir)


### PR DESCRIPTION
This is acheived by starting a local TCP server and a local UDP server
on the ports required to be external and sending a single request-reply
round-trip. If this fails for either the TCP and UDP ports (the external
port and the discovery port), then we print a "nice" error message. This
can false-positive, but only for users who really know what they're
doing with their firewalls or port-forwarding so there is a way to
opt-out with another flag. This is documented in the error message.

Tested only on a network where I can't open ports. Will test more
thoroughly on a better network later.

Example error message:

```
Failed to verify that your ports were open. If your ports aren't accessible externally, you could be banned from the Coda network without realizing it!

This could be a false positive. If you know what you are doing, please add `-no-check-open-ports` and we will skip this check.

More details:

Error: could not access ports externally
External port check failed: IO error: (monitor.ml.Error
 ("connection attempt timeout" 67.160.217.218:8302 src/tcp.ml:120:11)
 ("Raised at file \"src/error.ml\" (inlined), line 9, characters 14-30"
  "Called from file \"src/error.ml\" (inlined), line 5, characters 2-50"
  "Called from file \"src/tcp.ml\", line 120, characters 11-76"
  "Called from file \"src/job_queue.ml\" (inlined), line 131, characters 2-5"
  "Called from file \"src/job_queue.ml\", line 170, characters 6-47"
  "Caught by monitor try_with_or_error"))
Discover port check failed: Could not reach the server (timed out)

To resolve:

Are your ports open?
Find your local ip address with `ifconfig`.
Get miniupnpc (you can download via your favorite package manager).

Then run:
$ upnpc -a <your local ip> 8302 8302 tcp
$ upnpc -a <your local ip> 8303 8303 udp

If this doesn't work, check out portforwarding.com for more tips or go to Coda discord chat for help.
```