### PR TITLE
Make BG hash independent of the Checked.t monad chosen in Snarky

### DIFF
--- a/src/lib/snarky_bowe_gabizon_hash/snarky_bowe_gabizon_hash.ml
+++ b/src/lib/snarky_bowe_gabizon_hash/snarky_bowe_gabizon_hash.ml
@@ -34,7 +34,7 @@ struct
     >>| Field.Var.project
 
   let make_checked f =
-    M.make_checked f |> Checked.with_state (Impl.As_prover.return ())
+    M.make_checked f |> M.Internal_Basic.with_state (Impl.As_prover.return ())
 
   let group_map x =
     make_checked (fun () ->
@@ -225,7 +225,7 @@ let%test_module "test" =
       in
       Quickcheck.test ~trials:3 input ~f:(fun (message_length, inp) ->
           let typ =
-            let open Typ in
+            let open Impl.Typ in
             of_hlistable
               [ array ~length:message_length Impl.Boolean.typ
               ; Curve.Checked.typ


### PR DESCRIPTION
This PR switches BG hash to use calls through `Snark.Make`, instead of directly on `Snarky.Checked`/`Snarky.Typ`.

This is also necessary for o1-labs/snarky#311.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: