### PR TITLE
Initialise the ledger lazily

### DIFF
--- a/src/app/cli/src/coda_batch_payment_test.ml
+++ b/src/app/cli/src/coda_batch_payment_test.ml
@@ -9,7 +9,8 @@ let main () =
   Async.Scheduler.set_record_backtraces true ;
   let logger = Logger.create () in
   let keypairs =
-    List.map Genesis_ledger.accounts
+    List.map
+      (Lazy.force Genesis_ledger.accounts)
       ~f:Genesis_ledger.keypair_of_account_record_exn
   in
   let largest_account_keypair =

--- a/src/app/cli/src/coda_delegation_test.ml
+++ b/src/app/cli/src/coda_delegation_test.ml
@@ -21,8 +21,9 @@ let print_heartbeat () =
 
 let main () =
   let num_proposers = 3 in
+  let accounts = Lazy.force Genesis_ledger.accounts in
   let snark_work_public_keys ndx =
-    List.nth_exn Genesis_ledger.accounts ndx
+    List.nth_exn accounts ndx
     |> fun (_, acct) -> Some (Account.public_key acct)
   in
   let%bind testnet =
@@ -34,22 +35,20 @@ let main () =
   (* keep CI alive *)
   Deferred.don't_wait_for (print_heartbeat ()) ;
   (* dump account info to log *)
-  List.iteri Genesis_ledger.accounts ~f:(fun ndx ((_, acct) as record) ->
+  List.iteri accounts ~f:(fun ndx ((_, acct) as record) ->
       let keypair = Genesis_ledger.keypair_of_account_record_exn record in
       Logger.info logger ~module_:__MODULE__ ~location:__LOC__
         !"Account: %i private key: %{sexp: Import.Private_key.t} public key: \
           %{sexp: Account.key} balance: %{sexp: Currency.Balance.t}"
         ndx keypair.private_key (Account.public_key acct) acct.balance ) ;
   (* second account is delegator; see genesis_ledger/test_delegation_ledger.ml *)
-  let ((_, delegator_account) as delegator) =
-    List.nth_exn Genesis_ledger.accounts 2
-  in
+  let ((_, delegator_account) as delegator) = List.nth_exn accounts 2 in
   let delegator_pubkey = Account.public_key delegator_account in
   let delegator_keypair =
     Genesis_ledger.keypair_of_account_record_exn delegator
   in
   (* zeroth account is delegatee *)
-  let _, delegatee_account = List.nth_exn Genesis_ledger.accounts 0 in
+  let _, delegatee_account = List.nth_exn accounts 0 in
   let delegatee_pubkey = Account.public_key delegatee_account in
   let worker = testnet.workers.(0) in
   (* setup readers for proposals by delegator, delegatee *)

--- a/src/app/cli/src/coda_five_nodes_test.ml
+++ b/src/app/cli/src/coda_five_nodes_test.ml
@@ -10,7 +10,8 @@ let main () =
   let snark_work_public_keys = function
     | 0 ->
         Some
-          (List.nth_exn Genesis_ledger.accounts 5 |> snd |> Account.public_key)
+          ( List.nth_exn (Lazy.force Genesis_ledger.accounts) 5
+          |> snd |> Account.public_key )
     | _ ->
         None
   in

--- a/src/app/cli/src/coda_long_fork.ml
+++ b/src/app/cli/src/coda_long_fork.ml
@@ -6,7 +6,8 @@ let name = "coda-long-fork"
 let main n waiting_time () =
   let logger = Logger.create () in
   let keypairs =
-    List.map Genesis_ledger.accounts
+    List.map
+      (Lazy.force Genesis_ledger.accounts)
       ~f:Genesis_ledger.keypair_of_account_record_exn
   in
   let snark_work_public_keys i =

--- a/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
+++ b/src/app/cli/src/coda_restarts_and_txns_holy_grail.ml
@@ -7,10 +7,9 @@ let name = "coda-restarts-and-txns-holy-grail"
 let main n () =
   assert (n > 1) ;
   let logger = Logger.create () in
+  let accounts = Lazy.force Genesis_ledger.accounts in
   let snark_work_public_keys =
-    Fn.const
-    @@ Some
-         (List.nth_exn Genesis_ledger.accounts 5 |> snd |> Account.public_key)
+    Fn.const @@ Some (List.nth_exn accounts 5 |> snd |> Account.public_key)
   in
   let%bind testnet =
     Coda_worker_testnet.test logger n Option.some snark_work_public_keys
@@ -18,8 +17,7 @@ let main n () =
   in
   (* SEND TXNS *)
   let keypairs =
-    List.map Genesis_ledger.accounts
-      ~f:Genesis_ledger.keypair_of_account_record_exn
+    List.map accounts ~f:Genesis_ledger.keypair_of_account_record_exn
   in
   let random_node () = Random.int (n - 1) + 1 in
   Coda_worker_testnet.Payments.send_several_payments testnet ~node:0 ~keypairs

--- a/src/app/cli/src/coda_shared_prefix_multiproposer_test.ml
+++ b/src/app/cli/src/coda_shared_prefix_multiproposer_test.ml
@@ -7,7 +7,8 @@ let name = "coda-shared-prefix-multiproposer-test"
 let main n enable_payments () =
   let logger = Logger.create () in
   let keypairs =
-    List.map Genesis_ledger.accounts
+    List.map
+      (Lazy.force Genesis_ledger.accounts)
       ~f:Genesis_ledger.keypair_of_account_record_exn
   in
   let snark_work_public_keys i =

--- a/src/app/cli/src/coda_shared_state_test.ml
+++ b/src/app/cli/src/coda_shared_state_test.ml
@@ -8,7 +8,8 @@ let main () =
   let logger = Logger.create () in
   let n = 2 in
   let keypairs =
-    List.map Genesis_ledger.accounts
+    List.map
+      (Lazy.force Genesis_ledger.accounts)
       ~f:Genesis_ledger.keypair_of_account_record_exn
   in
   let snark_work_public_keys i =

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -375,7 +375,7 @@ module T = struct
           in
           let propose_keypair =
             Option.map proposer ~f:(fun i ->
-                List.nth_exn Genesis_ledger.accounts i
+                List.nth_exn (Lazy.force Genesis_ledger.accounts) i
                 |> Genesis_ledger.keypair_of_account_record_exn )
           in
           let initial_propose_keypairs =

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -342,7 +342,8 @@ let run_test () : unit Deferred.t =
         Genesis_ledger.keypair_of_account_record_exn sender
       in
       let other_accounts =
-        List.filter Genesis_ledger.accounts ~f:(fun (_, account) ->
+        List.filter (Lazy.force Genesis_ledger.accounts)
+          ~f:(fun (_, account) ->
             let reserved_public_keys =
               [ largest_account_keypair.public_key
               ; receiver_keypair.public_key

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -308,8 +308,9 @@ let create_genesis_frontier (config : Config.t) ~verifier =
           ; user_commands= []
           ; coinbase= Staged_ledger_diff.At_most_two.Zero }
         , None )
-    ; creator= Account.public_key (snd (List.hd_exn Genesis_ledger.accounts))
-    }
+    ; creator=
+        Account.public_key
+          (snd (List.hd_exn (Lazy.force Genesis_ledger.accounts))) }
   in
   let genesis_protocol_state =
     With_hash.data (Lazy.force Genesis_protocol_state.t)
@@ -321,10 +322,10 @@ let create_genesis_frontier (config : Config.t) ~verifier =
          ~protocol_state_proof:Precomputed_values.base_proof
          ~staged_ledger_diff:empty_diff)
   in
-  let genesis_ledger = Lazy.force Genesis_ledger.t in
   let ledger_db =
     Ledger.Db.create ?directory_name:config.ledger_db_location ()
   in
+  let genesis_ledger = Lazy.force Genesis_ledger.t in
   let root_snarked_ledger =
     Ledger_transfer.transfer_accounts ~src:genesis_ledger ~dest:ledger_db
   in

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2720,12 +2720,9 @@ module Hooks = struct
     let epoch = Epoch.of_int 5 in
     let start_time = Epoch.start_time epoch in
     let curr_epoch, curr_slot = Epoch.epoch_and_slot_of_time_exn start_time in
-    let consensus_state =
-      {(Lazy.force Consensus_state.negative_one) with curr_epoch; curr_slot}
-    in
-    let too_early =
-      Epoch.start_time (Lazy.force Consensus_state.negative_one).curr_slot
-    in
+    let negative_one = Lazy.force Consensus_state.negative_one in
+    let consensus_state = {negative_one with curr_epoch; curr_slot} in
+    let too_early = Epoch.start_time negative_one.curr_slot in
     let too_late =
       let delay = Constants.delta * 2 |> UInt32.of_int in
       let delayed_slot = UInt32.Infix.(curr_slot + delay) in

--- a/src/lib/genesis_ledger/functor.ml
+++ b/src/lib/genesis_ledger/functor.ml
@@ -8,7 +8,7 @@ let pk = Public_key.Compressed.of_base58_check_exn
 let sk = Private_key.of_base58_check_exn
 
 module type Base_intf = sig
-  val accounts : (Private_key.t option * Account.t) list
+  val accounts : (Private_key.t option * Account.t) list Lazy.t
 end
 
 module Make_from_base (Base : Base_intf) : Intf.S = struct
@@ -18,12 +18,12 @@ module Make_from_base (Base : Base_intf) : Intf.S = struct
   let t =
     lazy
       (let ledger = Ledger.create_ephemeral () in
-       List.iter accounts ~f:(fun (_, account) ->
+       List.iter (Lazy.force accounts) ~f:(fun (_, account) ->
            Ledger.create_new_account_exn ledger account.public_key account ) ;
        ledger)
 
   let find_account_record_exn ~f =
-    List.find_exn accounts ~f:(fun (_, account) -> f account)
+    List.find_exn (Lazy.force accounts) ~f:(fun (_, account) -> f account)
 
   let find_new_account_record_exn old_account_pks =
     find_account_record_exn ~f:(fun new_account ->
@@ -54,7 +54,7 @@ module Make_from_base (Base : Base_intf) : Intf.S = struct
       ^ "genesis ledger has no accounts"
     in
     Memo.unit (fun () ->
-        List.max_elt accounts ~compare:(fun (_, a) (_, b) ->
+        List.max_elt (Lazy.force accounts) ~compare:(fun (_, a) (_, b) ->
             Balance.compare a.balance b.balance )
         |> Option.value_exn ?here:None ?error:None ~message:error_msg )
 
@@ -67,14 +67,15 @@ module With_private = struct
     {pk: Public_key.Compressed.t; sk: Private_key.t; balance: int}
 
   module type Source_intf = sig
-    val accounts : account_data list
+    val accounts : account_data list Lazy.t
   end
 
   module Make (Source : Source_intf) : Intf.S = struct
     include Make_from_base (struct
       let accounts =
-        List.map Source.accounts ~f:(fun {pk; sk; balance} ->
-            (Some sk, Account.create pk (Balance.of_int balance)) )
+        lazy
+          (List.map (Lazy.force Source.accounts) ~f:(fun {pk; sk; balance} ->
+               (Some sk, Account.create pk (Balance.of_int balance)) ))
     end)
   end
 end
@@ -83,14 +84,15 @@ module Without_private = struct
   type account_data = {pk: Public_key.Compressed.t; balance: int}
 
   module type Source_intf = sig
-    val accounts : account_data list
+    val accounts : account_data list Lazy.t
   end
 
   module Make (Source : Source_intf) : Intf.S = struct
     include Make_from_base (struct
       let accounts =
-        List.map Source.accounts ~f:(fun {pk; balance} ->
-            (None, Account.create pk (Balance.of_int balance)) )
+        lazy
+          (List.map (Lazy.force Source.accounts) ~f:(fun {pk; balance} ->
+               (None, Account.create pk (Balance.of_int balance)) ))
     end)
   end
 end

--- a/src/lib/genesis_ledger/intf.ml
+++ b/src/lib/genesis_ledger/intf.ml
@@ -4,7 +4,7 @@ open Signature_lib
 module type S = sig
   val t : Ledger.t Lazy.t
 
-  val accounts : (Private_key.t option * Account.t) list
+  val accounts : (Private_key.t option * Account.t) list Lazy.t
 
   val find_account_record_exn :
     f:(Account.t -> bool) -> Private_key.t option * Account.t

--- a/src/lib/genesis_ledger/release_ledger.ml
+++ b/src/lib/genesis_ledger/release_ledger.ml
@@ -5,10 +5,11 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let high_balances = List.init 1 ~f:(Fn.const 10_000_000) in
-    let low_balances = List.init 17 ~f:(Fn.const 1_000) in
-    let balances = high_balances @ low_balances in
-    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
-    List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
+    lazy
+      (let high_balances = List.init 1 ~f:(Fn.const 10_000_000) in
+       let low_balances = List.init 17 ~f:(Fn.const 1_000) in
+       let balances = high_balances @ low_balances in
+       let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
+       List.mapi balances ~f:(fun i b ->
+           {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} ))
 end)

--- a/src/lib/genesis_ledger/test_delegation_ledger.ml
+++ b/src/lib/genesis_ledger/test_delegation_ledger.ml
@@ -3,9 +3,10 @@ open Core
 
 include Make (struct
   let accounts =
-    (* zeroth account becomes delegatee; first account is a placeholder; second account is delegator *)
-    let balances = [0; 0; 5_000_000] in
-    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
-    List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
+    lazy
+      ((* zeroth account becomes delegatee; first account is a placeholder; second account is delegator *)
+       let balances = [0; 0; 5_000_000] in
+       let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
+       List.mapi balances ~f:(fun i b ->
+           {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} ))
 end)

--- a/src/lib/genesis_ledger/test_five_even_stakes.ml
+++ b/src/lib/genesis_ledger/test_five_even_stakes.ml
@@ -4,10 +4,11 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
-    let balances =
-      [1_000_000; 1_000_000; 1_000_000; 1_000_000; 1_000_000; 1_000]
-    in
-    List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
+    lazy
+      (let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
+       let balances =
+         [1_000_000; 1_000_000; 1_000_000; 1_000_000; 1_000_000; 1_000]
+       in
+       List.mapi balances ~f:(fun i b ->
+           {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} ))
 end)

--- a/src/lib/genesis_ledger/test_ledger.ml
+++ b/src/lib/genesis_ledger/test_ledger.ml
@@ -3,28 +3,29 @@ open Core
 
 include Make (struct
   let accounts =
-    let balances =
-      [ 10_000_000
-      ; 100
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000
-      ; 1_000 ]
-    in
-    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
-    List.mapi balances ~f:(fun i b ->
-        let pk, sk = keypairs.(i) in
-        {pk; sk; balance= b} )
+    lazy
+      (let balances =
+         [ 10_000_000
+         ; 100
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000
+         ; 1_000 ]
+       in
+       let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
+       List.mapi balances ~f:(fun i b ->
+           let pk, sk = keypairs.(i) in
+           {pk; sk; balance= b} ))
 end)

--- a/src/lib/genesis_ledger/test_split_two_stakes_ledger.ml
+++ b/src/lib/genesis_ledger/test_split_two_stakes_ledger.ml
@@ -4,10 +4,11 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let high_balances = List.init 2 ~f:(Fn.const 5_000_000) in
-    let low_balances = List.init 16 ~f:(Fn.const 1_000) in
-    let balances = high_balances @ low_balances in
-    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
-    List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
+    lazy
+      (let high_balances = List.init 2 ~f:(Fn.const 5_000_000) in
+       let low_balances = List.init 16 ~f:(Fn.const 1_000) in
+       let balances = high_balances @ low_balances in
+       let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
+       List.mapi balances ~f:(fun i b ->
+           {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} ))
 end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -4,10 +4,11 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let high_balances = List.init 5 ~f:(Fn.const 5_000_000) in
-    let low_balances = List.init 13 ~f:(Fn.const 1_000) in
-    let balances = high_balances @ low_balances in
-    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
-    List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
+    lazy
+      (let high_balances = List.init 5 ~f:(Fn.const 5_000_000) in
+       let low_balances = List.init 13 ~f:(Fn.const 1_000) in
+       let balances = high_balances @ low_balances in
+       let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
+       List.mapi balances ~f:(fun i b ->
+           {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} ))
 end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger_many_proposers.ml
@@ -4,10 +4,11 @@ open Core
 (* TODO: generate new keypairs before public testnet *)
 include Make (struct
   let accounts =
-    let high_balances = List.init 50 ~f:(Fn.const 5_000_000) in
-    let low_balances = List.init 10 ~f:(Fn.const 1_000) in
-    let balances = high_balances @ low_balances in
-    let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
-    List.mapi balances ~f:(fun i b ->
-        {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} )
+    lazy
+      (let high_balances = List.init 50 ~f:(Fn.const 5_000_000) in
+       let low_balances = List.init 10 ~f:(Fn.const 1_000) in
+       let balances = high_balances @ low_balances in
+       let keypairs = Lazy.force Coda_base.Sample_keypairs.keypairs in
+       List.mapi balances ~f:(fun i b ->
+           {balance= b; pk= fst keypairs.(i); sk= snd keypairs.(i)} ))
 end)


### PR DESCRIPTION
A big chunk of the remaining loadtime for `-help` appears to be associated with generating the genesis ledger when we force the keys. This makes it lazy, so that it isn't loaded until needed.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: