### PR TITLE
GraphQL scalars for PublicKey and UInt64

### DIFF
--- a/frontend/wallet/schema.graphql
+++ b/frontend/wallet/schema.graphql
@@ -1,3 +1,6 @@
+scalar UInt64
+scalar PublicKey
+
 type Interval {
   start: String! # timespan
   end: String! # timespan
@@ -51,11 +54,11 @@ type DaemonStatus {
   stateHash: String
   commitId: String! # git sha
   confDir: String!
-  peers: [String!]!
+  peers: [PublicKey!]!
   userCommandsSent: Int!
   runSnarkWorker: Boolean!
   syncStatus: SyncStatus!
-  proposePubkeys: [String!]! @examples(values: [["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"]])
+  proposePubkeys: [PublicKey!]! @examples(values: [["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"]])
   histograms: Histograms
   consensusTimeBestTip: String
   consensusTimeNow: String!
@@ -74,24 +77,24 @@ enum ChainReorganizationStatus {
 }
 
 type SnarkWorker {
-  key: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
-  fee: String! @fake(type: number)
+  key: PublicKey! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
+  fee: UInt64! @fake(type: number)
 }
 
 type UserCommand {
   id: String!
   isDelegation: Boolean!
   nonce: Int!
-  from: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"]) 
-  to: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
-  amount: String! @fake(type: number)
-  fee: String! @fake(type: number)
+  from: PublicKey! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"]) 
+  to: PublicKey! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
+  amount: UInt64! @fake(type: number)
+  fee: UInt64! @fake(type: number)
   memo: String! @fake(type:hackerPhrase)
 }
 
 type FeeTransfer {
-  recipient: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
-  fee: String! @fake(type: number)
+  recipient: PublicKey! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
+  fee: UInt64! @fake(type: number)
 }
 
 type BlockchainState {
@@ -108,11 +111,11 @@ type ProtocolState {
 type Transactions {
   userCommands: [UserCommand!]!
   feeTransfer: [FeeTransfer!]!
-  coinbase: String! @fake(type: number)
+  coinbase: UInt64! @fake(type: number)
 }
 
 type Block {
-  creator: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
+  creator: PublicKey! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
   stateHash: String!
   protocolState: ProtocolState!
   transactions: Transactions!
@@ -124,15 +127,15 @@ type BlockConfirmation {
 }
 
 type AnnotatedBalance {
-  total: String! @fake(type: number)
-  unknown: String! @fake(type: number)
+  total: UInt64! @fake(type: number)
+  unknown: UInt64! @fake(type: number)
 }
 
 type Wallet {
-  publicKey: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
+  publicKey: PublicKey! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
   nonce: String!
   receiptChainHash: String!
-  delegate: String!
+  delegate: PublicKey!
   votingFor: String!
   balance: AnnotatedBalance!
   stakingActive: Boolean! # Actively staking. There is a lag between switching staking keys and them appearing here as you may be in the middle of a staking procedure with other keys.
@@ -146,12 +149,12 @@ type NodeStatus {
 ## Input types
 
 input AddWalletInput {
-  publicKey: String
+  publicKey: PublicKey
   privateKey: String
 }
 
 input DeleteWalletInput {
-  publicKey: String!
+  publicKey: PublicKey!
 }
 
 input AddPaymentReceiptInput {
@@ -163,37 +166,37 @@ input SetNetworkInput {
 }
 
 input SetSnarkWorkerInput {
-  worker: String!
-  fee: String!
+  worker: PublicKey!
+  fee: UInt64!
 }
 
 input CreatePaymentInput {
-  from: String!,
-  to: String!,
-  amount: String!,
-  fee: String!,
+  from: PublicKey!,
+  to: PublicKey!,
+  amount: UInt64!,
+  fee: UInt64!,
   memo: String
 }
 
 input CreateDelegationInput {
-  from: String!,
-  to: String,
-  fee: String!,
+  from: PublicKey!,
+  to: PublicKey,
+  fee: UInt64!,
   memo: String
 }
 
 input UserCommandFilterInput {
-  from: String,
+  from: PublicKey,
 }
 
 input BlockFilterInput {
-  relatedTo: String!,
+  relatedTo: PublicKey!,
 }
 
 input SetStakingInput {
   # Set to empty to stop staking
   # Set to a non-empty list of public keys to start staking on these keys
-  wallets: [String!]!
+  wallets: [PublicKey!]!
 }
 
 ## Payload types
@@ -219,17 +222,17 @@ type AddPaymentReceiptPayload {
 }
 
 type AddWalletPayload {
-  publicKey: String! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
+  publicKey: PublicKey! @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
 }
 
 type DeleteWalletPayload {
-  publicKey: String @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
+  publicKey: PublicKey @examples(values: ["PUB_KEY_E9873DF4453213303DA61F2", "PUB_KEY_F1173DF4453213303DA61F2"])
 }
 
 type SetStakingPayload {
   # Returns the last wallet public keys that were staking before
   # or empty if there were none
-  lastStaking: [String!]!
+  lastStaking: [PublicKey!]!
 }
 
 # Pagination types
@@ -269,9 +272,9 @@ type Query {
   # List of wallets currently tracked by the node
   ownedWallets: [Wallet!]!
   
-  wallet(publicKey: String!): Wallet
+  wallet(publicKey: PublicKey!): Wallet
   
-  pooledUserCommands(publicKey: String!): [UserCommand!]!
+  pooledUserCommands(publicKey: PublicKey!): [UserCommand!]!
   
   blocks(
     filter: BlockFilterInput!,
@@ -328,7 +331,7 @@ type Subscription {
   blockConfirmation: BlockConfirmation!
   
   # Subscribe to all blocks related to `key`
-  newBlock(key: String): Block!
+  newBlock(key: PublicKey): Block!
   
   # Triggered whenever the best tip changes
   # to another branch in the transition frontier

--- a/frontend/wallet/src/common/Wallet.re
+++ b/frontend/wallet/src/common/Wallet.re
@@ -1,9 +1,4 @@
 type t = {
-  key: PublicKey.t,
-  balance: string // TODO: Make this uint64
-};
-
-let ofGraphqlExn = data => {
-  key: PublicKey.ofStringExn(data##publicKey),
-  balance: data##balance##total,
+  publicKey: PublicKey.t,
+  balance: {. "total": int64},
 };

--- a/frontend/wallet/src/render/Apollo.re
+++ b/frontend/wallet/src/render/Apollo.re
@@ -33,9 +33,13 @@ let client = {
 };
 
 module Decoders = {
-  let int64 = Int64.of_string;
-  let optInt64 = Option.map(~f=Int64.of_string);
-  let publicKey = PublicKey.ofStringExn;
+  let int64 = pk =>
+    Js.Json.decodeString(pk) |> Option.getExn |> Int64.of_string;
+
+  let optInt64 = Option.map(~f=int64);
+
+  let publicKey = pk =>
+    Js.Json.decodeString(pk) |> Option.getExn |> PublicKey.ofStringExn;
 
   let date = Js.Date.fromString;
   let optDate = Option.map(~f=Js.Date.fromString);

--- a/frontend/wallet/src/render/components/RequestCodaModal.re
+++ b/frontend/wallet/src/render/components/RequestCodaModal.re
@@ -2,7 +2,7 @@ open Tc;
 
 module Styles = {
   open Css;
-    
+
   let modalBody =
     style([
       display(`flex),
@@ -10,7 +10,7 @@ module Styles = {
       alignItems(`center),
       justifyContent(`center),
     ]);
-  
+
   let bodyMargin = style([margin(`rem(1.0)), width(`percent(100.))]);
 
   let publicKey =
@@ -47,22 +47,22 @@ let make = (~wallets, ~setModalState) => {
           options={
             wallets
             |> Array.map(~f=wallet =>
-                (
-                  PublicKey.toString(wallet.Wallet.key),
-                  <WalletDropdownItem wallet />
-                )
-              )
+                 (
+                   PublicKey.toString(wallet.Wallet.publicKey),
+                   <WalletDropdownItem wallet />,
+                 )
+               )
             |> Array.toList
           }
         />
         <Spacer height=1. />
         {switch (selectedWallet) {
-        | None => React.null
-        | Some(selectedWallet) =>
-          <div className=Styles.publicKey>
-            {React.string(PublicKey.toString(selectedWallet))}
-          </div>
-        }}
+         | None => React.null
+         | Some(selectedWallet) =>
+           <div className=Styles.publicKey>
+             {React.string(PublicKey.toString(selectedWallet))}
+           </div>
+         }}
       </div>
       <div className=Css.(style([display(`flex)]))>
         <Button

--- a/frontend/wallet/src/render/components/SideBar.re
+++ b/frontend/wallet/src/render/components/SideBar.re
@@ -37,7 +37,7 @@ module AddWallet = [%graphql
   {|
     mutation addWallet {
         addWallet {
-            publicKey
+          publicKey @bsDecoder(fn: "Apollo.Decoders.publicKey")
         }
     }
   |}
@@ -80,8 +80,7 @@ let make = () => {
                    | EmptyResponse => ()
                    | Errors(_) => print_endline("Error adding wallet")
                    | Data(data) => {
-                       let pk = data##addWallet##publicKey;
-                       let key = PublicKey.ofStringExn(pk);
+                       let key = data##addWallet##publicKey;
                        updateAddressBook(AddressBook.set(~key, ~name));
                      },
                );

--- a/frontend/wallet/src/render/components/WalletDropdownItem.re
+++ b/frontend/wallet/src/render/components/WalletDropdownItem.re
@@ -1,6 +1,6 @@
 module Styles = {
   open Css;
-    
+
   let container =
     style([
       display(`flex),
@@ -8,20 +8,19 @@ module Styles = {
       width(`percent(100.)),
     ]);
 
-  let currencySymbol = 
-    style([Theme.Typeface.lucidaGrande]);
+  let currencySymbol = style([Theme.Typeface.lucidaGrande]);
 };
 
 [@react.component]
 let make = (~wallet) =>
   /* TODO(PM): Update styling here once we get mockup */
   <div className=Styles.container>
-    <WalletName pubkey={wallet.Wallet.key} />
+    <WalletName pubkey={wallet.Wallet.publicKey} />
     <span>
       {React.string(" ( ")}
-      <span className=Styles.currencySymbol>
-        {React.string({j|■|j})}
-      </span>
-      {React.string(" " ++ wallet.Wallet.balance ++ " )")}
+      <span className=Styles.currencySymbol> {React.string({j|■|j})} </span>
+      {React.string(
+         " " ++ Int64.to_string(wallet.Wallet.balance##total) ++ " )",
+       )}
     </span>
   </div>;

--- a/frontend/wallet/src/render/views/footer/SendButton.re
+++ b/frontend/wallet/src/render/views/footer/SendButton.re
@@ -142,16 +142,16 @@ let make = (~wallets, ~onSubmit) => {
                    Option.map(~f=s => {...s, fromStr: Some(value)}),
                  )
                }
-                options={
-                  wallets
-                  |> Array.map(~f=wallet =>
-                        (
-                          PublicKey.toString(wallet.Wallet.key),
-                          <WalletDropdownItem wallet />,
-                        )
+               options={
+                 wallets
+                 |> Array.map(~f=wallet =>
+                      (
+                        PublicKey.toString(wallet.Wallet.publicKey),
+                        <WalletDropdownItem wallet />,
                       )
-                  |> Array.toList
-                }
+                    )
+                 |> Array.toList
+               }
              />
              spacer
              <TextField

--- a/frontend/wallet/src/render/views/walletlist/WalletItem.re
+++ b/frontend/wallet/src/render/views/walletlist/WalletItem.re
@@ -20,13 +20,7 @@ module Styles = {
     ]);
 
   let inactiveWalletItem =
-    merge([
-      walletItem,
-      style([
-        hover([color(Colors.saville)])
-      ]),
-      notText,
-    ]);
+    merge([walletItem, style([hover([color(Colors.saville)])]), notText]);
 
   let activeWalletItem =
     merge([
@@ -52,7 +46,7 @@ module Styles = {
 let make = (~wallet: Wallet.t) => {
   let isActive =
     Option.map(Hooks.useActiveWallet(), ~f=activeWallet =>
-      PublicKey.equal(activeWallet, wallet.key)
+      PublicKey.equal(activeWallet, wallet.publicKey)
     )
     |> Option.withDefault(~default=false);
 
@@ -64,11 +58,15 @@ let make = (~wallet: Wallet.t) => {
       }
     }
     onClick={_ =>
-      ReasonReact.Router.push("/wallet/" ++ PublicKey.uriEncode(wallet.key))
+      ReasonReact.Router.push(
+        "/wallet/" ++ PublicKey.uriEncode(wallet.publicKey),
+      )
     }>
-    <WalletName pubkey={wallet.key} />
+    <WalletName pubkey={wallet.publicKey} />
     <div className=Styles.balance>
-      {ReasonReact.string({js|■ |js} ++ wallet.balance)}
+      {ReasonReact.string(
+         {js|■ |js} ++ Int64.to_string(wallet.balance##total),
+       )}
     </div>
   </div>;
 };

--- a/frontend/wallet/src/render/views/walletlist/WalletList.re
+++ b/frontend/wallet/src/render/views/walletlist/WalletList.re
@@ -15,8 +15,19 @@ module Styles = {
     ]);
 };
 
+type ownedWallets =
+  Wallet.t = {
+    publicKey: PublicKey.t,
+    balance: {. "total": int64},
+  };
+
 module Wallets = [%graphql
-  {| query getWallets { ownedWallets {publicKey, balance{total}}} |}
+  {| query getWallets { ownedWallets @bsRecord {
+      publicKey @bsDecoder(fn: "Apollo.Decoders.publicKey")
+      balance {
+          total @bsDecoder(fn: "Apollo.Decoders.int64")
+      }
+    }} |}
 ];
 module WalletQuery = ReasonApollo.CreateQuery(Wallets);
 
@@ -34,10 +45,10 @@ let make = () =>
                 ~f=
                   wallet =>
                     <WalletItem
-                      key={PublicKey.toString(wallet.key)}
+                      key={PublicKey.toString(wallet.publicKey)}
                       wallet
                     />,
-                Array.map(wallets##ownedWallets, ~f=Wallet.ofGraphqlExn),
+                wallets##ownedWallets,
               ),
             )}
          </div>

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -26,8 +26,6 @@ let result_field_no_inputs ~resolve =
       Deferred.return @@ resolve resolve_info src )
 
 module Doc = struct
-  let uint64 = sprintf !"%s (stringified uint64)"
-
   let date =
     sprintf
       !"%s (stringified Unix time - number of milliseconds since January 1, \
@@ -87,9 +85,6 @@ module Types = struct
   open Schema
 
   module Stringable = struct
-    (** base58 representation of public key that is compressed to make snark computation efficent *)
-    let public_key = Public_key.Compressed.to_base58_check
-
     (** string representation of IPv4 or IPv6 address *)
     let ip_address = Unix.Inet_addr.to_string
 
@@ -102,16 +97,6 @@ module Types = struct
           None
       | Banned_until tm ->
           Some (date tm)
-
-    (** Javascript only has 53-bit integers so we need to make them into strings  *)
-    let uint64 uint64 = Unsigned.UInt64.to_string uint64
-
-    (** Balance of Coda (a uint64 under the hood) *)
-    let balance b = Balance.to_uint64 b |> uint64
-
-    let fee fee = uint64 @@ Currency.Fee.to_uint64 fee
-
-    let amount amount = uint64 @@ Currency.Amount.to_uint64 amount
 
     module State_hash = Codable.Make_base58_check (State_hash.Stable.V1)
     module Ledger_hash = Codable.Make_base58_check (Ledger_hash.Stable.V1)
@@ -133,15 +118,13 @@ module Types = struct
       Base58_check.encode (Bigstring.to_string bigstring)
   end
 
-  let uint64_arg name ~doc ~typ =
-    let open Schema.Arg in
-    arg name ~typ ~doc:(Doc.uint64 doc)
+  let public_key =
+    scalar "PublicKey" ~doc:"Base58Check-encoded public key string"
+      ~coerce:(fun key -> `String (Public_key.Compressed.to_base58_check key))
 
-  let uint64_field name ~doc =
-    field name ~typ:(non_null string) ~doc:(Doc.uint64 doc)
-
-  let uint64_result_field name ~doc =
-    result_field_no_inputs name ~typ:(non_null string) ~doc:(Doc.uint64 doc)
+  let uint64 =
+    scalar "UInt64" ~doc:"String representing a uint64 number in base 10"
+      ~coerce:(fun num -> `String (Unsigned.UInt64.to_string num))
 
   let sync_status : ('context, [`Offline | `Synced | `Bootstrap] option) typ =
     enum "SyncStatus" ~doc:"Sync status of daemon"
@@ -226,8 +209,8 @@ module Types = struct
                ~sync_status:(id ~typ:(non_null sync_status))
                ~propose_pubkeys:
                  (Reflection.reflect
-                    ~typ:Schema.(non_null @@ list (non_null string))
-                    (List.map ~f:Stringable.public_key))
+                    ~typ:Schema.(non_null @@ list (non_null public_key))
+                    Fn.id)
                ~histograms:(id ~typ:histograms) ~consensus_time_best_tip:string
                ~consensus_time_now:nn_string ~consensus_mechanism:nn_string
                ~consensus_configuration:
@@ -236,7 +219,7 @@ module Types = struct
 
   let user_command : (Coda_lib.t, User_command.t option) typ =
     obj "UserCommand" ~fields:(fun _ ->
-        [ field "id" ~typ:(non_null string)
+        [ field "id" ~typ:(non_null guid)
             ~args:Arg.[]
             ~resolve:(fun _ user_command -> Id.user_command user_command)
         ; field "isDelegation" ~typ:(non_null bool)
@@ -257,21 +240,22 @@ module Types = struct
             ~resolve:(fun _ payment ->
               User_command_payload.nonce @@ User_command.payload payment
               |> Account.Nonce.to_int )
-        ; field "from" ~typ:(non_null string) ~doc:"Public key of the sender"
+        ; field "from" ~typ:(non_null public_key)
+            ~doc:"Public key of the sender"
             ~args:Arg.[]
-            ~resolve:(fun _ payment ->
-              User_command.sender payment |> Stringable.public_key )
-        ; field "to" ~typ:(non_null string) ~doc:"Public key of the receiver"
+            ~resolve:(fun _ payment -> User_command.sender payment)
+        ; field "to" ~typ:(non_null public_key)
+            ~doc:"Public key of the receiver"
             ~args:Arg.[]
             ~resolve:(fun _ payment ->
               match
                 User_command_payload.body (User_command.payload payment)
               with
               | Payment {Payment_payload.Poly.receiver; _} ->
-                  Stringable.public_key receiver
+                  receiver
               | Stake_delegation (Set_delegate {new_delegate}) ->
-                  Stringable.public_key new_delegate )
-        ; uint64_result_field "amount"
+                  new_delegate )
+        ; result_field_no_inputs "amount" ~typ:(non_null uint64)
             ~doc:
               "Amount that sender is sending to receiver - this is 0 for \
                delegations"
@@ -281,16 +265,15 @@ module Types = struct
                 User_command_payload.body (User_command.payload payment)
               with
               | Payment {Payment_payload.Poly.amount; _} ->
-                  Ok (amount |> Currency.Amount.to_uint64 |> Stringable.uint64)
+                  Ok (amount |> Currency.Amount.to_uint64)
               | Stake_delegation _ ->
                   (* Stake delegation does not have an amount, so we set it to 0 *)
-                  Ok "0" )
-        ; uint64_field "fee"
+                  Ok Unsigned.UInt64.zero )
+        ; field "fee" ~typ:(non_null uint64)
             ~doc:"Fee that sender is willing to pay for making the transaction"
             ~args:Arg.[]
             ~resolve:(fun _ payment ->
-              User_command.fee payment |> Currency.Fee.to_uint64
-              |> Stringable.uint64 )
+              User_command.fee payment |> Currency.Fee.to_uint64 )
         ; field "memo" ~typ:(non_null string)
             ~doc:"Short arbitrary message provided by the sender"
             ~args:Arg.[]
@@ -302,12 +285,13 @@ module Types = struct
     obj "FeeTransfer" ~fields:(fun _ ->
         [ field "recipient"
             ~args:Arg.[]
-            ~doc:"Public key of fee transfer recipient" ~typ:(non_null string)
-            ~resolve:(fun _ (pk, _) -> Stringable.public_key pk)
-        ; uint64_field "fee"
-            ~doc:"Amount that the recipient is paid in this fee transfer"
+            ~doc:"Public key of fee transfer recipient"
+            ~typ:(non_null public_key)
+            ~resolve:(fun _ (pk, _) -> pk)
+        ; field "fee" ~typ:(non_null uint64)
             ~args:Arg.[]
-            ~resolve:(fun _ (_, fee) -> Stringable.fee fee) ] )
+            ~doc:"Amount that the recipient is paid in this fee transfer"
+            ~resolve:(fun _ (_, fee) -> Currency.Fee.to_uint64 fee) ] )
 
   let transactions =
     let open Filtered_external_transition.Transactions in
@@ -325,10 +309,11 @@ module Types = struct
             ~typ:(non_null @@ list @@ non_null fee_transfer)
             ~args:Arg.[]
             ~resolve:(fun _ {fee_transfers; _} -> fee_transfers)
-        ; uint64_field "coinbase"
+        ; field "coinbase" ~typ:(non_null uint64)
             ~doc:"Amount of coda granted to the producer of this block"
             ~args:Arg.[]
-            ~resolve:(fun _ {coinbase; _} -> Stringable.amount coinbase) ] )
+            ~resolve:(fun _ {coinbase; _} -> Currency.Amount.to_uint64 coinbase)
+        ] )
 
   let blockchain_state =
     obj "BlockchainState" ~fields:(fun _ ->
@@ -371,11 +356,10 @@ module Types = struct
       typ =
     let open Filtered_external_transition in
     obj "Block" ~fields:(fun _ ->
-        [ field "creator" ~typ:(non_null string)
+        [ field "creator" ~typ:(non_null public_key)
             ~doc:"Public key of account that produced this block"
             ~args:Arg.[]
-            ~resolve:(fun _ {With_hash.data; _} ->
-              Stringable.public_key data.creator )
+            ~resolve:(fun _ {With_hash.data; _} -> data.creator)
         ; field "stateHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the state after this block"
             ~args:Arg.[]
@@ -393,12 +377,6 @@ module Types = struct
       ~doc:"Status for whenever the blockchain is reorganized"
       ~values:[enum_value "CHANGED" ~value:`Changed]
 
-  let pubkey_field ~resolve =
-    field "publicKey" ~typ:(non_null string)
-      ~doc:"The public identity of a wallet"
-      ~args:Arg.[]
-      ~resolve
-
   module Wallet = struct
     module AnnotatedBalance = struct
       type t = {total: Balance.t; unknown: Balance.t}
@@ -408,17 +386,16 @@ module Types = struct
           ~doc:
             "A total balance annotated with the amount that is currently \
              unknown with the invariant: unknown <= total" ~fields:(fun _ ->
-            [ field "total" ~typ:(non_null string)
-                ~doc:
-                  "The amount of coda owned by the account (stringified uint64)"
+            [ field "total" ~typ:(non_null uint64)
+                ~doc:"The amount of coda owned by the account"
                 ~args:Arg.[]
-                ~resolve:(fun _ (b : t) -> Stringable.balance b.total)
-            ; field "unknown" ~typ:(non_null string)
+                ~resolve:(fun _ (b : t) -> Balance.to_uint64 b.total)
+            ; field "unknown" ~typ:(non_null uint64)
                 ~doc:
                   "The amount of coda owned by the account whose origin is \
-                   currently unknown (stringified uint64)"
+                   currently unknown"
                 ~args:Arg.[]
-                ~resolve:(fun _ (b : t) -> Stringable.balance b.unknown) ] )
+                ~resolve:(fun _ (b : t) -> Balance.to_uint64 b.unknown) ] )
     end
 
     (** Hack: Account.Poly.t is only parameterized over 'pk once and so, in
@@ -440,9 +417,11 @@ module Types = struct
     let wallet =
       obj "Wallet" ~doc:"An account record according to the daemon"
         ~fields:(fun _ ->
-          [ pubkey_field ~resolve:(fun _ {account; _} ->
-                Stringable.public_key
-                @@ Option.value_exn account.Account.Poly.public_key )
+          [ field "publicKey" ~typ:(non_null public_key)
+              ~doc:"The public identity of a wallet"
+              ~args:Arg.[]
+              ~resolve:(fun _ {account; _} ->
+                Option.value_exn account.Account.Poly.public_key )
           ; field "balance"
               ~typ:(non_null AnnotatedBalance.obj)
               ~doc:"The amount of coda owned by the account"
@@ -462,14 +441,12 @@ module Types = struct
               ~resolve:(fun _ {account; _} ->
                 Option.map ~f:Receipt.Chain_hash.to_string
                   account.Account.Poly.receipt_chain_hash )
-          ; field "delegate" ~typ:string
+          ; field "delegate" ~typ:public_key
               ~doc:
                 "The public key to which you are delegating - if you are not \
                  delegating to anybody, this would return your public key"
               ~args:Arg.[]
-              ~resolve:(fun _ {account; _} ->
-                Option.map ~f:Stringable.public_key
-                  account.Account.Poly.delegate )
+              ~resolve:(fun _ {account; _} -> account.Account.Poly.delegate)
           ; field "votingFor" ~typ:string
               ~doc:
                 "The previous epoch lock hash of the chain which you are \
@@ -493,33 +470,30 @@ module Types = struct
 
   let snark_worker =
     obj "SnarkWorker" ~fields:(fun _ ->
-        [ field "key" ~typ:(non_null string)
+        [ field "key" ~typ:(non_null public_key)
             ~doc:"Public key of current snark worker"
             ~args:Arg.[]
-            ~resolve:(fun (_ : Coda_lib.t resolve_info) (key, _) ->
-              Stringable.public_key key )
-        ; field "fee" ~typ:(non_null string)
-            ~doc:
-              "Fee that snark worker is charging to generate a snark proof \
-               (stringified uint64)"
+            ~resolve:(fun (_ : Coda_lib.t resolve_info) (key, _) -> key)
+        ; field "fee" ~typ:(non_null uint64)
+            ~doc:"Fee that snark worker is charging to generate a snark proof"
             ~args:Arg.[]
             ~resolve:(fun (_ : Coda_lib.t resolve_info) (_, fee) ->
-              Stringable.uint64 (Currency.Fee.to_uint64 fee) ) ] )
+              Currency.Fee.to_uint64 fee ) ] )
 
   module Payload = struct
     let add_wallet : (Coda_lib.t, Account.key sexp_option) typ =
       obj "AddWalletPayload" ~fields:(fun _ ->
-          [ field "publicKey" ~typ:(non_null string)
+          [ field "publicKey" ~typ:(non_null public_key)
               ~doc:"Public key of the newly-created wallet"
               ~args:Arg.[]
-              ~resolve:(fun _ key -> Stringable.public_key key) ] )
+              ~resolve:(fun _ -> Fn.id) ] )
 
     let delete_wallet =
       obj "DeleteWalletPayload" ~fields:(fun _ ->
-          [ field "publicKey" ~typ:(non_null string)
+          [ field "publicKey" ~typ:(non_null public_key)
               ~doc:"Public key of the deleted wallet"
               ~args:Arg.[]
-              ~resolve:(fun _ key -> Stringable.public_key key) ] )
+              ~resolve:(fun _ -> Fn.id) ] )
 
     let trust_status =
       obj "TrustStatusPayload" ~fields:(fun _ ->
@@ -562,18 +536,12 @@ module Types = struct
               ~doc:
                 "Returns the last wallet public keys that were staking before \
                  or empty if there were none"
-              ~typ:(non_null (list (non_null string)))
+              ~typ:(non_null (list (non_null public_key)))
               ~args:Arg.[]
-              ~resolve:(fun _ keys -> List.map ~f:Stringable.public_key keys)
-          ] )
+              ~resolve:(fun _ -> Fn.id) ] )
   end
 
   module Arguments = struct
-    let public_key ~name public_key =
-      result_of_or_error
-        (Public_key.Compressed.of_base58_check public_key)
-        ~error:(sprintf !"%s address is not valid." name)
-
     let ip_address ~name ip_addr =
       result_of_exn Unix.Inet_addr.of_string ip_addr
         ~error:(sprintf !"%s is not valid." name)
@@ -582,14 +550,38 @@ module Types = struct
   module Input = struct
     open Schema.Arg
 
+    let public_key_arg =
+      scalar "PublicKey" ~doc:"Base58Check-encoded public key string"
+        ~coerce:(fun key ->
+          match key with
+          | `String s ->
+              Public_key.Compressed.of_base58_check s
+              |> Result.map_error ~f:(fun _ -> "Could not decode public key.")
+          | _ ->
+              Error "Invalid format for public key." )
+
+    let uint64_arg =
+      scalar "UInt64" ~doc:"String representing a uint64 number in base 10"
+        ~coerce:(fun key ->
+          match key with
+          | `String s ->
+              result_of_exn Unsigned.UInt64.of_string s
+                ~error:"Could not decode uint64."
+          | `Int n ->
+              if n < 0 then
+                Error "Could not convert negative number to uint64."
+              else Ok (Unsigned.UInt64.of_int n)
+          | _ ->
+              Error "Invalid format for public key." )
+
     module Fields = struct
-      let from ~doc = arg "from" ~typ:(non_null string) ~doc
+      let from ~doc = arg "from" ~typ:(non_null public_key_arg) ~doc
 
-      let to_ ~doc = arg "to" ~typ:(non_null string) ~doc
+      let to_ ~doc = arg "to" ~typ:(non_null public_key_arg) ~doc
 
-      let fee ~doc = uint64_arg "fee" ~typ:(non_null string) ~doc
+      let fee ~doc = arg "fee" ~typ:(non_null uint64_arg) ~doc
 
-      let memo ~doc = uint64_arg "memo" ~typ:string ~doc
+      let memo ~doc = arg "memo" ~typ:string ~doc
     end
 
     let send_payment =
@@ -599,8 +591,8 @@ module Types = struct
         ~fields:
           [ from ~doc:"Public key of recipient of payment"
           ; to_ ~doc:"Public key of sender of payment"
-          ; uint64_arg "amount" ~doc:"Amount of coda to send to to receiver"
-              ~typ:(non_null string)
+          ; arg "amount" ~doc:"Amount of coda to send to to receiver"
+              ~typ:(non_null uint64_arg)
           ; fee ~doc:"Fee amount in order to send payment"
           ; memo ~doc:"Short arbitrary message provided by the sender" ]
 
@@ -618,37 +610,37 @@ module Types = struct
       obj "DeleteWalletInput" ~coerce:Fn.id
         ~fields:
           [ arg "publicKey" ~doc:"Public key of account to be deleted"
-              ~typ:(non_null string) ]
+              ~typ:(non_null public_key_arg) ]
 
     let reset_trust_status =
       obj "ResetTrustStatusInput" ~coerce:Fn.id
         ~fields:[arg "ipAddress" ~typ:(non_null string)]
 
     (* TODO: Treat cases where filter_input has a null argument *)
-    let filter_input ~title ~arg_name ~arg_doc =
-      obj title ~coerce:Fn.id
-        ~fields:[arg arg_name ~doc:arg_doc ~typ:(non_null string)]
-
     let block_filter_input =
-      filter_input ~title:"BlockFilterInput" ~arg_name:"relatedTo"
-        ~arg_doc:"A public key of an user who has their transaction in a block"
+      obj "BlockFilterInput" ~coerce:Fn.id
+        ~fields:
+          [ arg "relatedTo"
+              ~doc:
+                "A public key of a user who has their\n\
+                \        transaction in the block, or produced the block"
+              ~typ:(non_null public_key_arg) ]
 
     let user_command_filter_input =
-      obj "UserCommandFilterType"
-        ~coerce:(fun public_key -> public_key)
+      obj "UserCommandFilterType" ~coerce:Fn.id
         ~fields:
           [ arg "toOrFrom"
               ~doc:
                 "Public key of sender or receiver of transactions you are \
                  looking for"
-              ~typ:(non_null string) ]
+              ~typ:(non_null public_key_arg) ]
 
     let set_staking =
       obj "SetStakingInput"
         ~coerce:(fun wallets -> wallets)
         ~fields:
           [ arg "wallets"
-              ~typ:(non_null (list (non_null string)))
+              ~typ:(non_null (list (non_null public_key_arg)))
               ~doc:
                 "Public keys of wallets you wish to stake - these must be \
                  wallets that are in ownedWallets" ]
@@ -734,7 +726,7 @@ module Types = struct
 
       val get_database : Coda_lib.t -> Pagination_database.t
 
-      val filter_argument : string option Schema.Arg.arg_typ
+      val filter_argument : Account.key option Schema.Arg.arg_typ
 
       val query_name : string
 
@@ -818,10 +810,6 @@ module Types = struct
           ~resolve:(fun {ctx= coda; _} () public_key first after last before ->
             let open Deferred.Result.Let_syntax in
             let%map result, total_counts =
-              let%bind public_key =
-                Deferred.return
-                @@ Arguments.public_key ~name:"publicKey" public_key
-              in
               let database = get_database coda in
               let resolve_cursor = function
                 | None ->
@@ -1033,14 +1021,10 @@ module Subscriptions = struct
       ~args:
         Arg.
           [ arg "publicKey" ~doc:"Public key that is included in the block"
-              ~typ:(non_null string) ]
+              ~typ:(non_null Types.Input.public_key_arg) ]
       ~resolve:(fun {ctx= coda; _} public_key ->
-        let open Deferred.Result.Let_syntax in
-        let%map public_key =
-          Deferred.return
-          @@ Types.Arguments.public_key ~name:"publicKey" public_key
-        in
-        Coda_commands.Subscriptions.new_block coda public_key )
+        Deferred.Result.return
+        @@ Coda_commands.Subscriptions.new_block coda public_key )
 
   let chain_reorganization =
     subscription_field "chainReorganization"
@@ -1078,19 +1062,13 @@ module Mutations = struct
       ~doc:"Delete a wallet that you own based on its public key"
       ~typ:(non_null Types.Payload.delete_wallet)
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.delete_wallet)]
-      ~resolve:(fun {ctx= coda; _} () public_key_input ->
+      ~resolve:(fun {ctx= coda; _} () public_key ->
         let open Deferred.Result.Let_syntax in
-        let%bind public_key =
-          Deferred.return
-          @@ Types.Arguments.public_key ~name:"public_key" public_key_input
-        in
         let wallets = Coda_lib.wallets coda in
         let%map () =
           Deferred.Result.map_error
             ~f:(fun `Not_found ->
-              sprintf
-                !"Could not find wallet with public key: %s"
-                public_key_input )
+              "Could not find wallet with specified public key" )
             (Secrets.Wallets.delete wallets public_key)
         in
         public_key )
@@ -1125,20 +1103,18 @@ module Mutations = struct
 
   let parse_user_command_input ~kind coda from to_ fee maybe_memo =
     let open Result.Let_syntax in
-    let%bind receiver = Types.Arguments.public_key ~name:"to" to_ in
-    let%bind sender = Types.Arguments.public_key ~name:"from" from in
     let%bind sender_account =
       Result.of_option
-        Partial_account.(of_pk coda sender |> to_full_account)
+        Partial_account.(of_pk coda from |> to_full_account)
         ~error:"Couldn't find the account for specified `sender`."
     in
     let%bind fee =
-      result_of_exn Currency.Fee.of_string fee
+      result_of_exn Currency.Fee.of_uint64 fee
         ~error:(sprintf "Invalid %s `fee` provided." kind)
     in
     let%bind sender_kp =
       Result.of_option
-        (Secrets.Wallets.find (Coda_lib.wallets coda) ~needle:sender)
+        (Secrets.Wallets.find (Coda_lib.wallets coda) ~needle:from)
         ~error:
           (sprintf
              "Couldn't find the private key for specified `sender`. Do you \
@@ -1151,7 +1127,7 @@ module Mutations = struct
           result_of_exn User_command_memo.create_by_digesting_string_exn memo
             ~error:"Invalid `memo` provided." )
     in
-    (sender_account, sender_kp, memo, receiver, fee)
+    (sender_account, sender_kp, memo, to_, fee)
 
   let send_delegation =
     io_field "sendDelegation"
@@ -1177,17 +1153,15 @@ module Mutations = struct
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.send_payment)]
       ~resolve:(fun {ctx= coda; _} () (from, to_, amount, fee, maybe_memo) ->
         let open Deferred.Result.Let_syntax in
-        let%bind amount =
-          Deferred.return
-          @@ result_of_exn Currency.Amount.of_string amount
-               ~error:"Invalid payment `amount` provided."
-        in
         let%bind sender_account, sender_kp, memo, receiver, fee =
           Deferred.return
           @@ parse_user_command_input ~kind:"payment" coda from to_ fee
                maybe_memo
         in
-        let body = User_command_payload.Body.Payment {receiver; amount} in
+        let body =
+          User_command_payload.Body.Payment
+            {receiver; amount= Amount.of_uint64 amount}
+        in
         build_user_command coda sender_account sender_kp memo body fee )
 
   let add_payment_receipt =
@@ -1212,24 +1186,14 @@ module Mutations = struct
         Some payment )
 
   let set_staking =
-    result_field "setStaking"
+    field "setStaking"
       ~doc:
         "Set keys you wish to stake with - silently fails if you pass keys \
          not tracked in ownedWallets"
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.set_staking)]
       ~typ:(non_null Types.Payload.set_staking)
-      ~resolve:(fun {ctx= coda; _} () pk_strings ->
-        let open Result.Let_syntax in
+      ~resolve:(fun {ctx= coda; _} () pks ->
         (* TODO: Handle errors like: duplicates, etc *)
-        let%map pks =
-          List.fold pk_strings ~init:(Result.return [])
-            ~f:(fun acc pk_string ->
-              let%bind acc = acc in
-              let%map pk =
-                Types.Arguments.public_key ~name:"wallets" pk_string
-              in
-              pk :: acc )
-        in
         let old_propose_keys = Coda_lib.propose_public_keys coda in
         ignore @@ Coda_commands.replace_proposers coda pks ;
         Public_key.Compressed.Set.to_list old_propose_keys )
@@ -1247,16 +1211,14 @@ module Queries = struct
   open Schema
 
   let pooled_user_commands =
-    result_field "pooledUserCommands"
+    field "pooledUserCommands"
       ~doc:"Retrieve all the user commands sent by a public key"
       ~typ:(non_null @@ list @@ non_null Types.user_command)
       ~args:
         Arg.
           [ arg "publicKey" ~doc:"Public key of sender of pooled user commands"
-              ~typ:(non_null string) ]
-      ~resolve:(fun {ctx= coda; _} () pk_string ->
-        let open Result.Let_syntax in
-        let%map pk = Types.Arguments.public_key ~name:"publicKey" pk_string in
+              ~typ:(non_null Types.Input.public_key_arg) ]
+      ~resolve:(fun {ctx= coda; _} () pk ->
         let transaction_pool = Coda_lib.transaction_pool coda in
         List.map
           (Network_pool.Transaction_pool.Resource_pool.all_from_user
@@ -1317,19 +1279,14 @@ module Queries = struct
                ; path= Secrets.Wallets.get_path wallets pk } ) )
 
   let wallet =
-    result_field "wallet" ~doc:"Find any wallet via a public key"
-      ~typ:
-        Types.Wallet.wallet
-        (* TODO: Is there anyway to describe `public_key` arg in a more typesafe way on our ocaml-side *)
+    field "wallet" ~doc:"Find any wallet via a public key"
+      ~typ:Types.Wallet.wallet
       ~args:
         Arg.
           [ arg "publicKey" ~doc:"Public key of wallet being retrieved"
-              ~typ:(non_null string) ]
-      ~resolve:(fun {ctx= coda; _} () (pk_string : string) ->
-        let open Result.Let_syntax in
+              ~typ:(non_null Types.Input.public_key_arg) ]
+      ~resolve:(fun {ctx= coda; _} () pk ->
         let propose_public_keys = Coda_lib.propose_public_keys coda in
-        let%map pk = Types.Arguments.public_key ~name:"publicKey" pk_string in
-        (* TODO: return null if the pubkey is not a valid base58check key *)
         Some
           { Types.Wallet.account= Partial_account.of_pk coda pk
           ; is_actively_staking=


### PR DESCRIPTION
Main change: Updating the graphql.ml to treat pubkey and uint64 as scalars
It's actually kinda nice, we can avoid a lot of repeated error checking now!
Later we can see how it goes and consider following up with DateTime etc.

The associated changes are just making the wallet build with the new schema and updating the faker schema to match.
