### PR TITLE
Revert investigation logs

### DIFF
--- a/src/lib/coda_base/transition_system.ml
+++ b/src/lib/coda_base/transition_system.ml
@@ -261,13 +261,6 @@ struct
                     (Fn.compose Verifier.proof_of_backend_proof
                        Prover_state.proof))
         in
-        Logger.error ~module_:__MODULE__ ~location:__LOC__ (Logger.create ())
-          !"When wrap executes: Step_vk key is $step_vk"
-          ~metadata:
-            [ ( "step_vk"
-              , `String
-                  (Tick0.Verification_key.to_string Step_vk.verification_key)
-              ) ] ;
         Verifier.verify step_vk_constant step_vk_precomp [input] proof
       in
       with_label __LOC__ (Boolean.Assert.is_true result)


### PR DESCRIPTION
The investigation finished, we solved the bug, and these logs are too noisy to keep in our codebase and usually won't have useful information