### PR TITLE
Refuse to build if missing working proving keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,7 @@ jobs:
                  no_output_timeout: 1h
                  environment:
                   DUNE_PROFILE: testnet_postake_medium_curves
+                  CODA_CI_DIE_IF_KEYS_OUTDATED: true
            - run:
                  name: Run all tests (on master)
                  command: echo "FIXME Tests not yet working on mac"

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -125,6 +125,7 @@ jobs:
                  no_output_timeout: 1h
                  environment:
                   DUNE_PROFILE: testnet_postake_medium_curves
+                  CODA_CI_DIE_IF_KEYS_OUTDATED: true
            - run:
                  name: Run all tests (on master)
                  command: echo "FIXME Tests not yet working on mac"

--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -216,7 +216,7 @@ module Make (T : Transaction_snark.Verification.S) = struct
         ~brew_install_path:Cache_dir.brew_install_path
         ~digest_input:
           (Fn.compose Md5.to_hex Tick.R1CS_constraint_system.digest)
-        ~create_env:Tick.Keypair.generate
+        ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Tick.Keypair.generate x)
         ~input:
           (Tick.constraint_system ~exposing:(Step_base.input ())
              (Step_base.main (Logger.null ())))
@@ -245,7 +245,7 @@ module Make (T : Transaction_snark.Verification.S) = struct
           ~brew_install_path:Cache_dir.brew_install_path
           ~digest_input:
             (Fn.compose Md5.to_hex Tock.R1CS_constraint_system.digest)
-          ~create_env:Tock.Keypair.generate
+          ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Tock.Keypair.generate x)
           ~input:(Tock.constraint_system ~exposing:Wrap.input Wrap.main)
       in
       let%map wrap_vk, wrap_pk = Cached.run wrap_cached in

--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -216,7 +216,9 @@ module Make (T : Transaction_snark.Verification.S) = struct
         ~brew_install_path:Cache_dir.brew_install_path
         ~digest_input:
           (Fn.compose Md5.to_hex Tick.R1CS_constraint_system.digest)
-        ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Tick.Keypair.generate x)
+        ~create_env:(fun x ->
+          Coda_base.Ci_die.skip_key_generation () ;
+          Tick.Keypair.generate x )
         ~input:
           (Tick.constraint_system ~exposing:(Step_base.input ())
              (Step_base.main (Logger.null ())))
@@ -245,7 +247,9 @@ module Make (T : Transaction_snark.Verification.S) = struct
           ~brew_install_path:Cache_dir.brew_install_path
           ~digest_input:
             (Fn.compose Md5.to_hex Tock.R1CS_constraint_system.digest)
-          ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Tock.Keypair.generate x)
+          ~create_env:(fun x ->
+            Coda_base.Ci_die.skip_key_generation () ;
+            Tock.Keypair.generate x )
           ~input:(Tock.constraint_system ~exposing:Wrap.input Wrap.main)
       in
       let%map wrap_vk, wrap_pk = Cached.run wrap_cached in

--- a/src/lib/coda_base/ci_die.ml
+++ b/src/lib/coda_base/ci_die.ml
@@ -1,0 +1,13 @@
+open Core_kernel
+
+(** exit 1 if CODA_CI_DIE_IF_KEYS_OUTDATED=true *)
+let skip_key_generation () =
+  if
+    Option.equal String.equal
+      (Sys.getenv_opt "CODA_CI_DIE_IF_KEYS_OUTDATED")
+      (Some "true")
+  then (
+    eprintf
+      "error: dying because CI says we shouldn't be generating these keys\n" ;
+    exit 14 )
+  else ()

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -539,7 +539,7 @@ module Base = struct
       ~digest_input:(fun x ->
         Md5.to_hex (R1CS_constraint_system.digest (Lazy.force x)) )
       ~input:(lazy (constraint_system ~exposing:(tick_input ()) main))
-      ~create_env:(fun x -> Keypair.generate (Lazy.force x))
+      ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Keypair.generate (Lazy.force x))
 end
 
 module Transition_data = struct
@@ -824,7 +824,7 @@ module Merge = struct
       ~digest_input:(fun x ->
         Md5.to_hex (R1CS_constraint_system.digest (Lazy.force x)) )
       ~input:(lazy (constraint_system ~exposing:(input ()) main))
-      ~create_env:(fun x -> Keypair.generate (Lazy.force x))
+      ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Keypair.generate (Lazy.force x))
 end
 
 module Verification = struct
@@ -1071,7 +1071,7 @@ struct
       ~brew_install_path:Cache_dir.brew_install_path
       ~digest_input:(Fn.compose Md5.to_hex R1CS_constraint_system.digest)
       ~input:(constraint_system ~exposing:wrap_input main)
-      ~create_env:Keypair.generate
+      ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Keypair.generate x)
 end
 
 module type S = sig

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -539,7 +539,9 @@ module Base = struct
       ~digest_input:(fun x ->
         Md5.to_hex (R1CS_constraint_system.digest (Lazy.force x)) )
       ~input:(lazy (constraint_system ~exposing:(tick_input ()) main))
-      ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Keypair.generate (Lazy.force x))
+      ~create_env:(fun x ->
+        Coda_base.Ci_die.skip_key_generation () ;
+        Keypair.generate (Lazy.force x) )
 end
 
 module Transition_data = struct
@@ -824,7 +826,9 @@ module Merge = struct
       ~digest_input:(fun x ->
         Md5.to_hex (R1CS_constraint_system.digest (Lazy.force x)) )
       ~input:(lazy (constraint_system ~exposing:(input ()) main))
-      ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Keypair.generate (Lazy.force x))
+      ~create_env:(fun x ->
+        Coda_base.Ci_die.skip_key_generation () ;
+        Keypair.generate (Lazy.force x) )
 end
 
 module Verification = struct
@@ -1071,7 +1075,9 @@ struct
       ~brew_install_path:Cache_dir.brew_install_path
       ~digest_input:(Fn.compose Md5.to_hex R1CS_constraint_system.digest)
       ~input:(constraint_system ~exposing:wrap_input main)
-      ~create_env:(fun x -> Coda_base.Ci_die.skip_key_generation () ; Keypair.generate x)
+      ~create_env:(fun x ->
+        Coda_base.Ci_die.skip_key_generation () ;
+        Keypair.generate x )
 end
 
 module type S = sig


### PR DESCRIPTION
Right now only enabled for build-macos.

Which builds should we enable this on? This should probably be the last PR we land in the key-management improvements..