### PR TITLE
Remove staged ledger hash from client status

### DIFF
--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -217,7 +217,6 @@ type active_state_fields =
   { num_accounts: int option
   ; blockchain_length: int option
   ; ledger_merkle_root: string option
-  ; staged_ledger_hash: string option
   ; state_hash: string option
   ; consensus_time_best_tip: string option }
 
@@ -289,7 +288,7 @@ let get_status ~flag t =
       Length.to_int
       @@ Consensus.Data.Consensus_state.blockchain_length consensus_state
     in
-    let%bind sync_status =
+    let%map sync_status =
       Coda_incremental.Status.stabilize () ;
       match
         Coda_incremental.Status.Observer.value_exn @@ Coda_lib.sync_status t
@@ -301,11 +300,6 @@ let get_status ~flag t =
       | `Synced ->
           `Active `Synced
     in
-    let%map staged_ledger = Coda_lib.best_staged_ledger t in
-    let staged_ledger_hash =
-      staged_ledger |> Staged_ledger.hash |> Staged_ledger_hash.sexp_of_t
-      |> Sexp.to_string
-    in
     let consensus_time_best_tip =
       Consensus.Data.Consensus_state.time_hum consensus_state
     in
@@ -313,7 +307,6 @@ let get_status ~flag t =
     , { num_accounts= Some num_accounts
       ; blockchain_length= Some blockchain_length
       ; ledger_merkle_root= Some ledger_merkle_root
-      ; staged_ledger_hash= Some staged_ledger_hash
       ; state_hash= Some state_hash
       ; consensus_time_best_tip= Some consensus_time_best_tip } )
   in
@@ -321,7 +314,6 @@ let get_status ~flag t =
       , { num_accounts
         ; blockchain_length
         ; ledger_merkle_root
-        ; staged_ledger_hash
         ; state_hash
         ; consensus_time_best_tip } ) =
     match active_status () with
@@ -332,7 +324,6 @@ let get_status ~flag t =
         , { num_accounts= None
           ; blockchain_length= None
           ; ledger_merkle_root= None
-          ; staged_ledger_hash= None
           ; state_hash= None
           ; consensus_time_best_tip= None } )
   in
@@ -341,7 +332,6 @@ let get_status ~flag t =
   ; blockchain_length
   ; uptime_secs
   ; ledger_merkle_root
-  ; staged_ledger_hash
   ; state_hash
   ; consensus_time_best_tip
   ; commit_id

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -217,8 +217,8 @@ module Types = struct
           List.rev
           @@ Daemon_rpcs.Types.Status.Fields.fold ~init:[] ~num_accounts:int
                ~blockchain_length:int ~uptime_secs:nn_int
-               ~ledger_merkle_root:string ~staged_ledger_hash:string
-               ~state_hash:string ~commit_id:nn_string ~conf_dir:nn_string
+               ~ledger_merkle_root:string ~state_hash:string
+               ~commit_id:nn_string ~conf_dir:nn_string
                ~peers:(id ~typ:Schema.(non_null @@ list (non_null string)))
                ~user_commands_sent:nn_int ~run_snark_worker:nn_bool
                ~sync_status:(id ~typ:(non_null sync_status))

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -233,7 +233,6 @@ module Types = struct
       ; blockchain_length: int option
       ; uptime_secs: int
       ; ledger_merkle_root: string option
-      ; staged_ledger_hash: string option
       ; state_hash: string option
       ; commit_id: Git_sha.t
       ; conf_dir: string
@@ -257,10 +256,10 @@ module Types = struct
       end) in
       let open M in
       Fields.to_list ~sync_status ~num_accounts ~blockchain_length ~uptime_secs
-        ~ledger_merkle_root ~staged_ledger_hash ~state_hash ~commit_id
-        ~conf_dir ~peers ~user_commands_sent ~run_snark_worker ~propose_pubkeys
-        ~histograms ~consensus_time_best_tip ~consensus_time_now
-        ~consensus_mechanism ~consensus_configuration
+        ~ledger_merkle_root ~state_hash ~commit_id ~conf_dir ~peers
+        ~user_commands_sent ~run_snark_worker ~propose_pubkeys ~histograms
+        ~consensus_time_best_tip ~consensus_time_now ~consensus_mechanism
+        ~consensus_configuration
       |> List.filter_map ~f:Fn.id
 
     let to_text (t : t) =


### PR DESCRIPTION
Remove ugly staged ledger hash from client status in CLI and GraphQL.