### PR TITLE
Bump snarky

### DIFF
--- a/src/lib/coda_base/hack_snarky_tests.ml
+++ b/src/lib/coda_base/hack_snarky_tests.ml
@@ -4,14 +4,14 @@ let%test_module "merkle_tree" =
   ( module struct
     open Snarky.Merkle_tree
 
-    let compress x y = Free_hash.Compress (x, y)
+    let merge x y = Free_hash.Merge (x, y)
 
     let hash =
       Option.value_map ~default:Free_hash.Hash_empty ~f:(fun x ->
           Free_hash.Hash_value x )
 
     let create_tree n =
-      let tree = create ~hash ~compress 0 in
+      let tree = create ~hash ~merge 0 in
       add_many tree (List.init (n - 1) ~f:(fun i -> i + 1))
 
     let n = 10
@@ -37,6 +37,6 @@ let%test_module "merkle_tree" =
     let%test_unit "merkle_root" =
       for key = 0 to n - 1 do
         let path = get_path tree key in
-        assert (implied_root ~compress key (hash (Some key)) path = root tree)
+        assert (implied_root ~merge key (hash (Some key)) path = root tree)
       done
   end )

--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -16,7 +16,7 @@ module Merkle_tree =
 
       let typ = Pedersen.Checked.Digest.typ
 
-      let hash ~height h1 h2 =
+      let merge ~height h1 h2 =
         let to_triples (bs : Pedersen.Checked.Digest.Unpacked.var) =
           Bitstring_lib.Bitstring.pad_to_triple_list ~default:Boolean.false_
             (bs :> Boolean.var list)

--- a/src/lib/coda_base/pending_coinbase.ml
+++ b/src/lib/coda_base/pending_coinbase.ml
@@ -388,7 +388,7 @@ struct
 
           let typ = Pedersen.Checked.Digest.typ
 
-          let hash ~height h1 h2 =
+          let merge ~height h1 h2 =
             let to_triples (bs : Pedersen.Checked.Digest.Unpacked.var) =
               Bitstring_lib.Bitstring.pad_to_triple_list
                 ~default:Boolean.false_


### PR DESCRIPTION
This PR
* bumps snarky to the latest version
  - this includes @psteckler's `compress`/`hash` -> `merge` rename in `Snarky.Merkel_tree`
* makes these rename changes to the `Merkel_tree` uses across coda

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
