### PR TITLE
Audit logs for postake code

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -930,8 +930,10 @@ module Data = struct
       let open Local_state in
       let open Snapshot in
       Logger.info logger ~module_:__MODULE__ ~location:__LOC__
-        "Checking vrf evaluations at %d:%d" (Epoch.to_int epoch)
-        (Epoch.Slot.to_int slot) ;
+        "Checking VRF evaluations at epoch: $epoch, slot: $slot"
+        ~metadata:
+          [ ("epoch", `Int (Epoch.to_int epoch))
+          ; ("slot", `Int (Epoch.Slot.to_int slot)) ] ;
       with_return (fun {return} ->
           Hashtbl.iteri
             ( Snapshot.delegators epoch_snapshot public_key_compressed
@@ -941,12 +943,19 @@ module Data = struct
                 T.eval ~private_key {epoch; slot; seed; delegator}
               in
               Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-                !"VRF result for %d: %d/%d -> %{sexp: Bignum_bigint.t}"
-                (Coda_base.Account.Index.to_int delegator)
-                (Balance.to_int balance)
-                (Amount.to_int total_stake)
-                (Bignum_bigint.of_bit_fold_lsb
-                   (Random_oracle.Digest.fold_bits vrf_result)) ;
+                "VRF result for delegator: $delegator, balance: $balance, \
+                 amount: $amount, result: $result"
+                ~metadata:
+                  [ ( "delegator"
+                    , `Int (Coda_base.Account.Index.to_int delegator) )
+                  ; ("balance", `Int (Balance.to_int balance))
+                  ; ("amount", `Int (Amount.to_int total_stake))
+                  ; ( "result"
+                    , `String
+                        (* use sexp representation; int might be too small *)
+                        ( Random_oracle.Digest.fold_bits vrf_result
+                        |> Bignum_bigint.of_bit_fold_lsb
+                        |> Bignum_bigint.sexp_of_t |> Sexp.to_string ) ) ] ;
               Coda_metrics.Counter.inc_one
                 Coda_metrics.Consensus.vrf_evaluations ;
               if
@@ -2217,13 +2226,12 @@ module Hooks = struct
 
       let implementation ~logger ~local_state conn ~version:_ ledger_hash =
         let open Coda_base in
-        let open Host_and_port in
         let open Local_state in
         let open Snapshot in
         Deferred.create (fun ivar ->
             Logger.info logger ~module_:__MODULE__ ~location:__LOC__
               ~metadata:
-                [ ("peer", `String (sprintf "%s:%d" conn.host conn.port))
+                [ ("peer", `String (Host_and_port.to_string conn))
                 ; ("ledger_hash", Coda_base.Ledger_hash.to_yojson ledger_hash)
                 ]
               "Serving epoch ledger query with hash $ledger_hash from $peer" ;
@@ -2249,12 +2257,12 @@ module Hooks = struct
             Result.iter_error response ~f:(fun err ->
                 Logger.info logger ~module_:__MODULE__ ~location:__LOC__
                   ~metadata:
-                    [ ("peer", `String (sprintf "%s:%d" conn.host conn.port))
+                    [ ("peer", `String (Host_and_port.to_string conn))
                     ; ("error", `String err)
                     ; ( "ledger_hash"
                       , Coda_base.Ledger_hash.to_yojson ledger_hash ) ]
                   "Failed to serve epoch ledger query with hash $ledger_hash \
-                   from $peer. See error for details: $error" ) ;
+                   from $peer: $error" ) ;
             Ivar.fill ivar response )
     end
 
@@ -2368,11 +2376,11 @@ module Hooks = struct
     let open Deferred.Let_syntax in
     let requested_syncs = Non_empty_list.to_list requested_syncs in
     Logger.info logger
-      "Syncing local state -- requesting %d snaphots from peers"
-      (List.length requested_syncs)
+      "Syncing local state; requesting $num_requested snapshots from peers"
       ~location:__LOC__ ~module_:__MODULE__
       ~metadata:
-        [ ( "requested_syncs"
+        [ ("num_requested", `Int (List.length requested_syncs))
+        ; ( "requested_syncs"
           , `List (List.map requested_syncs ~f:local_state_sync_to_yojson) )
         ; ("local_state", Local_state.to_yojson local_state) ] ;
     let sync {snapshot_id; expected_root= target_ledger_hash} =
@@ -2417,7 +2425,7 @@ module Hooks = struct
                   ~metadata:
                     [ ("peer", Network_peer.Peer.to_yojson peer)
                     ; ("error", `String err) ]
-                  "peer $peer failed to serve requested epoch ledger: $error" ;
+                  "Peer $peer failed to serve requested epoch ledger: $error" ;
                 return false
             | Error err ->
                 Logger.faulty_peer_without_punishment logger
@@ -2425,7 +2433,7 @@ module Hooks = struct
                   ~metadata:
                     [ ("peer", Network_peer.Peer.to_yojson peer)
                     ; ("error", `String (Error.to_string_hum err)) ]
-                  "error querying peer $peer: $error" ;
+                  "Error when querying peer $peer for epoch ledger: $error" ;
                 return false )
     in
     if%map Deferred.List.for_all requested_syncs ~f:sync then Ok ()
@@ -2459,7 +2467,10 @@ module Hooks = struct
     let string_of_choice = function `Take -> "Take" | `Keep -> "Keep" in
     let log_result choice msg =
       Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-        "RESULT: %s -- %s" (string_of_choice choice) msg
+        "Select result: $choice -- $message"
+        ~metadata:
+          [ ("choice", `String (string_of_choice choice))
+          ; ("message", `String msg) ]
     in
     let log_choice ~precondition_msg ~choice_msg choice =
       let choice_msg =
@@ -2579,7 +2590,7 @@ module Hooks = struct
   let next_proposal now (state : Consensus_state.Value.t) ~local_state
       ~keypairs ~logger =
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__
-      "Checking for next proposal..." ;
+      "Checking for next proposal" ;
     let curr_epoch, curr_slot =
       Epoch.epoch_and_slot_of_time_exn
         (Coda_base.Block_time.of_span_since_epoch
@@ -2610,9 +2621,10 @@ module Hooks = struct
             epoch_data
         | Error () ->
             Logger.error logger ~module_:__MODULE__ ~location:__LOC__
-              "system time is out of sync with protocol state time" ;
+              "System time is out of sync with protocol state time" ;
             failwith
-              "System time is out of sync. (hint: setup NTP if you haven't)"
+              "System time is out of sync with protocol state time; please \
+               setup NTP if you haven't)"
       in
       let total_stake = epoch_data.ledger.total_currency in
       let epoch_snapshot =


### PR DESCRIPTION
Audit log messages in `postake.ml`. I skipped most of the `debug` logs, since the task is to cleanup `warn` and `error`.