### PR TITLE
Find keys using brew prefix

### DIFF
--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -1,10 +1,19 @@
 open Core
+open Async
 
 let autogen_path = Filename.temp_dir_name ^/ "coda_cache_dir"
 
 let manual_install_path = "/var/lib/coda"
 
-let brew_install_path = "/usr/local/var/coda"
+let brew_install_path =
+  match
+    Thread_safe.block_on_async_exn (fun () ->
+        Process.run ~prog:"brew" ~args:["--prefix"] () )
+  with
+  | Ok brew ->
+      brew ^ "/var"
+  | _ ->
+      "/usr/local/var"
 
 let possible_paths base =
   List.map [manual_install_path; brew_install_path; autogen_path] ~f:(fun d ->


### PR DESCRIPTION
Blockingly query the brew install prefix to let us install more properly. Without this we're copying to an arbitrary place on the users disk, which might cause some issues if people have different homebrew configurations.

This isn't an ideal implementation because it blocks while querying but this command is fast so it might be ok?

Also eh if there's a better way to do this feel free to chime in
edit: hmm seems to break integration tests

```
time brew --prefix
/usr/local

real	0m0.030s
user	0m0.012s
sys	0m0.015s
```