### PR TITLE
bind rest server to all addresses on a machine

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -116,6 +116,12 @@ let daemon logger =
          (optional txn_fee)
      and enable_tracing =
        flag "tracing" no_arg ~doc:"Trace into $config-directory/$pid.trace"
+     and insecure_rest_server =
+       flag "insecure-rest-server" no_arg
+         ~doc:
+           "Have REST server listen on all addresses, not just localhost \
+            (this is INSECURE, make sure your firewall is configured \
+            correctly!)"
      and limit_connections =
        flag "limit-concurrent-connections"
          ~doc:
@@ -567,7 +573,7 @@ let daemon logger =
        let web_service = Web_pipe.get_service () in
        Web_pipe.run_service coda web_service ~conf_dir ~logger ;
        Coda_run.setup_local_server ?client_whitelist ?rest_server_port ~coda
-         ~client_port () ;
+         ~insecure_rest_server ~client_port () ;
        Coda_run.run_snark_worker ~client_port run_snark_worker_action ;
        let%bind () =
          Option.map metrics_server_port ~f:(fun port ->

--- a/src/app/cli/src/coda_run.ml
+++ b/src/app/cli/src/coda_run.ml
@@ -84,8 +84,8 @@ let log_shutdown ~conf_dir ~top_logger coda_ref =
           (Visualization_message.bootstrap "transition frontier") )
 
 (* TODO: handle participation_status more appropriately than doing participate_exn *)
-let setup_local_server ?(client_whitelist = []) ?rest_server_port ~coda
-    ~client_port () =
+let setup_local_server ?(client_whitelist = []) ?rest_server_port
+    ?(insecure_rest_server = false) ~coda ~client_port () =
   let client_whitelist =
     Unix.Inet_addr.Set.of_list (Unix.Inet_addr.localhost :: client_whitelist)
   in
@@ -223,7 +223,8 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port ~coda
                       ~metadata:
                         [ ("error", `String (Exn.to_string_mach exn))
                         ; ("context", `String "rest_server") ] ))
-              (Tcp.Where_to_listen.bind_to All_addresses
+              (Tcp.Where_to_listen.bind_to
+                 (if insecure_rest_server then All_addresses else Localhost)
                  (On_port rest_server_port))
               (fun ~body _sock req ->
                 let uri = Cohttp.Request.uri req in


### PR DESCRIPTION
We don't want the graphql server just to be ran on one address. So, we allow it to be run on all address for a machine.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
