### PR TITLE
Properly unregister masks when moving tf root + better error messages

### DIFF
--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -143,20 +143,20 @@ module Make (Inputs : Inputs_intf) = struct
     attached_mask
 
   let unregister_mask_exn (t : t) (mask : Mask.Attached.t) =
-    let error_msg_prefix =
-      sprintf "Couldn't unregister mask with UUID %s from parent %s"
+    let t_uuid = get_uuid t in
+    let error_msg suffix =
+      sprintf "Couldn't unregister mask with UUID %s from parent %s, %s"
         (Mask.Attached.get_uuid mask |> Uuid.to_string_hum)
         (get_uuid t |> Uuid.to_string_hum)
+        suffix
     in
-    let t_uuid = get_uuid t in
     match Uuid.Table.find registered_masks t_uuid with
     | None ->
-        failwith @@ error_msg_prefix ^ ", parent not in registered_masks"
+        failwith @@ error_msg "parent not in registered_masks"
     | Some masks ->
         ( match List.find masks ~f:(fun m -> phys_equal m mask) with
         | None ->
-            failwith @@ error_msg_prefix
-            ^ ", mask not registered with that parent"
+            failwith @@ error_msg "mask not registered with that parent"
         | Some _ -> (
             let bad, good =
               List.partition_tf masks ~f:(fun m -> phys_equal m mask)

--- a/src/lib/merkle_mask/maskable_merkle_tree.ml
+++ b/src/lib/merkle_mask/maskable_merkle_tree.ml
@@ -143,15 +143,20 @@ module Make (Inputs : Inputs_intf) = struct
     attached_mask
 
   let unregister_mask_exn (t : t) (mask : Mask.Attached.t) =
-    let error_msg = "unregister_mask: no such registered mask" in
+    let error_msg_prefix =
+      sprintf "Couldn't unregister mask with UUID %s from parent %s"
+        (Mask.Attached.get_uuid mask |> Uuid.to_string_hum)
+        (get_uuid t |> Uuid.to_string_hum)
+    in
     let t_uuid = get_uuid t in
     match Uuid.Table.find registered_masks t_uuid with
     | None ->
-        failwith error_msg
+        failwith @@ error_msg_prefix ^ ", parent not in registered_masks"
     | Some masks ->
         ( match List.find masks ~f:(fun m -> phys_equal m mask) with
         | None ->
-            failwith error_msg
+            failwith @@ error_msg_prefix
+            ^ ", mask not registered with that parent"
         | Some _ -> (
             let bad, good =
               List.partition_tf masks ~f:(fun m -> phys_equal m mask)

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -152,6 +152,8 @@ module Make (Inputs : Inputs_intf) :
       |> External_transition.Validated.protocol_state
       |> Protocol_state.previous_state_hash
 
+    let mask = Fn.compose Staged_ledger.ledger staged_ledger
+
     let equal breadcrumb1 breadcrumb2 =
       State_hash.equal (state_hash breadcrumb1) (state_hash breadcrumb2)
 
@@ -652,21 +654,20 @@ module Make (Inputs : Inputs_intf) :
    *   1) attach the breadcrumb to the transition frontier
    *   2) calculate the distance from the new node to the parent and the
    *      best tip node
-   *   3) set the new node as the best tip if the new node has a greater length than
-   *      the current best tip
+   *   3) set the new node as the best tip if the new node is selected over the
+   *      old best tip by the Consensus module.
    *   4) move the root if the path to the new node is longer than the max length
    *       I   ) find the immediate successor of the old root in the path to the
    *             longest node (the heir)
    *       II  ) find all successors of the other immediate successors of the
    *             old root (bads)
-   *       III ) cleanup bad node masks, but don't garbage collect yet
+   *       III ) drop bad nodes from the hashtable and clean up their masks
    *       IV  ) move_root the breadcrumbs (rewires staged ledgers, cleans up heir)
-   *       V   ) garbage collect the bads
-   *       VI  ) grab the new root staged ledger
-   *       VII ) notify the consensus mechanism of the new root
-   *       VIII) if commit on an heir node that just emitted proof txns then
+   *       V   ) grab the new root staged ledger
+   *       VI  ) notify the consensus mechanism of the new root
+   *       VII ) if commit on an heir node that just emitted proof txns then
    *             write them to snarked ledger
-   *       XI  ) add old root to root_history
+   *       VIII) add old root to root_history
    *   5) return a diff object describing what changed (for use in updating extensions)
   *)
   let add_breadcrumb_exn t breadcrumb =
@@ -713,7 +714,7 @@ module Make (Inputs : Inputs_intf) :
               = `Take ) ) ;
         let node = Hashtbl.find_exn t.table hash in
         (* 2 *)
-        let distance_to_parent = node.length - root_node.length in
+        let distance_to_root = node.length - root_node.length in
         let best_tip_node = Hashtbl.find_exn t.table t.best_tip in
         (* 3 *)
         let best_tip_change =
@@ -748,62 +749,69 @@ module Make (Inputs : Inputs_intf) :
         (* 4 *)
         (* note: new_root_node is the same as root_node if the root didn't change *)
         let garbage_breadcrumbs, new_root_node =
-          if distance_to_parent > max_length then (
-            Logger.info t.logger ~module_:__MODULE__ ~location:__LOC__
-              !"Distance to parent: %d exceeded max_lenth %d"
-              distance_to_parent max_length ;
+          if distance_to_root > max_length then (
+            Logger.debug t.logger ~module_:__MODULE__ ~location:__LOC__
+              "Moving the root of the transition frontier. The new node is \
+               $distance_to_root blocks after the root, which exceeds the max \
+               length of $max_length."
+              ~metadata:
+                [ ("distance_to_parent", `Int distance_to_root)
+                ; ("max_length", `Int max_length) ] ;
             (* 4.I *)
             let heir_hash = List.hd_exn (hash_path t node.breadcrumb) in
             let heir_node = Hashtbl.find_exn t.table heir_hash in
             (* 4.II *)
-            let bad_hashes =
+            let bad_children_hashes =
               List.filter root_node.successor_hashes
                 ~f:(Fn.compose not (State_hash.equal heir_hash))
             in
-            let bad_nodes =
-              List.map bad_hashes ~f:(Hashtbl.find_exn t.table)
+            let garbage_hashes =
+              bad_children_hashes
+              @ List.bind bad_children_hashes ~f:(successor_hashes_rec t)
+            in
+            let garbage_breadcrumbs =
+              List.map garbage_hashes ~f:(fun h ->
+                  Hashtbl.find_exn t.table h |> breadcrumb_of_node )
             in
             (* 4.III *)
-            let root_staged_ledger =
-              Breadcrumb.staged_ledger root_node.breadcrumb
+            let unregister_sl_mask breadcrumb =
+              let child = Breadcrumb.mask breadcrumb in
+              let parent =
+                Breadcrumb.mask @@ breadcrumb_of_node
+                @@ Hashtbl.find_exn t.table
+                @@ Breadcrumb.parent_hash breadcrumb
+              in
+              ignore @@ Ledger.unregister_mask_exn parent child
             in
-            let root_ledger = Staged_ledger.ledger root_staged_ledger in
-            List.map bad_nodes ~f:breadcrumb_of_node
-            |> List.iter ~f:(fun bad ->
-                   ignore
-                     (Ledger.unregister_mask_exn root_ledger
-                        (Breadcrumb.staged_ledger bad |> Staged_ledger.ledger))
-               ) ;
-            (* 4.IV *)
-            let new_root_node = move_root t heir_node in
-            (* 4.V *)
-            let garbage =
-              bad_hashes @ List.bind bad_hashes ~f:(successor_hashes_rec t)
+            let cleanup_bc bc =
+              unregister_sl_mask bc ;
+              Hashtbl.remove t.table (Breadcrumb.state_hash bc)
             in
             Logger.trace t.logger ~module_:__MODULE__ ~location:__LOC__
               ~metadata:
-                [ ("garbage", `List (List.map garbage ~f:State_hash.to_yojson))
-                ; ("length_of_garbage", `Int (List.length garbage))
-                ; ( "bad_hashes"
-                  , `List (List.map bad_hashes ~f:State_hash.to_yojson) )
+                [ ( "all_garbage"
+                  , `List (List.map garbage_hashes ~f:State_hash.to_yojson) )
+                ; ("length_of_garbage", `Int (List.length garbage_hashes))
+                ; ( "garbage_direct_descendants"
+                  , `List
+                      (List.map bad_children_hashes ~f:State_hash.to_yojson) )
                 ; ( "local_state"
                   , Consensus.Data.Local_state.to_yojson
                       t.consensus_local_state ) ]
-              "collecting $length_of_garbage nodes rooted from $bad_hashes" ;
-            let garbage_breadcrumbs =
-              List.map garbage ~f:(fun g ->
-                  (Hashtbl.find_exn t.table g).breadcrumb )
-            in
-            List.iter garbage ~f:(Hashtbl.remove t.table) ;
-            (* removed root + garbage, so total removed == 1 + #garbage *)
+              "Removing $length_of_garbage nodes because the old root is one \
+               of their ancestors and we're deleting it" ;
+            List.iter (List.rev garbage_breadcrumbs) ~f:cleanup_bc ;
+            (* removing root + garbage, so total removed == 1 + #garbage *)
             Coda_metrics.(
               Gauge.dec Transition_frontier.active_breadcrumbs
-                (Float.of_int @@ (1 + List.length garbage))) ;
-            (* 4.VI *)
+                (Float.of_int @@ (1 + List.length garbage_hashes))) ;
+            (* 4.IV *)
+            let new_root_node = move_root t heir_node in
+            (* 4.V *)
             let new_root_staged_ledger =
               Breadcrumb.staged_ledger new_root_node.breadcrumb
             in
-            (* 4.VII *)
+            (* 4.VI *)
             Consensus.Hooks.frontier_root_transition
               (Breadcrumb.consensus_state root_node.breadcrumb)
               (Breadcrumb.consensus_state new_root_node.breadcrumb)
@@ -845,7 +853,7 @@ module Make (Inputs : Inputs_intf) :
                       assert false )
                 | None ->
                     () ) ;
-            (* 4.VIII *)
+            (* 4.VII *)
             ( match
                 ( Staged_ledger.proof_txns new_root_staged_ledger
                 , heir_node.breadcrumb.just_emitted_a_proof )
@@ -887,7 +895,7 @@ module Make (Inputs : Inputs_intf) :
                    (Breadcrumb.blockchain_state new_root_node.breadcrumb))
               ( Ledger.Db.merkle_root t.root_snarked_ledger
               |> Frozen_ledger_hash.of_ledger_hash ) ;
-            (* 4.IX *)
+            (* 4.VIII *)
             let root_breadcrumb = Node.breadcrumb root_node in
             let root_state_hash = Breadcrumb.state_hash root_breadcrumb in
             Extensions.Root_history.enqueue t.extensions.root_history


### PR DESCRIPTION
Prior to this commit we unregistered the masks of the children of the old root
that were not on the winning chain, but ignored any descendants of those
children. This commit correctly unregisters all the masks. I also made the error
messages when you try to remove the parent of a mask that isn't attached
properly more informative.

This won't fix the issue @figitaki was seeing, but it'll at least make debugging easier since there will be less garbage in the visualizations.