### PR TITLE
CLI version info

### DIFF
--- a/src/lib/coda_version/coda_version.mli
+++ b/src/lib/coda_version/coda_version.mli
@@ -1,1 +1,3 @@
 val commit_id : string
+
+val branch : string

--- a/src/lib/coda_version/gen.sh
+++ b/src/lib/coda_version/gen.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+branch=$(git rev-parse --verify --abbrev-ref HEAD || echo "<none found>")
+
 if [ -n "$CODA_COMMIT_SHA1" ]; then
   # pull from env var if set
   id="$CODA_COMMIT_SHA1"
@@ -15,3 +17,4 @@ else
 fi
 
 echo "let commit_id = \"$id\"" > "$1"
+echo "let branch = \"$branch\"" >> "$1"


### PR DESCRIPTION
The `version` command to the CLI executable was printing garbage info, because the Jane St `Command` processor handles that one specially. To use it properly requires generating a C file from a script that's apparently not in the Jane St libraries.

Instead, we intercept `version` (and `version -help`) on the command line, and print the information desired.

There was already a script to generate the git commit as a value in an .ml file, here extended to generate the git branch. So now we have:
```
$ coda version
Commit 087220d on branch release/beta
```
The `-help` message mimics what the Jane Street library would have printed:
```
print version information

  coda.exe version

=== flags ===

  [-help]  print this help text and exit
           (alias: -?)
```
Closes #502.