### PR TITLE
Status shows the highest block length encountered

### DIFF
--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -274,6 +274,12 @@ let get_status ~flag t =
     | `None ->
         None
   in
+  let highest_block_length_received =
+    Length.to_int @@ Consensus.Data.Consensus_state.blockchain_length
+    @@ Coda_transition.External_transition.consensus_state
+    @@ Pipe_lib.Broadcast_pipe.Reader.peek
+         (Coda_lib.most_recent_valid_transition t)
+  in
   let active_status () =
     let open Participating_state.Let_syntax in
     let%bind ledger = Coda_lib.best_ledger t in
@@ -334,6 +340,7 @@ let get_status ~flag t =
   { Daemon_rpcs.Types.Status.num_accounts
   ; sync_status
   ; blockchain_length
+  ; highest_block_length_received
   ; uptime_secs
   ; ledger_merkle_root
   ; state_hash

--- a/src/app/cli/src/graphql.ml
+++ b/src/app/cli/src/graphql.ml
@@ -217,7 +217,8 @@ module Types = struct
                ~histograms:(id ~typ:histograms) ~consensus_time_best_tip:string
                ~consensus_time_now:nn_string ~consensus_mechanism:nn_string
                ~consensus_configuration:
-                 (id ~typ:(non_null consensus_configuration)) )
+                 (id ~typ:(non_null consensus_configuration))
+               ~highest_block_length_received:nn_int )
   end
 
   let user_command : (Coda_lib.t, User_command.t option) typ =

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -22,7 +22,7 @@ type components =
   ; transaction_pool: Network_pool.Transaction_pool.t
   ; snark_pool: Network_pool.Snark_pool.t
   ; transition_frontier: Transition_frontier.t option Broadcast_pipe.Reader.t
-  }
+  ; most_recent_valid_block: External_transition.t Broadcast_pipe.Reader.t }
 
 type pipes =
   { validated_transitions_reader:
@@ -248,6 +248,8 @@ let receipt_chain_database t = t.config.receipt_chain_database
 
 let top_level_logger t = t.config.logger
 
+let most_recent_valid_transition t = t.components.most_recent_valid_block
+
 let staged_ledger_ledger_proof t =
   let open Option.Let_syntax in
   let%bind sl = best_staged_ledger_opt t in
@@ -389,6 +391,11 @@ let create (config : Config.t) =
           let%bind ledger_db, transition_frontier =
             create_genesis_frontier config ~verifier
           in
+          let genesis_transition =
+            Transition_frontier.(
+              root transition_frontier |> Breadcrumb.external_transition
+              |> External_transition.Validated.forget_validation)
+          in
           let ledger_db =
             Ledger_transfer.transfer_accounts
               ~src:(Lazy.force Genesis_ledger.t)
@@ -455,6 +462,10 @@ let create (config : Config.t) =
               ~incoming_diffs:(Coda_networking.transaction_pool_diffs net)
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           in
+          let ((most_recent_valid_block_reader, _) as most_recent_valid_block)
+              =
+            Broadcast_pipe.create genesis_transition
+          in
           let valid_transitions =
             Transition_router.run ~logger:config.logger
               ~trust_system:config.trust_system ~verifier ~network:net
@@ -466,6 +477,7 @@ let create (config : Config.t) =
                 (Strict_pipe.Reader.map external_transitions_reader
                    ~f:(fun (tn, tm) -> (`Transition tn, `Time_received tm)))
               ~proposer_transition_reader transition_frontier
+              ~most_recent_valid_block
           in
           let ( valid_transitions_for_network
               , valid_transitions_for_api
@@ -571,7 +583,8 @@ let create (config : Config.t) =
                 { net
                 ; transaction_pool
                 ; snark_pool
-                ; transition_frontier= frontier_broadcast_pipe_r }
+                ; transition_frontier= frontier_broadcast_pipe_r
+                ; most_recent_valid_block= most_recent_valid_block_reader }
             ; pipes=
                 { validated_transitions_reader= valid_transitions_for_api
                 ; proposer_transition_writer

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -91,6 +91,9 @@ val receipt_chain_database : t -> Receipt_chain_database.t
 
 val wallets : t -> Secrets.Wallets.t
 
+val most_recent_valid_transition :
+  t -> External_transition.t Broadcast_pipe.Reader.t
+
 val top_level_logger : t -> Logger.t
 
 val config : t -> Config.t

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -178,6 +178,9 @@ module Types = struct
       let blockchain_length =
         int_option_entry "The Total Number of Blocks in the Blockchain"
 
+      let highest_block_length_received =
+        int_entry "Maximum Block Length Encountered from a Valid Block"
+
       let uptime_secs = map_entry "Local Uptime" ~f:(sprintf "%ds")
 
       let ledger_merkle_root = string_option_entry "Ledger Merkle Root"
@@ -231,6 +234,7 @@ module Types = struct
     type t =
       { num_accounts: int option
       ; blockchain_length: int option
+      ; highest_block_length_received: int
       ; uptime_secs: int
       ; ledger_merkle_root: string option
       ; state_hash: string option
@@ -255,11 +259,11 @@ module Types = struct
         let get field = Field.get field s
       end) in
       let open M in
-      Fields.to_list ~sync_status ~num_accounts ~blockchain_length ~uptime_secs
-        ~ledger_merkle_root ~state_hash ~commit_id ~conf_dir ~peers
-        ~user_commands_sent ~run_snark_worker ~propose_pubkeys ~histograms
-        ~consensus_time_best_tip ~consensus_time_now ~consensus_mechanism
-        ~consensus_configuration
+      Fields.to_list ~sync_status ~num_accounts ~blockchain_length
+        ~highest_block_length_received ~uptime_secs ~ledger_merkle_root
+        ~state_hash ~commit_id ~conf_dir ~peers ~user_commands_sent
+        ~run_snark_worker ~propose_pubkeys ~histograms ~consensus_time_best_tip
+        ~consensus_time_now ~consensus_mechanism ~consensus_configuration
       |> List.filter_map ~f:Fn.id
 
     let to_text (t : t) =

--- a/src/lib/transition_router/transition_router.mli
+++ b/src/lib/transition_router/transition_router.mli
@@ -62,6 +62,8 @@ module Make (Inputs : Inputs_intf) : sig
                                  Strict_pipe.Reader.t
     -> proposer_transition_reader:Transition_frontier.Breadcrumb.t
                                   Strict_pipe.Reader.t
+    -> most_recent_valid_block:External_transition.t Broadcast_pipe.Reader.t
+                               * External_transition.t Broadcast_pipe.Writer.t
     -> Transition_frontier.t
     -> (External_transition.Validated.t, State_hash.t) With_hash.t
        Strict_pipe.Reader.t
@@ -86,6 +88,8 @@ val run :
                                Strict_pipe.Reader.t
   -> proposer_transition_reader:Transition_frontier.Breadcrumb.t
                                 Strict_pipe.Reader.t
+  -> most_recent_valid_block:External_transition.t Broadcast_pipe.Reader.t
+                             * External_transition.t Broadcast_pipe.Writer.t
   -> Transition_frontier.t
   -> (External_transition.Validated.t, State_hash.t) With_hash.t
      Strict_pipe.Reader.t


### PR DESCRIPTION
We keep a record of the most recent transition that has been proof-validated. We compute the blockchain length of that transition. This will give us an indication of how synced a node is to the network

Ran `dune exec coda client status` and it showed this:

```
Coda Daemon Status 
-----------------------------------

Maximum Block Length Encountered from a Valid Block:  1
Local Uptime:                                         53s
GIT SHA1:                                             [DIRTY]a1a7bc64c5448f4b96737daf9cd50fd826fdbb14
Configuration Directory:                              /Users/johnwu/.coda-config
Peers:                                                Total: 0 ()
User_commands Sent:                                   0
Snark Worker Running:                                 false
Sync Status:                                          Bootstrap
Proposers Running:                                    Total: 0 ()
Consensus Time Now:                                   12989:71
Consensus Mechanism:                                  proof_of_stake
Consensus Configuration:                              
    delta = 3
    k = 24
    c = 8
    c_times_k = 192
    slots_per_epoch = 576
    slot_duration = 2000
    epoch_duration = 1152000
    acceptable_network_delay = 6000

```

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

