### PR TITLE
Make pretty logging prettier

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -254,10 +254,10 @@ let daemon logger =
            Logger.Processor.pretty ~log_level
              ~config:
                { Logproc_lib.Interpolator.mode= Inline
-               ; max_interpolation_length= 30
+               ; max_interpolation_length= 50
                ; pretty_print= true }
        in
-       Logger.Consumer_registry.register ~id:"primary_output"
+       Logger.Consumer_registry.register ~id:"default"
          ~processor:stdout_log_processor
          ~transport:(Logger.Transport.stdout ()) ;
        Parallel.init_master () ;

--- a/src/app/cli/src/coda_delegation_test.ml
+++ b/src/app/cli/src/coda_delegation_test.ml
@@ -5,11 +5,9 @@ open Signature_lib
 
 let name = "coda-delegation-test"
 
-let logger = Logger.create ()
-
 let heartbeat_flag = ref true
 
-let print_heartbeat () =
+let print_heartbeat logger =
   let rec loop () =
     if !heartbeat_flag then (
       Logger.warn logger ~module_:__MODULE__ ~location:__LOC__
@@ -21,6 +19,7 @@ let print_heartbeat () =
   loop ()
 
 let main () =
+  let logger = Logger.create () in
   let num_proposers = 3 in
   let snark_work_public_keys ndx =
     List.nth_exn Genesis_ledger.accounts ndx
@@ -33,7 +32,7 @@ let main () =
   in
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__ "Started test net" ;
   (* keep CI alive *)
-  Deferred.don't_wait_for (print_heartbeat ()) ;
+  Deferred.don't_wait_for (print_heartbeat logger) ;
   (* dump account info to log *)
   List.iteri Genesis_ledger.accounts ~f:(fun ndx ((_, acct) as record) ->
       let keypair = Genesis_ledger.keypair_of_account_record_exn record in

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -41,11 +41,9 @@ let setup_time_offsets () = ()
 
 [%%endif]
 
-let logger = Logger.create ()
-
 let heartbeat_flag = ref true
 
-let print_heartbeat () =
+let print_heartbeat logger =
   let rec loop () =
     if !heartbeat_flag then (
       Logger.warn logger ~module_:__MODULE__ ~location:__LOC__
@@ -57,8 +55,9 @@ let print_heartbeat () =
   loop ()
 
 let run_test () : unit Deferred.t =
+  let logger = Logger.create () in
   setup_time_offsets () ;
-  print_heartbeat () |> don't_wait_for ;
+  print_heartbeat logger |> don't_wait_for ;
   Parallel.init_master () ;
   File_system.with_temp_dir "full_test_config" ~f:(fun temp_conf_dir ->
       let keypair = Genesis_ledger.largest_account_keypair_exn () in


### PR DESCRIPTION
- Fixes a bug with the logging system which was causing logs to be formatted as json when the build included tests (o.O)
- Adds a timestamp to pretty logs
- Increases the max interpolation size from 30 to 50
- Print out uninterpolated variables when they go over the max size

Example (with an interpolation length of 10 to test printing out uninterpolated vars):
```
18:12:45 avery@mbp:~/git/coda $ coda.exe daemon -peer strawberry-milkshake.o1test.net:8302
2019-07-22 18:12:55 [Warn] Long async cycle: $span milliseconds
    span: "5.293928s"
2019-07-22 18:12:58 [Info] Starting Bootstrap Controller phase
2019-07-22 18:12:58 [Info] Bootstrapping right now. Cannot generate new blockchains or schedule event until it has finished. Pausing proposer
2019-07-22 18:12:58 [Info] Not running a web client pipe
2019-07-22 18:12:58 [Info] Daemon ready. Clients can now connect
```