### PR TITLE
Pretty-log in UTC time

### DIFF
--- a/src/lib/logger/impl.ml
+++ b/src/lib/logger/impl.ml
@@ -120,8 +120,8 @@ module Processor = struct
               |> String.concat ~sep:""
             in
             let time =
-              Core.Time.format msg.timestamp "%Y-%m-%d %H:%M:%S"
-                ~zone:(Lazy.force Time.Zone.local)
+              Core.Time.format msg.timestamp "%Y-%m-%d %H:%M:%S UTC"
+                ~zone:Time.Zone.utc
             in
             Some
               ( time ^ " [" ^ Level.show msg.level ^ "] " ^ str


### PR DESCRIPTION
By popular demand, switching the pretty-printed logs to use UTC (and include a timezone specifier)

```
08:48:02 avery@mbp:~/git/coda $ ./src/_build/default/app/cli/src/coda.exe daemon -peer ...
2019-07-23 15:48:21 UTC [Info] Starting Bootstrap Controller phase
2019-07-23 15:48:21 UTC [Info] Pausing block production while bootstrapping
2019-07-23 15:48:21 UTC [Info] Daemon ready. Clients can now connect
```