### PR TITLE
Add website cdn prefix check

### DIFF
--- a/frontend/website/src/Docs.re
+++ b/frontend/website/src/Docs.re
@@ -1,7 +1,7 @@
 module Styles = {
   open! Css;
 
-  let markdownStyles =
+  let markdownStyles = linkSvg =>
     style([
       position(`relative),
       selector(
@@ -24,7 +24,7 @@ module Styles = {
           color(`transparent),
           hover([color(`transparent)]),
           backgroundSize(`cover),
-          backgroundImage(url(Links.Cdn.url("/static/img/link.svg"))),
+          backgroundImage(url(linkSvg)),
         ],
       ),
       selector(
@@ -175,10 +175,11 @@ let make = _children => {
   render: _self => {
     // We need to calculate the CDN url and inject it into the template
     let chevronUrl = Links.Cdn.url("/static/img/chevron-down.svg");
+    let linkUrl = Links.Cdn.url("/static/img/link.svg");
     <div
       className=Css.(
         merge([
-          Styles.markdownStyles,
+          Styles.markdownStyles(linkUrl),
           style([
             display(`flex),
             flexDirection(`column),

--- a/frontend/website/src/Links.re
+++ b/frontend/website/src/Links.re
@@ -6,7 +6,18 @@ module Cdn = {
     [@bs.send] external digest: (t, string) => string = "";
   };
 
-  let prefix = ref("");
+  let prefix = ref(None);
+
+  let setPrefix = p => prefix := Some(p);
+
+  let prefix = () =>
+    switch (prefix^) {
+    | None =>
+      Js.Exn.raiseError(
+        "CDN Prefix unset -- Can't run Links.Cdn.url at the top level.",
+      )
+    | Some(prefix) => prefix
+    };
 
   let cache = Hashtbl.create(20);
 
@@ -36,7 +47,7 @@ module Cdn = {
     Hashtbl.find(cache, path);
   };
 
-  let url = path => prefix^ ++ getHashedPath(path);
+  let url = path => prefix() ++ getHashedPath(path);
 };
 
 module Named = {

--- a/frontend/website/src/Markdown.re
+++ b/frontend/website/src/Markdown.re
@@ -44,7 +44,7 @@ let load = path => {
       "pandoc " ++ "--filter src/filter.js " ++ path ++ " --mathjax",
       Child_process.option(
         ~env={
-          "CODA_CDN_URL": Links.Cdn.prefix^,
+          "CODA_CDN_URL": Links.Cdn.prefix(),
           "PATH": Js_dict.unsafeGet(Node.Process.process##env, "PATH"),
         },
         (),

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -34,9 +34,7 @@ module Rimraf = {
 
 let isProd = Array.length(Sys.argv) > 2 && Sys.argv[2] == "prod";
 
-if (isProd) {
-  Links.Cdn.prefix := "https://cdn.codaprotocol.com/website";
-};
+Links.Cdn.setPrefix(isProd ? "https://cdn.codaprotocol.com/website" : "");
 
 Style.Typeface.load();
 


### PR DESCRIPTION
This will avoid issues where the cdn prefix is used before it gets set in render (which has happened a couple of times)
- Also fixes an instance of this where the link svgs aren't showing up in the docs.