### PR TITLE
Dash-version on cli

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -726,12 +726,12 @@ let coda_commands logger =
 
 [%%endif]
 
-let print_version_help coda_exe =
+let print_version_help coda_exe version =
   (* mimic Jane Street command help *)
   let lines =
     [ "print version information"
     ; ""
-    ; sprintf "  %s version" (Filename.basename coda_exe)
+    ; sprintf "  %s %s" (Filename.basename coda_exe) version
     ; ""
     ; "=== flags ==="
     ; ""
@@ -754,14 +754,17 @@ let () =
   (* intercept command-line processing for "version", because we don't
      use the Jane Street scripts that generate their version information
    *)
-  ( match Sys.argv with
-  | [|_coda_exe; "version"|] ->
-      print_version_info ()
-  | [|coda_exe; "version"; s|]
-    when List.mem ["-help"; "-?"] s ~equal:String.equal ->
-      print_version_help coda_exe
-  | _ ->
-      Command.run
-        (Command.group ~summary:"Coda" ~preserve_subcommand_order:()
-           (coda_commands logger)) ) ;
+  (let make_list_mem ss s = List.mem ss s ~equal:String.equal in
+   let is_version_cmd = make_list_mem ["version"; "-version"] in
+   let is_help_flag = make_list_mem ["-help"; "-?"] in
+   match Sys.argv with
+   | [|_coda_exe; version|] when is_version_cmd version ->
+       print_version_info ()
+   | [|coda_exe; version; help|]
+     when is_version_cmd version && is_help_flag help ->
+       print_version_help coda_exe version
+   | _ ->
+       Command.run
+         (Command.group ~summary:"Coda" ~preserve_subcommand_order:()
+            (coda_commands logger))) ;
   Core.exit 0


### PR DESCRIPTION
Make `-version` on the CLI an alias for `version`, because many people will try that. `-version -help` also works.

It's not advertised: if you run just `coda`, only `version` appears, consistent with the other commands.

Closes #2972.