### PR TITLE
Don't log that we're bootstrapping when we're not

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -172,16 +172,16 @@ let sync_status t =
                 ~location:__LOC__ "Coda daemon is now listening" ;
               `Listening )
             else `Offline
-        | `Online ->
-            Option.value_map active_status
-              ~default:
-                ( Logger.trace (Logger.create ()) ~module_:__MODULE__
-                    ~location:__LOC__ "Coda daemon is now bootstrapping" ;
-                  `Bootstrap )
-              ~f:(fun _ ->
-                Logger.trace (Logger.create ()) ~module_:__MODULE__
-                  ~location:__LOC__ "Coda daemon is now synced" ;
-                `Synced ) )
+        | `Online -> (
+          match active_status with
+          | None ->
+              Logger.trace (Logger.create ()) ~module_:__MODULE__
+                ~location:__LOC__ "Coda daemon is now bootstrapping" ;
+              `Bootstrap
+          | Some _ ->
+              Logger.trace (Logger.create ()) ~module_:__MODULE__
+                ~location:__LOC__ "Coda daemon is now synced" ;
+              `Synced ) )
   in
   let observer = observe incremental_status in
   stabilize () ; observer


### PR DESCRIPTION
The `default` argument to `Option.value_map` is always evaluated, and so we always see the `Coda daemon is now bootstrapping` message in the logs, whether it's true or not.

This PR changes it to a match instead, so we only get the correct message.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: