### PR TITLE
Log commit and branch on daemon startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,7 @@ jobs:
                   name: Copy artifacts to cloud
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
     build-artifacts--testnet_postake_many_proposers_medium_curves:
-        resource_class: large
+        resource_class: xlarge
         docker:
             - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         environment:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -134,7 +134,7 @@ jobs:
 
     {%- for profile in build_artifact_profiles %}
     build-artifacts--{{profile}}:
-        {%- if profile == "testnet_postake_medium_curves" %}
+        {%- if profile in medium_curve_profiles %}
         resource_class: xlarge
         {%- else %}
         resource_class: large

--- a/src/lib/logger/impl.ml
+++ b/src/lib/logger/impl.ml
@@ -229,6 +229,7 @@ module Consumer_registry = struct
     else t := List.Assoc.add !t id {processor; transport} ~equal:( = )
 
   let broadcast_log_message msg =
+    (* TODO: warn or fail if there's no registered consumer? Issue #3000 *)
     List.iter !t ~f:(fun (_id, consumer) ->
         let (Processor.T ((module Processor_mod), processor)) =
           consumer.processor


### PR DESCRIPTION
Like this:
```
2019-07-25 21:40:59 UTC [Info] Coda daemon is booting up; built with commit "b568c51acceac7fbdf46fbdf40662f5406d4c3d2" on branch "release/beta"
```
Moved registration of log consumers earlier in daemon startup. Early log messages were getting dropped!

Closes #807.