### PR TITLE
Improve formatting of coda client status

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1879,7 +1879,7 @@ module Data = struct
       Core.Int.(checkpoint_window slot1 = checkpoint_window slot2)
 
     let time_hum (t : Value.t) =
-      sprintf "%d:%d"
+      sprintf "epoch:%d slot:%d"
         (Epoch.to_int t.curr_epoch)
         (Epoch.Slot.to_int t.curr_slot)
 
@@ -2973,7 +2973,7 @@ end
 
 let time_hum (now : Coda_base.Block_time.t) =
   let epoch, slot = Data.Epoch.epoch_and_slot_of_time_exn now in
-  Printf.sprintf "%d:%d" (Data.Epoch.to_int epoch)
+  Printf.sprintf "epoch:%d slot:%d" (Data.Epoch.to_int epoch)
     (Data.Epoch.Slot.to_int slot)
 
 let%test_module "Proof of stake tests" =

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1879,7 +1879,7 @@ module Data = struct
       Core.Int.(checkpoint_window slot1 = checkpoint_window slot2)
 
     let time_hum (t : Value.t) =
-      sprintf "epoch:%d slot:%d"
+      sprintf "epoch=%d, slot=%d"
         (Epoch.to_int t.curr_epoch)
         (Epoch.Slot.to_int t.curr_slot)
 
@@ -2973,7 +2973,7 @@ end
 
 let time_hum (now : Coda_base.Block_time.t) =
   let epoch, slot = Data.Epoch.epoch_and_slot_of_time_exn now in
-  Printf.sprintf "epoch:%d slot:%d" (Data.Epoch.to_int epoch)
+  Printf.sprintf "epoch=%d, slot=%d" (Data.Epoch.to_int epoch)
     (Data.Epoch.Slot.to_int slot)
 
 let%test_module "Proof of stake tests" =

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -186,7 +186,7 @@ module Types = struct
       let blockchain_length = int_option_entry "Block Height"
 
       let highest_block_length_received =
-        int_entry "Maximum Block Length Encountered from a Valid Block"
+        int_entry "Max Observed Valid Block Length"
 
       let uptime_secs =
         map_entry "Local Uptime" ~f:(fun secs ->

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -224,18 +224,17 @@ module Types = struct
           float_of_int i |> Time.Span.of_ms |> Time.Span.to_string
         in
         let render conf =
-          let use op field = op (Field.get field conf) in
+          let fmt_field name op field = (name, op (Field.get field conf)) in
           Consensus.Configuration.Fields.to_list
-            ~delta:(use (fun v -> ("Delta", string_of_int v)))
-            ~k:(use (fun v -> ("k", string_of_int v)))
-            ~c:(use (fun v -> ("c", string_of_int v)))
-            ~c_times_k:(use (fun v -> ("c * k", string_of_int v)))
-            ~slots_per_epoch:
-              (use (fun v -> ("Slots per epoch", string_of_int v)))
-            ~slot_duration:(use (fun v -> ("Slot duration", ms_to_string v)))
-            ~epoch_duration:(use (fun v -> ("Epoch duration", ms_to_string v)))
+            ~delta:(fmt_field "Delta" string_of_int)
+            ~k:(fmt_field "k" string_of_int)
+            ~c:(fmt_field "c" string_of_int)
+            ~c_times_k:(fmt_field "c * k" string_of_int)
+            ~slots_per_epoch:(fmt_field "Slots per epoch" string_of_int)
+            ~slot_duration:(fmt_field "Slot duration" ms_to_string)
+            ~epoch_duration:(fmt_field "Epoch duration" ms_to_string)
             ~acceptable_network_delay:
-              (use (fun v -> ("Acceptable network delay", ms_to_string v)))
+              (fmt_field "Acceptable network delay" ms_to_string)
           |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
           |> digest_entries ~title:""
         in

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -173,6 +173,14 @@ module Types = struct
 
       let int_option_entry = option_entry ~f:Int.to_string
 
+      let list_entry name ~to_string =
+        map_entry name ~f:(fun keys ->
+            let len = List.length keys in
+            let list_str =
+              if len > 0 then " " ^ List.to_string ~f:to_string keys else ""
+            in
+            Printf.sprintf "%d%s" len list_str )
+
       let num_accounts = int_option_entry "Global Number of Accounts"
 
       let blockchain_length = int_option_entry "Block Height"
@@ -194,10 +202,7 @@ module Types = struct
 
       let conf_dir = string_entry "Configuration Directory"
 
-      let peers =
-        map_entry "Peers" ~f:(fun peers ->
-            Printf.sprintf "Total: %d " (List.length peers)
-            ^ List.to_string ~f:Fn.id peers )
+      let peers = list_entry "Peers" ~to_string:Fn.id
 
       let user_commands_sent = int_entry "User_commands Sent"
 
@@ -206,9 +211,8 @@ module Types = struct
       let sync_status = map_entry "Sync Status" ~f:Sync_status.to_string
 
       let propose_pubkeys =
-        map_entry "Block producers running" ~f:(fun keys ->
-            Printf.sprintf "Total: %d " (List.length keys)
-            ^ List.to_string ~f:Public_key.Compressed.to_string keys )
+        list_entry "Block Producers Running"
+          ~to_string:Public_key.Compressed.to_string
 
       let histograms = option_entry "Histograms" ~f:Histograms.to_text
 

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -185,8 +185,7 @@ module Types = struct
 
       let blockchain_length = int_option_entry "Block Height"
 
-      let highest_block_length_received =
-        int_entry "Max Observed Block Length"
+      let highest_block_length_received = int_entry "Max Observed Block Length"
 
       let uptime_secs =
         map_entry "Local Uptime" ~f:(fun secs ->

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -226,20 +226,18 @@ module Types = struct
         let render conf =
           let use op field = op (Field.get field conf) in
           Consensus.Configuration.Fields.to_list
-            ~delta:(use (fun v -> sprintf "Delta: %d" v))
-            ~k:(use (fun v -> sprintf "k: %d" v))
-            ~c:(use (fun v -> sprintf "c: %d" v))
-            ~c_times_k:(use (fun v -> sprintf "c * k: %d" v))
-            ~slots_per_epoch:(use (fun v -> sprintf "Slots per epoch: %d" v))
-            ~slot_duration:
-              (use (fun v -> sprintf "Slot duration: %s" (ms_to_string v)))
-            ~epoch_duration:
-              (use (fun v -> sprintf "Epoch duration: %s" (ms_to_string v)))
+            ~delta:(use (fun v -> ("Delta", string_of_int v)))
+            ~k:(use (fun v -> ("k", string_of_int v)))
+            ~c:(use (fun v -> ("c", string_of_int v)))
+            ~c_times_k:(use (fun v -> ("c * k", string_of_int v)))
+            ~slots_per_epoch:
+              (use (fun v -> ("Slots per epoch", string_of_int v)))
+            ~slot_duration:(use (fun v -> ("Slot duration", ms_to_string v)))
+            ~epoch_duration:(use (fun v -> ("Epoch duration", ms_to_string v)))
             ~acceptable_network_delay:
-              (use (fun v ->
-                   sprintf "Acceptable network delay: %s" (ms_to_string v) ))
-          |> List.map ~f:(fun s -> "\n\t" ^ s)
-          |> String.concat ~sep:""
+              (use (fun v -> ("Acceptable network delay", ms_to_string v)))
+          |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
+          |> digest_entries ~title:""
         in
         map_entry "Consensus Configuration" ~f:render
     end

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -186,7 +186,7 @@ module Types = struct
       let blockchain_length = int_option_entry "Block Height"
 
       let highest_block_length_received =
-        int_entry "Max Observed Valid Block Length"
+        int_entry "Max Observed Block Length"
 
       let uptime_secs =
         map_entry "Local Uptime" ~f:(fun secs ->


### PR DESCRIPTION
Lots of alternatives to the formatting of the Consensus Configuration in this PR, I could swap the `:` back to a `=` too
before:
```
Coda Daemon Status
-----------------------------------

Local Uptime:                     140s
GIT SHA1:                         060e7f34009a0792ddac2698bf4402e57585cc7c
Configuration Directory:          /Users/avery/.coda-config
Peers:                            Total: 0 ()
User_commands Sent:               0
Snark Worker Running:             false
Sync Status:                      Bootstrap
Block Producers Running:          Total: 0 ()
Consensus Time Now (epoch:slot):  13214:9
Consensus Mechanism:              proof_of_stake
Consensus Configuration:          
    delta = 3
    k = 24
    c = 8
    c_times_k = 192
    slots_per_epoch = 576
    slot_duration = 2000
    epoch_duration = 1152000
    acceptable_network_delay = 6000
```

after:
```
Coda Daemon Status
-----------------------------------

Local Uptime:             9m10s
GIT SHA-1:                060e7f34009a0792ddac2698bf4402e57585cc7c
Configuration Directory:  /Users/avery/.coda-config
Peers:                    Total: 0 ()
User_commands Sent:       0
Snark Worker Running:     false
Sync Status:              Bootstrap
Block producers running:  Total: 0 ()
Consensus Time Now:       epoch:13213 slot:519
Consensus Mechanism:      proof_of_stake
Consensus Configuration:  
	Delta: 3
	k: 24
	c: 8
	c * k: 192
	Slots per epoch: 576
	Slot duration: 2s
	Epoch duration: 19m12s
	Acceptable network delay: 6s
```