### PR TITLE
Website: Make pragpro font optional for dev build

### DIFF
--- a/frontend/website/src/Config.re
+++ b/frontend/website/src/Config.re
@@ -1,0 +1,1 @@
+let isProd = Array.length(Sys.argv) > 2 && Sys.argv[2] == "prod";

--- a/frontend/website/src/Links.re
+++ b/frontend/website/src/Links.re
@@ -21,15 +21,17 @@ module Cdn = {
 
   let cache = Hashtbl.create(20);
 
+  let localAssetPath = path =>
+    if (path.[0] == '/') {
+      "." ++ path;
+    } else {
+      prerr_endline({j|"Expected cdn path `$path` to begin with /"|j});
+      exit(1);
+    };
+
   let getHashedPath = path => {
     if (!Hashtbl.mem(cache, path)) {
-      let localPath =
-        if (path.[0] == '/') {
-          "." ++ path;
-        } else {
-          prerr_endline("Expected cdn url to begin with /");
-          exit(1);
-        };
+      let localPath = localAssetPath(path);
       // Get file contents
       let content = Node.Fs.readFileAsUtf8Sync(localPath);
       // Generate hash of file

--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -32,9 +32,9 @@ module Rimraf = {
   [@bs.val] [@bs.module "rimraf"] external sync: string => unit = "";
 };
 
-let isProd = Array.length(Sys.argv) > 2 && Sys.argv[2] == "prod";
-
-Links.Cdn.setPrefix(isProd ? "https://cdn.codaprotocol.com/website" : "");
+Links.Cdn.setPrefix(
+  Config.isProd ? "https://cdn.codaprotocol.com/website" : "",
+);
 
 Style.Typeface.load();
 
@@ -254,7 +254,7 @@ copyFolder("static");
 
 // Special-case the jsoo-compiled files for now
 // They can't be loaded from cdn so they get copied to the site separately
-if (!isProd) {
+if (!Config.isProd) {
   moveToSite("static/main.bc.js");
   moveToSite("static/verifier_main.bc.js");
 };

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -161,7 +161,6 @@ module Typeface = {
           ),
         );
 
-      print_endline("hello");
       let _ =
         fontFamily(
           fontFace(

--- a/frontend/website/src/Style.re
+++ b/frontend/website/src/Style.re
@@ -138,34 +138,47 @@ module Typeface = {
       );
     ();
 
-    let _ =
-      fontFamily(
-        fontFace(
-          ~fontFamily="PragmataPro",
-          ~src=[
-            cdnUrl("/static/font/Essential-PragmataPro-Regular.woff2"),
-            cdnUrl("/static/font/Essential-PragmataPro-Regular.woff"),
-          ],
-          ~fontStyle=`normal,
-          ~fontWeight=`medium,
-          (),
-        ),
-      );
+    // Workaround to allow the website to be build for dev
+    // without needing the pragmatapro font.
+    // If you have the font asset, it will be used.
+    if (Node.Fs.existsSync(
+          Links.Cdn.localAssetPath(
+            "/static/font/Essential-PragmataPro-Regular.woff2",
+          ),
+        )
+        || Config.isProd) {
+      let _ =
+        fontFamily(
+          fontFace(
+            ~fontFamily="PragmataPro",
+            ~src=[
+              cdnUrl("/static/font/Essential-PragmataPro-Regular.woff2"),
+              cdnUrl("/static/font/Essential-PragmataPro-Regular.woff"),
+            ],
+            ~fontStyle=`normal,
+            ~fontWeight=`medium,
+            (),
+          ),
+        );
 
-    let _ =
-      fontFamily(
-        fontFace(
-          ~fontFamily="PragmataPro",
-          ~src=[
-            cdnUrl("/static/font/Essential-PragmataPro-Bold.woff2"),
-            cdnUrl("/static/font/Essential-PragmataPro-Bold.woff"),
-          ],
-          ~fontStyle=`normal,
-          ~fontWeight=`bold,
-          (),
-        ),
-      );
-    ();
+      print_endline("hello");
+      let _ =
+        fontFamily(
+          fontFace(
+            ~fontFamily="PragmataPro",
+            ~src=[
+              cdnUrl("/static/font/Essential-PragmataPro-Bold.woff2"),
+              cdnUrl("/static/font/Essential-PragmataPro-Bold.woff"),
+            ],
+            ~fontStyle=`normal,
+            ~fontWeight=`bold,
+            (),
+          ),
+        );
+      ();
+    } else {
+      print_endline("Warning: building without PragmataPro fonts");
+    };
   };
 
   let ibmplexserif = fontFamily("IBM Plex Serif, serif");


### PR DESCRIPTION
https://github.com/CodaProtocol/coda/pull/2988 accidentally made it so that this font is required for dev builds, which seems unnecessary. This makes it so that it is optional unless you're building for prod (so that we don't accidentally deploy the wrong font).