### PR TITLE
put the rpc_parallel submodule back where it was, with the macos bugfix

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,9 @@
 /azure-pipelines.yml @jkrauska
 /.circleci @jkrauska @bkase
 
+
+/src/external/ @cmr @bkase @psteckler
+
 /src/app/cli/ @cmr @nholland94 @bkase
 /src/app/kademlia-haskell/ @bkase @enolan
 /src/app/logproc/ @nholland94


### PR DESCRIPTION
This got lost from `release/beta` somewhere along the way.