### PR TITLE
Log not-performed bans; don't ban on add_trust

### DIFF
--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -120,7 +120,15 @@ struct
       Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
         ~metadata:([("peer", Peer_id.to_yojson peer)] @ action_metadata)
         "%s trust for peer $peer due to action %s. New trust is %f." verb
-        action_fmt simple_new.trust
+        action_fmt simple_new.trust ;
+      if
+        Record_inst.get_bans_disabled ()
+        && simple_old.trust >. -1. && simple_new.trust <=. -1.
+      then
+        Logger.info logger ~module_:__MODULE__ ~location:__LOC__
+          "Bans are disabled; otherwise, peer $peer would be banned (maybe \
+           already banned)"
+          ~metadata:[("peer", Peer_id.to_yojson peer)]
     in
     let%map () =
       match (simple_old.banned, simple_new.banned) with

--- a/src/lib/trust_system/record.mli
+++ b/src/lib/trust_system/record.mli
@@ -9,6 +9,8 @@ module type S = sig
 
   val disable_bans : unit -> unit
 
+  val get_bans_disabled : unit -> bool
+
   val add_trust : t -> float -> t
 
   val to_peer_status : t -> Peer_status.t


### PR DESCRIPTION
If bans are disabled, when an updated trust score is less than or equal to -1, and was greater than that before, log `info` the ban that would have occurred. (It might not be a new ban, since the trust score may have decayed to a value greater than -1.)

Also, check the disabled flag on `add_trust` to prevent `banned_until_opt` from becoming `Some time`. Wrongly, we were checking the flag on `update`, which can only remove the ban time.

Closes #3049.