### PR TITLE
Notify peers when they're banned

### DIFF
--- a/src/lib/coda_intf/network_intf.ml
+++ b/src/lib/coda_intf/network_intf.ml
@@ -15,6 +15,8 @@ module type Network_intf = sig
 
   type transaction_pool_diff
 
+  type ban_notification
+
   val states :
        t
     -> (external_transition Envelope.Incoming.t * Block_time.t)
@@ -58,6 +60,9 @@ module type Network_intf = sig
     -> (transaction_snark_scan_state * Ledger_hash.t * Pending_coinbase.t)
        Deferred.Or_error.t
 
+  val ban_notify :
+    t -> Network_peer.Peer.t -> Time.t -> unit Deferred.Or_error.t
+
   val snark_pool_diffs :
     t -> snark_pool_diff Envelope.Incoming.t Linear_pipe.Reader.t
 
@@ -89,6 +94,12 @@ module type Network_intf = sig
   val initial_peers : t -> Host_and_port.t list
 
   val peers_by_ip : t -> Unix.Inet_addr.t -> Network_peer.Peer.t list
+
+  val ban_notification_reader : t -> ban_notification Linear_pipe.Reader.t
+
+  val banned_peer : ban_notification -> Network_peer.Peer.t
+
+  val banned_until : ban_notification -> Time.t
 
   module Gossip_net : sig
     module Config : Gossip_net.Config_intf

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -567,11 +567,11 @@ let create (config : Config.t) =
                  let banned_until =
                    Coda_networking.banned_until notification
                  in
-                 (* ignore RPC errors, not critical for notifications *)
-                 let%bind _ =
+                 (* if RPC call fails, will be logged in gossip net code *)
+                 let%map _ =
                    Coda_networking.ban_notify net peer banned_until
                  in
-                 Deferred.unit )) ;
+                 () )) ;
           let%bind snark_pool =
             Network_pool.Snark_pool.load ~logger:config.logger
               ~trust_system:config.trust_system

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -637,7 +637,7 @@ module Make (Inputs : Inputs_intf) = struct
     let ban_notify_rpc conn ~version:_ ban_until =
       (* the port in `conn' is an ephemeral port, not of interest *)
       Logger.warn config.logger ~module_:__MODULE__ ~location:__LOC__
-        "Node banned by peer ($peer) until $ban_until"
+        "Node banned by peer $peer until $ban_until"
         ~metadata:
           [ ("peer", `String conn.Host_and_port.host)
           ; ( "ban_until"

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -535,6 +535,22 @@ struct
       end
     end
 
+    (* ban notification not implemented for these tests; satisfy interface *)
+    module Ban_notification = struct
+      type ban_notification = unit
+
+      let banned_until _ = failwith "banned_until: not implemented"
+
+      let banned_peer _ = failwith "banned_peer: not implemented"
+
+      let ban_notification_reader _ =
+        failwith "ban_notification_reader: not implemented"
+
+      let ban_notify _ = failwith "ban_notify: not implemented"
+    end
+
+    include Ban_notification
+
     module Config = struct
       type t =
         { logger: Logger.t

--- a/src/lib/trust_system/peer_trust.mli
+++ b/src/lib/trust_system/peer_trust.mli
@@ -54,7 +54,8 @@ module Make (Action : Action_intf) : sig
       proactively disconnect from peers when they're banned. You *must* consume
       this, otherwise the program will block indefinitely when a peer is
       banned. *)
-  val ban_pipe : t -> Unix.Inet_addr.Blocking_sexp.t Strict_pipe.Reader.t
+  val ban_pipe :
+    t -> (Unix.Inet_addr.Blocking_sexp.t * Time.t) Strict_pipe.Reader.t
 
   (** Record an action a peer took. This may result in a ban event being
       emitted *)


### PR DESCRIPTION
There's code in `Gossip_net` to read from the ban pipe. When a ban occurs, there's a call to a new Rpc, `Ban_notify`. The ban pipe now passes the banned-until time, as well as the IP address of the banned peer.

Upon notification, the banned peer uses `Logger.warn` to print out the banning peer and the ban expiration time.

Tested by temporarily making the notification occur on every connection, running the five-even-snarkless multiproposer test, and verifying the log message is printed.

The notification is eager, in the sense that it's sent when we get an entry on the ban pipe. Initially, the implementation sent the message when a banned peer tried to connect.

Because the trust system bans by IP addresses, while the network can know of multiple peers at an address, peers may receive ban notifications that have nothing to do with their own actions.

Closes #3013.