### PR TITLE
Less fatal find_ip

### DIFF
--- a/frontend/website/docs/getting-started.md
+++ b/frontend/website/docs/getting-started.md
@@ -57,7 +57,7 @@ If you're running another Linux distro or a different version of macOS, you can 
 
 ## Set up port forwarding and any firewalls
 
-If you are running a firewall, you should allow traffic on TCP port 8302 and UDP port 8303. Additionally, unless the `-external-ip YOUR_IP` flag is provided, the daemon will use HTTPS (443) and HTTP (80) to try and determine its own IP.
+If you are running a firewall, you should allow traffic on TCP port 8302 and UDP port 8303. Additionally, unless the `-external-ip YOUR_IP` flag is provided, the daemon will use HTTPS (443) and HTTP (80) to try and determine its own IP address.
 
 You may need to configure your router's port forwarding to allow inbound traffic to the following ports through your **external** IP address.
 

--- a/frontend/website/docs/getting-started.md
+++ b/frontend/website/docs/getting-started.md
@@ -55,9 +55,11 @@ Windows is not yet supported. If you have any interest in developing Coda for Wi
 
 If you're running another Linux distro or a different version of macOS, you can [try building Coda from source code](https://github.com/CodaProtocol/coda/blob/master/README-dev.md#building-coda). Please note that other operating systems haven't been tested thoroughly, and may have issues. Feel free to share any logs and get troubleshooting help in the Discord channel.
 
-## Set up port forwarding
+## Set up port forwarding and any firewalls
 
-You must allow inbound traffic to the following ports through your **external** IP address.
+If you are running a firewall, you should allow traffic on TCP port 8302 and UDP port 8303. Additionally, unless the `-external-ip YOUR_IP` flag is provided, the daemon will use HTTPS (443) and HTTP (80) to try and determine its own IP.
+
+You may need to configure your router's port forwarding to allow inbound traffic to the following ports through your **external** IP address.
 
 - `TCP` port `8302`
 - `UDP` port `8303`

--- a/frontend/website/docs/troubleshooting.md
+++ b/frontend/website/docs/troubleshooting.md
@@ -59,6 +59,10 @@ Depending on your router, you may see one of the following errors:
 
 If so, find your router model and search for `<model> port forwarding` and follow the instructions to forward the ports from your router to your device running the Coda node. You'll need to open the TCP port 8302, and the UDP port 8303 by default.
 
+### `couldn't determine our IP from the internet, use -external-ip flag`
+
+If you see this, the daemon failed to determine its own IP by making HTTP/S requests to [these](https://github.com/CodaProtocol/coda/blob/056d0203722ddfec1c7ad216846434648cd7af5e/src/app/cli/src/find_ip.ml#L7-L11) service providers. Your firewall may be blocking HTTP/S requests, or the network connection may not be working at all. If you know your external IP, use `-external-ip <your-ip>` to avoid these requests.
+
 ## macOS Hostname
 
 If you're running Coda on macOS and see the following time out error `monitor.ml.Error "Timed out getting connection from process"`, you'll need to add your hostname to `/etc/hosts` by running the following:

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -411,7 +411,7 @@ let daemon logger =
          let%bind external_ip =
            match external_ip_opt with
            | None ->
-               Find_ip.find ()
+               Find_ip.find ~logger
            | Some ip ->
                return @@ Unix.Inet_addr.of_string ip
          in

--- a/src/app/cli/src/find_ip.ml
+++ b/src/app/cli/src/find_ip.ml
@@ -21,7 +21,7 @@ let ip_service_result {uri; body_handler} ~logger =
       v
   | Error e ->
       Logger.error logger ~module_:__MODULE__ ~location:__LOC__
-        "failed to query our own IP from $provider: $exn"
+        "Failed to query our own IP from $provider: $exn"
         ~metadata:
           [("exn", `String (Exn.to_string e)); ("provider", `String uri)] ;
       None
@@ -38,5 +38,5 @@ let find ~logger =
   Unix.Inet_addr.of_string
   @@ Option.value_exn
        ~message:
-         "couldn't determine our IP from the internet, use -external-ip flag"
+         "Couldn't determine our IP from the internet, use -external-ip flag"
        our_ip_maybe

--- a/src/app/cli/src/find_ip.ml
+++ b/src/app/cli/src/find_ip.ml
@@ -10,16 +10,33 @@ let services =
   ; { uri= "http://ifconfig.co/ip"
     ; body_handler= String.rstrip ~drop:(fun c -> c = '\n') } ]
 
-let ip_service_result {uri; body_handler} =
-  let%bind resp, body = Client.get (Uri.of_string uri) in
-  Body.to_string body >>| body_handler
-  >>| fun s -> if resp.status = `OK then Some s else None
+let ip_service_result {uri; body_handler} ~logger =
+  match%map
+    Monitor.try_with (fun () ->
+        let%bind resp, body = Client.get (Uri.of_string uri) in
+        let%map body = Body.to_string body in
+        if resp.status = `OK then Some (body_handler body) else None )
+  with
+  | Ok v ->
+      v
+  | Error e ->
+      Logger.error logger ~module_:__MODULE__ ~location:__LOC__
+        "failed to query our own IP from $provider: $exn"
+        ~metadata:
+          [("exn", `String (Exn.to_string e)); ("provider", `String uri)] ;
+      None
 
-let find () =
+let find ~logger =
   let handler acc elem =
-    match acc with None -> ip_service_result elem | Some _ -> return acc
+    match acc with
+    | None ->
+        ip_service_result elem ~logger
+    | Some _ ->
+        return acc
   in
-  Deferred.List.fold services ~init:None ~f:handler
-  >>| fun x ->
+  let%map our_ip_maybe = Deferred.List.fold services ~init:None ~f:handler in
   Unix.Inet_addr.of_string
-  @@ Option.value_exn ~message:"couldn't determine our IP from the internet" x
+  @@ Option.value_exn
+       ~message:
+         "couldn't determine our IP from the internet, use -external-ip flag"
+       our_ip_maybe

--- a/src/app/cli/src/find_ip.mli
+++ b/src/app/cli/src/find_ip.mli
@@ -1,3 +1,3 @@
 open Core
 
-val find : unit -> Unix.Inet_addr.t Async_kernel.Deferred.t
+val find : logger:Logger.t -> Unix.Inet_addr.t Async_kernel.Deferred.t


### PR DESCRIPTION
This raises a better exception after failing to find our IP, and documents the error.

Closes #3039
