### PR TITLE
SIMPLE: add branch to pv key archive name

### DIFF
--- a/scripts/artifacts.sh
+++ b/scripts/artifacts.sh
@@ -28,6 +28,7 @@ do_copy () {
     do
         echo "Copying ${SOURCE} to ${DESTINATION}"
         gsutil -o GSUtil:parallel_composite_upload_threshold=100M -q cp ${SOURCE} ${DESTINATION}
+        gsutil ls ${DESTINATION}
     done
 }
 

--- a/scripts/pvkeys-download.sh
+++ b/scripts/pvkeys-download.sh
@@ -28,20 +28,21 @@ set +e
 
 # Derive branch being merged in to
 # Usually a fix/feature branch PR won't have PV keys
-PR_NUMBER=`basename ${CIRCLE_PULL_REQUEST}`
+PR_NUMBER=`basename ${CIRCLE_PULL_REQUEST:-NOPR}`
 GH_API="https://api.github.com/repos/CodaProtocol/coda/pulls"
 MERGE_INTO_BRANCH=`curl -s ${GH_API}/${PR_NUMBER} | jq -r .base.ref`
 
 # Iterate over a few name variations until you a match?
 NAME_VARIATIONS="
-keys-${CIRCLE_BRANCH}-${DUNE_PROFILE}.tar.bz2
-keys-${MERGE_INTO_BRANCH}-${DUNE_PROFILE}.tar.bz2
-keys-temporary_hack-${DUNE_PROFILE}.tar.bz2
+keys-${CIRCLE_BRANCH:-NOBRANCH}-${DUNE_PROFILE:-NOPROFILE}.tar.bz2
+keys-${MERGE_INTO_BRANCH:-NOBRANCH}-${DUNE_PROFILE:-NOPROFILE}.tar.bz2
+keys-temporary_hack-${DUNE_PROFILE:-NOPROFILE}.tar.bz2
 NOTFOUND
 "
 
 for TARBALL in ${NAME_VARIATIONS}
 do
+    echo "Checking for ${TARBALL}"
     if gsutil -q stat gs://proving-keys-stable/$TARBALL
     then
         # Found a file matching this name, keep it
@@ -53,7 +54,6 @@ if [[ $TARBALL = "NOTFOUND" ]]; then
     echo "No usable PV tarball found"
     exit 0
 fi
-
 
 URI="gs://proving-keys-stable/${TARBALL}"
 gsutil cp ${URI} /tmp/.

--- a/scripts/pvkeys-download.sh
+++ b/scripts/pvkeys-download.sh
@@ -4,15 +4,18 @@
 
 set -eo pipefail
 
-# Get fixed set of PV keys (which needs to be updated when snark changes)
-if [ -z "$JSON_GCLOUD_CREDENTIALS" ]; then
-    echo "WARNING: JSON_GCLOUD_CREDENTIALS not set, static PV keys not used"
-    exit 0
-fi
+# When running in CI
+if [ "$CI" = true ] ; then
+    # Get fixed set of PV keys (which needs to be updated when snark changes)
+    if [ -z "$JSON_GCLOUD_CREDENTIALS" ]; then
+        echo "WARNING: JSON_GCLOUD_CREDENTIALS not set, static PV keys not used"
+        exit 0
+    fi
 
-# GC credentials
-echo $JSON_GCLOUD_CREDENTIALS > google_creds.json
-/usr/bin/gcloud auth activate-service-account --key-file=google_creds.json
+    # GC credentials
+    echo $JSON_GCLOUD_CREDENTIALS > google_creds.json
+    /usr/bin/gcloud auth activate-service-account --key-file=google_creds.json
+fi
 
 # Debug output
 #set -x
@@ -20,9 +23,26 @@ echo $JSON_GCLOUD_CREDENTIALS > google_creds.json
 # Get cached keys
 echo "------------------------------------------------------------"
 echo "Downloading keys"
-PINNED_KEY_COMMIT=temporary_hack
-TARBALL="keys-${PINNED_KEY_COMMIT}-${DUNE_PROFILE}.tar.bz2"
-/usr/bin/gsutil cp gs://proving-keys-stable/$TARBALL /tmp/.
+
+set +e
+
+# Look for tar based on branch name
+if gsutil -q stat gs://proving-keys-stable/keys-${CIRCLE_BRANCH}-${DUNE_PROFILE}.tar.bz2
+then
+    TARBALL="keys-${CIRCLE_BRANCH}-${DUNE_PROFILE}.tar.bz2"
+# Fall back to old tar based on just DUNE_PROFILE
+elif gsutil -q stat gs://proving-keys-stable/keys-temporary_hack-${DUNE_PROFILE}.tar.bz2
+then
+    TARBALL="keys-temporary_hack-${DUNE_PROFILE}.tar.bz2"
+else
+    echo "PV Archive not found - Skipping"
+    exit 0
+fi
+
+echo "Found ${TARBALL}"
+
+URI="gs://proving-keys-stable/${TARBALL}"
+gsutil cp ${URI} /tmp/.
 
 # Unpack keys
 echo "------------------------------------------------------------"

--- a/scripts/pvkeys-download.sh
+++ b/scripts/pvkeys-download.sh
@@ -34,8 +34,8 @@ MERGE_INTO_BRANCH=`curl -s ${GH_API}/${PR_NUMBER} | jq -r .base.ref`
 
 # Iterate over a few name variations until you a match?
 NAME_VARIATIONS="
-keys-${MERGE_INTO_BRANCH}-${DUNE_PROFILE}.tar.bz2
 keys-${CIRCLE_BRANCH}-${DUNE_PROFILE}.tar.bz2
+keys-${MERGE_INTO_BRANCH}-${DUNE_PROFILE}.tar.bz2
 keys-temporary_hack-${DUNE_PROFILE}.tar.bz2
 NOTFOUND
 "


### PR DESCRIPTION
adds an optional branch name to PV key archive -- lets us maintain different key sets for different branches.

exposes an issue that when running a PR, you can't tell what branch you're merging in to.

but the benefit here is that we can maintain different PV key sets for different branches. (when the snark circuit changes in a branch)