### PR TITLE
discard transitioned_staged_ledger by unregistering its mask

### DIFF
--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -12,7 +12,7 @@
 
 [%%define genesis_ledger "test_five_even_stakes"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
-[%%define block_window_duration 1500]
+[%%define block_window_duration 2000]
 
 [%%define integration_tests true]
 [%%define force_updates false]

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -120,7 +120,7 @@ let generate_next_state ~previous_protocol_state ~time_controller
       in
       let%map ( `Hash_after_applying next_staged_ledger_hash
               , `Ledger_proof ledger_proof_opt
-              , `Staged_ledger _transitioned_staged_ledger
+              , `Staged_ledger transitioned_staged_ledger
               , `Pending_coinbase_data (is_new_stack, coinbase_amount) ) =
         let%map or_error =
           Staged_ledger.apply_diff_unchecked staged_ledger diff
@@ -128,6 +128,10 @@ let generate_next_state ~previous_protocol_state ~time_controller
         Or_error.ok_exn or_error
       in
       (*staged_ledger remains unchanged and transitioned_staged_ledger is discarded because the external transtion created out of this diff will be applied in Transition_frontier*)
+      ignore
+      @@ Ledger.unregister_mask_exn
+           (Staged_ledger.ledger staged_ledger)
+           (Staged_ledger.ledger transitioned_staged_ledger) ;
       ( diff
       , next_staged_ledger_hash
       , ledger_proof_opt

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -773,6 +773,12 @@ module Make (Inputs : Inputs_intf) :
                 ; ( "garbage_direct_descendants"
                   , `List
                       (List.map bad_children_hashes ~f:State_hash.to_yojson) )
+                ; ( "all_masks"
+                  , `List
+                      (List.map garbage_breadcrumbs ~f:(fun crumb ->
+                           `String
+                             ( Breadcrumb.mask crumb |> Ledger.get_uuid
+                             |> Uuid.to_string_hum ) )) )
                 ; ( "local_state"
                   , Consensus.Data.Local_state.to_yojson
                       t.consensus_local_state ) ]


### PR DESCRIPTION
Fixed a dangling mask bug,

Inside the `proposer.ml`, `transitioned_staged_ledger` should be properly discarded by unregistering its mask.
