### PR TITLE
Add graphql_ppx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "frontend/wallet/tablecloth"]
 	path = frontend/wallet/tablecloth
 	url = https://github.com/bkase/tablecloth
+[submodule "src/external/graphql_ppx"]
+	path = src/external/graphql_ppx
+	url = git@github.com:o1-labs/graphql_ppx.git

--- a/README-dev.md
+++ b/README-dev.md
@@ -152,6 +152,7 @@ with `dune`, so you need to add them manually:
 * `opam pin add src/external/rpc_parallel`
 * `opam pin add src/external/ocaml-extlib`
 * `opam pin add src/external/coda_base58`
+* `opam pin add src/external/graphql_ppx`
 
 There are a variety of C libraries we expect to be available in the system.
 These are also listed in the dockerfiles. Unlike most of the C libraries,

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -69,6 +69,10 @@ RUN sudo rm -rf /async_kernel/.git && cd /async_kernel && yes | opam pin add .
 ADD /src/external/coda_base58 /coda_base58
 RUN sudo rm -rf /coda_base58/.git && cd /coda_base58 && yes | opam pin add .
 
+# Source copy of graphql_ppx, updated for 4.07.1/4.08.0 support
+ADD /src/external/graphql_ppx /graphql_ppx
+RUN sudo rm -rf /graphql_ppx/.git && cd /graphql_ppx && yes | opam pin add .
+
 # Get coda-kademlia from packages repo
 RUN sudo apt-get install --yes apt-transport-https ca-certificates && \
       echo "deb [trusted=yes] https://packages.o1test.net unstable main" | sudo tee -a /etc/apt/sources.list.d/coda.list && \

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -68,6 +68,7 @@ if [[ $COMPILE_THINGS == "YES" ]]; then
   env TERM=xterm opam pin -y add src/external/digestif
   env TERM=xterm opam pin -y add src/external/async_kernel
   env TERM=xterm opam pin -y add src/external/coda_base58
+  env TERM=xterm opam pin -y add src/external/graphql_ppx
   eval $(opam config env)
 
   # Kademlia


### PR DESCRIPTION
This adds our fork of `graphql_ppx` as a submodule for pinning. The fork gives us
* 4.07.1/4.08.0 support
* tweaks to make the output compatible with Core.

I haven't been able to generate a `graphql_schema.json` for our schema, so I haven't been able to set up a full test query, but the code generated from a test schema looks how I would expect and compiles inside coda.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: