### PR TITLE
make mac build work again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -195,7 +195,7 @@ jobs:
     build-artifacts--testnet_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         environment:
             DUNE_PROFILE: testnet_postake_medium_curves
         steps:
@@ -234,7 +234,7 @@ jobs:
     build-artifacts--testnet_postake_many_proposers_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         environment:
             DUNE_PROFILE: testnet_postake_many_proposers_medium_curves
         steps:
@@ -273,7 +273,7 @@ jobs:
     test-unit--test_postake_snarkless_unittest:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -289,7 +289,7 @@ jobs:
     test-unit--dev:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -305,7 +305,7 @@ jobs:
     test-unit--test_postake_snarkless_medium_curves_unit_test:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -321,7 +321,7 @@ jobs:
     test-unit--dev_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -337,7 +337,7 @@ jobs:
     test--fake_hash:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -351,7 +351,7 @@ jobs:
     test--test_postake:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -368,7 +368,7 @@ jobs:
     test--test_postake_bootstrap:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -385,7 +385,7 @@ jobs:
     test--test_postake_catchup:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -399,7 +399,7 @@ jobs:
     test--test_postake_delegation:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -413,7 +413,7 @@ jobs:
     test--test_postake_five_even_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -427,7 +427,7 @@ jobs:
     test--test_postake_five_even_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -441,7 +441,7 @@ jobs:
     test--test_postake_holy_grail:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -458,7 +458,7 @@ jobs:
     test--test_postake_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -475,7 +475,7 @@ jobs:
     test--test_postake_split:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -489,7 +489,7 @@ jobs:
     test--test_postake_split_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -521,7 +521,7 @@ jobs:
     test--test_postake_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -538,7 +538,7 @@ jobs:
     test--test_postake_delegation_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -552,7 +552,7 @@ jobs:
     test--test_postake_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -571,7 +571,7 @@ jobs:
     test--test_postake_snarkless_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -588,7 +588,7 @@ jobs:
     test--test_postake_split_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -602,7 +602,7 @@ jobs:
     test--test_postake_split_snarkless_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -634,7 +634,7 @@ jobs:
     test--test_postake_txns_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -82,66 +82,125 @@ jobs:
                   command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status
 
     build-macos:
-       macos:
-           xcode: "10.2.1"
-       working_directory: /Users/distiller/coda
-       environment:
-           HOMEBREW_LOGS: /Users/distiller/homebrew.log
-           OPAMYES: 1
-       steps:
-           - run:
-               name: Make /nix paths
-               command: |
-                   sudo mkdir /nix
-                   sudo chown distiller /nix
-           - checkout
-           - restore_cache:
-                 keys:
-                     - homebrew-v1-{{ checksum "scripts/macos-setup.sh" }}
-                     - homebrew-v1-
-           - restore_cache:
-                 keys:
-                     - opam-v3-{{ checksum "src/opam.export" }}
-                     - opam-v3-
-           - run: git submodule sync && git submodule update --init --recursive
-           - run:
-                 name: Download Deps -- make macos-setup-download
-                 command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
-           - run:
-                 name: Compile Deps -- make macos-setup-compile
-                 command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
-           - save_cache:
-                 key: homebrew-v1-{{ checksum "scripts/macos-setup.sh" }}
-                 paths:
-                     - "/usr/local/Homebrew"
-                     - "/Users/distiller/Library/Caches/Homebrew"
-           - save_cache:
-                 key: opam-v3-{{ checksum "src/opam.export" }}
-                 paths:
-                     - "/Users/distiller/.opam"
-           - run:
-                 name: Build OCaml
-                 command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
-                 no_output_timeout: 1h
-                 environment:
-                  DUNE_PROFILE: testnet_postake_medium_curves
-           - run:
-                 name: Run all tests (on master)
-                 command: echo "FIXME Tests not yet working on mac"
-           - run:
-                 name: Publish to Artifactory
-                 command: ./scripts/skip_if_only_frontend.sh ./scripts/publish-macos.sh
+      # only run when there's a 'release' tag
+      # filters:
+      #   tags:
+      #      only: /^release.*/
+        macos:
+            xcode: "10.2.1"
+        resource_class: large
+        working_directory: /Users/distiller/coda
+        environment:
+            HOMEBREW_LOGS: /Users/distiller/homebrew.log
+            OPAMYES: 1
+        steps:
+            # Attach workspace from prior linux build
+            - attach_workspace:
+                at: /tmp/workspace
+            - run:
+                name: Unpack Workspace PV Keys
+                command: |
+                    sudo mkdir -p /var/lib/coda
+                    sudo tar xvf /tmp/workspace/coda*.bz2 -C /var/lib/coda/
+            - checkout
+            - run:
+                name: Update git submodules
+                command: git submodule sync && git submodule update --init --recursive
+            - restore_cache:
+                name: Restore cache - homebrew
+                keys:
+                    - homebrew-v5-{{ checksum "scripts/macos-setup.sh" }}
+                    - homebrew-v5-
+            - run:
+                name: Install macos dependancies - homebrew - make macos-setup-download
+                command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
+            - save_cache:
+                name: Save cache - homebrew
+                key: homebrew-v5-{{ checksum "scripts/macos-setup.sh" }}
+                paths:
+                    - "/usr/local/Homebrew"
+                    - "/Users/distiller/Library/Caches/Homebrew"
+
+            - restore_cache:
+                name: Restore cache - opam
+                keys:
+                    - opam-v5-{{ checksum "src/opam.export" }}
+                    - opam-v4-{{ checksum "src/opam.export" }}
+                    - opam-v3-{{ checksum "src/opam.export" }}
+            - run:
+                name: Ensure opam permisssions
+                command: |
+                    set +e
+                    sudo chown -R distiller /Users/distiller/.opam
+                    sudo chmod -R u+w /Users/distiller/.opam
+            - run:
+                name: Install macos dependancies - opam -- make macos-setup-compile
+                command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
+            - save_cache:
+                name: Save cache - opam
+                key: opam-v5-{{ checksum "src/opam.export" }}
+                paths:
+                    - "/Users/distiller/.opam"
+                no_output_timeout: 1h
+            - run:
+                name: Install nix and cachix
+                command: |
+                    curl https://nixos.org/nix/install | sh
+                    . ~/.nix-profile/etc/profile.d/nix.sh
+                    nix-env -iA cachix -f https://cachix.org/api/v1/install
+            - run:
+                name: Build kademlia using cachix
+                command: |
+                    . ~/.nix-profile/etc/profile.d/nix.sh
+                    cachix use codaprotocol
+                    cd src/app/kademlia-haskell
+                    nix-build release2.nix
+            - run:
+                name: Build ocaml
+                command: bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
+                no_output_timeout: 1h
+                environment:
+                DUNE_PROFILE: testnet_postake_medium_curves
+            - run:
+                name: Collect PV Keys
+                command: |
+                    mkdir -p package/keys
+                    cp /var/lib/coda/* package/keys/.
+            - run:
+                name: Collect and rewrite kademlia
+                command: |
+                    cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
+                    chmod +w package/kademlia
+                    ./scripts/librewrite-macos.sh package/kademlia
+            - run:
+                name: Collect coda binary
+                command: |
+                    cp src/_build/default/app/cli/src/coda.exe package/coda
+            - run:
+                name: Build homebrew package
+                command: |
+                    tar czvf homebrew-coda.tar.gz package
+                    openssl dgst -sha256 homebrew-coda.tar.gz > homebrew-coda.tar.gz.sha256
+                    cp homebrew-coda.tar.gz* package/.
+            - run:
+                  name: Copy artifacts to cloud
+                  bsckground: true
+                  command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
+            - store_artifacts:
+                  path: package
+            - run:
+                name: Publish to Artifactory
+                command: ./scripts/skip_if_only_frontend.sh ./scripts/publish-macos.sh
+                when: on_success
     build-artifacts--testnet_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         environment:
             DUNE_PROFILE: testnet_postake_medium_curves
         steps:
             - checkout
-            - run:
-                  name: Create artifact directory
-                  command: mkdir -p /tmp/artifacts
+            - run: mkdir -p /tmp/artifacts
             - run:
                   name: Update submodules
                   command: git submodule sync && git submodule update --init --recursive
@@ -161,23 +220,26 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh make genesiskeys
             - run:
                   name: Upload deb to repo
+                  background: true
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
-            - store_artifacts:
-                  path: /tmp/artifacts
             - run:
                   name: Copy artifacts to cloud
+                  bsckground: true
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
+            - persist_to_workspace:
+                root: /tmp/artifacts
+                paths: coda_pvkeys*
+            - store_artifacts:
+                  path: /tmp/artifacts
     build-artifacts--testnet_postake_many_proposers_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         environment:
             DUNE_PROFILE: testnet_postake_many_proposers_medium_curves
         steps:
             - checkout
-            - run:
-                  name: Create artifact directory
-                  command: mkdir -p /tmp/artifacts
+            - run: mkdir -p /tmp/artifacts
             - run:
                   name: Update submodules
                   command: git submodule sync && git submodule update --init --recursive
@@ -197,16 +259,21 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh make genesiskeys
             - run:
                   name: Upload deb to repo
+                  background: true
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
-            - store_artifacts:
-                  path: /tmp/artifacts
             - run:
                   name: Copy artifacts to cloud
+                  bsckground: true
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
+            - persist_to_workspace:
+                root: /tmp/artifacts
+                paths: coda_pvkeys*
+            - store_artifacts:
+                  path: /tmp/artifacts
     test-unit--test_postake_snarkless_unittest:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -222,7 +289,7 @@ jobs:
     test-unit--dev:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -238,7 +305,7 @@ jobs:
     test-unit--test_postake_snarkless_medium_curves_unit_test:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -254,7 +321,7 @@ jobs:
     test-unit--dev_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -270,7 +337,7 @@ jobs:
     test--fake_hash:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -284,7 +351,7 @@ jobs:
     test--test_postake:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -301,7 +368,7 @@ jobs:
     test--test_postake_bootstrap:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -318,7 +385,7 @@ jobs:
     test--test_postake_catchup:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -332,7 +399,7 @@ jobs:
     test--test_postake_delegation:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -346,7 +413,7 @@ jobs:
     test--test_postake_five_even_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -360,7 +427,7 @@ jobs:
     test--test_postake_five_even_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -374,7 +441,7 @@ jobs:
     test--test_postake_holy_grail:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -391,7 +458,7 @@ jobs:
     test--test_postake_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -408,7 +475,7 @@ jobs:
     test--test_postake_split:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -422,7 +489,7 @@ jobs:
     test--test_postake_split_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -454,7 +521,7 @@ jobs:
     test--test_postake_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -471,7 +538,7 @@ jobs:
     test--test_postake_delegation_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -485,7 +552,7 @@ jobs:
     test--test_postake_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -504,7 +571,7 @@ jobs:
     test--test_postake_snarkless_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -521,7 +588,7 @@ jobs:
     test--test_postake_split_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -535,7 +602,7 @@ jobs:
     test--test_postake_split_snarkless_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -567,7 +634,7 @@ jobs:
     test--test_postake_txns_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -593,7 +660,10 @@ workflows:
                     only: develop
             - tracetool
             - build-wallet
-            - build-macos
+            - build-macos:
+                # only run AFTER linux build
+                requires:
+                    - build-artifacts--testnet_postake_medium_curves
             - build-artifacts--testnet_postake_medium_curves
             - build-artifacts--testnet_postake_many_proposers_medium_curves
             - test-unit--test_postake_snarkless_unittest

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -50,7 +50,7 @@ jobs:
 
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -201,7 +201,7 @@ jobs:
         resource_class: large
         {%- endif %}
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         environment:
             DUNE_PROFILE: {{profile}}
         steps:
@@ -249,7 +249,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -268,7 +268,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -287,7 +287,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:
@@ -306,7 +306,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -50,7 +50,7 @@ jobs:
 
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -82,55 +82,116 @@ jobs:
                   command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status
 
     build-macos:
-       macos:
-           xcode: "10.2.1"
-       working_directory: /Users/distiller/coda
-       environment:
-           HOMEBREW_LOGS: /Users/distiller/homebrew.log
-           OPAMYES: 1
-       steps:
-           - run:
-               name: Make /nix paths
-               command: |
-                   sudo mkdir /nix
-                   sudo chown distiller /nix
-           - checkout
-           - restore_cache:
-                 keys:
-                     - homebrew-v1-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
-                     - homebrew-v1-
-           - restore_cache:
-                 keys:
-                     - opam-v3-{{'{{'}} checksum "src/opam.export" {{'}}'}}
-                     - opam-v3-
-           - run: git submodule sync && git submodule update --init --recursive
-           - run:
-                 name: Download Deps -- make macos-setup-download
-                 command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
-           - run:
-                 name: Compile Deps -- make macos-setup-compile
-                 command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
-           - save_cache:
-                 key: homebrew-v1-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
-                 paths:
-                     - "/usr/local/Homebrew"
-                     - "/Users/distiller/Library/Caches/Homebrew"
-           - save_cache:
-                 key: opam-v3-{{'{{'}} checksum "src/opam.export" {{'}}'}}
-                 paths:
-                     - "/Users/distiller/.opam"
-           - run:
-                 name: Build OCaml
-                 command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
-                 no_output_timeout: 1h
-                 environment:
-                  DUNE_PROFILE: testnet_postake_medium_curves
-           - run:
-                 name: Run all tests (on master)
-                 command: echo "FIXME Tests not yet working on mac"
-           - run:
-                 name: Publish to Artifactory
-                 command: ./scripts/skip_if_only_frontend.sh ./scripts/publish-macos.sh
+      # only run when there's a 'release' tag
+      # filters:
+      #   tags:
+      #      only: /^release.*/
+        macos:
+            xcode: "10.2.1"
+        resource_class: large
+        working_directory: /Users/distiller/coda
+        environment:
+            HOMEBREW_LOGS: /Users/distiller/homebrew.log
+            OPAMYES: 1
+        steps:
+            # Attach workspace from prior linux build
+            - attach_workspace:
+                at: /tmp/workspace
+            - run:
+                name: Unpack Workspace PV Keys
+                command: |
+                    sudo mkdir -p /var/lib/coda
+                    sudo tar xvf /tmp/workspace/coda*.bz2 -C /var/lib/coda/
+            - checkout
+            - run:
+                name: Update git submodules
+                command: git submodule sync && git submodule update --init --recursive
+            - restore_cache:
+                name: Restore cache - homebrew
+                keys:
+                    - homebrew-v5-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
+                    - homebrew-v5-
+            - run:
+                name: Install macos dependancies - homebrew - make macos-setup-download
+                command: ./scripts/skip_if_only_frontend.sh make macos-setup-download
+            - save_cache:
+                name: Save cache - homebrew
+                key: homebrew-v5-{{'{{'}} checksum "scripts/macos-setup.sh" {{'}}'}}
+                paths:
+                    - "/usr/local/Homebrew"
+                    - "/Users/distiller/Library/Caches/Homebrew"
+
+            - restore_cache:
+                name: Restore cache - opam
+                keys:
+                    - opam-v5-{{'{{'}} checksum "src/opam.export" {{'}}'}}
+                    - opam-v4-{{'{{'}} checksum "src/opam.export" {{'}}'}}
+                    - opam-v3-{{'{{'}} checksum "src/opam.export" {{'}}'}}
+            - run:
+                name: Ensure opam permisssions
+                command: |
+                    set +e
+                    sudo chown -R distiller /Users/distiller/.opam
+                    sudo chmod -R u+w /Users/distiller/.opam
+            - run:
+                name: Install macos dependancies - opam -- make macos-setup-compile
+                command: ./scripts/skip_if_only_frontend.sh make macos-setup-compile
+            - save_cache:
+                name: Save cache - opam
+                key: opam-v5-{{'{{'}} checksum "src/opam.export" {{'}}'}}
+                paths:
+                    - "/Users/distiller/.opam"
+                no_output_timeout: 1h
+            - run:
+                name: Install nix and cachix
+                command: |
+                    curl https://nixos.org/nix/install | sh
+                    . ~/.nix-profile/etc/profile.d/nix.sh
+                    nix-env -iA cachix -f https://cachix.org/api/v1/install
+            - run:
+                name: Build kademlia using cachix
+                command: |
+                    . ~/.nix-profile/etc/profile.d/nix.sh
+                    cachix use codaprotocol
+                    cd src/app/kademlia-haskell
+                    nix-build release2.nix
+            - run:
+                name: Build ocaml
+                command: bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
+                no_output_timeout: 1h
+                environment:
+                DUNE_PROFILE: testnet_postake_medium_curves
+            - run:
+                name: Collect PV Keys
+                command: |
+                    mkdir -p package/keys
+                    cp /var/lib/coda/* package/keys/.
+            - run:
+                name: Collect and rewrite kademlia
+                command: |
+                    cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
+                    chmod +w package/kademlia
+                    ./scripts/librewrite-macos.sh package/kademlia
+            - run:
+                name: Collect coda binary
+                command: |
+                    cp src/_build/default/app/cli/src/coda.exe package/coda
+            - run:
+                name: Build homebrew package
+                command: |
+                    tar czvf homebrew-coda.tar.gz package
+                    openssl dgst -sha256 homebrew-coda.tar.gz > homebrew-coda.tar.gz.sha256
+                    cp homebrew-coda.tar.gz* package/.
+            - run:
+                  name: Copy artifacts to cloud
+                  bsckground: true
+                  command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
+            - store_artifacts:
+                  path: package
+            - run:
+                name: Publish to Artifactory
+                command: ./scripts/skip_if_only_frontend.sh ./scripts/publish-macos.sh
+                when: on_success
 
     {%- for profile in build_artifact_profiles %}
     build-artifacts--{{profile}}:
@@ -140,14 +201,12 @@ jobs:
         resource_class: large
         {%- endif %}
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         environment:
             DUNE_PROFILE: {{profile}}
         steps:
             - checkout
-            - run:
-                  name: Create artifact directory
-                  command: mkdir -p /tmp/artifacts
+            - run: mkdir -p /tmp/artifacts
             - run:
                   name: Update submodules
                   command: git submodule sync && git submodule update --init --recursive
@@ -171,19 +230,26 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh make genesiskeys
             - run:
                   name: Upload deb to repo
+                  background: true
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
-            - store_artifacts:
-                  path: /tmp/artifacts
             - run:
                   name: Copy artifacts to cloud
+                  bsckground: true
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
+            {%- if profile in medium_curve_profiles %}
+            - persist_to_workspace:
+                root: /tmp/artifacts
+                paths: coda_pvkeys*
+            - store_artifacts:
+                  path: /tmp/artifacts
+            {%- endif %}
     {%- endfor %}
 
     {%- for profile in unit_test_profiles %}
     test-unit--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -202,7 +268,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -221,7 +287,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -240,7 +306,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-e855336d087a679f76f2dd2bbdc3fdfea9303be3
+            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
         steps:
             - checkout
             - run:
@@ -269,7 +335,10 @@ workflows:
                     only: develop
             - tracetool
             - build-wallet
-            - build-macos
+            - build-macos:
+                # only run AFTER linux build
+                requires:
+                    - build-artifacts--testnet_postake_medium_curves
             {%- for profile in build_artifact_profiles %}
             - build-artifacts--{{profile}}
             {%- endfor %}

--- a/scripts/artifacts.sh
+++ b/scripts/artifacts.sh
@@ -17,22 +17,37 @@ if [[ -z "$JSON_GCLOUD_CREDENTIALS" || "$JSON_GCLOUD_CREDENTIALS" == "" ]]; then
 fi
 
 do_copy () {
-    # GC credentials
-    echo $JSON_GCLOUD_CREDENTIALS > google_creds.json
-    /usr/bin/gcloud auth activate-service-account --key-file=google_creds.json
 
-    SOURCES="/tmp/artifacts/*"
+    # GC and credentials
+    set +e
+    path_to_gcloud=$(which gcloud)
+    if [ -x "$path_to_gcloud" ] ; then
+        echo "Found gcloud: $path_to_glcoud"
+    else
+        export HOMEBREW_NO_AUTO_UPDATE=1
+        brew cask install google-cloud-sdk
+    fi
+    set -e
+
+    echo $JSON_GCLOUD_CREDENTIALS > google_creds.json
+    gcloud auth activate-service-account --key-file=google_creds.json
+
+    SOURCES="/tmp/artifacts/* package/*"
     DESTINATION="gs://network-debug/${CIRCLE_BUILD_NUM}/build/"
 
     for SOURCE in $SOURCES
     do
+        set +e
         echo "Copying ${SOURCE} to ${DESTINATION}"
         gsutil -o GSUtil:parallel_composite_upload_threshold=100M -q cp ${SOURCE} ${DESTINATION}
         gsutil ls ${DESTINATION}
+        set -e
     done
 }
 
 case $CIRCLE_JOB in
-  "build-artifacts--testnet_postake" | "build-artifacts--testnet_postake_snarkless_fake_hash" | "build-artifacts--testnet_postake_medium_curves" |  "build-artifacts--testnet_postake_many_proposers_medium_curves") do_copy;;
-   *) echo "Not an active testnet job (${CIRCLE_JOB}), stopping." ; exit 0 ;;
+    "build-artifacts--testnet_postake_medium_curves") do_copy;;
+    "build-artifacts--testnet_postake_many_proposers_medium_curves") do_copy;;
+    "build-macos") do_copy;;
+    *) echo "Not an active testnet job (${CIRCLE_JOB}), stopping." ; exit 0 ;;
 esac

--- a/scripts/librewrite-macos.sh
+++ b/scripts/librewrite-macos.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# xcode technique to rewrite dynamic lib links
+# tweaks kademlia binaries built with nix to work with os installed libs
+
+check_file() {
+  mybin="$1"
+  if [ ! -f ${mybin} ]; then
+    echo "ERROR: ${mybin} missing"
+    exit 1
+  fi
+}
+
+# Allow for specific target
+TARGET=${1:-kademlia}
+
+# check for xcode tools
+for mybin in /usr/bin/install_name_tool /usr/bin/otool
+do
+  check_file $mybin
+done
+
+BUILD_DIR_NAME=package
+
+# Swap nix libs for brew libs (ugly hack)
+rewrite_lib() {
+  TARGET="$1"
+  LIB_NAME="$2"
+  NEW_PATH="$3"
+  # build env may not have these libs
+  #check_file ${NEW_PATH}
+  OLD_PATH=$(/usr/bin/otool -X -L ${TARGET} | grep "${LIB_NAME}" | grep '/nix'  | awk '{print $1}')
+  echo "Updating ${TARGET} - rewriting ${OLD_PATH} to ${NEW_PATH}"
+  /usr/bin/install_name_tool -change "$OLD_PATH" "$NEW_PATH" "${TARGET}"
+}
+
+# rewrite the libs
+rewrite_lib $TARGET 'libgmp' "/usr/local/opt/gmp/lib/libgmp.10.dylib"
+rewrite_lib $TARGET 'libffi' "/usr/local/opt/libffi/lib/libffi.6.dylib"
+rewrite_lib $TARGET 'libSystem' "/usr/lib/libSystem.B.dylib"
+rewrite_lib $TARGET 'libiconv' "/usr/lib/libiconv.dylib"

--- a/scripts/macos-setup.sh
+++ b/scripts/macos-setup.sh
@@ -38,10 +38,6 @@ if [[ $DOWNLOAD_THINGS == "YES" ]]; then
   else
     echo 'All brew packages have already been installed.'
   fi
-
-  # ocaml downloading
-  OPAMYES=1 opam init
-  eval $(opam config env)
 else
   echo 'Not running download step'
 fi
@@ -49,12 +45,26 @@ fi
 
 # Compile things
 if [[ $COMPILE_THINGS == "YES" ]]; then
+
+  # Keep compile dirs to avoid recompiles
+  export OPAMKEEPBUILDDIR='true'
+  export OPAMREUSEBUILDDIR='true'
+  export OPAMYES=1
+
+  # Set term to xterm if not set
+  export TERM=${TERM:-xterm}
+
+  # ocaml downloading
+  opam init
+  eval $(opam config env)
+
   opam update
   # This is dirty, keep the OCaml project version up to date!
-  opam switch create 4.07.1 || true 
+  opam switch create 4.07.1 || true
   opam switch 4.07.1
+
   # All our ocaml packages
-  env TERM=xterm opam switch -y import src/opam.export
+  opam switch -y import src/opam.export
   eval $(opam config env)
 
   # Extlib gets automatically installed, but we want our pin, so we should
@@ -62,41 +72,14 @@ if [[ $COMPILE_THINGS == "YES" ]]; then
   opam uninstall -y extlib
 
   # Our pins
-  env TERM=xterm opam pin -y add src/external/ocaml-sodium
-  env TERM=xterm opam pin -y add src/external/rpc_parallel
-  env TERM=xterm opam pin -y add src/external/ocaml-extlib
-  env TERM=xterm opam pin -y add src/external/digestif
-  env TERM=xterm opam pin -y add src/external/async_kernel
-  env TERM=xterm opam pin -y add src/external/coda_base58
+  opam pin -y add src/external/ocaml-sodium
+  opam pin -y add src/external/rpc_parallel
+  opam pin -y add src/external/ocaml-extlib
+  opam pin -y add src/external/digestif
+  opam pin -y add src/external/async_kernel
+  opam pin -y add src/external/coda_base58
   eval $(opam config env)
 
-  # Kademlia
-  curl https://nixos.org/nix/install | sh
-  touch ~/.profile
-  set +u
-  . ~/.nix-profile/etc/profile.d/nix.sh
-  if [[ "$CIRCLE_BUILD_NUM" ]]; then
-      mkdir -p ~/.config/nix
-      cat > ~/.config/nix/nix.conf <<EOF
-substituters = https://cache.nixos.org s3://o1-nix-cache
-# Checking signatures is broken with S3 based Nix caches, see
-# https://github.com/NixOS/nix/issues/2024
-require-sigs = false
-EOF
-  fi
-  set +e
-  nix-build --dry-run src/app/kademlia-haskell/release2.nix 2>&1 | grep -q 'these derivations will be built'
-  building_kad=$?
-  set -e
-  make kademlia
-  if [[ "$CIRCLE_BUILD_NUM" && "$building_kad" = 0 ]]; then
-      nix copy --to s3://o1-nix-cache src/app/kademlia-haskell/result/
-      # Incantation to copy build dependencies. We instantiate the nix
-      # expression to a derivation, get a list of the derivations it references,
-      # and copy the outputs of those derivations to our cache.
-      nix copy --to s3://o1-nix-cache $(nix-store -r $(nix-store -q --references $(nix-instantiate src/app/kademlia-haskell/release2.nix)))
-  fi
-  set -u
 else
   echo 'Not running compile step.'
 fi


### PR DESCRIPTION
- isolates opam and homebrew in macos script (better for build caching)
- makes macbuild use same keys from linux build
- use cachix binary cache for kademlia (1m30s kadem builds)
- copy results to cloud
- make some build tasks run in background