### PR TITLE
properly close sync_ledger pipe when retry bootstrap

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -245,6 +245,12 @@ end = struct
 
   let rec run ~logger ~trust_system ~verifier ~network ~frontier ~ledger_db
       ~transition_reader =
+    let sync_ledger_reader, sync_ledger_writer =
+      create ~name:"sync ledger pipe"
+        (Buffered (`Capacity 50, `Overflow Crash))
+    in
+    transfer_while_writer_alive transition_reader sync_ledger_writer ~f:Fn.id
+    |> don't_wait_for ;
     let initial_breadcrumb = Transition_frontier.root frontier in
     let initial_root_transition =
       External_transition.Validation.lower
@@ -267,7 +273,8 @@ end = struct
       let root_sync_ledger =
         Root_sync_ledger.create ledger_db ~logger:t.logger ~trust_system
       in
-      sync_ledger t ~root_sync_ledger ~transition_graph ~transition_reader
+      sync_ledger t ~root_sync_ledger ~transition_graph
+        ~transition_reader:sync_ledger_reader
       |> don't_wait_for ;
       let%map synced_db, root_data =
         Root_sync_ledger.valid_tree root_sync_ledger
@@ -319,6 +326,7 @@ end = struct
           "Failed to find scan state for the transition with hash $state_hash \
            from the peer or received faulty scan state: $error. Retry \
            bootstrap" ;
+        Writer.close sync_ledger_writer ;
         run ~logger ~trust_system ~verifier ~network ~frontier ~ledger_db
           ~transition_reader
     | Ok root_staged_ledger -> (
@@ -377,6 +385,7 @@ end = struct
             Logger.error logger ~module_:__MODULE__ ~location:__LOC__
               ~metadata:[("error", `String (Error.to_string_hum e))]
               "Local state sync failed: $error. Retry bootstrap" ;
+            Writer.close sync_ledger_writer ;
             run ~logger ~trust_system ~verifier ~network ~frontier ~ledger_db
               ~transition_reader
         | Ok () ->

--- a/src/lib/pipe_lib/strict_pipe.mli
+++ b/src/lib/pipe_lib/strict_pipe.mli
@@ -121,6 +121,6 @@ val transfer :
 
 val transfer_while_writer_alive :
      'a Reader.t
-  -> ('b, synchronous, unit Deferred.t) Writer.t
+  -> ('b, 'type_, 'write_return) Writer.t
   -> f:('a -> 'b)
   -> unit Deferred.t


### PR DESCRIPTION
This PR fixed a bug related to bootstrap controller.
Retry bootstrap should first close the transition_reader pipe used by previous bootstrap attempt.
