### PR TITLE
SIMPLE:move  dune profile setting in macos build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,6 @@ jobs:
         resource_class: large
         working_directory: /Users/distiller/coda
         environment:
-            DUNE_PROFILE: testnet_postake_medium_curves
             HOMEBREW_LOGS: /Users/distiller/homebrew.log
             OPAMYES: 1
         steps:
@@ -158,6 +157,8 @@ jobs:
                     nix-build release2.nix
             - run:
                 name: Build ocaml
+                environment:
+                    DUNE_PROFILE: testnet_postake_medium_curves
                 command: bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
                 no_output_timeout: 1h
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
         resource_class: large
         working_directory: /Users/distiller/coda
         environment:
+            DUNE_PROFILE: testnet_postake_medium_curves
             HOMEBREW_LOGS: /Users/distiller/homebrew.log
             OPAMYES: 1
         steps:
@@ -159,8 +160,6 @@ jobs:
                 name: Build ocaml
                 command: bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
                 no_output_timeout: 1h
-                environment:
-                DUNE_PROFILE: testnet_postake_medium_curves
             - run:
                 name: Collect PV Keys
                 command: |

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -91,7 +91,6 @@ jobs:
         resource_class: large
         working_directory: /Users/distiller/coda
         environment:
-            DUNE_PROFILE: testnet_postake_medium_curves
             HOMEBREW_LOGS: /Users/distiller/homebrew.log
             OPAMYES: 1
         steps:
@@ -158,6 +157,8 @@ jobs:
                     nix-build release2.nix
             - run:
                 name: Build ocaml
+                environment:
+                    DUNE_PROFILE: testnet_postake_medium_curves
                 command: bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
                 no_output_timeout: 1h
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -91,6 +91,7 @@ jobs:
         resource_class: large
         working_directory: /Users/distiller/coda
         environment:
+            DUNE_PROFILE: testnet_postake_medium_curves
             HOMEBREW_LOGS: /Users/distiller/homebrew.log
             OPAMYES: 1
         steps:
@@ -159,8 +160,6 @@ jobs:
                 name: Build ocaml
                 command: bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/buildocaml.log'
                 no_output_timeout: 1h
-                environment:
-                DUNE_PROFILE: testnet_postake_medium_curves
             - run:
                 name: Collect PV Keys
                 command: |


### PR DESCRIPTION
Apparently DUNE_PROFILE environment was never in use in mac build -- fix.