### PR TITLE
SIMPLE:expand with-balances to with-details

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -201,18 +201,18 @@ let reset_trust_status =
 let get_public_keys =
   let open Daemon_rpcs in
   let open Command.Param in
-  let with_balances_flag =
-    flag "with-balances" no_arg
-      ~doc:"Show corresponding balances to public keys"
+  let with_details_flag =
+    flag "with-details" no_arg
+      ~doc:"Show extra details (eg. balance, nonce) in addition to public keys"
   in
   Command.async ~summary:"Get public keys"
     (Cli_lib.Background_daemon.init
-       (Args.zip2 with_balances_flag Cli_lib.Flag.json)
+       (Args.zip2 with_details_flag Cli_lib.Flag.json)
        ~f:(fun port (is_balance_included, json) ->
          if is_balance_included then
            dispatch_pretty_message ~json
-             (module Cli_lib.Render.Public_key_with_balances)
-             Get_public_keys_with_balances.rpc () port
+             (module Cli_lib.Render.Public_key_with_details)
+             Get_public_keys_with_details.rpc () port
          else
            dispatch_pretty_message ~json
              (module Cli_lib.Render.String_list_formatter)

--- a/src/app/cli/src/coda_commands.ml
+++ b/src/app/cli/src/coda_commands.ml
@@ -95,12 +95,13 @@ let get_public_keys t =
   let%map account = get_accounts t in
   List.map account ~f:string_of_public_key
 
-let get_keys_with_balances t =
+let get_keys_with_details t =
   let open Participating_state.Let_syntax in
   let%map accounts = get_accounts t in
   List.map accounts ~f:(fun account ->
       ( string_of_public_key account
-      , account.Account.Poly.balance |> Currency.Balance.to_int ) )
+      , account.Account.Poly.balance |> Currency.Balance.to_int
+      , account.Account.Poly.nonce |> Account.Nonce.to_string ) )
 
 let get_inferred_nonce_from_transaction_pool_and_ledger t
     (addr : Public_key.Compressed.t) =

--- a/src/app/cli/src/coda_run.ml
+++ b/src/app/cli/src/coda_run.ml
@@ -138,9 +138,9 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
           in
           Coda_commands.prove_receipt coda ~proving_receipt
             ~resulting_receipt:account.Account.Poly.receipt_chain_hash )
-    ; implement Daemon_rpcs.Get_public_keys_with_balances.rpc (fun () () ->
+    ; implement Daemon_rpcs.Get_public_keys_with_details.rpc (fun () () ->
           return
-            ( Coda_commands.get_keys_with_balances coda
+            ( Coda_commands.get_keys_with_details coda
             |> Participating_state.active_exn ) )
     ; implement Daemon_rpcs.Get_public_keys.rpc (fun () () ->
           return

--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -38,12 +38,15 @@ module Prove_receipt = struct
       (to_yojson proof |> Yojson.Safe.pretty_to_string)
 end
 
-module Public_key_with_balances = struct
+module Public_key_with_details = struct
   module Pretty_account = struct
-    type t = string * int
+    type t = string * int * string
 
-    let to_yojson (public_key, balance) =
-      Yojson.Safe.from_string (sprintf !"{\"%s\":%d}" public_key balance)
+    let to_yojson (public_key, balance, nonce) =
+      Yojson.Safe.from_string
+        (sprintf
+           !"\"%s\" : {\"balance\": %d, \"nonce\": %s }"
+           public_key balance nonce)
   end
 
   type t = Pretty_account.t list [@@deriving to_yojson]
@@ -53,7 +56,7 @@ module Public_key_with_balances = struct
   let to_yojson t = format_to_yojson {accounts= t}
 
   let to_text account =
-    List.map account ~f:(fun (public_key, balance) ->
-        sprintf !"%s, %d" public_key balance )
+    List.map account ~f:(fun (public_key, balance, nonce) ->
+        sprintf !"%s, %d, %s" public_key balance nonce )
     |> String.concat ~sep:"\n"
 end

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -463,15 +463,15 @@ module Clear_hist_status = struct
       ~bin_response
 end
 
-module Get_public_keys_with_balances = struct
+module Get_public_keys_with_details = struct
   type query = unit [@@deriving bin_io]
 
-  type response = (string * int) list [@@deriving bin_io, sexp]
+  type response = (string * int * string) list [@@deriving bin_io, sexp]
 
   type error = unit [@@deriving bin_io]
 
   let rpc : (query, response) Rpc.Rpc.t =
-    Rpc.Rpc.create ~name:"Get_public_keys_with_balances" ~version:0 ~bin_query
+    Rpc.Rpc.create ~name:"Get_public_keys_with_details" ~version:0 ~bin_query
       ~bin_response
 end
 


### PR DESCRIPTION
We need a quick way to collect nonce summaries.
expanding -with-balances to -with-details (including balances and nonces) was an easy way to accomplish this.

New format:

```
coda.exe advanced get-pub -with-details
8QnLYnzAkhx3moXHHBBpK418LGCEiQZzYDgKggntsNkZqsUJLFos474Mzoy5mWJP9S, 10000000, 0
8QnLTHMZPbBFezS8j8kDPu6iLiwPsTPyX2vMwcFzjiDZbp6GQDEBEyLbYvzApSdTsE, 100, 0
8QnLWWJ33Wm1e4ejaMeYC6RsjpaodiVuYY3RzKZ3ys5UBAmpaupV1SD6LSU2a6KB3L, 1000, 0
8QnLZ1fit1QXTLiFPcSuaR4F7ySgDMK2ZHpDLZU8Jm2ABE1K9n2Fbswme9SaSTd8bJ, 1000, 0
8QnLYLvy4FLKVo3qt9A32yLRLyEFHqf5NZTTFynajH6gNMH3AR4HA2gZTju8NpCgDU, 1000, 0
8QnLTkPLvGe1nAjtLP6WQzaVw2VKxQ9pAPLRPMd3eVbkfUuUL7g4R7mFrzuTZQgByc, 1000, 0
8QnLTnAYna24EdfX9dDMstUtWnQqU39YQBS4G7PjJD2KjQVHKZEhrPDeNSLJFrKiyr, 1000, 0
8QnLYGKxLpHq3BLEBzJSD83meqaTExGZRtMGqYnptPhMtXxauSaq2xFw9GGZgr2gRL, 1000, 0
8QnLWA5QDK8QmBSoJBZqDFDw2DDdnoTqsrbMk5XhfssWKWjuwv4devH96vM93mhx2M, 1000, 0
8QnLXHMwqYs1EbsAZGW7kWypUno6gThzXPFB68h4RMTGjABJa6byqKC4cSzRvNuezj, 1000, 0
8QnLVn7EEPcPYC36TqtdE7orCnsUXZuq2ZNRxEFFNPzB16XzesDFknDifFGuSHXYzJ, 1000, 0
8QnLVLAosnB4F8V5NFmnKpaq1cwK2Rxfx3BbpPSNLUpC4ZKgwcPdzTUYNFmDjV1tC2, 1000, 0
8QnLVwUvKfjSrbnMvyN7Aug2dPVoZgQW2SxiPrjUuTtVem6yidXzd2jtm9rsLBkBoE, 1000, 0
8QnLV2Jzyk2CVvTxYm2FUMqkwN82UEQsqtTSpYZ28TAcs3bbPXmGocFXfbNtfourse, 1000, 0
8QnLVvGkxs7gRepXjpoZwvdJTo4nx163Edd86jaxqRwkN5PZFdHReHBf7Gz89JfBnW, 1000, 0
8QnLTa5HrkCFbG5iFKpkjygJ7jYbms1TyBAkPJCpHV8rCGTxGt49DGzYZoxjVjt6kC, 1000, 0
8QnLUPQhCoLAfXdN5uxgFicmHGj12Ew9RCafxW6UwUeJxqKdQ6KdTSV7j2jKs67jZB, 1000, 0
8QnLU5Qbfr2tp37R5EMjBBBwC9R1S8dwePDYJTfmuHD6sVNKgE4JRmF8DPYAVH4V5s, 1000, 0
```

and in json
```
coda.exe advanced get-pub -with-details -json | head -n 030
{
  "accounts": [
    {
      "key":
        "8QnLYnzAkhx3moXHHBBpK418LGCEiQZzYDgKggntsNkZqsUJLFos474Mzoy5mWJP9S",
      "balance": 10000000,
      "nonce": 0
    },
    {
      "key":
        "8QnLTHMZPbBFezS8j8kDPu6iLiwPsTPyX2vMwcFzjiDZbp6GQDEBEyLbYvzApSdTsE",
      "balance": 100,
      "nonce": 0
    },
    {
      "key":
        "8QnLWWJ33Wm1e4ejaMeYC6RsjpaodiVuYY3RzKZ3ys5UBAmpaupV1SD6LSU2a6KB3L",
      "balance": 1000,
      "nonce": 0
    },
    {
      "key":
        "8QnLZ1fit1QXTLiFPcSuaR4F7ySgDMK2ZHpDLZU8Jm2ABE1K9n2Fbswme9SaSTd8bJ",
      "balance": 1000,
      "nonce": 0
    },
...
```

