### PR TITLE
Website: Fix site/static mkdir crash

### DIFF
--- a/frontend/website/src/Render.re
+++ b/frontend/website/src/Render.re
@@ -10,24 +10,6 @@ type critical = {
 [@bs.module "emotion-server"]
 external extractCritical: string => critical = "";
 
-module Fs = {
-  [@bs.val] [@bs.module "fs"]
-  external mkdirSync:
-    (
-      string,
-      {
-        .
-        "recursive": bool,
-        "mode": int,
-      }
-    ) =>
-    unit =
-    "";
-
-  [@bs.val] [@bs.module "fs"]
-  external symlinkSync: (string, string) => unit = "";
-};
-
 module Rimraf = {
   [@bs.val] [@bs.module "rimraf"] external sync: string => unit = "";
 };
@@ -82,6 +64,31 @@ let posts = {
   );
 };
 
+module MoreFs = {
+  type stat;
+  [@bs.val] [@bs.module "fs"] external lstatSync: string => stat = "";
+  [@bs.send] external isDirectory: stat => bool = "";
+
+  [@bs.val] [@bs.module "fs"]
+  external copyFileSync: (string, string) => unit = "";
+
+  [@bs.val] [@bs.module "fs"]
+  external mkdirSync:
+    (
+      string,
+      {
+        .
+        "recursive": bool,
+        "mode": int,
+      }
+    ) =>
+    unit =
+    "";
+
+  [@bs.val] [@bs.module "fs"]
+  external symlinkSync: (string, string) => unit = "";
+};
+
 module Router = {
   type t =
     | File(string, ReasonReact.reactElement)
@@ -95,7 +102,7 @@ module Router = {
         }
       | Dir(name, routes) => {
           let path_ = path ++ "/" ++ name;
-          Fs.mkdirSync(path_, {"recursive": true, "mode": 0o755});
+          MoreFs.mkdirSync(path_, {"recursive": true, "mode": 0o755});
           routes |> Array.iter(helper(path_));
         };
 
@@ -216,20 +223,9 @@ Router.(
   )
 );
 
-module MoreFs = {
-  type stat;
-  [@bs.val] [@bs.module "fs"] external lstatSync: string => stat = "";
-  [@bs.send] external isDirectory: stat => bool = "";
-
-  [@bs.val] [@bs.module "fs"]
-  external copyFileSync: (string, string) => unit = "";
-
-  [@bs.val] [@bs.module "fs"] external mkdirSync: string => unit = "";
-};
-
 let ignoreFiles = ["main.bc.js", "verifier_main.bc.js", ".DS_Store"];
 let rec copyFolder = path => {
-  MoreFs.mkdirSync("site/" ++ path);
+  MoreFs.mkdirSync("site/" ++ path, {"recursive": true, "mode": 0o755});
   Array.iter(
     s => {
       let path = Filename.concat(path, s);
@@ -265,4 +261,7 @@ Markdown.Child_process.execSync(
   Markdown.Child_process.option(),
 );
 
-Fs.symlinkSync(Node.Process.cwd() ++ "/graphql-docs", "./site/docs/graphql");
+MoreFs.symlinkSync(
+  Node.Process.cwd() ++ "/graphql-docs",
+  "./site/docs/graphql",
+);


### PR DESCRIPTION
Adds recursive to the directory creation in `copyFolder`. According to the [node docs](https://nodejs.org/api/fs.html#fs_fs_mkdir_path_options_callback), " Calling fs.mkdir() when path is a directory that exists results in an error only when recursive is false.".
Hopefully this fixes the crash but I don't seem to be able to repro it 100% reliably. Also cleans up the bindings in this file a little.
