### PR TITLE
make proposer not crash if validation fails

### DIFF
--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -343,7 +343,13 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                           (Protocol_state.hash previous_protocol_state)
                         |> Option.value_exn
                       in
-                      let transition =
+                      let error_msg_prefix = "Validation failed: " in
+                      let reason_for_failure =
+                        " One possible reason could be a ledger-catchup is \
+                         triggered before we produce a proof for the proposed \
+                         transition."
+                      in
+                      match
                         External_transition.Validation.wrap
                           { With_hash.hash= transition_hash
                           ; data=
@@ -359,99 +365,114 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                              `This_transition_was_not_received_via_gossip
                         |> Transition_frontier_validation
                            .validate_frontier_dependencies ~logger ~frontier
-                        |> Result.map_error ~f:(fun err ->
-                               let exn name =
-                                 Error.to_exn
-                                   (Error.of_string
+                      with
+                      | Error `Already_in_frontier ->
+                          Logger.error logger ~module_:__MODULE__
+                            ~location:__LOC__
+                            ~metadata:
+                              [ ( "protocol_state"
+                                , Protocol_state.value_to_yojson protocol_state
+                                ) ]
+                            "%sproposed transition is already in frontier"
+                            error_msg_prefix ;
+                          return ()
+                      | Error `Not_selected_over_frontier_root ->
+                          Logger.warn logger ~module_:__MODULE__
+                            ~location:__LOC__
+                            "%sproposed transition is not selected over the \
+                             root of transition frontier.%s"
+                            error_msg_prefix reason_for_failure ;
+                          return ()
+                      | Error `Parent_missing_from_frontier ->
+                          Logger.warn logger ~module_:__MODULE__
+                            ~location:__LOC__
+                            "%sparent of proposed transition is missing from \
+                             the frontier.%s"
+                            error_msg_prefix reason_for_failure ;
+                          return ()
+                      | Ok transition -> (
+                          let%bind breadcrumb_result =
+                            Breadcrumb.build ~logger ~verifier ~trust_system
+                              ~parent:crumb ~transition ~sender:None
+                          in
+                          let breadcrumb =
+                            Result.map_error breadcrumb_result ~f:(fun err ->
+                                let exn name =
+                                  Error.to_exn
+                                    (Error.of_string
+                                       (sprintf
+                                          "Error building breadcrumb from \
+                                           proposed transition: %s"
+                                          name))
+                                in
+                                match err with
+                                | `Fatal_error e ->
+                                    exn
+                                      (sprintf "fatal error -- %s"
+                                         (Exn.to_string e))
+                                | `Invalid_staged_ledger_diff e ->
+                                    exn
                                       (sprintf
-                                         "Error validating proposed \
-                                          transition frontier dependencies: %s"
-                                         name))
-                               in
-                               match err with
-                               | `Already_in_frontier ->
-                                   exn "already in frontier"
-                               | `Not_selected_over_frontier_root ->
-                                   exn "not selected over frontier root"
-                               | `Parent_missing_from_frontier ->
-                                   exn "parent missing from frontier" )
-                        |> Result.ok_exn
-                      in
-                      let%bind breadcrumb_result =
-                        Breadcrumb.build ~logger ~verifier ~trust_system
-                          ~parent:crumb ~transition ~sender:None
-                      in
-                      let breadcrumb =
-                        Result.map_error breadcrumb_result ~f:(fun err ->
-                            let exn name =
-                              Error.to_exn
-                                (Error.of_string
-                                   (sprintf
-                                      "Error building breadcrumb from \
-                                       proposed transition: %s"
-                                      name))
-                            in
-                            match err with
-                            | `Fatal_error e ->
-                                exn
-                                  (sprintf "fatal error -- %s"
-                                     (Exn.to_string e))
-                            | `Invalid_staged_ledger_diff e ->
-                                exn
-                                  (sprintf "invalid staged ledger diff -- %s"
-                                     (Error.to_string_hum e))
-                            | `Invalid_staged_ledger_hash e ->
-                                exn
-                                  (sprintf "invalid staged ledger hash -- %s"
-                                     (Error.to_string_hum e)) )
-                        |> Result.ok_exn
-                      in
-                      let metadata =
-                        [("state_hash", State_hash.to_yojson transition_hash)]
-                      in
-                      Logger.info logger ~module_:__MODULE__ ~location:__LOC__
-                        !"Submitting newly produced block $state_hash to the \
-                          transition frontier controller"
-                        ~metadata ;
-                      Coda_metrics.(Counter.inc_one Proposer.blocks_proposed) ;
-                      let%bind () =
-                        Strict_pipe.Writer.write transition_writer breadcrumb
-                      in
-                      Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-                        ~metadata
-                        "Waiting for transition $state_hash to be inserted \
-                         into frontier" ;
-                      Deferred.choose
-                        [ Deferred.choice
-                            (Transition_frontier.wait_for_transition frontier
-                               transition_hash)
-                            (Fn.const `Transition_accepted)
-                        ; Deferred.choice
-                            ( Time.Timeout.create time_controller
-                                (* We allow up to 15 seconds for the transition to make its way from the transition_writer to the frontier.
+                                         "invalid staged ledger diff -- %s"
+                                         (Error.to_string_hum e))
+                                | `Invalid_staged_ledger_hash e ->
+                                    exn
+                                      (sprintf
+                                         "invalid staged ledger hash -- %s"
+                                         (Error.to_string_hum e)) )
+                            |> Result.ok_exn
+                          in
+                          let metadata =
+                            [ ( "state_hash"
+                              , State_hash.to_yojson transition_hash ) ]
+                          in
+                          Logger.info logger ~module_:__MODULE__
+                            ~location:__LOC__
+                            !"Submitting newly produced block $state_hash to \
+                              the transition frontier controller"
+                            ~metadata ;
+                          Coda_metrics.(
+                            Counter.inc_one Proposer.blocks_proposed) ;
+                          let%bind () =
+                            Strict_pipe.Writer.write transition_writer
+                              breadcrumb
+                          in
+                          Logger.debug logger ~module_:__MODULE__
+                            ~location:__LOC__ ~metadata
+                            "Waiting for transition $state_hash to be \
+                             inserted into frontier" ;
+                          Deferred.choose
+                            [ Deferred.choice
+                                (Transition_frontier.wait_for_transition
+                                   frontier transition_hash)
+                                (Fn.const `Transition_accepted)
+                            ; Deferred.choice
+                                ( Time.Timeout.create time_controller
+                                    (* We allow up to 15 seconds for the transition to make its way from the transition_writer to the frontier.
                                   This value is chosen to be reasonably generous. In theory, this should not take terribly long. But long
                                   cycles do happen in our system, and with medium curves those long cycles can be substantial. *)
-                                (Time.Span.of_ms 20000L)
-                                ~f:(Fn.const ())
-                            |> Time.Timeout.to_deferred )
-                            (Fn.const `Timed_out) ]
-                      >>| function
-                      | `Transition_accepted ->
-                          Logger.info logger ~module_:__MODULE__
-                            ~location:__LOC__ ~metadata
-                            "Generated transition $state_hash was accepted \
-                             into transition frontier"
-                      | `Timed_out ->
-                          let str =
-                            "Timed out waiting for generated transition \
-                             $state_hash to enter transition frontier. \
-                             Continuing to produce new blocks anyway. This \
-                             may mean your CPU is overloaded. Consider \
-                             disabling `-run-snark-worker` if it's configured."
-                          in
-                          (* FIXME #3167: this should be fatal, and more importantly, shouldn't happen. *)
-                          Logger.error logger ~module_:__MODULE__
-                            ~location:__LOC__ ~metadata "%s" str )) )
+                                    (Time.Span.of_ms 20000L)
+                                    ~f:(Fn.const ())
+                                |> Time.Timeout.to_deferred )
+                                (Fn.const `Timed_out) ]
+                          >>| function
+                          | `Transition_accepted ->
+                              Logger.info logger ~module_:__MODULE__
+                                ~location:__LOC__ ~metadata
+                                "Generated transition $state_hash was \
+                                 accepted into transition frontier"
+                          | `Timed_out ->
+                              let str =
+                                "Timed out waiting for generated transition \
+                                 $state_hash to enter transition frontier. \
+                                 Continuing to produce new blocks anyway. \
+                                 This may mean your CPU is overloaded. \
+                                 Consider disabling `-run-snark-worker` if \
+                                 it's configured."
+                              in
+                              (* FIXME #3167: this should be fatal, and more importantly, shouldn't happen. *)
+                              Logger.error logger ~module_:__MODULE__
+                                ~location:__LOC__ ~metadata "%s" str ) )) )
       in
       let proposal_supervisor = Singleton_supervisor.create ~task:propose in
       let scheduler = Singleton_scheduler.create time_controller in


### PR DESCRIPTION
This PR didn't get into the release-beta2, so I move it to `develop` instead.

The following scenario happened once in the testnet:

proposer comes online, doing bootstrap
bootstrap finishes but catchup is not done yet, the proposer happened to propose at that point
proposer is stuck by doing proof; meanwhile ledger-catchup finishes and updated the transition frontier and, unfortunately, the parent of the proposed transition is dropped.
proposer finally finishes the proof and start doing the validation, but it finds the parent is no longer in the transition frontier.
A crash happens.
I changed the proposer code so that validation failure won't cause crashes, instead we just print some error messages that tells user what happened.
