### PR TITLE
Lookup all peer addresses

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -403,7 +403,7 @@ let daemon logger =
                      ~metadata:[("host", `String host)] ;
                    None )
          in
-         (* flatten lists of lists of host-and-ports *)
+         (* flatten list of lists of host-and-ports *)
          let initial_peers_cleaned = List.concat initial_peers_cleaned_lists in
          let%bind () =
            if

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -376,29 +376,35 @@ let daemon logger =
          in
          let discovery_port = external_port + 1 in
          if enable_tracing then Coda_tracing.start conf_dir |> don't_wait_for ;
-         let%bind initial_peers_cleaned =
+         let%bind initial_peers_cleaned_lists =
+           (* for each provided peer, lookup all its addresses *)
            Deferred.List.filter_map ~how:(`Max_concurrent_jobs 8)
              initial_peers_raw ~f:(fun addr ->
                let host = Host_and_port.host addr in
-               match%bind
+               match%map
                  Monitor.try_with_or_error (fun () ->
-                     Unix.Inet_addr.of_string_or_getbyname host )
+                     Async.Unix.Host.getbyname_exn host )
                with
-               | Ok inet_addr ->
-                   return
-                   @@ Some
-                        (Host_and_port.create
-                           ~host:(Unix.Inet_addr.to_string inet_addr)
-                           ~port:(Host_and_port.port addr))
+               | Ok unix_host ->
+                   (* assume addresses is nonempty *)
+                   let addresses = Array.to_list unix_host.addresses in
+                   let port = Host_and_port.port addr in
+                   Some
+                     (List.map addresses ~f:(fun inet_addr ->
+                          Host_and_port.create
+                            ~host:(Unix.Inet_addr.to_string inet_addr)
+                            ~port ))
                | Error e ->
                    Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
-                     "Error on getaddr: $error"
+                     "Error on getbyname: $error"
                      ~metadata:[("error", `String (Error.to_string_mach e))] ;
                    Logger.error logger ~module_:__MODULE__ ~location:__LOC__
-                     "Failed to get address for host $host, skipping"
+                     "Failed to get addresses for host $host, skipping"
                      ~metadata:[("host", `String host)] ;
-                   return None )
+                   None )
          in
+         (* flatten lists of lists of host-and-ports *)
+         let initial_peers_cleaned = List.concat initial_peers_cleaned_lists in
          let%bind () =
            if
              List.length initial_peers_raw <> 0


### PR DESCRIPTION
We were looking up a single address of type `Inet_addr.t` for peers passed to the daemon.

Instead, we use `Unix.Host.getbyname` to get an array of addresses for each peer. Often, that's just one address, but might help in some cases.

Closes #3156.
