### PR TITLE
Update parameters for new staking testnet release

### DIFF
--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,11 +1,16 @@
 [%%define ledger_depth 11]
 [%%import "config/curve/medium.mlh"]
 [%%import "config/coinbase/standard.mlh"]
-[%%import "config/consensus/postake_medium_curve.mlh"]
 [%%import "config/scan_state/point1tps.mlh"]
 [%%import "config/debug_level/some.mlh"]
 [%%import "config/proof_level/full.mlh"]
 [%%import "config/txpool_size.mlh"]
+
+(* custom consensus parameters for the testnet release *)
+[%%define consensus_mechanism "proof_of_stake"]
+[%%define k 5]
+[%%define c 8]
+[%%define delta 2]
 
 [%%define time_offsets false]
 [%%define cache_exceptions false]
@@ -14,7 +19,7 @@
 [%%define genesis_ledger "testnet_postake"]
 
 [%%define genesis_state_timestamp "2019-08-09 12:00:00-07:00"]
-[%%define block_window_duration 300000]
+[%%define block_window_duration 360000]
 
 [%%define integration_tests false]
 [%%define force_updates false]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -8,7 +8,7 @@
 
 (* custom consensus parameters for the testnet release *)
 [%%define consensus_mechanism "proof_of_stake"]
-[%%define k 5]
+[%%define k 10]
 [%%define c 8]
 [%%define delta 2]
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -793,7 +793,7 @@ module Data = struct
       open Bignum_bigint
 
       (* TEMPORARY HACK FOR TESTNETS: c should be 1 (or possibly 2) otherwise *)
-      let c = `Two_to_the 0
+      let c = `Two_to_the 1
 
       let base = Bignum.(one / of_int 2)
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -793,7 +793,7 @@ module Data = struct
       open Bignum_bigint
 
       (* TEMPORARY HACK FOR TESTNETS: c should be 1 (or possibly 2) otherwise *)
-      let c = `Two_to_the 1
+      let c = `Two_to_the 0
 
       let base = Bignum.(one / of_int 2)
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -793,7 +793,7 @@ module Data = struct
       open Bignum_bigint
 
       (* TEMPORARY HACK FOR TESTNETS: c should be 1 (or possibly 2) otherwise *)
-      let c = `Two_to_the 2
+      let c = `Two_to_the 1
 
       let base = Bignum.(one / of_int 2)
 


### PR DESCRIPTION
The following changes were made in order to decrease the probability of a fork happening during the staking testnet:

- 2x artifical inflation on VRF threshold was removed
- `k` was increased to 10 from 3
- `block_window_duration` was increased to 6min from 5min

The artificial 2x inflation on the VRF threshold (which gives all proposers a 2x chance to win a slot) was contributing the the probability of the network forking with a low k value. This was further increased by having a small window of time in between the block proving time and the total slot time. The main effect (at least, as the running theory goes) is that if two proposers keep on winning blocks in a row, but don't process blocks from the other proposers before starting on their next block, they will fork the network if they continue in this state for `k` blocks. Therefore, `block_window_duration` was also bumped some, as this will only get worse when we start letting people produce blocks on smaller machines. 