### PR TITLE
HACK: non-fatal proposer timeout

### DIFF
--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -422,7 +422,7 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                                 (* We allow up to 15 seconds for the transition to make its way from the transition_writer to the frontier.
                                   This value is chosen to be reasonably generous. In theory, this should not take terribly long. But long
                                   cycles do happen in our system, and with medium curves those long cycles can be substantial. *)
-                                (Time.Span.of_ms 15000L)
+                                (Time.Span.of_ms 20000L)
                                 ~f:(Fn.const ())
                             |> Time.Timeout.to_deferred )
                             (Fn.const `Timed_out) ]
@@ -434,12 +434,15 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                              into transition frontier"
                       | `Timed_out ->
                           let str =
-                            "Generated transition $state_hash was never \
-                             accepted into transition frontier"
+                            "Timed out waiting for generated transition \
+                             $state_hash to enter transition frontier. \
+                             Continuing to produce new blocks anyway. This \
+                             may mean your CPU is overloaded. Consider \
+                             disabling `-run-snark-worker` if it's configured."
                           in
-                          Logger.fatal logger ~module_:__MODULE__
-                            ~location:__LOC__ ~metadata "%s" str ;
-                          Error.raise (Error.of_string str) )) )
+                          (* FIXME #3167: this should be fatal, and more importantly, shouldn't happen. *)
+                          Logger.error logger ~module_:__MODULE__
+                            ~location:__LOC__ ~metadata "%s" str )) )
       in
       let proposal_supervisor = Singleton_supervisor.create ~task:propose in
       let scheduler = Singleton_scheduler.create time_controller in


### PR DESCRIPTION
Closes #3160

We're seeing large (largest I saw so far was ~17s, @ghost-not-in-the-shell has seen more) async cycles causing this timeout to trigger. I turned it up, so hopefully it won't happen as often on decent CPUs, but also remove the exception. If the timeout fires, we aren't guaranteed to make our next proposal on top of our own block, even if it ended up displacing the best tip. I think this actually can break Ouroboros, and is insecure, but shouldn't be prone to accidental forks with the reasonable k that @nholland94 is adding. I think. We should disable this at some point, which I've created #3167 to track.