### PR TITLE
Can query all blocks in database via blocks graphql command

### DIFF
--- a/src/lib/auxiliary_database/external_transition_database.ml
+++ b/src/lib/auxiliary_database/external_transition_database.ml
@@ -53,7 +53,7 @@ let create ~logger directory =
   let pagination = Pagination.create () in
   List.iter (Database.to_alist database) ~f:(fun (hash, (block_data, time)) ->
       add_user_blocks pagination ({With_hash.hash; data= block_data}, time) ) ;
-  {database; pagination= Pagination.create (); logger}
+  {database; pagination; logger}
 
 let add {database; pagination; logger}
     ( {With_hash.hash= state_hash; data= filtered_external_transition} as
@@ -73,6 +73,8 @@ let add {database; pagination; logger}
 let get_total_values {pagination; _} = Pagination.get_total_values pagination
 
 let get_values {pagination; _} = Pagination.get_values pagination
+
+let get_all_values {pagination; _} = Pagination.get_all_values pagination
 
 let get_earlier_values {pagination; _} =
   Pagination.get_earlier_values pagination

--- a/src/lib/auxiliary_database/intf.ml
+++ b/src/lib/auxiliary_database/intf.ml
@@ -15,6 +15,9 @@ module type Pagination = sig
       participant. *)
   val get_values : t -> Public_key.Compressed.t -> value list
 
+  (** [get_all_values t] queries all the values that are in the database  *)
+  val get_all_values : t -> value list
+
   (** [get_earlier_values t pk cursor n] queries [n] values (or all if n is
       None) involving peer, [pk], added before the value corresponding to
       [cursor] (exclusively) if [cursor] is non-null. Otherwise, it queries the
@@ -22,7 +25,6 @@ module type Pagination = sig
       before the earliest value in the query. It also indicates any values that
       occurred after [cursor]. It outputs an empty list of values if there are
       no values related to [pk] in the database *)
-
   val get_earlier_values :
        t
     -> Public_key.Compressed.t

--- a/src/lib/auxiliary_database/pagination.ml
+++ b/src/lib/auxiliary_database/pagination.ml
@@ -55,6 +55,9 @@ struct
           ~data:(Set.add user_cursors (cursor, date)) ) ;
     Hashtbl.set pagination.all_values ~key:cursor ~data:(date, value)
 
+  let get_all_values {all_values; _} =
+    List.map (Hashtbl.data all_values) ~f:(fun (_, value) -> value)
+
   let get_total_values {user_cursors; _} public_key =
     let open Option.Let_syntax in
     let%map cursor_with_dates = Hashtbl.find user_cursors public_key in

--- a/src/lib/auxiliary_database/transaction_database.ml
+++ b/src/lib/auxiliary_database/transaction_database.ml
@@ -51,6 +51,8 @@ struct
 
   let get_values {pagination; _} = Pagination.get_values pagination
 
+  let get_all_values {pagination; _} = Pagination.get_all_values pagination
+
   let get_earlier_values {pagination; _} =
     Pagination.get_earlier_values pagination
 


### PR DESCRIPTION
Quick fix to query all the blocks that a node has.

So in order to record all seen blocks, run the following command while running the daemon:

```
src/_build/default/app/cli/src/coda.exe daemon -rest 8080
```

Then, you can query the blocks via:
```
{
  blocks(first:3) {
    nodes {
      stateHash
    }
    pageInfo
    { lastCursor}
  }
}
```

As a result, you will get the following:

```
{
  "data": {
    "blocks": {
      "nodes": [
        {
          "stateHash": "TWog8UE3YdZHKcqJ9xKnQk4yAVpGNxNYjwbFi3CrE8TCrSpHynzjscsVAzHFvN8q"
        },
        {
          "stateHash": "TWogv1wpfnwWK91xa1JjncRWCQxUEiH28Bb3XcfHYYvWFEoMtEAQA7VPXB6YED7x"
        },
        {
          "stateHash": "TWoftHQ2GXDM8v1Ufqp8BcJmhYgDn3BckVMu3NeUrtytRowacKzCWv6J9VoG8UPx"
        }
      ],
      "pageInfo": {
        "lastCursor": "TWoftHQ2GXDM8v1Ufqp8BcJmhYgDn3BckVMu3NeUrtytRowacKzCWv6J9VoG8UPx"
      }
    }
  }
}
```