### PR TITLE
Snark worker will start after setting up server

### DIFF
--- a/src/app/cli/src/client.ml
+++ b/src/app/cli/src/client.ml
@@ -16,8 +16,9 @@ let dispatch rpc query port =
       | Error exn ->
           return
             (Or_error.errorf
-               !"Error connecting to the daemon on port %d: %s"
-               port (Exn.to_string exn))
+               !"Error connecting to the daemon on port %d using the RPC \
+                 call, %s,: %s"
+               port (Rpc.Rpc.name rpc) (Exn.to_string exn))
       | Ok conn ->
           Rpc.Rpc.dispatch rpc conn query )
 

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -596,11 +596,12 @@ let daemon logger =
        in
        coda_ref := Some coda ;
        let%bind () = maybe_sleep 3. in
-       Coda_lib.start coda ;
        let web_service = Web_pipe.get_service () in
        Web_pipe.run_service coda web_service ~conf_dir ~logger ;
        Coda_run.setup_local_server ?client_whitelist ~rest_server_port
          ~insecure_rest_server coda ;
+       Coda_lib.start_proposer coda ;
+       Coda_lib.start_snark_worker coda ;
        let%bind () =
          Option.map metrics_server_port ~f:(fun port ->
              Coda_metrics.server ~port ~logger >>| ignore )

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -600,8 +600,7 @@ let daemon logger =
        Web_pipe.run_service coda web_service ~conf_dir ~logger ;
        Coda_run.setup_local_server ?client_whitelist ~rest_server_port
          ~insecure_rest_server coda ;
-       Coda_lib.start_proposer coda ;
-       Coda_lib.start_snark_worker coda ;
+       let%bind () = Coda_lib.start coda in
        let%bind () =
          Option.map metrics_server_port ~f:(fun port ->
              Coda_metrics.server ~port ~logger >>| ignore )

--- a/src/app/cli/src/coda_process.ml
+++ b/src/app/cli/src/coda_process.ml
@@ -52,11 +52,6 @@ let local_config ?proposal_interval:_ ~peers ~addrs_and_ports ~acceptable_delay
   in
   config
 
-let disconnect (conn, proc, _) =
-  let%bind () = Coda_worker.Connection.close conn in
-  let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
-  ()
-
 let peers_exn (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.peers ~arg:()
 
@@ -146,3 +141,10 @@ let best_path (conn, _proc, _) =
 let replace_snark_worker_key (conn, _proc, _) key =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.replace_snark_worker_key ~arg:key
+
+let disconnect ((conn, proc, _) as t) =
+  let%bind () = Coda_worker.Connection.close conn in
+  (* This kills any strangling snark worker processes *)
+  let%bind () = replace_snark_worker_key t None in
+  let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
+  ()

--- a/src/app/cli/src/coda_process.ml
+++ b/src/app/cli/src/coda_process.ml
@@ -143,8 +143,8 @@ let replace_snark_worker_key (conn, _proc, _) key =
     ~f:Coda_worker.functions.replace_snark_worker_key ~arg:key
 
 let disconnect ((conn, proc, _) as t) =
+  let%bind () = replace_snark_worker_key t None in
   let%bind () = Coda_worker.Connection.close conn in
   (* This kills any strangling snark worker processes *)
-  let%bind () = replace_snark_worker_key t None in
   let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
   ()

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -509,11 +509,7 @@ module T = struct
           Logger.info logger "Worker finish setting up coda"
             ~module_:__MODULE__ ~location:__LOC__ ;
           let coda_peers () = return (Coda_lib.peers coda) in
-          let coda_start () =
-            return
-              ( Coda_lib.start_proposer coda ;
-                Coda_lib.start_snark_worker coda )
-          in
+          let coda_start () = Coda_lib.start coda in
           let coda_get_all_transitions pk =
             let external_transition_database =
               Coda_lib.external_transition_database coda
@@ -581,7 +577,7 @@ module T = struct
                   e ()
           in
           let coda_replace_snark_worker_key =
-            Fn.compose Deferred.return (Coda_lib.replace_snark_worker_key coda)
+            Coda_lib.replace_snark_worker_key coda
           in
           let coda_new_block key =
             Deferred.return @@ Coda_commands.Subscriptions.new_block coda key

--- a/src/app/cli/src/coda_worker.ml
+++ b/src/app/cli/src/coda_worker.ml
@@ -509,7 +509,11 @@ module T = struct
           Logger.info logger "Worker finish setting up coda"
             ~module_:__MODULE__ ~location:__LOC__ ;
           let coda_peers () = return (Coda_lib.peers coda) in
-          let coda_start () = return (Coda_lib.start coda) in
+          let coda_start () =
+            return
+              ( Coda_lib.start_proposer coda ;
+                Coda_lib.start_snark_worker coda )
+          in
           let coda_get_all_transitions pk =
             let external_transition_database =
               Coda_lib.external_transition_database coda

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -215,8 +215,7 @@ let run_test () : unit Deferred.t =
               (sprintf !"Invalid Account: %{sexp: Public_key.Compressed.t}" pk)
       in
       Coda_run.setup_local_server coda ;
-      Coda_lib.start_proposer coda ;
-      Coda_lib.start_snark_worker coda ;
+      let%bind () = Coda_lib.start coda in
       (* Let the system settle *)
       let%bind () = Async.after (Time.Span.of_ms 100.) in
       (* No proof emitted by the parallel scan at the begining *)

--- a/src/app/cli/src/full_test.ml
+++ b/src/app/cli/src/full_test.ml
@@ -172,7 +172,6 @@ let run_test () : unit Deferred.t =
              ~consensus_local_state ~transaction_database
              ~external_transition_database ~work_reassignment_wait:420000 ())
       in
-      Coda_lib.start coda ;
       don't_wait_for
         (Strict_pipe.Reader.iter_without_pushback
            (Coda_lib.validated_transitions coda)
@@ -216,6 +215,8 @@ let run_test () : unit Deferred.t =
               (sprintf !"Invalid Account: %{sexp: Public_key.Compressed.t}" pk)
       in
       Coda_run.setup_local_server coda ;
+      Coda_lib.start_proposer coda ;
+      Coda_lib.start_snark_worker coda ;
       (* Let the system settle *)
       let%bind () = Async.after (Time.Span.of_ms 100.) in
       (* No proof emitted by the parallel scan at the begining *)

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -383,7 +383,7 @@ let request_work t =
   if List.is_empty instances then None
   else Some {Snark_work_lib.Work.Spec.instances; fee}
 
-let start t =
+let start_proposer t =
   Proposer.run ~logger:t.config.logger ~verifier:t.processes.verifier
     ~prover:t.processes.prover ~trust_system:t.config.trust_system
     ~transaction_resource_pool:
@@ -396,6 +396,19 @@ let start t =
     ~consensus_local_state:t.config.consensus_local_state
     ~frontier_reader:t.components.transition_frontier
     ~transition_writer:t.pipes.proposer_transition_writer
+
+let start_snark_worker t =
+  match t.config.snark_worker_config.initial_snark_worker_key with
+  | Some _ ->
+      Logger.debug t.config.logger
+        !"Starting snark worker process"
+        ~module_:__MODULE__ ~location:__LOC__ ;
+      ignore @@ Lazy.force t.processes.snark_worker
+  | None ->
+      Logger.debug t.config.logger
+        !"Not starting snark worker process since initial snark_worker_key is \
+          set to none"
+        ~module_:__MODULE__ ~location:__LOC__
 
 let create_genesis_frontier (config : Config.t) ~verifier =
   let consensus_local_state = config.consensus_local_state in

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -84,7 +84,7 @@ let propose_public_keys t : Public_key.Compressed.Set.t =
 let replace_propose_keypairs t kps = Agent.update t.propose_keypairs kps
 
 module Snark_worker = struct
-  let run_process ~logger ?(shutdown_on_disconnect = true) client_port =
+  let run_process ~logger client_port =
     let%map snark_worker_process =
       let our_binary = Sys.executable_name in
       Process.create_exn () ~prog:our_binary
@@ -93,7 +93,7 @@ module Snark_worker = struct
           :: Snark_worker.arguments
                ~daemon_address:
                  (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
-               ~shutdown_on_disconnect )
+               ~shutdown_on_disconnect:false )
     in
     don't_wait_for
       ( match%bind Process.wait snark_worker_process with

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -23,10 +23,13 @@ exception Snark_worker_signal_interrupt of Signal.t
    this lazy value will run the snark worker process. A snark work is
    assigned to a public key. This public key can change throughout the entire time
    the daemon is running *)
-type snark_worker = Public_key.Compressed.t option ref Lazy.t
+type snark_worker =
+  {public_key: Public_key.Compressed.t; process: Process.t Ivar.t}
 
 type processes =
-  {prover: Prover.t; verifier: Verifier.t; snark_worker: snark_worker}
+  { prover: Prover.t
+  ; verifier: Verifier.t
+  ; mutable snark_worker: snark_worker option }
 
 type components =
   { net: Coda_networking.t
@@ -80,58 +83,133 @@ let propose_public_keys t : Public_key.Compressed.Set.t =
 
 let replace_propose_keypairs t kps = Agent.update t.propose_keypairs kps
 
-let create_snark_worker ~logger ?(shutdown_on_disconnect = true) client_port =
-  let%bind p =
-    let our_binary = Sys.executable_name in
-    Process.create_exn () ~prog:our_binary
-      ~args:
-        ( "internal" :: Snark_worker.Intf.command_name
-        :: Snark_worker.arguments
-             ~daemon_address:
-               (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
-             ~shutdown_on_disconnect )
-  in
-  don't_wait_for
-    ( match%bind Process.wait p with
-    | Ok () ->
-        Logger.info logger
-          "Snark worker process died normally, so the daemon will die as well"
+module Snark_worker = struct
+  let run_process ~logger ?(shutdown_on_disconnect = true) client_port =
+    let%map snark_worker_process =
+      let our_binary = Sys.executable_name in
+      Process.create_exn () ~prog:our_binary
+        ~args:
+          ( "internal" :: Snark_worker.Intf.command_name
+          :: Snark_worker.arguments
+               ~daemon_address:
+                 (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
+               ~shutdown_on_disconnect )
+    in
+    don't_wait_for
+      ( match%bind Process.wait snark_worker_process with
+      | Ok () ->
+          Logger.info logger "Snark worker process died" ~module_:__MODULE__
+            ~location:__LOC__ ;
+          Deferred.unit
+      | Error (`Exit_non_zero non_zero_error) ->
+          Logger.fatal logger
+            !"Snark worker process died with a nonzero error %i"
+            non_zero_error ~module_:__MODULE__ ~location:__LOC__ ;
+          raise (Snark_worker_error non_zero_error)
+      | Error (`Signal signal) when Signal.equal signal Signal.term -> (
+          Logger.info logger
+            !"Snark worker received term signal. Expecting it to fully \
+              terminate"
+            ~module_:__MODULE__ ~location:__LOC__ ;
+          match%bind Process.wait snark_worker_process with
+          | Ok () ->
+              Logger.info logger
+                !"Snark worker process fully died after receiving term signal."
+                ~module_:__MODULE__ ~location:__LOC__ ;
+              Deferred.unit
+          | Error error -> (
+              Logger.info logger
+                !"Snark worker process died unexpectedly after getting the \
+                  term signal. Aborting the daemon"
+                ~module_:__MODULE__ ~location:__LOC__ ;
+              match error with
+              | `Exit_non_zero non_zero_error ->
+                  raise (Snark_worker_error non_zero_error)
+              | `Signal signal ->
+                  raise (Snark_worker_signal_interrupt signal) ) )
+      | Error (`Signal signal) ->
+          Logger.info logger
+            !"Snark worker died with signal %{sexp:Signal.t}. Aborting daemon"
+            signal ~module_:__MODULE__ ~location:__LOC__ ;
+          raise (Snark_worker_signal_interrupt signal) ) ;
+    Logger.trace logger
+      !"Created snark worker with pid: %i"
+      ~module_:__MODULE__ ~location:__LOC__
+      (Pid.to_int @@ Process.pid snark_worker_process) ;
+    (* We want these to be printfs so we don't double encode our logs here *)
+    Pipe.iter_without_pushback
+      (Async.Reader.pipe (Process.stdout snark_worker_process))
+      ~f:(fun s -> printf "%s" s)
+    |> don't_wait_for ;
+    Pipe.iter_without_pushback
+      (Async.Reader.pipe (Process.stderr snark_worker_process))
+      ~f:(fun s -> printf "%s" s)
+    |> don't_wait_for ;
+    snark_worker_process
+
+  let start t =
+    match t.processes.snark_worker with
+    | Some {process= process_ivar; _} ->
+        Logger.debug t.config.logger
+          !"Starting snark worker process"
           ~module_:__MODULE__ ~location:__LOC__ ;
-        exit 0
-    | Error (`Exit_non_zero non_zero_error) ->
-        Logger.fatal logger
-          !"Snark worker process died with a nonzero error %i"
-          non_zero_error ~module_:__MODULE__ ~location:__LOC__ ;
-        raise (Snark_worker_error non_zero_error)
-    | Error (`Signal signal) ->
+        let%map snark_worker_process =
+          run_process ~logger:t.config.logger
+            t.config.net_config.gossip_net_params.addrs_and_ports.client_port
+        in
+        Ivar.fill process_ivar snark_worker_process
+    | None ->
+        Logger.info t.config.logger
+          !"Attempted to turn on snark worker, but snark worker key is set to \
+            none"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        Deferred.unit
+
+  let stop t =
+    match t.processes.snark_worker with
+    | Some {public_key= _; process} ->
+        Logger.info t.config.logger "Killing snark worker" ~module_:__MODULE__
+          ~location:__LOC__ ;
+        let%map process = Ivar.read process in
+        Signal.send_exn Signal.term (`Pid (Process.pid process))
+    | None ->
+        Logger.warn t.config.logger
+          "Attempted to turn off snark worker, but no snark worker was running"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        Deferred.unit
+
+  let get_key {processes= {snark_worker; _}; _} =
+    Option.map snark_worker ~f:(fun {public_key; _} -> public_key)
+
+  let replace_key ({processes= {snark_worker; _}; config= {logger; _}; _} as t)
+      new_key =
+    match (snark_worker, new_key) with
+    | None, None ->
         Logger.info logger
-          !"Snark worker died with signal %{sexp:Signal.t}. Aborting daemon"
-          signal ~module_:__MODULE__ ~location:__LOC__ ;
-        raise (Snark_worker_signal_interrupt signal) ) ;
-  Logger.trace logger
-    !"Created snark worker with pid: %i"
-    ~module_:__MODULE__ ~location:__LOC__
-    (Pid.to_int @@ Process.pid p) ;
-  (* We want these to be printfs so we don't double encode our logs here *)
-  Pipe.iter_without_pushback
-    (Async.Reader.pipe (Process.stdout p))
-    ~f:(fun s -> printf "%s" s)
-  |> don't_wait_for ;
-  Pipe.iter_without_pushback
-    (Async.Reader.pipe (Process.stderr p))
-    ~f:(fun s -> printf "%s" s)
-  |> don't_wait_for ;
-  Deferred.unit
+          "Snark work is still not happening since keys snark worker keys are \
+           still set to None"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        Deferred.unit
+    | None, Some new_key ->
+        let process = Ivar.create () in
+        t.processes.snark_worker <- Some {public_key= new_key; process} ;
+        start t
+    | Some {public_key= _; process}, Some new_key ->
+        Logger.debug logger
+          !"Changing snark worker key from $old to $new"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        t.processes.snark_worker <- Some {public_key= new_key; process} ;
+        Deferred.unit
+    | Some _, None ->
+        let%map () = stop t in
+        t.processes.snark_worker <- None
+end
 
-let snark_worker_key {processes; _} =
-  if Lazy.is_val processes.snark_worker then
-    !(Lazy.force processes.snark_worker)
-  else None
+let replace_snark_worker_key = Snark_worker.replace_key
 
-let replace_snark_worker_key {processes; _} new_key =
-  if Option.is_some new_key || Lazy.is_val processes.snark_worker then
-    Lazy.force processes.snark_worker := new_key
-  else ()
+let snark_worker_key = Snark_worker.get_key
+
+let stop_snark_worker = Snark_worker.stop
 
 let best_tip_opt t =
   let open Option.Let_syntax in
@@ -383,7 +461,7 @@ let request_work t =
   if List.is_empty instances then None
   else Some {Snark_work_lib.Work.Spec.instances; fee}
 
-let start_proposer t =
+let start t =
   Proposer.run ~logger:t.config.logger ~verifier:t.processes.verifier
     ~prover:t.processes.prover ~trust_system:t.config.trust_system
     ~transaction_resource_pool:
@@ -395,20 +473,8 @@ let start_proposer t =
     ~keypairs:(Agent.read_only t.propose_keypairs)
     ~consensus_local_state:t.config.consensus_local_state
     ~frontier_reader:t.components.transition_frontier
-    ~transition_writer:t.pipes.proposer_transition_writer
-
-let start_snark_worker t =
-  match t.config.snark_worker_config.initial_snark_worker_key with
-  | Some _ ->
-      Logger.debug t.config.logger
-        !"Starting snark worker process"
-        ~module_:__MODULE__ ~location:__LOC__ ;
-      ignore @@ Lazy.force t.processes.snark_worker
-  | None ->
-      Logger.debug t.config.logger
-        !"Not starting snark worker process since initial snark_worker_key is \
-          set to none"
-        ~module_:__MODULE__ ~location:__LOC__
+    ~transition_writer:t.pipes.proposer_transition_writer ;
+  Snark_worker.start t
 
 let create_genesis_frontier (config : Config.t) ~verifier =
   let consensus_local_state = config.consensus_local_state in
@@ -494,17 +560,9 @@ let create (config : Config.t) =
           let%bind prover = Prover.create () in
           let%bind verifier = Verifier.create () in
           let snark_worker =
-            Lazy.from_fun
-            @@ fun () ->
-            let {Kademlia.Node_addrs_and_ports.client_port; _} =
-              config.net_config.gossip_net_params.addrs_and_ports
-            in
-            create_snark_worker ~logger:config.logger client_port
-            |> don't_wait_for ;
-            ref config.snark_worker_config.initial_snark_worker_key
+            Option.map config.snark_worker_config.initial_snark_worker_key
+              ~f:(fun public_key -> {public_key; process= Ivar.create ()})
           in
-          Option.iter config.snark_worker_config.initial_snark_worker_key
-            ~f:(fun _key -> ignore @@ Lazy.force snark_worker) ;
           let external_transitions_reader, external_transitions_writer =
             Strict_pipe.create Synchronous
           in

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -80,7 +80,9 @@ val external_transition_database :
 
 val snark_pool : t -> Network_pool.Snark_pool.t
 
-val start : t -> unit
+val start_proposer : t -> unit
+
+val start_snark_worker : t -> unit
 
 val create : Config.t -> t Deferred.t
 

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -21,7 +21,8 @@ val propose_public_keys : t -> Public_key.Compressed.Set.t
 
 val replace_propose_keypairs : t -> Keypair.And_compressed_pk.Set.t -> unit
 
-val replace_snark_worker_key : t -> Public_key.Compressed.t option -> unit
+val replace_snark_worker_key :
+  t -> Public_key.Compressed.t option -> unit Deferred.t
 
 val add_block_subscriber :
      t
@@ -80,9 +81,9 @@ val external_transition_database :
 
 val snark_pool : t -> Network_pool.Snark_pool.t
 
-val start_proposer : t -> unit
+val start : t -> unit Deferred.t
 
-val start_snark_worker : t -> unit
+val stop_snark_worker : t -> unit Deferred.t
 
 val create : Config.t -> t Deferred.t
 

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -90,10 +90,7 @@ module Make (Inputs : Intf.Inputs_intf) :
               "Base SNARK generated in $time"
               ~metadata:[("time", `String (Time.Span.to_string_hum total))] )
 
-  let main daemon_address shutdown_on_disconnect =
-    let logger =
-      Logger.create () ~metadata:[("process", `String "Snark Worker")]
-    in
+  let main ~logger daemon_address shutdown_on_disconnect =
     let%bind state = Worker_state.create () in
     let wait ?(sec = 0.5) () = after (Time.Span.of_sec sec) in
     let rec go () =
@@ -160,7 +157,16 @@ module Make (Inputs : Intf.Inputs_intf) :
             "true|false Shutdown when disconnected from daemon (default:true)"
       in
       fun () ->
-        main daemon_port (Option.value ~default:true shutdown_on_disconnect))
+        let logger =
+          Logger.create () ~metadata:[("process", `String "Snark Worker")]
+        in
+        Signal.handle [Signal.term] ~f:(fun _signal ->
+            Logger.info logger
+              !"Received signal to terminate. Aborting snark worker process"
+              ~module_:__MODULE__ ~location:__LOC__ ;
+            Core.exit 0 ) ;
+        main ~logger daemon_port
+          (Option.value ~default:true shutdown_on_disconnect))
 
   let arguments ~daemon_address ~shutdown_on_disconnect =
     [ "-daemon-address"

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -66,8 +66,15 @@ module Make (Inputs : Intf.Inputs_intf) :
     match res with
     | Error exn ->
         if shutdown_on_disconnect then
-          failwithf !"Shutting down. Error: %s" (Exn.to_string_mach exn) ()
-        else Or_error.of_exn exn
+          failwithf
+            !"Shutting down. Error using the RPC call, %s,: %s"
+            (Rpc.Rpc.name rpc) (Exn.to_string_mach exn) ()
+        else
+          Error
+            ( Error.createf
+                !"Error using the RPC call, %s: %s"
+                (Rpc.Rpc.name rpc)
+            @@ Exn.to_string_mach exn )
     | Ok res ->
         res
 


### PR DESCRIPTION
You guys may have noticed that your integration tests are flaking due to the following error:

```
((rpc_error (Connection_closed ("EOF or connection closed")))
```

This is mainly because the snark worker process is trying to make RPC calls to the daemon before the daemon sets up their server. This can be circumvented by having the snark worker process spawn after the server starts.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
