### PR TITLE
Empty versioned types

### DIFF
--- a/src/lib/ppx_coda/tests/Makefile
+++ b/src/lib/ppx_coda/tests/Makefile
@@ -63,15 +63,18 @@ negative-tests :
 	@ echo -n "Versioned type with bad version name, should fail..."
 	@ ! dune build versioned_bad_version_name.cma ${REDIRECT}
 	@ echo "OK"
-	@ echo -n "Versioned types with bad contained types, should fail..."
+	@ echo -n "Versioned type with bad contained types, should fail..."
 	@ ! dune build versioned_bad_contained_types.cma ${REDIRECT}
 	@ echo "OK"
-	@ echo -n "Versioned types with unversioned type with type parameters, should fail..."
+	@ echo -n "Versioned type with unversioned type with type parameters, should fail..."
 	@ ! dune build versioned_bad_type_parameters.cma ${REDIRECT}
 	@ echo "OK"
-	@ echo -n "Versioned types with GADT type with unversioned inputs, should fail..."
+	@ echo -n "Versioned type with GADT type with unversioned inputs, should fail..."
 	@ ! dune build versioned_bad_gadt.cma ${REDIRECT}
 	@ echo "OK"
-	@ echo -n "Versioned types with GADT type with unversioned results, should fail..."
+	@ echo -n "Versioned type with GADT type with unversioned results, should fail..."
 	@ ! dune build versioned_bad_gadt_results.cma ${REDIRECT}
+	@ echo "OK"
+	@ echo -n "Versioned type with invalid empty type, should fail..."
+	@ ! dune build versioned_bad_empty.cma ${REDIRECT}
 	@ echo "OK"

--- a/src/lib/ppx_coda/tests/dune
+++ b/src/lib/ppx_coda/tests/dune
@@ -107,3 +107,9 @@
   (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (libraries core_kernel)
   (modules versioned_bad_gadt_results))
+
+(library
+  (name versioned_bad_empty)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (libraries core_kernel)
+  (modules versioned_bad_empty))

--- a/src/lib/ppx_coda/tests/versioned_bad_empty.ml
+++ b/src/lib/ppx_coda/tests/versioned_bad_empty.ml
@@ -1,0 +1,3 @@
+(* a claimed-to-be empty type with inhabitants *)
+
+type empty = int [@@deriving bin_io, version {empty}]

--- a/src/lib/ppx_coda/tests/versioned_good.ml
+++ b/src/lib/ppx_coda/tests/versioned_good.ml
@@ -308,3 +308,16 @@ module M18 = struct
     end
   end
 end
+
+(* versioned type mentions type with no inhabitants *)
+module M19 = struct
+  type empty [@@deriving bin_io, version {empty}]
+
+  module Stable = struct
+    module V1 = struct
+      module T = struct
+        type t = empty list [@@deriving bin_io, version]
+      end
+    end
+  end
+end

--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -50,7 +50,7 @@ module Extend
     we assert versioning here, and use tests to assure the serialization
     doesn't change
   *)
-  let __versioned__ = true
+  let __versioned__ = ()
 
   include (Unsigned : Unsigned_intf with type t := t)
 


### PR DESCRIPTION
Some code has empty type definitions, used as type tokens:
```
type foo
```
We'd like to use those types in versioned types. This PR adds an option to allow that:
```
type foo [@@deriving version {empty}]
```
Unlike other versioned types, which reside in a module hierarchy of the form `Stable.Vn`, such types can be declared anywhere. Since an empty type cannot change, as long as it remains empty, this strategy seems without risk. The `empty` option enforces that there is no right-hand side of the type definition. Perhaps perversely, the option enforces that the type *not* be named `t`.

How it works: using the option for a type `foo` generates a definition:
```
  let foo__empty_versioned__ = ()
```
and when `foo` appears in a versioned type, we generate:
```
  let _ = foo__empty_versioned__
```
I haven't thought about how this works across modules. Probably need to add a similar capability to signatures.

Also in this PR, for ordinary versioned types, changed
```
   let __versioned__ = true
```
to 
```
  let __versioned__ = ()
```
because all we care about is that the definition exists, not its value.




