### PR TITLE
Re-enable dynamic snark workers (from #2767)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,6 +522,9 @@ jobs:
                   name: Running test -- test_postake_split_snarkless:coda-restart-node-test
                   command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && ./scripts/test.py run "test_postake_split_snarkless:coda-restart-node-test"'
             - run:
+                  name: Running test -- test_postake_split_snarkless:coda-change-snark-worker-test
+                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && ./scripts/test.py run "test_postake_split_snarkless:coda-change-snark-worker-test"'
+            - run:
                   name: Running test -- test_postake_split_snarkless:coda-archive-node-test
                   command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && ./scripts/test.py run "test_postake_split_snarkless:coda-archive-node-test"'
             - store_artifacts:
@@ -634,6 +637,9 @@ jobs:
             - run:
                   name: Running test -- test_postake_split_snarkless_medium_curves:coda-restart-node-test
                   command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && ./scripts/test.py run "test_postake_split_snarkless_medium_curves:coda-restart-node-test"'
+            - run:
+                  name: Running test -- test_postake_split_snarkless_medium_curves:coda-change-snark-worker-test
+                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && ./scripts/test.py run "test_postake_split_snarkless_medium_curves:coda-change-snark-worker-test"'
             - run:
                   name: Running test -- test_postake_split_snarkless_medium_curves:coda-archive-node-test
                   command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && ./scripts/test.py run "test_postake_split_snarkless_medium_curves:coda-archive-node-test"'

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -36,6 +36,7 @@ integration_tests = [
     'coda-shared-prefix-test -who-proposes 0',
     'coda-shared-prefix-test -who-proposes 1',
     'coda-restart-node-test',
+    'coda-change-snark-worker-test',
     'coda-archive-node-test'
 ]
 

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -610,11 +610,11 @@ let daemon logger =
        in
        coda_ref := Some coda ;
        let%bind () = maybe_sleep 3. in
-       Coda_lib.start coda ;
        let web_service = Web_pipe.get_service () in
        Web_pipe.run_service coda web_service ~conf_dir ~logger ;
        Coda_run.setup_local_server ?client_whitelist ~rest_server_port
          ~insecure_rest_server coda ;
+       let%bind () = Coda_lib.start coda in
        let%bind () =
          Option.map metrics_server_port ~f:(fun port ->
              Coda_metrics.server ~port ~logger >>| ignore )

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -297,12 +297,8 @@ let daemon logger =
        Parallel.init_master () ;
        let monitor = Async.Monitor.create ~name:"coda" () in
        let module Coda_initialization = struct
-         type ('a, 'b, 'c, 'd, 'e) t =
-           { coda: 'a
-           ; client_whitelist: 'b
-           ; rest_server_port: 'c
-           ; client_port: 'd
-           ; run_snark_worker_action: 'e }
+         type ('a, 'b, 'c) t =
+           {coda: 'a; client_whitelist: 'b; rest_server_port: 'c}
        end in
        let coda_initialization_deferred () =
          let%bind config =
@@ -447,7 +443,8 @@ let daemon logger =
            { external_ip
            ; bind_ip
            ; discovery_port
-           ; communication_port= external_port }
+           ; communication_port= external_port
+           ; client_port }
          in
          let wallets_disk_location = conf_dir ^/ "wallets" in
          (* HACK: Until we can properly change propose keys at runtime we'll
@@ -509,17 +506,12 @@ let daemon logger =
            (Async.Scheduler.long_cycles
               ~at_least:(sec 0.5 |> Time_ns.Span.of_span_float_round_nearest))
            ~f:(fun span ->
-             Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-               "Long async cycle: $span milliseconds"
-               ~metadata:[("span", `String (Time_ns.Span.to_string span))] ) ;
-         let run_snark_worker_action =
-           Option.value_map run_snark_worker_flag ~default:`Don't_run
-             ~f:(fun k -> `With_public_key k)
-         in
-         let trace_database_initialization typ location directory =
-           Logger.trace logger ~module_:__MODULE__ ~location
-             "Creating database of type $typ in directory $directory"
-             ~metadata:[("typ", `String typ); ("directory", `String directory)]
+             Logger.warn logger ~module_:__MODULE__ ~location:__LOC__
+               "long async cycle %s"
+               (Time_ns.Span.to_string span) ) ;
+         let trace_database_initialization typ location =
+           Logger.trace logger "Creating %s at %s" ~module_:__MODULE__
+             ~location typ
          in
          let trust_dir = conf_dir ^/ "trust" in
          let () = Snark_params.set_chunked_hashing true in
@@ -592,7 +584,10 @@ let daemon logger =
                 ~work_selection_method:
                   (Cli_lib.Arg_type.work_selection_method_to_module
                      work_selection_method)
-                ?snark_worker_key:run_snark_worker_flag
+                ~snark_worker_config:
+                  { Coda_lib.Config.Snark_worker_config.initial_snark_worker_key=
+                      run_snark_worker_flag
+                  ; shutdown_on_disconnect= true }
                 ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")
                 ~wallets_disk_location:(conf_dir ^/ "wallets")
                 ~ledger_db_location:(conf_dir ^/ "ledger_db")
@@ -602,22 +597,15 @@ let daemon logger =
                 ~transaction_database ~external_transition_database
                 ~is_archive_node ~work_reassignment_wait ())
          in
-         { Coda_initialization.coda
-         ; client_whitelist
-         ; rest_server_port
-         ; client_port
-         ; run_snark_worker_action }
+         {Coda_initialization.coda; client_whitelist; rest_server_port}
        in
        (* Breaks a dependency cycle with monitor initilization and coda *)
        let coda_ref : Coda_lib.t option ref = ref None in
        Coda_run.handle_shutdown ~monitor ~conf_dir ~top_logger:logger coda_ref ;
        Async.Scheduler.within' ~monitor
        @@ fun () ->
-       let%bind { Coda_initialization.coda
-                ; client_whitelist
-                ; rest_server_port
-                ; client_port
-                ; run_snark_worker_action } =
+       let%bind {Coda_initialization.coda; client_whitelist; rest_server_port}
+           =
          coda_initialization_deferred ()
        in
        coda_ref := Some coda ;
@@ -625,9 +613,8 @@ let daemon logger =
        Coda_lib.start coda ;
        let web_service = Web_pipe.get_service () in
        Web_pipe.run_service coda web_service ~conf_dir ~logger ;
-       Coda_run.setup_local_server ?client_whitelist ~rest_server_port ~coda
-         ~insecure_rest_server ~client_port () ;
-       Coda_run.run_snark_worker ~client_port run_snark_worker_action ;
+       Coda_run.setup_local_server ?client_whitelist ~rest_server_port
+         ~insecure_rest_server coda ;
        let%bind () =
          Option.map metrics_server_port ~f:(fun port ->
              Coda_metrics.server ~port ~logger >>| ignore )
@@ -771,6 +758,7 @@ let coda_commands logger =
         ; (module Coda_batch_payment_test)
         ; (module Coda_long_fork)
         ; (module Coda_delegation_test)
+        ; (module Coda_change_snark_worker_test)
         ; (module Full_test)
         ; (module Transaction_snark_profiler)
         ; (module Coda_archive_node_test) ]

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -16,8 +16,9 @@ let dispatch rpc query port =
       | Error exn ->
           return
             (Or_error.errorf
-               !"Error connecting to the daemon on port %d: %s"
-               port (Exn.to_string exn))
+               !"Error connecting to the daemon on port %d using the RPC \
+                 call, %s,: %s"
+               port (Rpc.Rpc.name rpc) (Exn.to_string exn))
       | Ok conn ->
           Rpc.Rpc.dispatch rpc conn query )
 

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -201,7 +201,7 @@ let make_report_and_log_shutdown exn_str ~conf_dir ~top_logger coda_ref =
 
 (* TODO: handle participation_status more appropriately than doing participate_exn *)
 let setup_local_server ?(client_whitelist = []) ?rest_server_port
-    ?(insecure_rest_server = false) ~coda ~client_port () =
+    ?(insecure_rest_server = false) coda =
   let client_whitelist =
     Unix.Inet_addr.Set.of_list (Unix.Inet_addr.localhost :: client_whitelist)
   in
@@ -307,15 +307,17 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
   in
   let snark_worker_impls =
     [ implement Snark_worker.Rpcs.Get_work.Latest.rpc (fun () () ->
-          let r = Coda_lib.request_work coda in
-          Option.iter r ~f:(fun r ->
-              Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
-                ~metadata:
-                  [ ( "work_spec"
-                    , `String (sprintf !"%{sexp:Snark_worker.Work.Spec.t}" r)
-                    ) ]
-                "responding to a Get_work request with some new work" ) ;
-          return r )
+          Deferred.return
+            (let open Option.Let_syntax in
+            let%bind snark_worker_key = Coda_lib.snark_worker_key coda in
+            let%map r = Coda_lib.request_work coda in
+            Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
+              ~metadata:
+                [ ( "work_spec"
+                  , `String (sprintf !"%{sexp:Snark_worker.Work.Spec.t}" r) )
+                ]
+              "responding to a Get_work request with some new work" ;
+            (r, snark_worker_key)) )
     ; implement Snark_worker.Rpcs.Submit_work.Latest.rpc
         (fun () (work : Snark_worker.Work.Result.t) ->
           Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
@@ -381,7 +383,8 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
                    rest_server_port ~module_:__MODULE__ ~location:__LOC__ ) )
       |> ignore ) ;
   let where_to_listen =
-    Tcp.Where_to_listen.bind_to All_addresses (On_port client_port)
+    Tcp.Where_to_listen.bind_to All_addresses
+      (On_port (Coda_lib.client_port coda))
   in
   trace_task "client RPC handling" (fun () ->
       Tcp.Server.create
@@ -424,36 +427,21 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
                     Deferred.unit )) ) )
   |> ignore
 
-let create_snark_worker ~public_key ~client_port ~shutdown_on_disconnect =
-  let%map p =
-    let our_binary = Sys.executable_name in
-    Process.create_exn () ~prog:our_binary
-      ~args:
-        ( "internal" :: Snark_worker.Intf.command_name
-        :: Snark_worker.arguments ~public_key
-             ~daemon_address:
-               (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
-             ~shutdown_on_disconnect )
-  in
-  (* We want these to be printfs so we don't double encode our logs here *)
-  Pipe.iter_without_pushback
-    (Reader.pipe (Process.stdout p))
-    ~f:(fun s -> printf "%s" s)
-  |> don't_wait_for ;
-  Pipe.iter_without_pushback
-    (Reader.pipe (Process.stderr p))
-    ~f:(fun s -> printf "%s" s)
-  |> don't_wait_for ;
-  Deferred.unit
+let handle_crash e =
+  Core.eprintf
+    !{err|
 
-let run_snark_worker ?shutdown_on_disconnect:(s = true) ~client_port
-    run_snark_worker =
-  match run_snark_worker with
-  | `Don't_run ->
-      ()
-  | `With_public_key public_key ->
-      create_snark_worker ~shutdown_on_disconnect:s ~public_key ~client_port
-      |> ignore
+  💀 Coda's Daemon Crashed. The Coda Protocol developers would like to know why!
+
+  Please:
+    Open an issue:
+      https://github.com/CodaProtocol/coda/issues/new
+
+    Tell us what you were doing, and paste the last 20 lines of log messages.
+    And then paste the following:
+
+    %s%!|err}
+    (Exn.to_string e)
 
 let handle_shutdown ~monitor ~conf_dir ~top_logger coda_ref =
   Monitor.detach_and_iter_errors monitor ~f:(fun exn ->

--- a/src/app/cli/src/tests/coda_change_snark_worker_test.ml
+++ b/src/app/cli/src/tests/coda_change_snark_worker_test.ml
@@ -1,0 +1,102 @@
+open Core
+open Coda_base
+open Coda_transition
+open Signature_lib
+open Async
+
+let name = "coda-change-snark-worker-test"
+
+let main () =
+  let snark_worker_and_proposer_id = 0 in
+  let logger = Logger.create () in
+  let n = 2 in
+  let proposers i =
+    if i = snark_worker_and_proposer_id then Some i else None
+  in
+  let largest_public_key =
+    let _, account = Genesis_ledger.largest_account_exn () in
+    Account.public_key account
+  in
+  let snark_work_public_keys i =
+    if i = snark_worker_and_proposer_id then Some largest_public_key else None
+  in
+  let%bind testnet =
+    Coda_worker_testnet.test logger n proposers snark_work_public_keys
+      Cli_lib.Arg_type.Sequence ~max_concurrent_connections:None
+  in
+  let%bind new_block_pipe1, new_block_pipe2 =
+    let%map pipe =
+      Coda_worker_testnet.Api.validated_transitions_keyswaptest testnet
+        snark_worker_and_proposer_id
+    in
+    Pipe.fork ~pushback_uses:`Fast_consumer_only (Option.value_exn pipe).pipe
+  in
+  let wait_for_snark_worker_proof new_block_pipe public_key =
+    let found_snark_prover_ivar = Ivar.create () in
+    Pipe.iter new_block_pipe ~f:(fun {With_hash.hash= _; data= transition} ->
+        let completed_works =
+          Staged_ledger_diff.completed_works
+          @@ External_transition.staged_ledger_diff transition
+        in
+        if
+          List.exists completed_works
+            ~f:(fun {Transaction_snark_work.prover; _} ->
+              Logger.trace logger "Prover of completed work"
+                ~module_:__MODULE__ ~location:__LOC__
+                ~metadata:[("Prover", Public_key.Compressed.to_yojson prover)] ;
+              Public_key.Compressed.equal prover public_key )
+        then (
+          Logger.trace logger "Found snark prover ivar filled"
+            ~module_:__MODULE__ ~location:__LOC__
+            ~metadata:
+              [("public key", Public_key.Compressed.to_yojson public_key)] ;
+          Ivar.fill_if_empty found_snark_prover_ivar () )
+        else () ;
+        Deferred.unit )
+    |> don't_wait_for ;
+    Ivar.read found_snark_prover_ivar
+  in
+  Logger.trace logger "Waiting to get snark work from largest public key"
+    ~module_:__MODULE__ ~location:__LOC__
+    ~metadata:
+      [ ( "largest public key"
+        , Public_key.Compressed.to_yojson largest_public_key ) ] ;
+  let%bind () =
+    wait_for_snark_worker_proof new_block_pipe1 largest_public_key
+  in
+  let new_snark_worker =
+    List.find_map_exn Genesis_ledger.accounts ~f:(fun (_, account) ->
+        let public_key = Account.public_key account in
+        Option.some_if
+          (not @@ Public_key.Compressed.equal largest_public_key public_key)
+          public_key )
+  in
+  Logger.trace logger "Setting new snark worker key"
+    ~metadata:
+      [("new snark worker", Public_key.Compressed.to_yojson new_snark_worker)]
+    ~module_:__MODULE__ ~location:__LOC__ ;
+  let%bind () =
+    let%map opt =
+      Coda_worker_testnet.Api.replace_snark_worker_key testnet
+        snark_worker_and_proposer_id (Some new_snark_worker)
+    in
+    Option.value_exn opt
+  in
+  let%bind () = wait_for_snark_worker_proof new_block_pipe2 new_snark_worker in
+  Logger.trace logger "Finished waiting for snark work with updated key"
+    ~module_:__MODULE__ ~location:__LOC__ ;
+  (* Testing that nothing should break if the snark worker is set to None *)
+  let%bind () =
+    let%map opt =
+      Coda_worker_testnet.Api.replace_snark_worker_key testnet
+        snark_worker_and_proposer_id None
+    in
+    Option.value_exn opt
+  in
+  let%bind () = after (Time.Span.of_sec 30.) in
+  Coda_worker_testnet.Api.teardown testnet
+
+let command =
+  Command.async
+    ~summary:"Test that a node can change the snark worker dynamically"
+    (Async.Command.Spec.return main)

--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -19,7 +19,7 @@ let spawn_exn (config : Coda_worker.Input.t) =
   return (conn, process, config)
 
 let local_config ?proposal_interval:_ ~peers ~addrs_and_ports ~acceptable_delay
-    ~program_dir ~proposer ~snark_worker_config ~work_selection_method ~offset
+    ~program_dir ~proposer ~snark_worker_key ~work_selection_method ~offset
     ~trace_dir ~max_concurrent_connections ~is_archive_node () =
   let conf_dir =
     Filename.temp_dir_name
@@ -40,7 +40,7 @@ let local_config ?proposal_interval:_ ~peers ~addrs_and_ports ~acceptable_delay
                      (function [a; b] -> Some (a, b) | _ -> None)
                      (String.split ~on:'=')) )
     ; proposer
-    ; snark_worker_config
+    ; snark_worker_key
     ; work_selection_method
     ; peers
     ; conf_dir
@@ -99,6 +99,14 @@ let verified_transitions_exn (conn, _proc, _) =
   in
   Linear_pipe.wrap_reader r
 
+(* TODO: 2836 delete once transition_frontier extensions refactoring gets in *)
+let validated_transitions_keyswaptest_exn (conn, _, _) =
+  let%map r =
+    Coda_worker.Connection.run_exn conn
+      ~f:Coda_worker.functions.validated_transitions_keyswaptest ~arg:()
+  in
+  Linear_pipe.wrap_reader r
+
 let new_block_exn (conn, _proc, __) key =
   let%map r =
     Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.new_block
@@ -134,3 +142,7 @@ let dump_tf (conn, _proc, _) =
 let best_path (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.best_path
     ~arg:()
+
+let replace_snark_worker_key (conn, _proc, _) key =
+  Coda_worker.Connection.run_exn conn
+    ~f:Coda_worker.functions.replace_snark_worker_key ~arg:key

--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -52,11 +52,6 @@ let local_config ?proposal_interval:_ ~peers ~addrs_and_ports ~acceptable_delay
   in
   config
 
-let disconnect (conn, proc, _) =
-  let%bind () = Coda_worker.Connection.close conn in
-  let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
-  ()
-
 let peers_exn (conn, _proc, _) =
   Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.peers ~arg:()
 
@@ -146,3 +141,10 @@ let best_path (conn, _proc, _) =
 let replace_snark_worker_key (conn, _proc, _) key =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.replace_snark_worker_key ~arg:key
+
+let disconnect ((conn, proc, _) as t) =
+  (* This kills any strangling snark worker process *)
+  let%bind () = replace_snark_worker_key t None in
+  let%bind () = Coda_worker.Connection.close conn in
+  let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
+  ()

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -7,17 +7,21 @@ open Async
 let init () = Parallel.init_master ()
 
 let net_configs n =
-  let external_ports = List.init n ~f:(fun i -> 23000 + (i * 2)) in
-  let discovery_ports = List.init n ~f:(fun i -> 23000 + 1 + (i * 2)) in
   let ips =
     List.init n ~f:(fun i ->
-        Unix.Inet_addr.of_string @@ sprintf "127.0.0.%d" (i + 10) )
+        Unix.Inet_addr.of_string @@ sprintf "127.0.0.1%i" i )
   in
   let addrs_and_ports_list =
-    List.map3_exn external_ports discovery_ports ips
-      ~f:(fun communication_port discovery_port ip ->
+    List.mapi ips ~f:(fun i ip ->
+        let communication_port = 23000 + (i * 2) in
+        let discovery_port = 23000 + 1 + (i * 2) in
+        let client_port = 20000 + i in
         Kademlia.Node_addrs_and_ports.
-          {external_ip= ip; bind_ip= ip; discovery_port; communication_port} )
+          { external_ip= ip
+          ; bind_ip= ip
+          ; discovery_port
+          ; communication_port
+          ; client_port } )
   in
   let all_peers =
     List.map addrs_and_ports_list
@@ -46,18 +50,11 @@ let local_configs ?proposal_interval ?(proposers = Fn.const None)
   let configs =
     List.mapi args ~f:(fun i (addrs_and_ports, peers) ->
         let public_key =
-          Option.map snark_worker_public_keys ~f:(fun keys ->
+          Option.bind snark_worker_public_keys ~f:(fun keys ->
               List.nth_exn keys i )
         in
-        let snark_worker_config =
-          Option.bind public_key ~f:(fun public_key ->
-              Option.bind public_key ~f:(fun public_key ->
-                  Some
-                    { Coda_worker.Snark_worker_config.public_key
-                    ; port= 20000 + i } ) )
-        in
         Coda_process.local_config ?proposal_interval ~addrs_and_ports ~peers
-          ~snark_worker_config ~program_dir ~acceptable_delay
+          ~snark_worker_key:public_key ~program_dir ~acceptable_delay
           ~proposer:(proposers i) ~work_selection_method ~trace_dir
           ~is_archive_node:(is_archive_node i) ~offset:(Lazy.force offset)
           ~max_concurrent_connections () )

--- a/src/app/cli/src/tests/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/tests/coda_transitive_peers_test.ml
@@ -32,9 +32,9 @@ let main () =
     peers ;
   let config =
     Coda_process.local_config ~peers ~addrs_and_ports ~acceptable_delay
-      ~snark_worker_config:None ~proposer:None ~program_dir
-      ~work_selection_method ~trace_dir ~offset:Time.Span.zero ()
-      ~max_concurrent_connections ~is_archive_node:false
+      ~snark_worker_key:None ~proposer:None ~program_dir ~work_selection_method
+      ~trace_dir ~offset:Time.Span.zero () ~max_concurrent_connections
+      ~is_archive_node:false
   in
   let%bind worker = Coda_process.spawn_exn config in
   let%bind _ = after (Time.Span.of_sec 10.) in

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -7,18 +7,12 @@ open Signature_lib
 open Pipe_lib
 open Init
 
-module Snark_worker_config = struct
-  (* TODO : version *)
-  type t = {port: int; public_key: Public_key.Compressed.Stable.V1.t}
-  [@@deriving bin_io]
-end
-
 module Input = struct
   type t =
     { addrs_and_ports: Kademlia.Node_addrs_and_ports.t
+    ; snark_worker_key: Public_key.Compressed.Stable.V1.t option
     ; env: (string * string) list
     ; proposer: int option
-    ; snark_worker_config: Snark_worker_config.t option
     ; work_selection_method: Cli_lib.Arg_type.work_selection_method
     ; conf_dir: string
     ; trace_dir: string option
@@ -115,6 +109,13 @@ module T = struct
         ( 'worker
         , unit
         , State_hash.Stable.Latest.t list )
+        Rpc_parallel.Function.t
+    ; replace_snark_worker_key:
+        ('worker, Public_key.Compressed.t option, unit) Rpc_parallel.Function.t
+    ; validated_transitions_keyswaptest:
+        ( 'worker
+        , unit
+        , (External_transition.t, State_hash.t) With_hash.t Pipe.Reader.t )
         Rpc_parallel.Function.t }
 
   type coda_functions =
@@ -140,6 +141,15 @@ module T = struct
     ; coda_get_all_user_commands:
            Public_key.Compressed.Stable.V1.t
         -> User_command.Stable.V1.t list Deferred.t
+    ; coda_replace_snark_worker_key:
+        Public_key.Compressed.Stable.V1.t option -> unit Deferred.t
+    ; coda_validated_transitions_keyswaptest:
+           unit
+        -> ( External_transition.Stable.V1.t
+           , State_hash.Stable.V1.t )
+           With_hash.t
+           Pipe.Reader.t
+           Deferred.t
     ; coda_root_diff:
            unit
         -> Transition_frontier.Diff.Root_diff.view Pipe.Reader.t Deferred.t
@@ -225,6 +235,12 @@ module T = struct
 
     let best_path_impl ~worker_state ~conn_state:() () =
       worker_state.coda_best_path ()
+
+    let replace_snark_worker_key_impl ~worker_state ~conn_state:() key =
+      worker_state.coda_replace_snark_worker_key key
+
+    let validated_transitions_keyswaptest_impl ~worker_state ~conn_state:() =
+      worker_state.coda_validated_transitions_keyswaptest
 
     let get_all_transitions_impl ~worker_state ~conn_state:() pk =
       worker_state.coda_get_all_transitions pk
@@ -320,6 +336,21 @@ module T = struct
       C.create_rpc ~f:best_path_impl ~bin_input:Unit.bin_t
         ~bin_output:[%bin_type_class: State_hash.Stable.Latest.t list] ()
 
+    let validated_transitions_keyswaptest =
+      C.create_pipe ~f:validated_transitions_keyswaptest_impl
+        ~bin_input:Unit.bin_t
+        ~bin_output:
+          [%bin_type_class:
+            ( External_transition.Stable.Latest.t
+            , State_hash.Stable.Latest.t )
+            With_hash.Stable.Latest.t] ()
+
+    let replace_snark_worker_key =
+      C.create_rpc ~f:replace_snark_worker_key_impl
+        ~bin_input:
+          [%bin_type_class: Public_key.Compressed.Stable.Latest.t option]
+        ~bin_output:Unit.bin_t ()
+
     let functions =
       { peers
       ; start
@@ -337,12 +368,14 @@ module T = struct
       ; sync_status
       ; new_user_command
       ; get_all_user_commands
+      ; replace_snark_worker_key
+      ; validated_transitions_keyswaptest
       ; get_all_transitions }
 
     let init_worker_state
         { addrs_and_ports
         ; proposer
-        ; snark_worker_config
+        ; snark_worker_key
         ; work_selection_method
         ; conf_dir
         ; trace_dir
@@ -449,8 +482,10 @@ module T = struct
                  ~work_selection_method:
                    (Cli_lib.Arg_type.work_selection_method_to_module
                       work_selection_method)
-                 ?snark_worker_key:
-                   (Option.map snark_worker_config ~f:(fun c -> c.public_key))
+                 ~snark_worker_config:
+                   Coda_lib.Config.Snark_worker_config.
+                     { initial_snark_worker_key= snark_worker_key
+                     ; shutdown_on_disconnect= true }
                  ~snark_pool_disk_location:(conf_dir ^/ "snark_pool")
                  ~wallets_disk_location:(conf_dir ^/ "wallets")
                  ~time_controller ~receipt_chain_database
@@ -467,17 +502,14 @@ module T = struct
               (fun () ->
                 let%map coda = coda_deferred () in
                 coda_ref := Some coda ;
-                Option.iter snark_worker_config ~f:(fun config ->
-                    let run_snark_worker =
-                      `With_public_key config.public_key
-                    in
-                    Coda_run.setup_local_server ~client_port:config.port ~coda
-                      () ;
-                    Coda_run.run_snark_worker ~client_port:config.port
-                      run_snark_worker ) ;
+                Logger.info logger "Setting up snark worker "
+                  ~module_:__MODULE__ ~location:__LOC__ ;
+                Coda_run.setup_local_server coda ;
                 coda )
               ()
           in
+          Logger.info logger "Worker finish setting up coda"
+            ~module_:__MODULE__ ~location:__LOC__ ;
           let coda_peers () = return (Coda_lib.peers coda) in
           let coda_start () = return (Coda_lib.start coda) in
           let coda_get_all_transitions pk =
@@ -546,14 +578,26 @@ module T = struct
                   !"Failed to construct payment proof: %{sexp:Error.t}"
                   e ()
           in
+          let coda_replace_snark_worker_key =
+            Fn.compose Deferred.return (Coda_lib.replace_snark_worker_key coda)
+          in
           let coda_new_block key =
             Deferred.return @@ Coda_commands.Subscriptions.new_block coda key
+          in
+          (* TODO: #2836 Remove validated_transitions_keyswaptest once the refactoring of broadcast pipe enters the code base *)
+          let ( validated_transitions_keyswaptest_reader
+              , validated_transitions_keyswaptest_writer ) =
+            Pipe.create ()
           in
           let coda_verified_transitions () =
             let r, w = Linear_pipe.create () in
             don't_wait_for
               (Strict_pipe.Reader.iter (Coda_lib.validated_transitions coda)
                  ~f:(fun t ->
+                   Pipe.write_without_pushback_if_open
+                     validated_transitions_keyswaptest_writer
+                     (With_hash.map t
+                        ~f:External_transition.Validated.forget_validation) ;
                    let p =
                      External_transition.Validated.protocol_state
                        (With_hash.data t)
@@ -572,6 +616,9 @@ module T = struct
                      (prev_state_hash, state_hash) ;
                    Deferred.unit )) ;
             return r.pipe
+          in
+          let coda_validated_transitions_keyswaptest () =
+            Deferred.return validated_transitions_keyswaptest_reader
           in
           let coda_root_diff () =
             let r, w = Linear_pipe.create () in
@@ -647,6 +694,10 @@ module T = struct
           ; coda_sync_status= with_monitor coda_sync_status
           ; coda_new_user_command= with_monitor coda_new_user_command
           ; coda_get_all_user_commands= with_monitor coda_get_all_user_commands
+          ; coda_validated_transitions_keyswaptest=
+              with_monitor coda_validated_transitions_keyswaptest
+          ; coda_replace_snark_worker_key=
+              with_monitor coda_replace_snark_worker_key
           ; coda_get_all_transitions= with_monitor coda_get_all_transitions }
       )
 

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -511,7 +511,7 @@ module T = struct
           Logger.info logger "Worker finish setting up coda"
             ~module_:__MODULE__ ~location:__LOC__ ;
           let coda_peers () = return (Coda_lib.peers coda) in
-          let coda_start () = return (Coda_lib.start coda) in
+          let coda_start () = Coda_lib.start coda in
           let coda_get_all_transitions pk =
             let external_transition_database =
               Coda_lib.external_transition_database coda
@@ -579,7 +579,7 @@ module T = struct
                   e ()
           in
           let coda_replace_snark_worker_key =
-            Fn.compose Deferred.return (Coda_lib.replace_snark_worker_key coda)
+            Coda_lib.replace_snark_worker_key coda
           in
           let coda_new_block key =
             Deferred.return @@ Coda_commands.Subscriptions.new_block coda key

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -177,6 +177,17 @@ module Api = struct
       ~f:(fun worker -> Coda_process.new_block_exn worker key)
       t i
 
+  let replace_snark_worker_key t i key =
+    run_online_worker
+      ~f:(fun worker -> Coda_process.replace_snark_worker_key worker key)
+      t i
+
+  let validated_transitions_keyswaptest t i =
+    run_online_worker
+      ~f:(fun worker ->
+        Coda_process.validated_transitions_keyswaptest_exn worker )
+      t i
+
   let new_user_command_and_subscribe t i key =
     ignore @@ new_block t i key ;
     new_user_command t i key
@@ -328,6 +339,8 @@ let start_payment_check logger root_pipe (testnet : Api.t) =
                       testnet.root_lengths.(i) + (Consensus.Constants.k / 2)
                       < length - 1
                     then (
+                      Logger.info logger !"Filled catchup ivar"
+                        ~module_:__MODULE__ ~location:__LOC__ ;
                       Ivar.fill signal () ;
                       testnet.restart_signals.(i) <- None )
                     else () ) ;

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -174,7 +174,6 @@ let run_test () : unit Deferred.t =
              ~consensus_local_state ~transaction_database
              ~external_transition_database ~work_reassignment_wait:420000 ())
       in
-      Coda_lib.start coda ;
       don't_wait_for
         (Strict_pipe.Reader.iter_without_pushback
            (Coda_lib.validated_transitions coda)
@@ -218,6 +217,7 @@ let run_test () : unit Deferred.t =
               (sprintf !"Invalid Account: %{sexp: Public_key.Compressed.t}" pk)
       in
       Coda_run.setup_local_server coda ;
+      let%bind () = Coda_lib.start coda in
       (* Let the system settle *)
       let%bind () = Async.after (Time.Span.of_ms 100.) in
       (* No proof emitted by the parallel scan at the begining *)

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -121,6 +121,9 @@ let run_test () : unit Deferred.t =
           (Public_key.Compressed.Set.singleton
              (Public_key.compress keypair.public_key))
       in
+      let discovery_port = 8001 in
+      let communication_port = 8000 in
+      let client_port = 8123 in
       let net_config =
         Coda_networking.Config.
           { logger
@@ -137,8 +140,9 @@ let run_test () : unit Deferred.t =
               ; addrs_and_ports=
                   { external_ip= Unix.Inet_addr.localhost
                   ; bind_ip= Unix.Inet_addr.localhost
-                  ; discovery_port= 8001
-                  ; communication_port= 8000 }
+                  ; discovery_port
+                  ; communication_port
+                  ; client_port }
               ; trust_system
               ; max_concurrent_connections= Some 10 } }
       in
@@ -146,10 +150,6 @@ let run_test () : unit Deferred.t =
       Async.Scheduler.set_record_backtraces true ;
       let largest_account_keypair =
         Genesis_ledger.largest_account_keypair_exn ()
-      in
-      let run_snark_worker =
-        `With_public_key
-          (Public_key.compress largest_account_keypair.public_key)
       in
       let fee = Currency.Fee.of_int in
       let snark_work_fee, transaction_fee =
@@ -162,8 +162,12 @@ let run_test () : unit Deferred.t =
              ~work_selection_method:
                (module Work_selector.Selection_methods.Sequence)
              ~initial_propose_keypairs:(Keypair.Set.singleton keypair)
-             ~snark_worker_key:
-               (Public_key.compress largest_account_keypair.public_key)
+             ~snark_worker_config:
+               Coda_lib.Config.Snark_worker_config.
+                 { initial_snark_worker_key=
+                     Some
+                       (Public_key.compress largest_account_keypair.public_key)
+                 ; shutdown_on_disconnect= true }
              ~snark_pool_disk_location:(temp_conf_dir ^/ "snark_pool")
              ~wallets_disk_location:(temp_conf_dir ^/ "wallets")
              ~time_controller ~receipt_chain_database ~snark_work_fee
@@ -213,9 +217,7 @@ let run_test () : unit Deferred.t =
             failwith
               (sprintf !"Invalid Account: %{sexp: Public_key.Compressed.t}" pk)
       in
-      let client_port = 8123 in
-      Coda_run.setup_local_server ~client_port ~coda () ;
-      Coda_run.run_snark_worker ~client_port run_snark_worker ;
+      Coda_run.setup_local_server coda ;
       (* Let the system settle *)
       let%bind () = Async.after (Time.Span.of_ms 100.) in
       (* No proof emitted by the parallel scan at the begining *)

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -23,10 +23,13 @@ exception Snark_worker_signal_interrupt of Signal.t
    this lazy value will run the snark worker process. A snark work is
    assigned to a public key. This public key can change throughout the entire time
    the daemon is running *)
-type snark_worker = Public_key.Compressed.t option ref Lazy.t
+type snark_worker =
+  {public_key: Public_key.Compressed.t; process: Process.t Ivar.t}
 
 type processes =
-  {prover: Prover.t; verifier: Verifier.t; snark_worker: snark_worker}
+  { prover: Prover.t
+  ; verifier: Verifier.t
+  ; mutable snark_worker: snark_worker option }
 
 type components =
   { net: Coda_networking.t
@@ -80,58 +83,147 @@ let propose_public_keys t : Public_key.Compressed.Set.t =
 
 let replace_propose_keypairs t kps = Agent.update t.propose_keypairs kps
 
-let create_snark_worker ~logger ?(shutdown_on_disconnect = true) client_port =
-  let%bind p =
-    let our_binary = Sys.executable_name in
-    Process.create_exn () ~prog:our_binary
-      ~args:
-        ( "internal" :: Snark_worker.Intf.command_name
-        :: Snark_worker.arguments
-             ~daemon_address:
-               (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
-             ~shutdown_on_disconnect )
-  in
-  don't_wait_for
-    ( match%bind Process.wait p with
-    | Ok () ->
-        Logger.info logger
-          "Snark worker process died normally, so the daemon will die as well"
+module Snark_worker = struct
+  let run_process ~logger client_port =
+    let%map snark_worker_process =
+      let our_binary = Sys.executable_name in
+      Process.create_exn () ~prog:our_binary
+        ~args:
+          ( "internal" :: Snark_worker.Intf.command_name
+          :: Snark_worker.arguments
+               ~daemon_address:
+                 (Host_and_port.create ~host:"127.0.0.1" ~port:client_port)
+               ~shutdown_on_disconnect:false )
+    in
+    don't_wait_for
+      ( match%bind Process.wait snark_worker_process with
+      | Ok () ->
+          Logger.info logger "Snark worker process died" ~module_:__MODULE__
+            ~location:__LOC__ ;
+          Deferred.unit
+      | Error (`Exit_non_zero non_zero_error) ->
+          Logger.fatal logger
+            !"Snark worker process died with a nonzero error %i"
+            non_zero_error ~module_:__MODULE__ ~location:__LOC__ ;
+          raise (Snark_worker_error non_zero_error)
+      | Error (`Signal signal) when Signal.equal signal Signal.term ->
+          Logger.info logger
+            !"Snark worker received term signal. Expecting it to fully \
+              terminate"
+            ~module_:__MODULE__ ~location:__LOC__ ;
+          let wait_graceful_exit =
+            match%bind Process.wait snark_worker_process with
+            | Ok () ->
+                Logger.info logger
+                  !"Snark worker process fully died after receiving term \
+                    signal."
+                  ~module_:__MODULE__ ~location:__LOC__ ;
+                Deferred.unit
+            | Error error -> (
+                Logger.info logger
+                  !"Snark worker process died unexpectedly after getting the \
+                    term signal. Aborting the daemon"
+                  ~module_:__MODULE__ ~location:__LOC__ ;
+                match error with
+                | `Exit_non_zero non_zero_error ->
+                    raise (Snark_worker_error non_zero_error)
+                | `Signal signal ->
+                    raise (Snark_worker_signal_interrupt signal) )
+          in
+          Deferred.any
+            [ wait_graceful_exit
+            ; (* If the snark worker process was not able to fully abort, then kill the daemon *)
+              ( after (Core.Time.Span.of_sec 20.0)
+              >>= fun () ->
+              if not @@ Deferred.is_determined wait_graceful_exit then
+                Logger.error logger
+                  !"Snark worker process didn't die gracefully in a short \
+                    amount of time"
+                  ~module_:__MODULE__ ~location:__LOC__ ;
+              Deferred.unit ) ]
+      | Error (`Signal signal) ->
+          Logger.info logger
+            !"Snark worker died with signal %{sexp:Signal.t}. Aborting daemon"
+            signal ~module_:__MODULE__ ~location:__LOC__ ;
+          raise (Snark_worker_signal_interrupt signal) ) ;
+    Logger.trace logger
+      !"Created snark worker with pid: %i"
+      ~module_:__MODULE__ ~location:__LOC__
+      (Pid.to_int @@ Process.pid snark_worker_process) ;
+    (* We want these to be printfs so we don't double encode our logs here *)
+    Pipe.iter_without_pushback
+      (Async.Reader.pipe (Process.stdout snark_worker_process))
+      ~f:(fun s -> printf "%s" s)
+    |> don't_wait_for ;
+    Pipe.iter_without_pushback
+      (Async.Reader.pipe (Process.stderr snark_worker_process))
+      ~f:(fun s -> printf "%s" s)
+    |> don't_wait_for ;
+    snark_worker_process
+
+  let start t =
+    match t.processes.snark_worker with
+    | Some {process= process_ivar; _} ->
+        Logger.debug t.config.logger
+          !"Starting snark worker process"
           ~module_:__MODULE__ ~location:__LOC__ ;
-        exit 0
-    | Error (`Exit_non_zero non_zero_error) ->
-        Logger.fatal logger
-          !"Snark worker process died with a nonzero error %i"
-          non_zero_error ~module_:__MODULE__ ~location:__LOC__ ;
-        raise (Snark_worker_error non_zero_error)
-    | Error (`Signal signal) ->
+        let%map snark_worker_process =
+          run_process ~logger:t.config.logger
+            t.config.net_config.gossip_net_params.addrs_and_ports.client_port
+        in
+        Ivar.fill process_ivar snark_worker_process
+    | None ->
+        Logger.info t.config.logger
+          !"Attempted to turn on snark worker, but snark worker key is set to \
+            none"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        Deferred.unit
+
+  let stop t =
+    match t.processes.snark_worker with
+    | Some {public_key= _; process} ->
+        Logger.info t.config.logger "Killing snark worker" ~module_:__MODULE__
+          ~location:__LOC__ ;
+        let%map process = Ivar.read process in
+        Signal.send_exn Signal.term (`Pid (Process.pid process))
+    | None ->
+        Logger.warn t.config.logger
+          "Attempted to turn off snark worker, but no snark worker was running"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        Deferred.unit
+
+  let get_key {processes= {snark_worker; _}; _} =
+    Option.map snark_worker ~f:(fun {public_key; _} -> public_key)
+
+  let replace_key ({processes= {snark_worker; _}; config= {logger; _}; _} as t)
+      new_key =
+    match (snark_worker, new_key) with
+    | None, None ->
         Logger.info logger
-          !"Snark worker died with signal %{sexp:Signal.t}. Aborting daemon"
-          signal ~module_:__MODULE__ ~location:__LOC__ ;
-        raise (Snark_worker_signal_interrupt signal) ) ;
-  Logger.trace logger
-    !"Created snark worker with pid: %i"
-    ~module_:__MODULE__ ~location:__LOC__
-    (Pid.to_int @@ Process.pid p) ;
-  (* We want these to be printfs so we don't double encode our logs here *)
-  Pipe.iter_without_pushback
-    (Async.Reader.pipe (Process.stdout p))
-    ~f:(fun s -> printf "%s" s)
-  |> don't_wait_for ;
-  Pipe.iter_without_pushback
-    (Async.Reader.pipe (Process.stderr p))
-    ~f:(fun s -> printf "%s" s)
-  |> don't_wait_for ;
-  Deferred.unit
+          "Snark work is still not happening since keys snark worker keys are \
+           still set to None"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        Deferred.unit
+    | None, Some new_key ->
+        let process = Ivar.create () in
+        t.processes.snark_worker <- Some {public_key= new_key; process} ;
+        start t
+    | Some {public_key= _; process}, Some new_key ->
+        Logger.debug logger
+          !"Changing snark worker key from $old to $new"
+          ~module_:__MODULE__ ~location:__LOC__ ;
+        t.processes.snark_worker <- Some {public_key= new_key; process} ;
+        Deferred.unit
+    | Some _, None ->
+        let%map () = stop t in
+        t.processes.snark_worker <- None
+end
 
-let snark_worker_key {processes; _} =
-  if Lazy.is_val processes.snark_worker then
-    !(Lazy.force processes.snark_worker)
-  else None
+let replace_snark_worker_key = Snark_worker.replace_key
 
-let replace_snark_worker_key {processes; _} new_key =
-  if Option.is_some new_key || Lazy.is_val processes.snark_worker then
-    Lazy.force processes.snark_worker := new_key
-  else ()
+let snark_worker_key = Snark_worker.get_key
+
+let stop_snark_worker = Snark_worker.stop
 
 let best_tip_opt t =
   let open Option.Let_syntax in
@@ -395,7 +487,8 @@ let start t =
     ~keypairs:(Agent.read_only t.propose_keypairs)
     ~consensus_local_state:t.config.consensus_local_state
     ~frontier_reader:t.components.transition_frontier
-    ~transition_writer:t.pipes.proposer_transition_writer
+    ~transition_writer:t.pipes.proposer_transition_writer ;
+  Snark_worker.start t
 
 let create_genesis_frontier (config : Config.t) ~verifier =
   let consensus_local_state = config.consensus_local_state in
@@ -483,17 +576,9 @@ let create (config : Config.t) =
           let%bind prover = Prover.create () in
           let%bind verifier = Verifier.create () in
           let snark_worker =
-            Lazy.from_fun
-            @@ fun () ->
-            let {Kademlia.Node_addrs_and_ports.client_port; _} =
-              config.net_config.gossip_net_params.addrs_and_ports
-            in
-            create_snark_worker ~logger:config.logger client_port
-            |> don't_wait_for ;
-            ref config.snark_worker_config.initial_snark_worker_key
+            Option.map config.snark_worker_config.initial_snark_worker_key
+              ~f:(fun public_key -> {public_key; process= Ivar.create ()})
           in
-          Option.iter config.snark_worker_config.initial_snark_worker_key
-            ~f:(fun _key -> ignore @@ Lazy.force snark_worker) ;
           let external_transitions_reader, external_transitions_writer =
             Strict_pipe.create Synchronous
           in

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -10,12 +10,18 @@ module Subscriptions = Coda_subscriptions
 
 type t
 
+exception Snark_worker_error of int
+
+exception Snark_worker_signal_interrupt of Signal.t
+
 val subscription : t -> Coda_subscriptions.t
 
 (** Derived from local state (aka they may not reflect the latest public keys to which you've attempted to change *)
 val propose_public_keys : t -> Public_key.Compressed.Set.t
 
 val replace_propose_keypairs : t -> Keypair.And_compressed_pk.Set.t -> unit
+
+val replace_snark_worker_key : t -> Public_key.Compressed.t option -> unit
 
 val add_block_subscriber :
      t
@@ -50,6 +56,8 @@ val visualize_frontier : filename:string -> t -> unit Participating_state.t
 val peers : t -> Network_peer.Peer.t list
 
 val initial_peers : t -> Host_and_port.t list
+
+val client_port : t -> int
 
 val validated_transitions :
      t

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -21,7 +21,8 @@ val propose_public_keys : t -> Public_key.Compressed.Set.t
 
 val replace_propose_keypairs : t -> Keypair.And_compressed_pk.Set.t -> unit
 
-val replace_snark_worker_key : t -> Public_key.Compressed.t option -> unit
+val replace_snark_worker_key :
+  t -> Public_key.Compressed.t option -> unit Deferred.t
 
 val add_block_subscriber :
      t
@@ -80,7 +81,9 @@ val external_transition_database :
 
 val snark_pool : t -> Network_pool.Snark_pool.t
 
-val start : t -> unit
+val start : t -> unit Deferred.t
+
+val stop_snark_worker : t -> unit Deferred.t
 
 val create : Config.t -> t Deferred.t
 

--- a/src/lib/coda_lib/config.ml
+++ b/src/lib/coda_lib/config.ml
@@ -5,6 +5,12 @@ open Signature_lib
 
 (* TODO: Pass banlist to modules discussed in Ban Reasons issue: https://github.com/CodaProtocol/coda/issues/852 *)
 
+module Snark_worker_config = struct
+  type t =
+    { initial_snark_worker_key: Public_key.Compressed.t option
+    ; shutdown_on_disconnect: bool }
+end
+
 (** If ledger_db_location is None, will auto-generate a db based on a UUID *)
 type t =
   { conf_dir: string
@@ -13,7 +19,7 @@ type t =
   ; monitor: Monitor.t option
   ; initial_propose_keypairs: Keypair.Set.t
   ; work_selection_method: (module Work_selector.Selection_method_intf)
-  ; snark_worker_key: Public_key.Compressed.Stable.V1.t option
+  ; snark_worker_config: Snark_worker_config.t
   ; work_reassignment_wait: int
   ; net_config: Coda_networking.Config.t
   ; snark_pool_disk_location: string

--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -165,7 +165,8 @@ module Haskell_process = struct
         { external_ip= ip1
         ; bind_ip= ip1
         ; discovery_port= 8000
-        ; communication_port= 8001 }
+        ; communication_port= 8001
+        ; client_port= 3000 }
     in
     let me_discovery = Host_and_port.create ~host:"1.1.1.1" ~port:8000 in
     let other = Host_and_port.create ~host:"1.1.1.2" ~port:8000 in
@@ -520,7 +521,8 @@ let%test_module "Tests" =
                 { external_ip= Unix.Inet_addr.localhost
                 ; bind_ip= Unix.Inet_addr.localhost
                 ; discovery_port= 3001
-                ; communication_port= 3000 }
+                ; communication_port= 3000
+                ; client_port= 2000 }
               ~logger:(Logger.null ())
               ~conf_dir:(Filename.temp_dir_name ^/ "membership-test")
           with
@@ -633,7 +635,8 @@ let%test_module "Tests" =
         { external_ip= Unix.Inet_addr.localhost
         ; bind_ip= Unix.Inet_addr.localhost
         ; discovery_port= 3006 + i
-        ; communication_port= 3005 + i }
+        ; communication_port= 3005 + i
+        ; client_port= 1000 + i }
 
     let conf_dir = Filename.temp_dir_name ^/ ".kademlia-test-"
 

--- a/src/lib/kademlia/node_addrs_and_ports.ml
+++ b/src/lib/kademlia/node_addrs_and_ports.ml
@@ -5,7 +5,8 @@ type t =
   { external_ip: Unix.Inet_addr.t
   ; bind_ip: Unix.Inet_addr.t
   ; discovery_port: int
-  ; communication_port: int }
+  ; communication_port: int
+  ; client_port: int }
 [@@deriving bin_io]
 
 let to_peer : t -> Peer.t = function

--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -1,7 +1,6 @@
 open Core
 open Async
 open Coda_base
-open Signature_lib
 
 module Make (Inputs : Intf.Inputs_intf) :
   Intf.S with type ledger_proof := Inputs.Ledger_proof.t = struct
@@ -84,8 +83,10 @@ module Make (Inputs : Intf.Inputs_intf) :
               "Base SNARK generated in $time"
               ~metadata:[("time", `String (Time.Span.to_string_hum total))] )
 
-  let main daemon_address public_key shutdown_on_disconnect =
-    let logger = Logger.create () in
+  let main daemon_address shutdown_on_disconnect =
+    let logger =
+      Logger.create () ~metadata:[("process", `String "Snark Worker")]
+    in
     let%bind state = Worker_state.create () in
     let wait ?(sec = 0.5) () = after (Time.Span.of_sec sec) in
     let rec go () =
@@ -111,7 +112,7 @@ module Make (Inputs : Intf.Inputs_intf) :
           (* No work to be done -- quietly take a brief nap *)
           let%bind () = wait ~sec:random_delay () in
           go ()
-      | Ok (Some work) -> (
+      | Ok (Some (work, public_key)) -> (
           Logger.info logger ~module_:__MODULE__ ~location:__LOC__
             "SNARK work received from $address. Starting proof generation"
             ~metadata:
@@ -146,23 +147,16 @@ module Make (Inputs : Intf.Inputs_intf) :
         flag "daemon-address"
           (required (Arg_type.create Host_and_port.of_string))
           ~doc:"HOST-AND-PORT address daemon is listening on"
-      and public_key =
-        flag "public-key"
-          (required Cli_lib.Arg_type.public_key_compressed)
-          ~doc:"PUBLICKEY Public key to send SNARKing fees to"
       and shutdown_on_disconnect =
         flag "shutdown-on-disconnect" (optional bool)
           ~doc:
             "true|false Shutdown when disconnected from daemon (default:true)"
       in
       fun () ->
-        main daemon_port public_key
-          (Option.value ~default:true shutdown_on_disconnect))
+        main daemon_port (Option.value ~default:true shutdown_on_disconnect))
 
-  let arguments ~public_key ~daemon_address ~shutdown_on_disconnect =
-    [ "-public-key"
-    ; Public_key.Compressed.to_base58_check public_key
-    ; "-daemon-address"
+  let arguments ~daemon_address ~shutdown_on_disconnect =
+    [ "-daemon-address"
     ; Host_and_port.to_string daemon_address
     ; "-shutdown-on-disconnect"
     ; Bool.to_string shutdown_on_disconnect ]

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -59,7 +59,7 @@ module type S = sig
       module V1 : sig
         type query = unit
 
-        type response = Work.Spec.t option
+        type response = (Work.Spec.t * Public_key.Compressed.t) option
 
         val rpc : (query, response) Rpc.Rpc.t
       end
@@ -83,8 +83,7 @@ module type S = sig
   val command : Command.t
 
   val arguments :
-       public_key:Public_key.Compressed.t
-    -> daemon_address:Host_and_port.t
+       daemon_address:Host_and_port.t
     -> shutdown_on_disconnect:bool
     -> string list
 end

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -1,6 +1,7 @@
 open Core_kernel
 open Async
 open Coda_base
+open Signature_lib
 
 (* for versioning of the types here, see
 
@@ -24,11 +25,12 @@ module Make (Inputs : Intf.Inputs_intf) = struct
         type query = unit
 
         type response =
-          ( Transaction.t
-          , Transaction_witness.t
-          , Ledger_proof.t )
-          Work.Single.Spec.t
-          Work.Spec.t
+          ( ( Transaction.t
+            , Transaction_witness.t
+            , Ledger_proof.t )
+            Work.Single.Spec.t
+            Work.Spec.t
+          * Public_key.Compressed.t )
           option
       end
 
@@ -45,11 +47,12 @@ module Make (Inputs : Intf.Inputs_intf) = struct
         type query = unit [@@deriving bin_io, version {rpc}]
 
         type response =
-          ( Transaction.Stable.V1.t
-          , Transaction_witness.Stable.V1.t
-          , Ledger_proof.Stable.V1.t )
-          Work.Single.Spec.Stable.V1.t
-          Work.Spec.Stable.V1.t
+          ( ( Transaction.Stable.V1.t
+            , Transaction_witness.Stable.V1.t
+            , Ledger_proof.Stable.V1.t )
+            Work.Single.Spec.Stable.V1.t
+            Work.Spec.Stable.V1.t
+          * Public_key.Compressed.Stable.V1.t )
           option
         [@@deriving bin_io, version {rpc}]
 


### PR DESCRIPTION
This PR consists of two PRs, which me unreverting my change for "Setting snark worker dynamically"

I fixed the flakyness that my PR caused for the integration tests. This is what I did:

1.  Snark worker process dies when the snark worker key is set to none
    
2. Snark worker process will be invoked after rpc servers are setup
