### PR TITLE
remove background in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,11 +224,9 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh make genesiskeys
             - run:
                   name: Upload deb to repo
-                  background: true
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
             - run:
                   name: Copy artifacts to cloud
-                  bsckground: true
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
             - persist_to_workspace:
                 root: /tmp/artifacts
@@ -267,11 +265,9 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh make genesiskeys
             - run:
                   name: Upload deb to repo
-                  background: true
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
             - run:
                   name: Copy artifacts to cloud
-                  bsckground: true
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
             - persist_to_workspace:
                 root: /tmp/artifacts

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -234,11 +234,9 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh make genesiskeys
             - run:
                   name: Upload deb to repo
-                  background: true
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
             - run:
                   name: Copy artifacts to cloud
-                  bsckground: true
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
             {%- if profile in medium_curve_profiles %}
             - persist_to_workspace:


### PR DESCRIPTION
other jobs in whole run were finishing before background job to upload debs -- this stopped the upload job.  :(

removing background was less gross than adding hack step to check for all background jobs to be done.