### PR TITLE
Same yojson encoding in stable and unstable Public_key.Compressed

### DIFF
--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -138,7 +138,14 @@ module Compressed = struct
 
   include Comparable.Make_binable (Stable.Latest)
   include Hashable.Make_binable (Stable.Latest)
-  include Codable.Make_base58_check (Stable.Latest)
+
+  [%%define_locally
+  Stable.Latest.
+    ( of_yojson
+    , to_yojson
+    , to_base58_check
+    , of_base58_check
+    , of_base58_check_exn )]
 
   let compress (x, y) : t = {x; is_odd= parity y}
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -109,16 +109,30 @@ module Compressed = struct
       module T = struct
         type t = (Field.t, bool) Poly.Stable.V1.t
         [@@deriving bin_io, sexp, eq, compare, hash, version {asserted}]
-
-        let description = "Non zero curve point compressed"
-
-        let version_byte =
-          Base58_check.Version_bytes.non_zero_curve_point_compressed
       end
 
       include T
-      include Registration.Make_latest_version (T)
-      include Codable.Make_base58_check (T)
+      module Registered = Registration.Make_latest_version (T)
+      include Registered
+
+      let description = "Non zero curve point compressed"
+
+      let version_byte =
+        Base58_check.Version_bytes.non_zero_curve_point_compressed
+
+      (* Registered contains shadowed versions of bin_io functions in T;
+	 we call the same functor below with Stable.Latest, which also has
+	 the shadowed versions
+       *)
+      include Codable.Make_base58_check (struct
+        type nonrec t = t
+
+        include Registered
+
+        let description = description
+
+        let version_byte = version_byte
+      end)
     end
 
     module Latest = V1
@@ -138,14 +152,7 @@ module Compressed = struct
 
   include Comparable.Make_binable (Stable.Latest)
   include Hashable.Make_binable (Stable.Latest)
-
-  [%%define_locally
-  Stable.Latest.
-    ( of_yojson
-    , to_yojson
-    , to_base58_check
-    , of_base58_check
-    , of_base58_check_exn )]
+  include Codable.Make_base58_check (Stable.Latest)
 
   let compress (x, y) : t = {x; is_odd= parity y}
 


### PR DESCRIPTION
`to_yojson` in `Public_key.Compressed` and `Public_key.Compressed.Stable.V1` was producing different results. Strange, because those functions were produced by the same functor, and I verified the functor was being passed identical relevant arguments. 

The functor was passed arguments that also happened to be defined in the functor body, maybe it was using the passed ones, though they're not mentioned in the signature of the functor input.

In any case, a fix is to just import the `to_yojson` from `Stable.Latest` (and other functions created by the functor). I verified the results are the same when that's done.

Closes #3210

Update: changed the approach here. The difference in serialization was due to the different `bin_io` functions in the functor argument. `Stable.Latest` contains shadowed versions of the ones in `Stable.V1.T`, created by the module version registration. So we make sure to use the shadowed versions in both cases, which allows using the serializations we've already created.