### PR TITLE
Asynchronously stop snark worker

### DIFF
--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -142,9 +142,12 @@ let replace_snark_worker_key (conn, _proc, _) key =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.replace_snark_worker_key ~arg:key
 
+let stop (conn, _proc, _) =
+  Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.stop ~arg:()
+
 let disconnect ((conn, proc, _) as t) =
   (* This kills any strangling snark worker process *)
-  let%bind () = replace_snark_worker_key t None in
+  let%bind () = stop t in
   let%bind () = Coda_worker.Connection.close conn in
   let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
   ()


### PR DESCRIPTION
Quick fix to stop the flaking tests for bootstrapping.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
