### PR TITLE
snark work prometheus metrics

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -321,9 +321,11 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
                   , `String (sprintf !"%{sexp:Snark_worker.Work.Spec.t}" r) )
                 ]
               "responding to a Get_work request with some new work" ;
+            Coda_metrics.(Counter.inc_one Snark_work.snark_work_sent_rpc) ;
             (r, snark_worker_key)) )
     ; implement Snark_worker.Rpcs.Submit_work.Latest.rpc
         (fun () (work : Snark_worker.Work.Result.t) ->
+          Coda_metrics.(Counter.inc_one Snark_work.snark_work_received_rpc) ;
           Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
             "received completed work from a snark worker"
             ~metadata:

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -321,11 +321,11 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
                   , `String (sprintf !"%{sexp:Snark_worker.Work.Spec.t}" r) )
                 ]
               "responding to a Get_work request with some new work" ;
-            Coda_metrics.(Counter.inc_one Snark_work.snark_work_sent_rpc) ;
+            Coda_metrics.(Counter.inc_one Snark_work.snark_work_assigned_rpc) ;
             (r, snark_worker_key)) )
     ; implement Snark_worker.Rpcs.Submit_work.Latest.rpc
         (fun () (work : Snark_worker.Work.Result.t) ->
-          Coda_metrics.(Counter.inc_one Snark_work.snark_work_received_rpc) ;
+          Coda_metrics.(Counter.inc_one Snark_work.snark_work_completed_rpc) ;
           Logger.trace logger ~module_:__MODULE__ ~location:__LOC__
             "received completed work from a snark worker"
             ~metadata:

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -321,7 +321,7 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
                   , `String (sprintf !"%{sexp:Snark_worker.Work.Spec.t}" r) )
                 ]
               "responding to a Get_work request with some new work" ;
-            Coda_metrics.(Counter.inc_one Snark_work.snark_work_assigned_rpc) ;
+            Coda_metrics.(Counter.inc_one Snark_work.snark_job_assigned_rpc) ;
             (r, snark_worker_key)) )
     ; implement Snark_worker.Rpcs.Submit_work.Latest.rpc
         (fun () (work : Snark_worker.Work.Result.t) ->

--- a/src/lib/coda_metrics/coda_metrics.ml
+++ b/src/lib/coda_metrics/coda_metrics.ml
@@ -220,21 +220,28 @@ module Snark_work = struct
     let help = "# of snark work received from peers" in
     Counter.v "snark_work_received_gossip" ~help ~namespace ~subsystem
 
-  let snark_work_received_rpc : Counter.t =
+  let snark_work_completed_rpc : Counter.t =
     let help = "# of snark work received via rpc" in
-    Counter.v "snark_work_received_rpc" ~help ~namespace ~subsystem
+    Counter.v "snark_work_completed_rpc" ~help ~namespace ~subsystem
 
-  let snark_work_sent_rpc : Counter.t =
+  let snark_work_assigned_rpc : Counter.t =
     let help = "# of snark work sent via rpc" in
-    Counter.v "snark_work_sent_rpc" ~help ~namespace ~subsystem
+    Counter.v "snark_work_assigned_rpc" ~help ~namespace ~subsystem
+
+  let snark_work_timed_out : Counter.t =
+    let help =
+      "# of snark work sent via rpc that did not complete within \
+       work-reassignment-wait"
+    in
+    Counter.v "snark_work_timed_out" ~help ~namespace ~subsystem
 
   let snark_pool_size : Gauge.t =
     let help = "# of snark works in the snark pool" in
     Gauge.v "snark_pool_size" ~help ~namespace ~subsystem
 
-  let snark_work_per_block : Gauge.t =
+  let snark_work_last_block : Gauge.t =
     let help = "# of snark work purchased per block" in
-    Gauge.v "snark_work_per_block" ~help ~namespace ~subsystem
+    Gauge.v "snark_work_last_block" ~help ~namespace ~subsystem
 
   let scan_state_snark_jobs : Gauge.t =
     let help = "# of jobs in the scan state after every block" in

--- a/src/lib/coda_metrics/coda_metrics.ml
+++ b/src/lib/coda_metrics/coda_metrics.ml
@@ -213,6 +213,34 @@ module Network = struct
   (* TODO: track non gossip RPC messages as well *)
 end
 
+module Snark_work = struct
+  let subsystem = "Snark_work"
+
+  let snark_work_received_gossip : Counter.t =
+    let help = "# of snark work received from peers" in
+    Counter.v "snark_work_received_gossip" ~help ~namespace ~subsystem
+
+  let snark_work_received_rpc : Counter.t =
+    let help = "# of snark work received via rpc" in
+    Counter.v "snark_work_received_rpc" ~help ~namespace ~subsystem
+
+  let snark_work_sent_rpc : Counter.t =
+    let help = "# of snark work sent via rpc" in
+    Counter.v "snark_work_sent_rpc" ~help ~namespace ~subsystem
+
+  let snark_pool_size : Gauge.t =
+    let help = "# of snark works in the snark pool" in
+    Gauge.v "snark_pool_size" ~help ~namespace ~subsystem
+
+  let snark_work_per_block : Gauge.t =
+    let help = "# of snark work purchased per block" in
+    Gauge.v "snark_work_per_block" ~help ~namespace ~subsystem
+
+  let scan_state_snark_jobs : Gauge.t =
+    let help = "# of jobs in the scan state after every block" in
+    Gauge.v "scan_state_snark_jobs" ~help ~namespace ~subsystem
+end
+
 module Trust_system = struct
   let subsystem = "Trust_system"
 

--- a/src/lib/coda_metrics/coda_metrics.ml
+++ b/src/lib/coda_metrics/coda_metrics.ml
@@ -224,16 +224,16 @@ module Snark_work = struct
     let help = "# of snark work received via rpc" in
     Counter.v "snark_work_completed_rpc" ~help ~namespace ~subsystem
 
-  let snark_work_assigned_rpc : Counter.t =
+  let snark_job_assigned_rpc : Counter.t =
     let help = "# of snark work sent via rpc" in
-    Counter.v "snark_work_assigned_rpc" ~help ~namespace ~subsystem
+    Counter.v "snark_job_assigned_rpc" ~help ~namespace ~subsystem
 
-  let snark_work_timed_out : Counter.t =
+  let snark_work_timed_out_rpc : Counter.t =
     let help =
       "# of snark work sent via rpc that did not complete within \
        work-reassignment-wait"
     in
-    Counter.v "snark_work_timed_out" ~help ~namespace ~subsystem
+    Counter.v "snark_work_timed_out_rpc" ~help ~namespace ~subsystem
 
   let snark_pool_size : Gauge.t =
     let help = "# of snark works in the snark pool" in

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -788,6 +788,8 @@ module Make (Inputs : Inputs_intf) = struct
                     ; ( "sender"
                       , Envelope.(Sender.to_yojson (Incoming.sender envelope))
                       ) ] ;
+              Coda_metrics.(
+                Counter.inc_one Snark_work.snark_work_received_gossip) ;
               `Snd (Envelope.Incoming.map envelope ~f:(fun _ -> diff))
           | Transaction_pool_diff diff ->
               `Trd (Envelope.Incoming.map envelope ~f:(fun _ -> diff)) )

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -168,11 +168,15 @@ end)
                         return ()
                       else (
                         removedCounter := 0 ;
+                        Statement_table.filter_keys_inplace t.snark_table
+                          ~f:(fun work ->
+                            Option.is_some
+                              (Statement_table.find refcount_table work) ) ;
                         return
-                          (Statement_table.filter_keys_inplace t.snark_table
-                             ~f:(fun work ->
-                               Option.is_some
-                                 (Statement_table.find refcount_table work) )) )
+                          (*when snark works removed from the pool*)
+                          Coda_metrics.(
+                            Gauge.set Snark_work.snark_pool_size
+                              (Float.of_int @@ Hashtbl.length t.snark_table)) )
                   )
                 in
                 deferred
@@ -206,6 +210,10 @@ end)
         if work_is_referenced t work then
           let update_and_rebroadcast () =
             Hashtbl.set t.snark_table ~key:work ~data:{proof; fee} ;
+            (*when snark work added to the pool*)
+            Coda_metrics.(
+              Gauge.set Snark_work.snark_pool_size
+                (Float.of_int @@ Hashtbl.length t.snark_table)) ;
             `Rebroadcast
           in
           match Statement_table.find t.snark_table work with

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -663,6 +663,9 @@ struct
     let%bind transactions, works, user_commands_count, coinbases =
       Deferred.return pre_diff_info
     in
+    Coda_metrics.(
+      Gauge.set Snark_work.snark_work_per_block
+        (Float.of_int (List.length works))) ;
     let%bind is_new_stack, data, stack_update =
       update_coinbase_stack_and_get_data t.scan_state new_ledger
         t.pending_coinbase_collection transactions
@@ -713,6 +716,9 @@ struct
             (Error.to_string_hum e) ) ;
       Deferred.return (to_staged_ledger_or_error r)
     in
+    Coda_metrics.(
+      Gauge.set Snark_work.scan_state_snark_jobs
+        (Float.of_int (List.length (Scan_state.all_work_pairs_exn scan_state')))) ;
     let%bind updated_pending_coinbase_collection' =
       update_pending_coinbase_collection t.pending_coinbase_collection
         stack_update ~is_new_stack ~ledger_proof:res_opt

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -664,7 +664,7 @@ struct
       Deferred.return pre_diff_info
     in
     Coda_metrics.(
-      Gauge.set Snark_work.snark_work_per_block
+      Gauge.set Snark_work.snark_work_last_block
         (Float.of_int (List.length works))) ;
     let%bind is_new_stack, data, stack_update =
       update_coinbase_stack_and_get_data t.scan_state new_ledger

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -716,9 +716,17 @@ struct
             (Error.to_string_hum e) ) ;
       Deferred.return (to_staged_ledger_or_error r)
     in
-    Coda_metrics.(
-      Gauge.set Snark_work.scan_state_snark_jobs
-        (Float.of_int (List.length (Scan_state.all_work_pairs_exn scan_state')))) ;
+    let () =
+      try
+        Coda_metrics.(
+          Gauge.set Snark_work.scan_state_snark_jobs
+            (Float.of_int
+               (List.length (Scan_state.all_work_pairs_exn scan_state'))))
+      with exn ->
+        Logger.error logger ~module_:__MODULE__ ~location:__LOC__
+          ~metadata:[("error", `String (Exn.to_string exn))]
+          !"Error when getting all work pairs from scan state: $error"
+    in
     let%bind updated_pending_coinbase_collection' =
       update_pending_coinbase_collection t.pending_coinbase_collection
         stack_update ~is_new_stack ~ledger_proof:res_opt

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -43,7 +43,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
             Logger.info logger ~module_:__MODULE__ ~location:__LOC__
               ~metadata:[("work", Seen_key.to_yojson work)]
               "Waited too long to get work for $work. Ready to be reassigned" ;
-            Coda_metrics.(Counter.inc_one Snark_work.snark_work_timed_out) ;
+            Coda_metrics.(Counter.inc_one Snark_work.snark_work_timed_out_rpc) ;
             false )
           else true )
 

--- a/src/lib/work_selector/work_lib.ml
+++ b/src/lib/work_selector/work_lib.ml
@@ -43,6 +43,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
             Logger.info logger ~module_:__MODULE__ ~location:__LOC__
               ~metadata:[("work", Seen_key.to_yojson work)]
               "Waited too long to get work for $work. Ready to be reassigned" ;
+            Coda_metrics.(Counter.inc_one Snark_work.snark_work_timed_out) ;
             false )
           else true )
 


### PR DESCRIPTION
Added the following metrics:
  1. snark_work_received_gossip: # of snark work received from peers
  2. snark_work_received_rpc: # of snark work received via rpc 
  3. snark_work_sent_rpc: # of snark work sent via rpc
  4. snark_pool_size: # of snark works in the snark pool
  5. snark_work_per_block: # of snark work purchased per block
  6. scan_state_snark_jobs: # of jobs in the scan state after every block

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

