### PR TITLE
Replace README codaprocotol.org with .com version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-<a href="https://codaprotocol.org">
+<a href="https://codaprotocol.com">
 	<img width="200" src="./frontend/website/static/img/coda-logo@3x.png" alt="Coda Logo" />
 </a>
 <hr/>
 
-Coda is the first cryptocurrency with a lightweight, constant-sized blockchain. This is the main source code repository for the Coda project. It contains code for the OCaml protocol implementation, [website](https://codaprotocol.org), and wallet.
+Coda is the first cryptocurrency with a lightweight, constant-sized blockchain. This is the main source code repository for the Coda project. It contains code for the OCaml protocol implementation, [website](https://codaprotocol.com), and wallet.
 
 ## Notes
 


### PR DESCRIPTION
.org should redirect but it's having some issues I guess and we should probably be consistent anyway