### PR TITLE
Synchronously stop snark workers

### DIFF
--- a/src/app/cli/src/tests/coda_process.ml
+++ b/src/app/cli/src/tests/coda_process.ml
@@ -142,12 +142,9 @@ let replace_snark_worker_key (conn, _proc, _) key =
   Coda_worker.Connection.run_exn conn
     ~f:Coda_worker.functions.replace_snark_worker_key ~arg:key
 
-let stop (conn, _proc, _) =
-  Coda_worker.Connection.run_exn conn ~f:Coda_worker.functions.stop ~arg:()
-
 let disconnect ((conn, proc, _) as t) =
   (* This kills any strangling snark worker process *)
-  let%bind () = stop t in
+  let%bind () = replace_snark_worker_key t None in
   let%bind () = Coda_worker.Connection.close conn in
   let%map (_ : Unix.Exit_or_signal.t) = Process.wait proc in
   ()

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -116,8 +116,7 @@ module T = struct
         ( 'worker
         , unit
         , (External_transition.t, State_hash.t) With_hash.t Pipe.Reader.t )
-        Rpc_parallel.Function.t
-    ; stop: ('worker, unit, unit) Rpc_parallel.Function.t }
+        Rpc_parallel.Function.t }
 
   type coda_functions =
     { coda_peers: unit -> Network_peer.Peer.t list Deferred.t
@@ -172,8 +171,7 @@ module T = struct
            Pipe.Reader.t
            Deferred.t
     ; coda_dump_tf: unit -> string Deferred.t
-    ; coda_best_path: unit -> State_hash.Stable.Latest.t list Deferred.t
-    ; coda_stop: unit -> unit Deferred.t }
+    ; coda_best_path: unit -> State_hash.Stable.Latest.t list Deferred.t }
 
   module Worker_state = struct
     type init_arg = Input.t [@@deriving bin_io]
@@ -246,8 +244,6 @@ module T = struct
 
     let get_all_transitions_impl ~worker_state ~conn_state:() pk =
       worker_state.coda_get_all_transitions pk
-
-    let stop_impl ~worker_state ~conn_state:() = worker_state.coda_stop
 
     let get_all_transitions =
       C.create_rpc ~f:get_all_transitions_impl
@@ -355,9 +351,6 @@ module T = struct
           [%bin_type_class: Public_key.Compressed.Stable.Latest.t option]
         ~bin_output:Unit.bin_t ()
 
-    let stop =
-      C.create_rpc ~f:stop_impl ~bin_input:Unit.bin_t ~bin_output:Unit.bin_t ()
-
     let functions =
       { peers
       ; start
@@ -377,8 +370,7 @@ module T = struct
       ; get_all_user_commands
       ; replace_snark_worker_key
       ; validated_transitions_keyswaptest
-      ; get_all_transitions
-      ; stop }
+      ; get_all_transitions }
 
     let init_worker_state
         { addrs_and_ports
@@ -589,11 +581,6 @@ module T = struct
           let coda_replace_snark_worker_key =
             Coda_lib.replace_snark_worker_key coda
           in
-          (* This should be used to kill any processes that is not killed when the daemon dies. *)
-          let coda_stop () =
-            don't_wait_for (Coda_lib.replace_snark_worker_key coda None) ;
-            Deferred.unit
-          in
           let coda_new_block key =
             Deferred.return @@ Coda_commands.Subscriptions.new_block coda key
           in
@@ -711,8 +698,8 @@ module T = struct
               with_monitor coda_validated_transitions_keyswaptest
           ; coda_replace_snark_worker_key=
               with_monitor coda_replace_snark_worker_key
-          ; coda_get_all_transitions= with_monitor coda_get_all_transitions
-          ; coda_stop= with_monitor coda_stop } )
+          ; coda_get_all_transitions= with_monitor coda_get_all_transitions }
+      )
 
     let init_connection_state ~connection:_ ~worker_state:_ = return
   end

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -397,6 +397,7 @@ let events workers start_reader =
     (Linear_pipe.iter start_reader ~f:(fun (i, config, started, synced) ->
          don't_wait_for
            (let%bind worker = Coda_process.spawn_exn config in
+            let%bind () = Coda_process.start_exn worker in
             workers.(i) <- worker ;
             started () ;
             don't_wait_for

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -278,14 +278,15 @@ let start_prefix_check logger workers events testnet ~acceptable_delay =
        let diff = Time.diff (Time.now ()) !last_time in
        let diff = Time.Span.to_sec diff in
        if
-         not
-           ( diff
-           < Time.Span.to_sec acceptable_delay
-             +. epsilon
-             +. Int.to_float
-                  ( (Consensus.Constants.c - 1)
-                  * Consensus.Constants.block_window_duration_ms )
-                /. 1000. )
+         (not (Array.for_all testnet.status ~f:(fun status -> status = `Off)))
+         && not
+              ( diff
+              < Time.Span.to_sec acceptable_delay
+                +. epsilon
+                +. Int.to_float
+                     ( (Consensus.Constants.c - 1)
+                     * Consensus.Constants.block_window_duration_ms )
+                   /. 1000. )
        then (
          Logger.fatal logger ~module_:__MODULE__ ~location:__LOC__
            "No recent blocks" ;

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -278,7 +278,7 @@ let start_prefix_check logger workers events testnet ~acceptable_delay =
        let diff = Time.diff (Time.now ()) !last_time in
        let diff = Time.Span.to_sec diff in
        if
-         (not (Array.for_all testnet.status ~f:(fun status -> status = `Off)))
+         Array.existsi testnet.status ~f:(fun i _ -> Api.synced testnet i)
          && not
               ( diff
               < Time.Span.to_sec acceptable_delay

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -171,6 +171,11 @@ module Snark_worker = struct
           run_process ~logger:t.config.logger
             t.config.net_config.gossip_net_params.addrs_and_ports.client_port
         in
+        Logger.debug t.config.logger ~module_:__MODULE__ ~location:__LOC__
+          ~metadata:
+            [ ( "snark_worker_pid"
+              , `Int (Pid.to_int (Process.pid snark_worker_process)) ) ]
+          "Started snark worker process with pid: $snark_worker_pid" ;
         Ivar.fill process_ivar snark_worker_process
     | None ->
         Logger.info t.config.logger
@@ -182,9 +187,12 @@ module Snark_worker = struct
   let stop t =
     match t.processes.snark_worker with
     | Some {public_key= _; process} ->
-        Logger.info t.config.logger "Killing snark worker" ~module_:__MODULE__
-          ~location:__LOC__ ;
         let%map process = Ivar.read process in
+        Logger.info t.config.logger
+          "Killing snark worker process with pid: $snark_worker_pid"
+          ~module_:__MODULE__ ~location:__LOC__
+          ~metadata:
+            [("snark_worker_pid", `Int (Pid.to_int (Process.pid process)))] ;
         Signal.send_exn Signal.term (`Pid (Process.pid process))
     | None ->
         Logger.warn t.config.logger


### PR DESCRIPTION
This PR undos #3219.

The reason we introduced #3219 is that turning off snark worker takes a while, and this would cause some bug in long-fork integration test. So in #3219 we try to asynchronously stop snark worker. But this would cause some other bug as described in #3231. This proper fix is to change the integration test infrastructure, so that once the nodes are offline, prefix-check should also be turned off.

Close #3231