### PR TITLE
Fix double-logging issue

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -196,10 +196,8 @@ let daemon logger =
          if is_background then (
            Core.printf "Starting background coda daemon. (Log Dir: %s)\n%!"
              conf_dir ;
-           Daemon.daemonize
-             ~redirect_stdout:(`File_append (conf_dir ^/ "coda.log"))
-             ~redirect_stderr:(`File_append (conf_dir ^/ "coda.log"))
-             () )
+           Daemon.daemonize ~redirect_stdout:`Dev_null
+             ~redirect_stderr:`Dev_null () )
          else ()
        in
        let stdout_log_processor =


### PR DESCRIPTION
Stops redirecting all stdout/stderr to coda.log
We're already writing the logs to coda.log using the logger, this seems
redundant and probably breaks log rotation anyway.

Without this change, we get weird stuff like this in coda.log:
```
{"timestamp":"2019-08-20 01:24:27.231129Z","level":"Warn","source":{"module":"Coda","location":"File \"app/cli/src/coda.ml\", line 509, characters 62-69"},"message":"long async cycle 5.682799s","metadata":{"pid":1435}}
2019-08-20 01:24:27 UTC [Warn] long async cycle 5.682799s
```

Fixes #2993