### PR TITLE
Log gossip heard

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -157,7 +157,7 @@ let daemon logger =
          (optional bool)
      and log_received_blocks =
        flag "log-received-blocks"
-         ~doc:"true|false Log blocks received from peers (default:true)"
+         ~doc:"true|false Log blocks received from peers (default:false)"
          (optional bool)
      and log_transaction_pool_diff =
        flag "log-txn-pool-gossip"
@@ -402,7 +402,7 @@ let daemon logger =
          in
          let log_received_blocks =
            or_from_config YJ.Util.to_bool_option "log-received-blocks"
-             ~default:true log_received_blocks
+             ~default:false log_received_blocks
          in
          let log_transaction_pool_diff =
            or_from_config YJ.Util.to_bool_option "log-txn-pool-gossip"

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -155,6 +155,16 @@ let daemon logger =
          ~doc:
            "true|false Log snark-pool diff received from peers (default:false)"
          (optional bool)
+     and log_received_blocks =
+       flag "log-received-blocks"
+         ~doc:"true|false Log blocks received from peers (default:true)"
+         (optional bool)
+     and log_transaction_pool_diff =
+       flag "log-txn-pool-gossip"
+         ~doc:
+           "true|false Log transaction-pool diff received from peers \
+            (default:false)"
+         (optional bool)
      and no_bans =
        let module Expiration = struct
          [%%expires_after "20190907"]
@@ -390,6 +400,20 @@ let daemon logger =
            or_from_config YJ.Util.to_bool_option "log-snark-work-gossip"
              ~default:false log_received_snark_pool_diff
          in
+         let log_received_blocks =
+           or_from_config YJ.Util.to_bool_option "log-received-blocks"
+             ~default:true log_received_blocks
+         in
+         let log_transaction_pool_diff =
+           or_from_config YJ.Util.to_bool_option "log-txn-pool-gossip"
+             ~default:false log_transaction_pool_diff
+         in
+         let log_gossip_heard =
+           { Coda_networking.Gossip_net.Config.snark_pool_diff=
+               log_received_snark_pool_diff
+           ; transaction_pool_diff= log_transaction_pool_diff
+           ; new_state= log_received_blocks }
+         in
          let initial_peers_raw =
            List.concat
              [ initial_peers_raw
@@ -562,7 +586,7 @@ let daemon logger =
                ; addrs_and_ports
                ; trust_system
                ; max_concurrent_connections
-               ; log_received_snark_pool_diff } }
+               ; log_gossip_heard } }
          in
          let receipt_chain_dir_name = conf_dir ^/ "receipt_chain" in
          let%bind () = Async.Unix.mkdir ~p:() receipt_chain_dir_name in

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -479,7 +479,10 @@ module T = struct
                 ; logger
                 ; trust_system
                 ; max_concurrent_connections
-                ; log_received_snark_pool_diff= false } }
+                ; log_gossip_heard=
+                    { snark_pool_diff= false
+                    ; transaction_pool_diff= false
+                    ; new_state= false } } }
           in
           let monitor = Async.Monitor.create ~name:"coda" () in
           let with_monitor f input =

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -145,7 +145,10 @@ let run_test () : unit Deferred.t =
                   ; client_port }
               ; trust_system
               ; max_concurrent_connections= Some 10
-              ; log_received_snark_pool_diff= false } }
+              ; log_gossip_heard=
+                  { snark_pool_diff= false
+                  ; transaction_pool_diff= false
+                  ; new_state= false } } }
       in
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -68,6 +68,10 @@ module type Message_intf = sig
 end
 
 module type Config_intf = sig
+  type log_gossip_heard =
+    {snark_pool_diff: bool; transaction_pool_diff: bool; new_state: bool}
+  [@@deriving make]
+
   type t =
     { timeout: Time.Span.t
     ; target_peer_count: int
@@ -78,7 +82,7 @@ module type Config_intf = sig
     ; logger: Logger.t
     ; trust_system: Trust_system.t
     ; max_concurrent_connections: int option
-    ; log_received_snark_pool_diff: bool }
+    ; log_gossip_heard: log_gossip_heard }
   [@@deriving make]
 end
 
@@ -183,6 +187,10 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
     }
 
   module Config = struct
+    type log_gossip_heard =
+      {snark_pool_diff: bool; transaction_pool_diff: bool; new_state: bool}
+    [@@deriving make]
+
     type t =
       { timeout: Time.Span.t
       ; target_peer_count: int
@@ -193,7 +201,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
       ; logger: Logger.t
       ; trust_system: Trust_system.t
       ; max_concurrent_connections: int option
-      ; log_received_snark_pool_diff: bool }
+      ; log_gossip_heard: log_gossip_heard }
     [@@deriving make]
   end
 

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -42,13 +42,10 @@ end)
         | Add_solved_work (work, {proof= _; fee= {fee; prover}}) ->
             `Assoc
               [ ("work_id", `Int (Work.hash work))
-              ; ("fee", Currency.Fee.to_yojson fee)
-              ; ("prover", Signature_lib.Public_key.Compressed.to_yojson prover)
-                (*TODO: This should be 
-              Signature_lib.Public_key.Compressed.Stable.V1.to_yojson but for 
-              some reason both are returning two different strings and so using 
-              what mostly used in cli. Paul is looking into it*)
-               ]
+              ; ("fee", Currency.Fee.Stable.V1.to_yojson fee)
+              ; ( "prover"
+                , Signature_lib.Public_key.Compressed.Stable.V1.to_yojson
+                    prover ) ]
     end
 
     module Latest = V1

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -561,6 +561,10 @@ struct
 
     module Gossip_net = struct
       module Config = struct
+        type log_gossip_heard =
+          {snark_pool_diff: bool; transaction_pool_diff: bool; new_state: bool}
+        [@@deriving make]
+
         type t =
           { timeout: Time.Span.t
           ; target_peer_count: int
@@ -571,7 +575,7 @@ struct
           ; logger: Logger.t
           ; trust_system: Trust_system.t
           ; max_concurrent_connections: int option
-          ; log_received_snark_pool_diff: bool }
+          ; log_gossip_heard: log_gossip_heard }
         [@@deriving make]
       end
     end


### PR DESCRIPTION
This is an extension of the snark work log (#3223 ) PR to log received blocks and transaction pool diffs if the flags `log-received-blocks` and `log-txn-pool-gossip` are set resp. 

Snark pool diff log:

```
{"timestamp":"2019-08-20 01:16:50.306045Z","level":"Debug","source":{"module":"Coda_networking","location":"File \"src/lib/coda_networking/coda_networking.ml\", line 792, characters 28-35"},"message":"Received Snark-pool diff $work from $sender","metadata":{"pid":42138,"sender":{"Remote":"10.111.4.160"},"work":{"work_id":441587705,"fee":1,"prover":"8QnLYnzAkhx3moXHHBBpK418LGCEiQZzYDgKggntsNkZqsUJLFos474Mzoy5mWJP9S"}}}
```

Blocks received log

```
{"timestamp":"2019-08-20 01:16:52.318599Z","level":"Debug","source":{"module":"Coda_networking","location":"File \"src/lib/coda_networking/coda_networking.ml\", line 780, characters 28-35"},"message":"Received a block $block from $sender","metadata":{"block":{"protocol_state":{"previous_state_hash":"361399536367600408097950188260359043852477933823142835777616791645145497017800734886502302","body":{"blockchain_state":{"staged_ledger_hash":{"non_snark":{"ledger_hash":"232336260859997032683582830704085003237602715630521559940679538264458926983433475829267661","aux_hash":"PZhNQMPUF3xJxRaWghhFKRcrpofPC6tZfmoSUicgN1LpUrC6td","pending_coinbase_aux":"5LBUm6iEHyPoinfS9yf4dwjndAA27L4UETRBWDTphayD8Ji4VcX"},"pending_coinbase_hash":"209831798737413302154532589724764557800319727334306458931239522920379194330710495667185729"},"snarked_ledger_hash":"206913150313219038289657175864085016367048203265759794195864480590201902983577847042193075","timestamp":"1566263809725"},"consensus_state":{"blockchain_length":"16","epoch_count":"0","min_epoch_length":"576","last_vrf_output":"8KPJSRH6MWKhZZ2RZ7MGT1FQqZQnjEEptNsogynxeqpobnh93G","total_currency":10016100,"curr_global_slot":"144","staking_epoch_data":{"ledger":{"hash":"206913150313219038289657175864085016367048203265759794195864480590201902983577847042193075","total_currency":10016100},"seed":"332637027557984585263317650500984572911029666110240270052776816409842001629441009391914692","start_checkpoint":"332637027557984585263317650500984572911029666110240270052776816409842001629441009391914692","lock_checkpoint":"332637027557984585263317650500984572911029666110240270052776816409842001629441009391914692","epoch_length":"1"},"next_epoch_data":{"ledger":{"hash":"206913150313219038289657175864085016367048203265759794195864480590201902983577847042193075","total_currency":10016100},"seed":"332637027557984585263317650500984572911029666110240270052776816409842001629441009391914692","start_checkpoint":"332637027557984585263317650500984572911029666110240270052776816409842001629441009391914692","lock_checkpoint":null,"epoch_length":"17"},"has_ancestor_in_same_checkpoint_window":true,"checkpoints":{"data":{"prefix":["265842232030149099085265005743463475107447718536453721329538175859355851376126638925391708"],"tail":"0"},"hash":"47986492118097348521389761417560157063324717776710860700807496894359551294983372110965426"}}}},"protocol_state_proof":"<opaque>","staged_ledger_diff":"<opaque>","delta_transition_chain_proof":"<opaque>"},"pid":42138,"sender":{"Remote":"10.111.4.160"}}}
```

Transaction pool diff log

```
{"timestamp":"2019-08-20 01:40:03.997832Z","level":"Debug","source":{"module":"Coda_networking","location":"File \"src/lib/coda_networking/coda_networking.ml\", line 807, characters 28-35"},"message":"Received transaction-pool diff $txns from $sender","metadata":{"pid":42785,"sender":{"Remote":"10.111.4.160"},"txns":[{"payload":{"common":{"fee":5,"nonce":"0","memo":"2pmu64f2x97tNiDXMycnLwBSECDKbX77MTXVWVsG8hcRFsedhXDWWq"},"body":["Payment",{"receiver":"8QnLT8wtfzC2QwijdWsynuD1SfxUTfKRa92jhmsLwBPAwzPSrawfbh6saE225diYAJ","amount":10}]},"sender":"NgvZmrDTBPAokxMFrrq2xywkzatf43xDksCKSpvp1by4TPGGxVU7W5PPqbAHAfv5vtNb7McVHtn3krfAAGheMJt3zZ51fZoLRsRU1tqQA4cr578iAqSTCyh","signature":"HJCXxpYsgcJo425uBqqNKG1Jp8BPFU9cHkErBGhzcFjvZV9VJSyDvn1ePiaygmZjN8tRFb8onPoSPXgQ4MRkicK8VLgGt5TuYRWXCPgLZL3oaBzH6CkMKWn"}]}}
```

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

