### PR TITLE
Add "next proposal" field to status

### DIFF
--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -386,7 +386,9 @@ let get_status ~flag t =
     let str time =
       let open Time in
       let time = Int64.to_float time |> Span.of_ms |> of_span_since_epoch in
-      sprintf "in %s" (Time.Span.to_string_hum (diff time (now ())))
+      let diff = diff time (now ()) in
+      if Span.(zero < diff) then sprintf "in %s" (Time.Span.to_string_hum diff)
+      else "Computing next proposal state..."
     in
     Option.map (Coda_lib.next_proposal t) ~f:(function
       | `Propose_now _ ->

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -386,8 +386,7 @@ let get_status ~flag t =
     let str time =
       let open Time in
       let time = Int64.to_float time |> Span.of_ms |> of_span_since_epoch in
-      sprintf "%s (in %s)" (to_string time)
-        (Span.to_string_hum (diff time (now ())))
+      sprintf "in %s" (Time.Span.to_string_hum (diff time (now ())))
     in
     Option.map (Coda_lib.next_proposal t) ~f:(function
       | `Propose_now _ ->

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -217,7 +217,7 @@ module Types = struct
           let open Reflection.Shorthand in
           List.rev
           @@ Daemon_rpcs.Types.Status.Fields.fold ~init:[] ~num_accounts:int
-               ~blockchain_length:int ~uptime_secs:nn_int
+               ~next_proposal:string ~blockchain_length:int ~uptime_secs:nn_int
                ~ledger_merkle_root:string ~state_hash:string
                ~commit_id:nn_string ~conf_dir:nn_string
                ~peers:(id ~typ:Schema.(non_null @@ list (non_null string)))

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -21,6 +21,8 @@ val propose_public_keys : t -> Public_key.Compressed.Set.t
 
 val replace_propose_keypairs : t -> Keypair.And_compressed_pk.Set.t -> unit
 
+val next_proposal : t -> Consensus.Hooks.proposal option
+
 val replace_snark_worker_key :
   t -> Public_key.Compressed.t option -> unit Deferred.t
 

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -440,6 +440,12 @@ module type S = sig
       -> logger:Logger.t
       -> [`Keep | `Take]
 
+    type proposal =
+      [ `Check_again of Unix_timestamp.t
+      | `Propose_now of Signature_lib.Keypair.t * Proposal_data.t
+      | `Propose of
+        Unix_timestamp.t * Signature_lib.Keypair.t * Proposal_data.t ]
+
     (**
      * Determine if and when to perform the next transition proposal. Either
      * informs the callee to check again at some time in the future, or to
@@ -453,10 +459,7 @@ module type S = sig
       -> local_state:Local_state.t
       -> keypairs:Signature_lib.Keypair.And_compressed_pk.Set.t
       -> logger:Logger.t
-      -> [ `Check_again of Unix_timestamp.t
-         | `Propose_now of Signature_lib.Keypair.t * Proposal_data.t
-         | `Propose of
-           Unix_timestamp.t * Signature_lib.Keypair.t * Proposal_data.t ]
+      -> proposal
 
     (**
      * A hook for managing local state when the locked tip is updated.

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -2511,6 +2511,12 @@ module Hooks = struct
     log_choice ~precondition_msg ~choice_msg choice ;
     choice
 
+  type proposal =
+    [ `Check_again of Unix_timestamp.t
+    | `Propose_now of Signature_lib.Keypair.t * Proposal_data.t
+    | `Propose of Unix_timestamp.t * Signature_lib.Keypair.t * Proposal_data.t
+    ]
+
   let next_proposal now (state : Consensus_state.Value.t) ~local_state
       ~keypairs ~logger =
     let info_if_proposing =

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -287,7 +287,7 @@ module Types = struct
         ~state_hash ~commit_id ~conf_dir ~peers ~user_commands_sent
         ~snark_worker ~propose_pubkeys ~histograms ~consensus_time_best_tip
         ~consensus_time_now ~consensus_mechanism ~consensus_configuration
-        ~snark_work_fee ~next_proposal
+        ~next_proposal ~snark_work_fee
       |> List.filter_map ~f:Fn.id
 
     let to_text (t : t) =

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -171,7 +171,7 @@ module Types = struct
 
       let option_entry ~(f : 'a -> string) (name : string)
           (field : 'a option FieldT.t) =
-        match FieldT.get field with None -> None | Some x -> Some (name, f x)
+        Option.map (FieldT.get field) ~f:(fun x -> (name, f x))
 
       let string_option_entry = option_entry ~f:Fn.id
 
@@ -224,6 +224,8 @@ module Types = struct
       let consensus_time_best_tip =
         string_option_entry "Best tip consensus time"
 
+      let next_proposal = string_option_entry "Next proposal"
+
       let consensus_time_now = string_entry "Consensus time now"
 
       let consensus_mechanism = string_entry "Consensus mechanism"
@@ -267,6 +269,7 @@ module Types = struct
       ; propose_pubkeys: string list
       ; histograms: Histograms.t option
       ; consensus_time_best_tip: string option
+      ; next_proposal: string option
       ; consensus_time_now: string
       ; consensus_mechanism: string
       ; consensus_configuration: Consensus.Configuration.t }
@@ -284,7 +287,7 @@ module Types = struct
         ~state_hash ~commit_id ~conf_dir ~peers ~user_commands_sent
         ~snark_worker ~propose_pubkeys ~histograms ~consensus_time_best_tip
         ~consensus_time_now ~consensus_mechanism ~consensus_configuration
-        ~snark_work_fee
+        ~snark_work_fee ~next_proposal
       |> List.filter_map ~f:Fn.id
 
     let to_text (t : t) =

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -235,7 +235,8 @@ let generate_next_state ~previous_protocol_state ~time_controller
 
 let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
     ~transaction_resource_pool ~time_controller ~keypairs
-    ~consensus_local_state ~frontier_reader ~transition_writer =
+    ~consensus_local_state ~frontier_reader ~transition_writer
+    ~set_next_proposal =
   trace_task "block_producer" (fun () ->
       let log_bootstrap_mode () =
         Logger.info logger ~module_:__MODULE__ ~location:__LOC__
@@ -534,12 +535,14 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                     ~local_state:consensus_local_state
                   = None ) ;
                 let now = Time.now time_controller in
-                match
+                let next_proposal =
                   measure "asking conensus what to do" (fun () ->
                       Consensus.Hooks.next_proposal (time_to_ms now)
                         consensus_state ~local_state:consensus_local_state
                         ~keypairs ~logger )
-                with
+                in
+                set_next_proposal next_proposal ;
+                match next_proposal with
                 | `Check_again time ->
                     Singleton_scheduler.schedule scheduler (time_of_ms time)
                       ~f:check_for_proposal


### PR DESCRIPTION
This PR adds a "next proposal" field to the client status output that says when the next proposal will be if the daemon is configured as a proposer.

I had some trouble testing because I can't get the proposer to produce blocks. Is there an easy way to propose using a key in the test ledger?