### PR TITLE
Code JSON directly

### DIFF
--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -40,12 +40,12 @@ end
 
 module Public_key_with_details = struct
   module Pretty_account = struct
-    type t = string * int * string
+    type t = string * int * int
 
     let to_yojson (public_key, balance, nonce) =
       `Assoc
         [ ( public_key
-          , `Assoc [("balance", `Int balance); ("nonce", `String nonce)] ) ]
+          , `Assoc [("balance", `Int balance); ("nonce", `Int nonce)] ) ]
   end
 
   type t = Pretty_account.t list [@@deriving to_yojson]
@@ -56,6 +56,6 @@ module Public_key_with_details = struct
 
   let to_text account =
     List.map account ~f:(fun (public_key, balance, nonce) ->
-        sprintf !"%s, %d, %s" public_key balance nonce )
+        sprintf !"%s, %d, %d" public_key balance nonce )
     |> String.concat ~sep:"\n"
 end

--- a/src/lib/cli_lib/render.ml
+++ b/src/lib/cli_lib/render.ml
@@ -43,10 +43,9 @@ module Public_key_with_details = struct
     type t = string * int * string
 
     let to_yojson (public_key, balance, nonce) =
-      Yojson.Safe.from_string
-        (sprintf
-           !"\"%s\" : {\"balance\": %d, \"nonce\": %s }"
-           public_key balance nonce)
+      `Assoc
+        [ ( public_key
+          , `Assoc [("balance", `Int balance); ("nonce", `String nonce)] ) ]
   end
 
   type t = Pretty_account.t list [@@deriving to_yojson]

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -101,7 +101,7 @@ let get_keys_with_details t =
   List.map accounts ~f:(fun account ->
       ( string_of_public_key account
       , account.Account.Poly.balance |> Currency.Balance.to_int
-      , account.Account.Poly.nonce |> Account.Nonce.to_string ) )
+      , account.Account.Poly.nonce |> Account.Nonce.to_int ) )
 
 let get_inferred_nonce_from_transaction_pool_and_ledger t
     (addr : Public_key.Compressed.t) =

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -469,7 +469,7 @@ end
 module Get_public_keys_with_details = struct
   type query = unit [@@deriving bin_io]
 
-  type response = (string * int * string) list Or_error.t
+  type response = (string * int * int) list Or_error.t
   [@@deriving bin_io, sexp]
 
   type error = unit [@@deriving bin_io]


### PR DESCRIPTION
Instead of converting a string to JSON, code the JSON directly, which won't fail.

Closes #3233.