### PR TITLE
Check OCaml word size

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -9,6 +9,9 @@ open Signature_lib
 open Init
 module YJ = Yojson.Safe
 
+[%%check_ocaml_word_size
+64]
+
 [%%if
 fake_hash]
 

--- a/src/lib/ppx_coda/check_ocaml_word_size.ml
+++ b/src/lib/ppx_coda/check_ocaml_word_size.ml
@@ -1,0 +1,26 @@
+open Core_kernel
+open Ppxlib
+open Asttypes
+
+(** This is a ppx to check that we're building with an n-bits OCaml
+
+    Usage: [%%check_ocaml_word_size n]
+
+    There will be a compile-time error if the check fails
+ *)
+
+let name = "check_ocaml_word_size"
+
+let expand ~loc ~path:_ expected_word_size =
+  if Int.(not @@ equal Sys.word_size expected_word_size) then
+    Location.raise_errorf ~loc "OCaml word size must be %d, got %d"
+      expected_word_size Sys.word_size ;
+  [%stri let () = ()]
+
+let ext =
+  Extension.declare name Extension.Context.structure_item
+    Ast_pattern.(single_expr_payload (eint __))
+    expand
+
+let () =
+  Driver.register_transformation name ~rules:[Context_free.Rule.extension ext]

--- a/src/lib/ppx_coda/check_ocaml_word_size.ml
+++ b/src/lib/ppx_coda/check_ocaml_word_size.ml
@@ -12,7 +12,7 @@ open Asttypes
 let name = "check_ocaml_word_size"
 
 let expand ~loc ~path:_ expected_word_size =
-  if Int.(not @@ equal Sys.word_size expected_word_size) then
+  if not (Int.equal Sys.word_size expected_word_size) then
     Location.raise_errorf ~loc "OCaml word size must be %d, got %d"
       expected_word_size Sys.word_size ;
   [%stri let () = ()]


### PR DESCRIPTION
Make sure we're building `coda.exe` with a 64-bit OCaml. Compile-time error if not.