### PR TITLE
Ship logproc as coda-logproc in mac dist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ jobs:
             - run:
                   name: Upload deb to repo
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
+                  no_output_timeout: 20m
             - run:
                   name: Copy artifacts to cloud
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
@@ -275,6 +276,7 @@ jobs:
             - run:
                   name: Upload deb to repo
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
+                  no_output_timeout: 20m
             - run:
                   name: Copy artifacts to cloud
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,10 +174,12 @@ jobs:
                     mkdir -p package/keys
                     cp /var/lib/coda/* package/keys/.
             - run:
-                name: Collect and rewrite kademlia
+                name: Collect and rewrite aux binaries (kademlia + logproc)
                 command: |
                     cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
                     chmod +w package/kademlia
+                    cp src/_build/default/app/logproc/logproc.exe package/coda-logproc
+                    chmod +wx package/coda-logproc
                     ./scripts/librewrite-macos.sh package/kademlia
             - run:
                 name: Collect coda binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,9 +178,9 @@ jobs:
                 command: |
                     cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
                     chmod +w package/kademlia
+                    ./scripts/librewrite-macos.sh package/kademlia
                     cp src/_build/default/app/logproc/logproc.exe package/coda-logproc
                     chmod +wx package/coda-logproc
-                    ./scripts/librewrite-macos.sh package/kademlia
             - run:
                 name: Collect coda binary
                 command: |

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -244,6 +244,7 @@ jobs:
             - run:
                   name: Upload deb to repo
                   command: ./scripts/skip_if_only_frontend.sh make publish_deb
+                  no_output_timeout: 20m
             - run:
                   name: Copy artifacts to cloud
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -174,10 +174,12 @@ jobs:
                     mkdir -p package/keys
                     cp /var/lib/coda/* package/keys/.
             - run:
-                name: Collect and rewrite kademlia
+                name: Collect and rewrite aux binaries (kademlia + logproc)
                 command: |
                     cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
                     chmod +w package/kademlia
+                    cp src/_build/default/app/logproc/logproc.exe package/coda-logproc
+                    chmod +wx package/coda-logproc
                     ./scripts/librewrite-macos.sh package/kademlia
             - run:
                 name: Collect coda binary

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -178,9 +178,9 @@ jobs:
                 command: |
                     cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
                     chmod +w package/kademlia
+                    ./scripts/librewrite-macos.sh package/kademlia
                     cp src/_build/default/app/logproc/logproc.exe package/coda-logproc
                     chmod +wx package/coda-logproc
-                    ./scripts/librewrite-macos.sh package/kademlia
             - run:
                 name: Collect coda binary
                 command: |

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -40,7 +40,7 @@ cat ${BUILDDIR}/DEBIAN/control
 echo "------------------------------------------------------------"
 mkdir -p ${BUILDDIR}/usr/local/bin
 cp ./default/app/cli/src/coda.exe ${BUILDDIR}/usr/local/bin/coda
-cp ./default/app/logproc/logproc.exe ${BUILDDIR}/usr/local/bin/logproc
+cp ./default/app/logproc/logproc.exe ${BUILDDIR}/usr/local/bin/coda-logproc
 
 # Better approach for packaging keys
 # Identify actual keys used in build


### PR DESCRIPTION
To follow: coda-logproc in deb dist.

See CodaProtocol/homebrew-coda@10217e7 for homebrew related changes