### PR TITLE
Memory profile file in config dir

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -170,9 +170,9 @@ let daemon logger =
             (default: false)"
          (optional bool)
      and memory_profiling =
-       flag "memory-profiling" no_arg ~doc:"enable memory profiling"
+       flag "memory-profiling" no_arg ~doc:"Enable memory profiling"
      and sampling_rate =
-       flag "sampling-rate"
+       flag "memory-profiling-sampling-rate"
          ~doc:
            (sprintf "FLOAT Sampling rate for memory profiling (default: %F)"
               Memprof_helpers.default_sampling_rate)
@@ -656,7 +656,7 @@ let daemon logger =
        (* this has to be after `handle_shutdown` so that it can trap SIGUSR1 *)
        if memory_profiling then
          Memprof_helpers.start ~sampling_rate ~callstack_size:20
-           ~min_samples_print:100 ;
+           ~min_samples_print:100 ~conf_dir ;
        Async.Scheduler.within' ~monitor
        @@ fun () ->
        let%bind {Coda_initialization.coda; client_whitelist; rest_server_port}

--- a/src/app/cli/src/memprof_helpers.ml
+++ b/src/app/cli/src/memprof_helpers.ml
@@ -1,3 +1,5 @@
+(* modified version of file at https://github.com/jhjourdan/ocaml/blob/memprof/memprofHelpers.ml *)
+
 open Memprof
 open Printexc
 
@@ -124,7 +126,7 @@ let dump () =
   in
   sort_sampleTree (aux (STC ([], 0, Hashtbl.create 3)) 0)
 
-let start ~sampling_rate ~callstack_size ~min_samples_print =
+let start ~sampling_rate ~callstack_size ~min_samples_print ~conf_dir =
   Memprof.start {sampling_rate; callstack_size; callback} ;
   Sys.set_signal Sys.sigusr1
     (Sys.Signal_handle
@@ -133,7 +135,8 @@ let start ~sampling_rate ~callstack_size ~min_samples_print =
          let chan =
            open_out_gen
              [Open_wronly; Open_creat; Open_text; Open_append]
-             0o666 "memory_profile"
+             0o666
+             Filename.(concat conf_dir "memory_profile")
          in
          print chan min_samples_print (dump ()) ;
          close_out chan ;


### PR DESCRIPTION
Write the memprof output file to the config dir.

Change flag to `-memory-profiling-sampling-rate`, so it shows up next to `-memory-profiling` in `-help`.

Add comment to file we cribbed from the memprof distribution.
