### PR TITLE
fix the merkle_root mismatch

### DIFF
--- a/src/lib/sync_handler/sync_handler.ml
+++ b/src/lib/sync_handler/sync_handler.ml
@@ -92,7 +92,7 @@ module Make (Inputs : Inputs_intf) :
     in
     let scan_state = Staged_ledger.scan_state staged_ledger in
     let merkle_root =
-      Staged_ledger.ledger staged_ledger |> Ledger.merkle_root
+      Staged_ledger.hash staged_ledger |> Staged_ledger_hash.ledger_hash
     in
     let pending_coinbases =
       Staged_ledger.pending_coinbase_collection staged_ledger

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -35,7 +35,7 @@ module Make (Inputs : Inputs_intf) :
   module Breadcrumb = struct
     type t =
       { validated_transition: External_transition.Validated.t
-      ; mutable staged_ledger: Staged_ledger.t sexp_opaque
+      ; staged_ledger: Staged_ledger.t sexp_opaque
       ; just_emitted_a_proof: bool }
     [@@deriving sexp, fields]
 


### PR DESCRIPTION
This should fix the "received faulty scan state".

This would also allow us to download the scan state even if the peer's root has moved.

Closes #3269 
