### PR TITLE
Memos for user commands

### DIFF
--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -238,11 +238,16 @@ let run_test () : unit Deferred.t =
                 ( Coda_commands.get_nonce coda (pk_of_sk sender_sk)
                 |> Participating_state.active_exn )
             in
+            let memo =
+              User_command_memo.create_from_string_exn
+                "A memo created in full-test"
+            in
             let payload : User_command.Payload.t =
-              User_command.Payload.create ~fee ~nonce
-                ~memo:User_command_memo.dummy
+              User_command.Payload.create ~fee ~nonce ~memo
                 ~body:(Payment {receiver= receiver_pk; amount})
             in
+            (* verify memo is in the payload *)
+            assert (User_command_memo.equal memo payload.common.memo) ;
             User_command.sign (Keypair.of_private_key_exn sender_sk) payload )
       in
       let assert_ok x = assert (Or_error.is_ok x) in


### PR DESCRIPTION
User commands (payments, delegations) take an optional `-memo` flag:
```
  coda.exe client send-payment 

=== flags ===

  -amount VALUE        Payment amount you want to send
  -privkey-path FILE   File to read private key from
  -receiver PUBLICKEY  Public key address to which you want to send money
  [-daemon-port PORT]  Client to daemon local communication (default: 8301)
  [-fee FEE]           Amount you are willing to pay to process the transaction
                       (default: 5)
  [-memo STRING]       Memo accompanying the transaction (up to 32 characters)
  [-nonce NONCE]       Nonce that you would like to set for your transaction
                       (default: nonce of your account on the best ledger or the
                       successor of highest value nonce of your sent
                       transactions from the transaction pool )
  [-help]              print this help text and exit
                       (alias: -?)
```
If the memo provided exceeds 32 characters, an exception will be raised.
