### PR TITLE
Add basic bot dockerfile

### DIFF
--- a/frontend/bot/Dockerfile
+++ b/frontend/bot/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12.9.0-stretch-slim
+
+COPY package.json yarn.lock ./
+
+RUN yarn && \
+    yarn cache clean
+
+COPY ./graphql_schema.json bsconfig.json ./
+COPY ./src ./src
+
+RUN yarn build-without-copy
+
+ENTRYPOINT ["yarn", "start" ]

--- a/frontend/bot/Dockerfile
+++ b/frontend/bot/Dockerfile
@@ -5,7 +5,7 @@ COPY package.json yarn.lock ./
 RUN yarn && \
     yarn cache clean
 
-COPY ./graphql_schema.json bsconfig.json ./
+COPY graphql_schema.json bsconfig.json ./
 COPY ./src ./src
 
 RUN yarn build-without-copy

--- a/frontend/bot/package.json
+++ b/frontend/bot/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "build": "yarn run copy-schema && bsb -make-world",
+    "build-without-copy": "bsb -make-world",
     "build-ci": "yarn build",
     "clean": "bsb -clean-world",
     "reformat": "bsrefmt --in-place $(find src -name '*.re' -or -name '*.rei')",


### PR DESCRIPTION
Open questions:
- I'm assuming we're passing in env vars with `-e` or something
- This assumes that graphql_schema.json is in the build directory. This isn't true in git, it's actually in the root of the repo. Either we need to build from the repo root and update the dockerfile accordingly, or somehow copy the file into the build directory.

Basically we need to run
```bash
cp coda/graphql_schema.json coda/frontend/bot/graphql_schema.json
```
