### PR TITLE
TRIVIAL: enable time offsets on develop

### DIFF
--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -12,7 +12,7 @@
 [%%define c 8]
 [%%define delta 2]
 
-[%%define time_offsets false]
+[%%define time_offsets true]
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 


### PR DESCRIPTION
In order to run nightly testnets, we need time offsets enabled.