### PR TITLE
Fix links in node-operator docs page

### DIFF
--- a/frontend/website/docs/node-operator.md
+++ b/frontend/website/docs/node-operator.md
@@ -8,15 +8,15 @@ Now that we've set up our Coda node and sent our first transaction, let's turn o
 
 ## Participating in Consensus
 
-The Coda network is secured by [Proof-of-Stake consensus](/glossary/#proof-of-stake). With this model of consensus, you don't need to have complex equipment like in Bitcoin mining. By simply having coda in our wallet, we can choose to either stake it ourselves, or delegate it to another node. Let's first see how to stake coda ourselves:
+The Coda network is secured by [Proof-of-Stake consensus](/docs/glossary/#proof-of-stake). With this model of consensus, you don't need to have complex equipment like in Bitcoin mining. By simply having coda in our wallet, we can choose to either stake it ourselves, or delegate it to another node. Let's first see how to stake coda ourselves:
 
 ### Staking coda
 
-<!-- Since we have some funds in our wallet from [the previous step](/my-first-transaction), we can configure that wallet to stake its coda by issuing the following command, passing in the file path for the associated private key (we previously created the keypair in `keys/my-wallet`): -->
+<!-- Since we have some funds in our wallet from [the previous step](/docs/my-first-transaction), we can configure that wallet to stake its coda by issuing the following command, passing in the file path for the associated private key (we previously created the keypair in `keys/my-wallet`): -->
 
 <!-- coda client set-staking -privkey-path keys/my-wallet -->
 
-Since we have some funds in our wallet from [the previous step](/my-first-transaction), we can now start the daemon with the `-propose-key` flag to begin staking coda. Let's stop our current daemon process, and restart it with the following command, passing in the file path for the associated private key (we previously created the keypair in `keys/my-wallet`):
+Since we have some funds in our wallet from [the previous step](/docs/my-first-transaction), we can now start the daemon with the `-propose-key` flag to begin staking coda. Let's stop our current daemon process, and restart it with the following command, passing in the file path for the associated private key (we previously created the keypair in `keys/my-wallet`):
 
     coda daemon -peer medium-rare.o1test.net:8303 -propose-key keys/my-wallet
 


### PR DESCRIPTION
Tweaked some links to make them point to the correct pages (under `docs/`).

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: