### PR TITLE
Convert cancel-txn to use rpc

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -558,13 +558,17 @@ let send_payment =
     ~error:"Failed to send payment"
 
 let cancel_transaction =
+  let txn_id_flag =
+    Command.Param.(
+      flag "id" ~doc:"ID Transaction ID to be cancelled" (required string))
+  in
+  let args = Args.zip2 Cli_lib.Flag.privkey_read_path txn_id_flag in
   Command.async
     ~summary:
       "Cancel a transaction -- this submits a replacement transaction with a \
        fee larger than the cancelled transaction."
-    (Cli_lib.Background_daemon.init ~rest:true
-       Command.Param.(anon @@ ("txn-id" %: string))
-       ~f:(fun port serialized_transaction ->
+    (Cli_lib.Background_daemon.init args
+       ~f:(fun port (privkey_read_path, serialized_transaction) ->
          match User_command.of_base58_check serialized_transaction with
          | Ok user_command ->
              let receiver =
@@ -576,30 +580,31 @@ let cancel_transaction =
                | Stake_delegation (Set_delegate {new_delegate}) ->
                    new_delegate
              in
-             let nonce_query =
-               let open Graphql_client.Encoders in
-               Graphql_client.Get_inferred_nonce.make
-                 ~public_key:(public_key (User_command.sender user_command))
-                 ()
+             let%bind sender_kp =
+               Secrets.Keypair.Terminal_stdin.read_exn privkey_read_path
              in
-             let open Deferred.Let_syntax in
-             let%bind nonce_response = Graphql_client.query nonce_query port in
-             let maybe_inferred_nonce =
-               let open Option.Let_syntax in
-               let%bind wallet = nonce_response#wallet in
-               let%map nonce = wallet#inferredNonce in
-               int_of_string nonce
+             let cancel_sender = User_command.sender user_command in
+             if
+               not
+                 (Public_key.Compressed.equal
+                    (Public_key.compress sender_kp.public_key)
+                    cancel_sender)
+             then (
+               eprintf
+                 "Provided key doesn't match transaction to be cancelled.\n\
+                  Wanted key for %s\n"
+                 (Public_key.Compressed.to_base58_check cancel_sender) ;
+               Deferred.don't_wait_for (exit 17) ) ;
+             let%bind inferred_nonce =
+               get_nonce_exn ~rpc:Daemon_rpcs.Get_inferred_nonce.rpc
+                 sender_kp.public_key port
              in
-             let cancelled_nonce =
-               Coda_numbers.Account_nonce.to_int
-                 (User_command.nonce user_command)
-             in
-             let inferred_nonce =
-               Option.value maybe_inferred_nonce ~default:cancelled_nonce
-             in
+             let cancelled_nonce = User_command.nonce user_command in
              let cancel_fee =
                let diff =
-                 Unsigned.UInt64.of_int (inferred_nonce - cancelled_nonce + 1)
+                 Unsigned.UInt64.of_int
+                   Coda_numbers.Account_nonce.(
+                     to_int inferred_nonce - to_int cancelled_nonce + 1)
                in
                let fee =
                  Currency.Fee.to_uint64 (User_command.fee user_command)
@@ -609,28 +614,33 @@ let cancel_transaction =
                in
                let open Unsigned.UInt64.Infix in
                (* fee amount "inspired by" network_pool/indexed_pool.ml *)
-               fee + (replace_fee * diff)
+               Currency.Fee.of_uint64 (fee + (replace_fee * diff))
              in
              printf "Fee to cancel transaction is %s coda.\n"
-               (Unsigned.UInt64.to_string cancel_fee) ;
-             let cancel_query =
-               let open Graphql_client.Encoders in
-               Graphql_client.Cancel_user_command.make
-                 ~from:(public_key (User_command.sender user_command))
-                 ~to_:(public_key receiver) ~fee:(uint64 cancel_fee)
-                 ~nonce:
-                   (uint32
-                      (Coda_numbers.Account_nonce.to_uint32
-                         (User_command.nonce user_command)))
-                 ()
+               (Currency.Fee.to_string cancel_fee) ;
+             let body =
+               User_command_payload.Body.Payment
+                 {receiver; amount= Currency.Amount.zero}
              in
-             let%map cancel_response =
-               Graphql_client.query cancel_query port
+             let command =
+               Coda_commands.setup_user_command ~fee:cancel_fee
+                 ~nonce:cancelled_nonce ~memo:User_command_memo.dummy
+                 ~sender_kp body
              in
-             printf "Cancelled transaction! Cancel ID: %s\n"
-               ((cancel_response#sendPayment)#payment)#id
+             dispatch_with_message Daemon_rpcs.Send_user_command.rpc command
+               port
+               ~success:(fun receipt_chain_hash ->
+                 sprintf
+                   "Dispatched cancel transaction with ID %s\n\
+                    Receipt chain hash is now %s\n"
+                   (User_command.to_base58_check command)
+                   (Receipt.Chain_hash.to_string receipt_chain_hash) )
+               ~error:(fun e ->
+                 sprintf "Failed to cancel transaction: %s"
+                   (Error.to_string_hum e) )
+               ~join_error:Or_error.join
          | Error _e ->
-             eprintf "Could not deserialize user command\n" ;
+             eprintf "could not deserialize user command\n" ;
              exit 16 ))
 
 let get_transaction_status =

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -604,7 +604,7 @@ let cancel_transaction =
                let diff =
                  Unsigned.UInt64.of_int
                    Coda_numbers.Account_nonce.(
-                     to_int inferred_nonce - to_int cancelled_nonce + 1)
+                     to_int inferred_nonce - to_int cancelled_nonce)
                in
                let fee =
                  Currency.Fee.to_uint64 (User_command.fee user_command)


### PR DESCRIPTION
We realized at the last minute that we can't use gql for this of CLI command until we have the new accounts system in place. Otherwise you'd only be able to cancel txns sent from "ownedAccounts".

This converts us to using RPC to cancel transactions.

```
$ coda client send-payment -amount 1 -fee 1 -privkey-path tmpkeydir/largest -receiver 8QnLUuaLFKHpRnfAS3NPMh8zpkWgVZ5hMuziZ8m3zum493aib4u5gQcWpCCDqbkf7W
Secret key password: 
Dispatched payment with ID Bf2dBf29M9V796NcNK5Xh3P3N1w7gYHBiun7MEERvS51YhUE9NsuzdCvaECZ8KeFkiDeGRDU97mt9atr5vkKSHjUoVGXjWV6Wpf1dP7kSvKsxkRk7sCK6x3fDaS8XRzZU6oPJDJuouWgdoF5JSvt3PAk6Q7Hep6SGTsfVvVyr6ae7q6fRrPTVDozFpbwg9pDJP1MkWb3WX8hbT36nRzJVoPKPmx9YQeESmsFRq1XJ2UrRNctm5nuGBKj6KeCkNp7AQaFT3pLguf7re9rTQ9WGe7dkGSSeh4d3BQThVH6ydhpL13
Receipt chain hash is now 2JgVwf1PBxtDbGiV7FdxWmR3NypQZ52BZFDRnSH8A3mEN5TXfiTQi24R5VaS2S1cv

$ coda client cancel-transaction -privkey-path tmpkeydir/tmpkey -id Bf2dBf29M9V796NcNK5Xh3P3N1w7gYHBiun7MEERvS51YhUE9NsuzdCvaECZ8KeFkiDeGRDU97mt9atr5vkKSHjUoVGXjWV6Wpf1dP7kSvKsxkRk7sCK6x3fDaS8XRzZU6oPJDJuouWgdoF5JSvt3PAk6Q7Hep6SGTsfVvVyr6ae7q6fRrPTVDozFpbwg9pDJP1MkWb3WX8hbT36nRzJVoPKPmx9YQeESmsFRq1XJ2UrRNctm5nuGBKj6KeCkNp7AQaFT3pLguf7re9rTQ9WGe7dkGSSeh4d3BQThVH6ydhpL13
Secret key password: 
Provided key doesn't match transaction to be cancelled.
Wanted key for 8QnLYnzAkhx3moXHHBBpK418LGCEiQZzYDgKggntsNkZqsUJLFos474Mzoy5mWJP9S

$ coda client cancel-transaction -privkey-path tmpkeydir/largest -id Bf2dBf29M9V796NcNK5Xh3P3N1w7gYHBiun7MEERvS51YhUE9NsuzdCvaECZ8KeFkiDeGRDU97mt9atr5vkKSHjUoVGXjWV6Wpf1dP7kSvKsxkRk7sCK6x3fDaS8XRzZU6oPJDJuouWgdoF5JSvt3PAk6Q7Hep6SGTsfVvVyr6ae7q6fRrPTVDozFpbwg9pDJP1MkWb3WX8hbT36nRzJVoPKPmx9YQeESmsFRq1XJ2UrRNctm5nuGBKj6KeCkNp7AQaFT3pLguf7re9rTQ9WGe7dkGSSeh4d3BQThVH6ydhpL13
Secret key password: 
Fee to cancel transaction is 11 coda.
Dispatched cancel transaction with ID Bf2dBf2JefGsQLCZpL9B2Edmy1u6zpCoKQrpKqMzuqEUQvFw2TL7K5bMVeJVc6ps2K7kphFw1EF3bgY4nFexZLpfgF61dU8JtNspFY1DpfQMM3iLNwCi3JNfuV7bewmXkioEwwYcBFxUdVwA5TkK5wFYjp2DQmpPYacB4Xctk2PaWyZvdHtb19zb5qmFJd1Awah4WW4YNnQfThrhnQ5iu7PdQXjTYqn2cbPqzEL69gNutvXzrvcC3NBRwT71DM6TQ75yeFWMcWnvZF4MXuEY7ZZE4nMLhen3Wn4LAQpr9oLHjfH
Receipt chain hash is now 2JgVxMkdXPg1AfpBTF4rEcHtcvVfmhUrX77Ht3REtNj2xKwriCwAx8dFucuauyj42
```