### PR TITLE
Add optional libp2p discovery

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -395,12 +395,13 @@ let daemon logger =
            or_from_config YJ.Util.to_int_option "rest-port"
              ~default:Port.default_rest rest_server_port
          in
-         ignore libp2p_port ; (* FIXME HACK: make this configurable when we can pass the port in the CLI *)
+         ignore libp2p_port ;
+         (* FIXME HACK: make this configurable when we can pass the port in the CLI *)
          let libp2p_port =
-          (*
+           (*
            or_from_config YJ.Util.to_int_option "libp2p-port"
              ~default:Port.default_libp2p libp2p_port *)
-            Port.default_libp2p
+           Port.default_libp2p
          in
          let snark_work_fee_flag =
            let json_to_currency_fee_option json =
@@ -512,7 +513,7 @@ let daemon logger =
            ; discovery_port
            ; communication_port= external_port
            ; client_port
-           ; libp2p_port= libp2p_port }
+           ; libp2p_port }
          in
          let wallets_disk_location = conf_dir ^/ "wallets" in
          (* HACK: Until we can properly change propose keys at runtime we'll

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -177,7 +177,7 @@ let daemon logger =
        flag "libp2p-discovery" no_arg ~doc:"Use libp2p for peer discovery"
      and libp2p_port =
        flag "libp2p-port" (optional int)
-         ~doc:"Port to use for libp2p (default: 8304)"
+         ~doc:"Port to use for libp2p (default: 28675)"
      and disable_haskell =
        flag "disable-old-discovery" no_arg
          ~doc:"Disable the old discovery mechanism"
@@ -395,9 +395,12 @@ let daemon logger =
            or_from_config YJ.Util.to_int_option "rest-port"
              ~default:Port.default_rest rest_server_port
          in
+         ignore libp2p_port ; (* FIXME HACK: make this configurable when we can pass the port in the CLI *)
          let libp2p_port =
+          (*
            or_from_config YJ.Util.to_int_option "libp2p-port"
-             ~default:Port.default_libp2p libp2p_port
+             ~default:Port.default_libp2p libp2p_port *)
+            Port.default_libp2p
          in
          let snark_work_fee_flag =
            let json_to_currency_fee_option json =

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -6,7 +6,7 @@ open Async
 
 let init () = Parallel.init_master ()
 
-type ports = {communication_port:int;discovery_port:int;libp2p_port:int}
+type ports = {communication_port: int; discovery_port: int; libp2p_port: int}
 
 let net_configs n =
   let ips =
@@ -15,7 +15,7 @@ let net_configs n =
   in
   let addrs_and_ports_list =
     List.mapi ips ~f:(fun i ip ->
-        let base  = 23000  + (i * 3 ) in
+        let base = 23000 + (i * 3) in
         let communication_port = base in
         let discovery_port = base + 1 in
         let libp2p_port = base + 2 in

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -6,6 +6,8 @@ open Async
 
 let init () = Parallel.init_master ()
 
+type ports = {communication_port:int;discovery_port:int;libp2p_port:int}
+
 let net_configs n =
   let ips =
     List.init n ~f:(fun i ->
@@ -13,14 +15,17 @@ let net_configs n =
   in
   let addrs_and_ports_list =
     List.mapi ips ~f:(fun i ip ->
-        let communication_port = 23000 + (i * 2) in
-        let discovery_port = 23000 + 1 + (i * 2) in
+        let base  = 23000  + (i * 3 ) in
+        let communication_port = base in
+        let discovery_port = base + 1 in
+        let libp2p_port = base + 2 in
         let client_port = 20000 + i in
         Kademlia.Node_addrs_and_ports.
           { external_ip= ip
           ; bind_ip= ip
           ; discovery_port
           ; communication_port
+          ; libp2p_port
           ; client_port } )
   in
   let all_peers =

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -465,6 +465,8 @@ module T = struct
                 ; addrs_and_ports
                 ; logger
                 ; trust_system
+                ; enable_libp2p= false
+                ; disable_haskell= false
                 ; max_concurrent_connections
                 ; log_gossip_heard=
                     { snark_pool_diff= false

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -467,6 +467,8 @@ module T = struct
                 ; trust_system
                 ; enable_libp2p= false
                 ; disable_haskell= false
+                ; libp2p_keypair= None
+                ; libp2p_peers= []
                 ; max_concurrent_connections
                 ; log_gossip_heard=
                     { snark_pool_diff= false

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -148,6 +148,8 @@ let run_test () : unit Deferred.t =
               ; trust_system
               ; enable_libp2p= false
               ; disable_haskell= false
+              ; libp2p_keypair= None
+              ; libp2p_peers= []
               ; max_concurrent_connections= Some 10
               ; log_gossip_heard=
                   { snark_pool_diff= false

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -124,6 +124,7 @@ let run_test () : unit Deferred.t =
       let discovery_port = 8001 in
       let communication_port = 8000 in
       let client_port = 8123 in
+      let libp2p_port = 8002 in
       let net_config =
         Coda_networking.Config.
           { logger
@@ -142,8 +143,11 @@ let run_test () : unit Deferred.t =
                   ; bind_ip= Unix.Inet_addr.localhost
                   ; discovery_port
                   ; communication_port
+                  ; libp2p_port
                   ; client_port }
               ; trust_system
+              ; enable_libp2p= false
+              ; disable_haskell= false
               ; max_concurrent_connections= Some 10
               ; log_gossip_heard=
                   { snark_pool_diff= false

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -4,19 +4,27 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"os"
+	"path"
+	"strconv"
+	"time"
+
 	dsb "github.com/ipfs/go-ds-badger"
+	logging "github.com/ipfs/go-log"
 	p2p "github.com/libp2p/go-libp2p"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	host "github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
 	routing "github.com/libp2p/go-libp2p-core/routing"
 	discovery "github.com/libp2p/go-libp2p-discovery"
 	kad "github.com/libp2p/go-libp2p-kad-dht"
 	kadopts "github.com/libp2p/go-libp2p-kad-dht/opts"
-	"github.com/libp2p/go-libp2p-peerstore"
 	"github.com/libp2p/go-libp2p-peerstore/pstoreds"
 	pnet "github.com/libp2p/go-libp2p-pnet"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p-record"
+	record "github.com/libp2p/go-libp2p-record"
 	secio "github.com/libp2p/go-libp2p-secio"
 	p2pconfig "github.com/libp2p/go-libp2p/config"
 	mdns "github.com/libp2p/go-libp2p/p2p/discovery"
@@ -24,27 +32,24 @@ import (
 	ws "github.com/libp2p/go-ws-transport"
 	"github.com/multiformats/go-multiaddr"
 	"golang.org/x/crypto/blake2b"
-	"log"
-	"os"
-	"path"
-	"strconv"
-	"time"
 )
 
 // Helper contains all the daemon state
 type Helper struct {
-	Host   host.Host
-	Mdns   mdns.Service
-	Dht    *kad.IpfsDHT
-	Ctx    context.Context
-	Pubsub *pubsub.PubSub
+	Host            host.Host
+	Mdns            mdns.Service
+	Dht             *kad.IpfsDHT
+	Ctx             context.Context
+	Pubsub          *pubsub.PubSub
+	Logger          logging.EventLogger
+	DiscoveredPeers chan peer.AddrInfo
 }
 
 type mdnsListener struct {
-	FoundPeer chan peerstore.PeerInfo
+	FoundPeer chan peer.AddrInfo
 }
 
-func (l *mdnsListener) HandlePeerFound(info peerstore.PeerInfo) {
+func (l *mdnsListener) HandlePeerFound(info peer.AddrInfo) {
 	l.FoundPeer <- info
 }
 
@@ -64,6 +69,7 @@ func (cv customValidator) Select(key string, values [][]byte) (int, error) {
 
 // MakeHelper does all the initialization to run one host
 func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir string, pk crypto.PrivKey, networkID string) (*Helper, error) {
+	logger := logging.Logger("codanet.Helper")
 	dso := dsb.DefaultOptions
 
 	bp := path.Join(statedir, strconv.Itoa(os.Getpid()))
@@ -85,7 +91,9 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 		return nil, err
 	}
 
-	pnetKey := blake2b.Sum256([]byte("/coda/0.0.1"))
+	rendezvousString := fmt.Sprintf("/coda/0.0.1/%s", networkID)
+
+	pnetKey := blake2b.Sum256([]byte(rendezvousString))
 	prot, err := pnet.NewV1ProtectorFromBytes(&pnetKey)
 	if err != nil {
 		return nil, err
@@ -93,6 +101,7 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 
 	rv := customValidator{Base: record.NamespacedValidator{"pk": record.PublicKeyValidator{}}}
 
+	// gross hack to exfiltrate a channel from the side effect of option evaluation
 	kadch := make(chan *kad.IpfsDHT)
 
 	// Make sure this doesn't get too out of sync with the defaults,
@@ -118,13 +127,11 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 		return nil, err
 	}
 
-	rendezvousString := fmt.Sprintf("/coda/0.0.1/%s", networkID)
-
 	mdns, err := mdns.NewMdnsService(ctx, host, time.Minute, "_coda-discovery._udp.local")
 	if err != nil {
 		return nil, err
 	}
-	l := &mdnsListener{FoundPeer: make(chan peerstore.PeerInfo)}
+	l := &mdnsListener{FoundPeer: make(chan peer.AddrInfo)}
 	mdns.RegisterNotifee(l)
 
 	kad := <-kadch
@@ -137,31 +144,42 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 	log.Println("Announcing ourselves for", rendezvousString)
 	discovery.Advertise(ctx, routingDiscovery, rendezvousString)
 
-	// try and find some peers for this chain
-	//dhtpeers, err := routingDiscovery.FindPeers(ctx, rendezvousString, discovery.Limit(16))
-	//if err != nil {
-	//	return nil, err
-	//}
+	discovered := make(chan peer.AddrInfo)
 
-	foundPeer := func(info peerstore.PeerInfo, source string) {
+	foundPeer := func(info peer.AddrInfo, source string) {
 		if info.ID != "" {
 			ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-            defer cancel()
-            // TODO: do a GetCodaInfo request to learn communication port?
+			defer cancel()
 			if err := host.Connect(ctx, info); err != nil {
-				log.Printf("Warn: couldn't connect to %s peer %v (different chain?): %v", source, info.Loggable(), err)
+				logger.Warning("couldn't connect to %s peer %v (maybe the network ID mismatched?): %v", source, info.Loggable(), err)
 			} else {
-                log.Printf("Found a %s peer: %s", source, info.Loggable())
-                // TODO: additionally have a callback here
-				host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.PermanentAddrTTL)
+				logger.Info("Found a %s peer: %s", source, info.Loggable())
+				host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.ConnectedAddrTTL)
+				discovered <- info
 			}
 		}
 	}
 
+	// report local discovery peers
+	go func() {
+		for info := range l.FoundPeer {
+			foundPeer(info, "local")
+		}
+	}()
+
+	// report dht peers
 	go func() {
 		for {
-			info := <-l.FoundPeer
-			foundPeer(info, "local")
+			// default is to yield only 100 peers at a time. for now, always be
+			// looking... TODO: Is there a better way to use discovery? Should we only
+			// have to explicitly search once?
+			dhtpeers, err := routingDiscovery.FindPeers(ctx, rendezvousString)
+			if err != nil {
+				logger.Error("failed to find DHT peers: ", err)
+			}
+			for info := range dhtpeers {
+				foundPeer(info, "dht")
+			}
 		}
 	}()
 
@@ -171,10 +189,12 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 	}
 
 	return &Helper{
-		Host:   host,
-		Ctx:    ctx,
-		Mdns:   mdns,
-		Dht:    kad,
-		Pubsub: pubsub,
+		Host:            host,
+		Ctx:             ctx,
+		Mdns:            mdns,
+		Dht:             kad,
+		Pubsub:          pubsub,
+		Logger:          logger,
+		DiscoveredPeers: discovered,
 	}, nil
 }

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -146,11 +146,13 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 	foundPeer := func(info peerstore.PeerInfo, source string) {
 		if info.ID != "" {
 			ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
-			defer cancel()
+            defer cancel()
+            // TODO: do a GetCodaInfo request to learn communication port?
 			if err := host.Connect(ctx, info); err != nil {
 				log.Printf("Warn: couldn't connect to %s peer %v (different chain?): %v", source, info.Loggable(), err)
 			} else {
-				log.Printf("Found a %s peer: %s", source, info.Loggable())
+                log.Printf("Found a %s peer: %s", source, info.Loggable())
+                // TODO: additionally have a callback here
 				host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.PermanentAddrTTL)
 			}
 		}

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -43,6 +43,8 @@ type Helper struct {
 	Pubsub          *pubsub.PubSub
 	Logger          logging.EventLogger
 	DiscoveredPeers chan peer.AddrInfo
+	Rendezvous      string
+	Discovery       *discovery.RoutingDiscovery
 }
 
 type mdnsListener struct {
@@ -142,7 +144,6 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 	routingDiscovery := discovery.NewRoutingDiscovery(kad)
 
 	log.Println("Announcing ourselves for", rendezvousString)
-	discovery.Advertise(ctx, routingDiscovery, rendezvousString)
 
 	discovered := make(chan peer.AddrInfo)
 
@@ -196,5 +197,7 @@ func MakeHelper(ctx context.Context, listenOn []multiaddr.Multiaddr, statedir st
 		Pubsub:          pubsub,
 		Logger:          logger,
 		DiscoveredPeers: discovered,
+		Rendezvous:      rendezvousString,
+		Discovery:       routingDiscovery,
 	}, nil
 }

--- a/src/app/libp2p_helper/src/generate_methodidx/main.go
+++ b/src/app/libp2p_helper/src/generate_methodidx/main.go
@@ -99,7 +99,7 @@ func main() {
 		Command:     "generate_methodidx",
 		PackageName: "main",
 		TypesAndValues: map[string][]string{
-			"methodIdx": []string{"configure", "listen", "publish", "subscribe", "unsubscribe",  "validationComplete", "generateKeypair", "openStream", "closeStream", "resetStream", "sendStreamMsg", "removeStreamHandler", "addStreamHandler", "listeningAddrs"},
+			"methodIdx": []string{"configure", "listen", "publish", "subscribe", "unsubscribe", "validationComplete", "generateKeypair", "openStream", "closeStream", "resetStream", "sendStreamMsg", "removeStreamHandler", "addStreamHandler", "listeningAddrs", "addPeer", "beginAdvertising"},
 		},
 	}
 

--- a/src/app/libp2p_helper/src/libp2p_helper/methodidx_jsonenum.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/methodidx_jsonenum.go
@@ -23,6 +23,8 @@ var (
 		"removeStreamHandler": removeStreamHandler,
 		"addStreamHandler":    addStreamHandler,
 		"listeningAddrs":      listeningAddrs,
+		"addPeer":             addPeer,
+		"beginAdvertising":    beginAdvertising,
 	}
 
 	_methodIdxValueToName = map[methodIdx]string{
@@ -40,6 +42,8 @@ var (
 		removeStreamHandler: "removeStreamHandler",
 		addStreamHandler:    "addStreamHandler",
 		listeningAddrs:      "listeningAddrs",
+		addPeer:             "addPeer",
+		beginAdvertising:    "beginAdvertising",
 	}
 )
 
@@ -61,6 +65,8 @@ func init() {
 			interface{}(removeStreamHandler).(fmt.Stringer).String(): removeStreamHandler,
 			interface{}(addStreamHandler).(fmt.Stringer).String():    addStreamHandler,
 			interface{}(listeningAddrs).(fmt.Stringer).String():      listeningAddrs,
+			interface{}(addPeer).(fmt.Stringer).String():             addPeer,
+			interface{}(beginAdvertising).(fmt.Stringer).String():    beginAdvertising,
 		}
 	}
 }

--- a/src/coda_net2.opam
+++ b/src/coda_net2.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+

--- a/src/lib/cli_lib/port.ml
+++ b/src/lib/cli_lib/port.ml
@@ -9,6 +9,6 @@ let default_rest = 0xc0d
 (* This is always computed as default_external+1 *)
 let default_discovery = 8303
 
-let default_libp2p = 8304
+let default_libp2p = 28675
 
 let of_local port = Host_and_port.create ~host:"127.0.0.1" ~port

--- a/src/lib/cli_lib/port.ml
+++ b/src/lib/cli_lib/port.ml
@@ -6,4 +6,9 @@ let default_external = 8302
 
 let default_rest = 0xc0d
 
+(* This is always computed as default_external+1 *)
+let default_discovery = 8303
+
+let default_libp2p = 8304
+
 let of_local port = Host_and_port.create ~host:"127.0.0.1" ~port

--- a/src/lib/coda_net2/coda_net2.mli
+++ b/src/lib/coda_net2/coda_net2.mli
@@ -137,7 +137,8 @@ val create : logger:Logger.t -> conf_dir:string -> net Deferred.Or_error.t
   *
   * Listens on each address in [maddrs].
   *
-  * This will only connect to peers that share the same [network_id].
+  * This will only connect to peers that share the same [network_id]. [on_new_peer], if present,
+  * will be called for each peer we discover.
   *
   * This fails if initializing libp2p fails for any reason.
 *)
@@ -146,6 +147,7 @@ val configure :
   -> me:Keypair.t
   -> maddrs:Multiaddr.t list
   -> network_id:string
+  -> ?on_new_peer:(Network_peer.Peer.t -> unit)
   -> unit Deferred.Or_error.t
 
 (** The keypair the network was configured with.

--- a/src/lib/coda_net2/coda_net2.mli
+++ b/src/lib/coda_net2/coda_net2.mli
@@ -42,7 +42,14 @@ module Keypair : sig
   (** Securely generate a new keypair. *)
   val random : net -> t Deferred.t
 
+  (** Formats this keypair to a ;-separated list of public key, secret key, and peer_id. *)
   val to_string : t -> string
+
+  (** Undo [to_string t].
+  
+    Only fails if the string has the wrong format, not if the embedded
+    keypair data is corrupt. *)
+  val of_string : string -> t Core.Or_error.t
 
   val to_peerid : t -> peer_id
 end
@@ -258,6 +265,16 @@ val listen_on : net -> Multiaddr.t -> Multiaddr.t list Deferred.Or_error.t
   on an address.
 *)
 val listening_addrs : net -> Multiaddr.t list Deferred.Or_error.t
+
+(** Connect to a peer, ensuring it enters our peerbook and DHT.
+
+  This can fail if the connection fails. *)
+val add_peer : net -> Multiaddr.t -> unit Deferred.Or_error.t
+
+(** Announce our existence on the DHT.
+
+  Call this after using [add_peer] to add any bootstrap peers. *)
+val begin_advertising : net -> unit Deferred.Or_error.t
 
 (** Stop listening, close all connections and subscription pipes, and kill the subprocess. *)
 val shutdown : net -> unit Deferred.t

--- a/src/lib/coda_net2/coda_net2.mli
+++ b/src/lib/coda_net2/coda_net2.mli
@@ -147,7 +147,7 @@ val configure :
   -> me:Keypair.t
   -> maddrs:Multiaddr.t list
   -> network_id:string
-  -> ?on_new_peer:(Network_peer.Peer.t -> unit)
+  -> on_new_peer:(PeerID.t -> unit)
   -> unit Deferred.Or_error.t
 
 (** The keypair the network was configured with.

--- a/src/lib/coda_net2/dune
+++ b/src/lib/coda_net2/dune
@@ -1,6 +1,6 @@
 (library
  (name coda_net2)
  (public_name coda_net2)
- (libraries core async file_system yojson digestif.ocaml pipe_lib envelope logger base58)
+ (libraries core async network_peer file_system yojson digestif.ocaml pipe_lib envelope logger base58)
  (inline_tests)
  (preprocess (pps ppx_jane ppx_let ppx_deriving_yojson)))

--- a/src/lib/coda_net2/dune
+++ b/src/lib/coda_net2/dune
@@ -1,5 +1,6 @@
 (library
  (name coda_net2)
+ (public_name coda_net2)
  (libraries core async file_system yojson digestif.ocaml pipe_lib envelope logger base58)
  (inline_tests)
  (preprocess (pps ppx_jane ppx_let ppx_deriving_yojson)))

--- a/src/lib/gossip_net/dune
+++ b/src/lib/gossip_net/dune
@@ -3,7 +3,7 @@
  (public_name gossip_net)
  (library_flags -linkall)
  (inline_tests)
- (libraries perf_histograms core coda_base trust_system pipe_lib logger kademlia async async_extra o1trace coda_metrics)
+ (libraries perf_histograms core coda_base coda_net2 trust_system pipe_lib logger kademlia async async_extra o1trace coda_metrics)
  (preprocess
   (pps ppx_coda ppx_inline_test ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson bisect_ppx ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_custom_printf -- -conditional))
  (synopsis "Gossip Network"))

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -82,6 +82,8 @@ module type Config_intf = sig
     ; logger: Logger.t
     ; trust_system: Trust_system.t
     ; max_concurrent_connections: int option
+    ; enable_libp2p: bool
+    ; disable_haskell: bool
     ; log_gossip_heard: log_gossip_heard }
   [@@deriving make]
 end
@@ -213,6 +215,8 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
       ; logger: Logger.t
       ; trust_system: Trust_system.t
       ; max_concurrent_connections: int option
+      ; enable_libp2p: bool
+      ; disable_haskell: bool
       ; log_gossip_heard: log_gossip_heard }
     [@@deriving make]
   end

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -623,8 +623,9 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
                      |> Yojson.Safe.from_string |> Peer.of_yojson
                      |> Result.ok_or_failwith
                    in
-                   ignore them_as_peer)
-                  (* Inject into Membership.changes *)
+                   Option.iter haskell_membership ~f:(fun membership ->
+                       Membership.Hacky_glue.inject_event membership
+                         (Peer.Event.Connect [them_as_peer]) ))
                   |> don't_wait_for
                 in
                 let%bind _disc_handler =

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -99,6 +99,7 @@ module type S = sig
 
   type t
 
+  module Config : Config_intf
 
   val create :
     Config.t -> Host_and_port.t Rpc.Implementation.t list -> t Deferred.t
@@ -204,6 +205,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
     ; ban_notification_reader: ban_notification Linear_pipe.Reader.t
     ; ban_notification_writer: ban_notification Linear_pipe.Writer.t
     ; mutable haskell_membership: Membership.t option
+    ; mutable libp2p_membership: Coda_net2.net option
     ; connections:
         ( Unix.Inet_addr.t
         , (Uuid.t, Connection_with_state.t) Hashtbl.t )
@@ -591,6 +593,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
           ; ban_notification_writer
           ; chain_id= config.chain_id
           ; haskell_membership= membership
+          ; libp2p_membership= None
           ; connections= Hashtbl.create (module Unix.Inet_addr)
           ; first_connect }
         in

--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -166,7 +166,8 @@ module Haskell_process = struct
         ; bind_ip= ip1
         ; discovery_port= 8000
         ; communication_port= 8001
-        ; client_port= 3000 }
+        ; client_port= 3000
+        ; libp2p_port= 8002 }
     in
     let me_discovery = Host_and_port.create ~host:"1.1.1.1" ~port:8000 in
     let other = Host_and_port.create ~host:"1.1.1.2" ~port:8000 in
@@ -521,7 +522,8 @@ let%test_module "Tests" =
                 ; bind_ip= Unix.Inet_addr.localhost
                 ; discovery_port= 3001
                 ; communication_port= 3000
-                ; client_port= 2000 }
+                ; client_port= 2000
+                ; libp2p_port= 3002 }
               ~logger:(Logger.null ())
               ~conf_dir:(Filename.temp_dir_name ^/ "membership-test")
           with
@@ -630,11 +632,13 @@ let%test_module "Tests" =
       fold_membership (module M) ~init:false ~f:(fun b _e -> b || true)
 
     let node_addrs_and_ports_of_int i =
+      let base = 3005 + (i * 3) in
       Node_addrs_and_ports.
         { external_ip= Unix.Inet_addr.localhost
         ; bind_ip= Unix.Inet_addr.localhost
-        ; discovery_port= 3006 + i
-        ; communication_port= 3005 + i
+        ; communication_port= base
+        ; discovery_port= base + 1
+        ; libp2p_port= base + 2 
         ; client_port= 1000 + i }
 
     let conf_dir = Filename.temp_dir_name ^/ ".kademlia-test-"
@@ -781,7 +785,7 @@ let%test_module "Tests" =
                 let%bind () = Haskell_trust.stop new_banner_node
                 and () = Haskell.stop normal_node in
                 Deferred.unit ) *)
-      
+
       end )
 
     let%test_unit "lockfile does not exist after connection calling stop" =

--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -25,6 +25,10 @@ module type S = sig
   val changes : t -> Peer.Event.t Linear_pipe.Reader.t
 
   val stop : t -> unit Deferred.t
+
+  module Hacky_glue : sig
+    val inject_event : t -> Peer.Event.t -> unit
+  end
 end
 
 module type Process_intf = sig
@@ -471,6 +475,11 @@ end = struct
   let changes t = t.changes_reader
 
   let stop t = P.kill t.p
+
+  module Hacky_glue = struct
+    let inject_event t e =
+      Linear_pipe.write t.changes_writer e |> don't_wait_for
+  end
 
   module For_tests = struct
     let node node_addrs_and_ports (peers : Host_and_port.t list) conf_dir

--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -638,7 +638,7 @@ let%test_module "Tests" =
         ; bind_ip= Unix.Inet_addr.localhost
         ; communication_port= base
         ; discovery_port= base + 1
-        ; libp2p_port= base + 2 
+        ; libp2p_port= base + 2
         ; client_port= 1000 + i }
 
     let conf_dir = Filename.temp_dir_name ^/ ".kademlia-test-"
@@ -785,7 +785,7 @@ let%test_module "Tests" =
                 let%bind () = Haskell_trust.stop new_banner_node
                 and () = Haskell.stop normal_node in
                 Deferred.unit ) *)
-
+      
       end )
 
     let%test_unit "lockfile does not exist after connection calling stop" =

--- a/src/lib/kademlia/membership.mli
+++ b/src/lib/kademlia/membership.mli
@@ -23,4 +23,8 @@ module Haskell : sig
   val changes : t -> Peer.Event.t Linear_pipe.Reader.t
 
   val stop : t -> unit Deferred.t
+
+  module Hacky_glue : sig
+    val inject_event : t -> Peer.Event.t -> unit
+  end
 end

--- a/src/lib/kademlia/node_addrs_and_ports.ml
+++ b/src/lib/kademlia/node_addrs_and_ports.ml
@@ -7,7 +7,8 @@ type t =
   ; discovery_port: int
   ; client_port: int
   ; libp2p_port: int
-  ; communication_port: int } [@@deriving bin_io]
+  ; communication_port: int }
+[@@deriving bin_io]
 
 let to_peer : t -> Peer.t = function
   | {external_ip; discovery_port; communication_port; _} ->

--- a/src/lib/kademlia/node_addrs_and_ports.ml
+++ b/src/lib/kademlia/node_addrs_and_ports.ml
@@ -5,9 +5,9 @@ type t =
   { external_ip: Unix.Inet_addr.t
   ; bind_ip: Unix.Inet_addr.t
   ; discovery_port: int
-  ; communication_port: int
-  ; client_port: int }
-[@@deriving bin_io]
+  ; client_port: int
+  ; libp2p_port: int
+  ; communication_port: int } [@@deriving bin_io]
 
 let to_peer : t -> Peer.t = function
   | {external_ip; discovery_port; communication_port; _} ->

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -550,6 +550,8 @@ struct
           ; logger: Logger.t
           ; trust_system: Trust_system.t
           ; max_concurrent_connections: int option
+          ; enable_libp2p: bool
+          ; disable_haskell: bool
           ; log_gossip_heard: log_gossip_heard }
         [@@deriving make]
       end

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -552,6 +552,8 @@ struct
           ; max_concurrent_connections: int option
           ; enable_libp2p: bool
           ; disable_haskell: bool
+          ; libp2p_keypair: Coda_net2.Keypair.t option
+          ; libp2p_peers: Coda_net2.Multiaddr.t list
           ; log_gossip_heard: log_gossip_heard }
         [@@deriving make]
       end


### PR DESCRIPTION
use `-libp2p-discovery` as daemon arg to enable. There is a `-libp2p-port` argument but it is IGNORED at the moment in favor of the hardcoded port 28675 (arbitrary). When we remove the Haskell Kademlia, we'll take over the existing port infrastructure.

There's a `-disable-old-discovery` that turns off old discovery as well. Risky!