### PR TITLE
transition system library

### DIFF
--- a/src/lib/transition_system/dune
+++ b/src/lib/transition_system/dune
@@ -1,0 +1,14 @@
+(library
+ (name transition_system)
+ (public_name transition_system)
+ (library_flags -linkall)
+ (inline_tests)
+ (libraries 
+    logger
+    sexp_diff_kernel
+    hash_prefix_states coda_compile_config snarky snark_params core)
+ (preprocessor_deps ../../config.mlh)
+ (preprocess
+  (pps 
+    ppx_snarky ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+ (synopsis "The core recursive composition for a transition system"))

--- a/src/lib/transition_system/intf.ml
+++ b/src/lib/transition_system/intf.ml
@@ -1,0 +1,62 @@
+open Snark_params
+open Tuple_lib
+open Fold_lib
+
+module type Digest_intf = sig
+  open Tick
+
+  type t
+
+  module Unchecked : sig
+    type t
+
+    val fold : t -> bool Triple.t Fold.t
+  end
+
+  val typ : (t, Unchecked.t) Typ.t
+
+  val to_triples : t -> Boolean.var Triple.t list
+end
+
+module type Step_inputs_intf = sig
+  open Tick
+
+  (* The hash section for the previous state could be reused in either the squashed or nested approach.
+      1. Squashed: Reuse when hashing the the previous state itself (when comparing against the previous_state_hash field)
+      2. Nested: Reuse when hashing the new state.
+
+      I believe squashed is better and saves about 1000 constraints, but it is difficult to implement.
+  *)
+  module Update : sig
+    type t
+
+    module Unchecked : sig
+      type t
+    end
+
+    val typ : (t, Unchecked.t) Typ.t
+  end
+
+  module State : sig
+    type t
+
+    module Hash : sig
+      include Digest_intf
+
+      val is_base : t -> Boolean.var
+    end
+
+    module Unchecked : sig
+      type t [@@deriving sexp]
+
+      val hash : t -> Hash.Unchecked.t
+    end
+
+    val typ : (t, Unchecked.t) Typ.t
+
+    val hash : t -> Hash.t
+
+    val update :
+      Hash.t * t -> Update.t -> Hash.t * t * [`Success of Boolean.var]
+  end
+end

--- a/src/lib/transition_system/step.ml
+++ b/src/lib/transition_system/step.ml
@@ -1,0 +1,211 @@
+open Core
+open Fold_lib
+open Snark_params
+open Bitstring_lib
+open Tick
+open Run
+
+let ( ! ) = run_checked
+
+let pad_to_triples = Bitstring.pad_to_triple_list ~default:Boolean.false_
+
+module Witness = struct
+  type ('state, 'update) t =
+    {proof: Tock.Proof.t; previous_state: 'state; update: 'update}
+end
+
+let input_size = Step_input.size
+
+module Verification_keys = struct
+  type t =
+    { wrap_vk: Wrap_vk_compressed.Unchecked.t
+    ; step_vk: Step_vk_compressed.Unchecked.t
+    ; hash_state: Pedersen.State.t }
+
+  let create ~wrap_vk ~step_vk =
+    let wrap_vk = Wrap_vk_compressed.Unchecked.of_backend_vk wrap_vk in
+    let step_vk = Step_vk_compressed.Unchecked.of_backend_vk step_vk in
+    let hash_state =
+      let wrap_vk_bits =
+        Wrap_vk_compressed.to_bits wrap_vk ~unpack_field:(fun t ~length ->
+            List.take (Tick.Field.unpack t) length )
+      and step_vk_bits =
+        Step_vk_compressed.to_bits step_vk ~unpack_field:(fun t ~length ->
+            List.take (Tock.Field.unpack t) length )
+      in
+      Pedersen.State.update_fold Hash_prefix_states.transition_system_snark
+        Fold.(
+          group3 ~default:false (of_list wrap_vk_bits +> of_list step_vk_bits))
+    in
+    {wrap_vk; step_vk; hash_state}
+end
+
+module Make (Inputs : Intf.Step_inputs_intf) = struct
+  open Inputs
+
+  module Witness = struct
+    type t = (State.Unchecked.t, Update.Unchecked.t) Witness.t
+  end
+
+  (* Returns the function that computes
+
+   fun state_hash -> hash(wrap_vk || step_vk || state_hash) *)
+  let to_instance_hash ~wrap_vk_compressed ~step_vk_compressed =
+    let open Pedersen.Checked in
+    let vks =
+      let wrap_vk_bits =
+        Wrap_vk_compressed.to_bits ~unpack_field:Field.choose_preimage_var
+          wrap_vk_compressed
+      and step_vk_bits =
+        Tock.Verifier.Verification_key.Compressed.to_list step_vk_compressed
+        |> List.concat
+      in
+      !(Section.append
+          (hash_prefix Hash_prefix_states.transition_system_snark)
+          (pad_to_triples (wrap_vk_bits @ step_vk_bits)))
+    in
+    stage (fun s ->
+        !(Section.append vks (State.Hash.to_triples s))
+        |> Section.to_initial_segment_digest_exn |> fst )
+
+  let instance_hash {Verification_keys.hash_state; _} s =
+    Pedersen.digest_fold hash_state
+      (State.Hash.Unchecked.fold (State.Unchecked.hash s))
+
+  (* Return the function that computes
+
+   fun x proof -> verify_wrap (step_vk, x) proof *)
+  let verify_wrap ~wrap_vk_compressed ~step_vk_compressed =
+    let wrap_vk =
+      !(Verifier.Verification_key.Compressed.decompress wrap_vk_compressed)
+    and step_vk = Step_vk_compressed.to_scalars step_vk_compressed in
+    let pc = !(Verifier.Verification_key.Precomputation.create wrap_vk) in
+    stage (fun x proof ->
+        !(let%bind x = Wrap_input.Checked.tick_field_to_scalars x in
+          Verifier.verify wrap_vk pc (step_vk @ x) proof) )
+
+  let verify_wrap =
+    match Coda_compile_config.proof_level with
+    | "full" ->
+        verify_wrap
+    | "check" | "none" ->
+        fun ~wrap_vk_compressed:_ ~step_vk_compressed:_ ->
+          stage (fun _ _ -> Boolean.true_)
+    | _ ->
+        failwith "unknown proof_level"
+
+  include struct
+    open Snarky.Request
+
+    type _ t +=
+      | Wrap_vk : Wrap_vk_compressed.Unchecked.t t
+      | Previous_state : State.Unchecked.t t
+      | Step_vk : Step_vk_compressed.Unchecked.t t
+      | Proof : (Inner_curve.t, Pairing.G2.Unchecked.t) Verifier.Proof.t_ t
+      | Update : Update.Unchecked.t t
+  end
+
+  let main (h : Field.t) =
+    let verify, to_top_hash =
+      let wrap_vk_compressed =
+        exists Wrap_vk_compressed.typ ~request:(fun () -> Wrap_vk)
+      and step_vk_compressed =
+        exists Step_vk_compressed.typ ~request:(fun () -> Step_vk)
+      in
+      ( unstage (verify_wrap ~wrap_vk_compressed ~step_vk_compressed)
+      , unstage (to_instance_hash ~wrap_vk_compressed ~step_vk_compressed) )
+    in
+    let previous_state =
+      exists State.typ ~request:(fun () -> Previous_state)
+    in
+    let previous_state_hash = State.hash previous_state in
+    let previous_state_valid =
+      let pi = exists Verifier.Proof.typ ~request:(fun () -> Proof) in
+      verify (to_top_hash previous_state_hash) pi
+    in
+    let update = exists Update.typ ~request:(fun () -> Update) in
+    let next_state_hash, next_state, `Success update_succeeded =
+      State.update (previous_state_hash, previous_state) update
+    in
+    let next_top_hash = to_top_hash next_state_hash in
+    Field.Assert.equal h next_top_hash ;
+    Boolean.(
+      Assert.any
+        [ previous_state_valid && update_succeeded
+        ; State.Hash.is_base next_state_hash ]) ;
+    (next_state, next_top_hash)
+
+  let make_handler ~(wrap_vk : Wrap_vk_compressed.Unchecked.t)
+      ~(step_vk : Step_vk_compressed.Unchecked.t)
+      ({proof; previous_state; update} : Witness.t) : Handler.t =
+   fun (With {request; respond}) ->
+    let provide x = respond (Provide x) in
+    match request with
+    | Wrap_vk ->
+        provide wrap_vk
+    | Step_vk ->
+        provide step_vk
+    | Proof ->
+        provide (Verifier.proof_of_backend_proof proof)
+    | Previous_state ->
+        provide previous_state
+    | Update ->
+        provide update
+    | _ ->
+        unhandled
+
+  let constraint_system () =
+    constraint_system ~exposing:Step_input.input (fun x () -> main x |> ignore)
+
+  let check_against_expected_state (expected_state, expected_top_hash)
+      (next_state, next_top_hash) =
+    let logger = Logger.create () in
+    as_prover
+      As_prover.(
+        fun () ->
+          let in_snark_next_state = read State.typ next_state in
+          let next_top_hash = read Field.typ next_top_hash in
+          let updated = State.Unchecked.sexp_of_t in_snark_next_state in
+          let original = State.Unchecked.sexp_of_t expected_state in
+          if not (Field.Constant.equal next_top_hash expected_top_hash) then
+            let diff = Sexp_diff_kernel.Algo.diff ~original ~updated () in
+            Logger.fatal logger
+              "Out-of-SNARK and in-SNARK calculations of the next top hash \
+               differ"
+              ~metadata:
+                [ ( "state_sexp_diff"
+                  , `String
+                      (Sexp_diff_kernel.Display.display_as_plain_string diff)
+                  ) ]
+              ~location:__LOC__ ~module_:__MODULE__)
+
+  let handled_main ?(handler = fun _ -> unhandled) vks expected_next_state
+      witness =
+    let top_hash = instance_hash vks expected_next_state in
+    let main x () =
+      let next_state = main x in
+      check_against_expected_state (expected_next_state, top_hash) next_state
+    in
+    let main x () =
+      handle
+        (fun () ->
+          handle (main x)
+            (make_handler ~wrap_vk:vks.wrap_vk ~step_vk:vks.step_vk witness) )
+        handler
+    in
+    (top_hash, main)
+
+  let check_constraints ?handler vks expected_next_state witness =
+    let top_hash, main =
+      handled_main ?handler vks expected_next_state witness
+    in
+    check (main (Field.constant top_hash)) ()
+
+  let prove ?handler vks pk expected_next_state witness =
+    let top_hash, main =
+      handled_main ?handler vks expected_next_state witness
+    in
+    Or_error.try_with (fun () ->
+        let proof = prove pk Step_input.input main () top_hash in
+        (top_hash, proof) )
+end

--- a/src/lib/transition_system/step.mli
+++ b/src/lib/transition_system/step.mli
@@ -1,0 +1,45 @@
+open Base
+open Snark_params
+
+module Witness : sig
+  type ('state, 'update) t =
+    {proof: Tock.Proof.t; previous_state: 'state; update: 'update}
+end
+
+val input_size : int
+
+module Verification_keys : sig
+  type t
+
+  val create :
+    wrap_vk:Tock.Verification_key.t -> step_vk:Tick.Verification_key.t -> t
+end
+
+module Make (Inputs : Intf.Step_inputs_intf) : sig
+  open Inputs
+  open Tick.Run
+
+  module Witness : sig
+    type t = (State.Unchecked.t, Update.Unchecked.t) Witness.t
+  end
+
+  val instance_hash :
+    Verification_keys.t -> State.Unchecked.t -> Tick.Pedersen.Digest.t
+
+  val constraint_system : unit -> R1CS_constraint_system.t
+
+  val check_constraints :
+       ?handler:Handler.t
+    -> Verification_keys.t
+    -> State.Unchecked.t
+    -> Witness.t
+    -> unit Base.Or_error.t
+
+  val prove :
+       ?handler:Handler.t
+    -> Verification_keys.t
+    -> Proving_key.t
+    -> State.Unchecked.t
+    -> Witness.t
+    -> (Tick.Pedersen.Digest.t * Proof.t) Or_error.t
+end

--- a/src/lib/transition_system/step_input.ml
+++ b/src/lib/transition_system/step_input.ml
@@ -1,0 +1,5 @@
+open Snark_params.Tick
+
+let input = Data_spec.[Pedersen.Checked.Digest.typ]
+
+let size = Data_spec.size input

--- a/src/lib/transition_system/step_vk_compressed.ml
+++ b/src/lib/transition_system/step_vk_compressed.ml
@@ -1,0 +1,47 @@
+open Core_kernel
+open Snark_params
+open Tock
+open Tuple_lib
+open Bitstring_lib
+open Verifier
+open Verification_key.Compressed
+
+type nonrec 'f t_ = ('f, 'f Double.t) t_
+
+type t = Tick.Boolean.var list t_
+
+let typ =
+  let input_size = Step_input.size in
+  let fq' size =
+    let unpack, length =
+      match size with
+      | `Full ->
+          (Field.unpack, Field.size_in_bits)
+      | `Small n ->
+          ((fun x -> List.take (Field.unpack x) n), n)
+    in
+    Tick.Typ.transport
+      (Tick.Typ.list Tick.Boolean.typ ~length)
+      ~there:unpack ~back:Field.project
+  in
+  let fq = fq' `Full in
+  let fqe = Tick.Typ.tuple2 fq fq in
+  typ' ~input_size ~fq ~fqe ~y_bits:(fq' (`Small (Y_bits.length ~input_size)))
+
+let to_scalars vk = List.map ~f:Bitstring.Lsb_first.of_list (to_list vk)
+
+(* TODO: Make the y_coordinate a "Bits.t" or something that caches the unpacking since
+  decompress does the unpacking internally. *)
+let to_bits ~unpack_field vk =
+  let fq t = unpack_field t ~length:Field.size_in_bits in
+  to_list' vk ~fq
+    ~fqe:(fun x -> List.map (Pairing.Fqe.to_list x) ~f:fq)
+    ~y_bits:(fun x ->
+      unpack_field x ~length:(Y_bits.length ~input_size:Step_input.size) )
+  |> List.concat
+
+module Unchecked = struct
+  type t = Field.t t_
+
+  let of_backend_vk vk : t = Unchecked.compress (vk_of_backend_vk vk)
+end

--- a/src/lib/transition_system/step_vk_compressed.mli
+++ b/src/lib/transition_system/step_vk_compressed.mli
@@ -1,0 +1,19 @@
+open Snark_params
+open Tuple_lib
+
+type 'f t_ = ('f, 'f Double.t) Tock.Verifier.Verification_key.Compressed.t_
+
+type t = Tick.Boolean.var list t_
+
+val to_scalars : 'a list t_ -> 'a Bitstring_lib.Bitstring.Lsb_first.t list
+
+module Unchecked : sig
+  type t = Tock.Field.t t_
+
+  val of_backend_vk : Tick.Verification_key.t -> t
+end
+
+val to_bits :
+  unpack_field:('f -> length:int -> 'bool list) -> 'f t_ -> 'bool list
+
+val typ : (t, Unchecked.t) Tick.Typ.t

--- a/src/lib/transition_system/transition_system.ml
+++ b/src/lib/transition_system/transition_system.ml
@@ -1,0 +1,2 @@
+module Step = Step
+module Wrap = Wrap

--- a/src/lib/transition_system/wrap.ml
+++ b/src/lib/transition_system/wrap.ml
@@ -1,0 +1,41 @@
+open Core
+open Snark_params
+open Tock
+
+let step_vk_typ =
+  Verifier.Verification_key.Compressed.typ ~input_size:Step_input.size
+
+let input = Data_spec.[step_vk_typ; Wrap_input.typ]
+
+let input_size = Data_spec.size input
+
+(* The verification key is compressed so that the input to this wrap SNARK is smaller,
+    which then means it has a smaller verification key and we do less work verifying it
+    in the Tick SNARKs that recursively verify these (by avoiding the exponentiations
+    associated with each public input.)
+*)
+let main (vk : _ Tock.Verifier.Verification_key.Compressed.t_)
+    (x : Wrap_input.var) =
+  let open Tock.Verifier in
+  let%bind pi = exists Tock.Verifier.Proof.typ ~compute:As_prover.get_state
+  and input = Wrap_input.Checked.to_scalar x
+  and vk = Verification_key.Compressed.decompress vk in
+  let%bind pvk = Verification_key.Precomputation.create vk in
+  let%bind result = verify vk pvk [input] pi in
+  Boolean.Assert.is_true result
+
+let constraint_system () = constraint_system ~exposing:input main
+
+let prove step_vk pk =
+  let compressed = Step_vk_compressed.Unchecked.of_backend_vk step_vk in
+  stage (fun statement proof ->
+      Or_error.try_with (fun () ->
+          prove pk input
+            (Verifier.proof_of_backend_proof proof)
+            main compressed
+            (Wrap_input.of_tick_field statement) ) )
+
+let verify step_vk vk =
+  let compressed = Step_vk_compressed.Unchecked.of_backend_vk step_vk in
+  stage (fun statement proof ->
+      verify proof vk input compressed (Wrap_input.of_tick_field statement) )

--- a/src/lib/transition_system/wrap.mli
+++ b/src/lib/transition_system/wrap.mli
@@ -1,0 +1,16 @@
+open Core
+open Snark_params
+
+val input_size : int
+
+val constraint_system : unit -> Tock.R1CS_constraint_system.t
+
+val prove :
+     Tick.Verification_key.t
+  -> Tock.Proving_key.t
+  -> (Tick.Field.t -> Tick.Proof.t -> Tock.Proof.t Or_error.t) Staged.t
+
+val verify :
+     Tick.Verification_key.t
+  -> Tock.Verification_key.t
+  -> (Tick.Field.t -> Tock.Proof.t -> bool) Staged.t

--- a/src/lib/transition_system/wrap_vk_compressed.ml
+++ b/src/lib/transition_system/wrap_vk_compressed.ml
@@ -1,0 +1,28 @@
+open Core_kernel
+open Tuple_lib
+open Snark_params.Tick
+open Run
+open Verifier
+open Verification_key.Compressed
+
+type nonrec 'f t_ = ('f, 'f Triple.t) t_
+
+type t = Field.t t_
+
+(* TODO: Make the y_coordinate a "Bits.t" or something that caches the unpacking since
+  decompress does the unpacking internally. *)
+let to_bits ~unpack_field vk =
+  let fq t = unpack_field t ~length:Field.size_in_bits in
+  to_list' vk ~fq
+    ~fqe:(fun x -> List.map (Pairing.Fqe.to_list x) ~f:fq)
+    ~y_bits:(fun x ->
+      unpack_field x ~length:(Y_bits.length ~input_size:Wrap.input_size) )
+  |> List.concat
+
+module Unchecked = struct
+  type t = Field.Constant.t t_
+
+  let of_backend_vk vk : t = Unchecked.compress (vk_of_backend_vk vk)
+end
+
+let typ = typ ~input_size:Wrap.input_size

--- a/src/lib/transition_system/wrap_vk_compressed.mli
+++ b/src/lib/transition_system/wrap_vk_compressed.mli
@@ -1,0 +1,20 @@
+open Snark_params
+open Tuple_lib
+open Tick
+
+type 'f t_ = ('f, 'f Triple.t) Verifier.Verification_key.Compressed.t_
+
+type t = Field.Var.t t_
+
+module Unchecked : sig
+  type t = Field.t t_
+
+  val of_backend_vk : Tock.Verification_key.t -> t
+end
+
+open Run
+
+val to_bits :
+  unpack_field:('f -> length:int -> 'bool list) -> 'f t_ -> 'bool list
+
+val typ : (t, Unchecked.t) Typ.t

--- a/src/transition_system.opam
+++ b/src/transition_system.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
This library is intended to replace the current implementation of recursive composition in coda_base/transition_system.ml.

It differs in that a setup for this construction can be performed for the "step" and "wrap" SNARKs at the same time because the wrap key is no longer hardcoded inside the step SNARK. The "main" SNARKs are

- step: step.ml, lines 108-136
- wrap: wrap.ml, lines 17-25.

Depends on https://github.com/CodaProtocol/coda/pull/3360