### PR TITLE
Base58uncheck tool

### DIFF
--- a/src/app/base58uncheck/base58uncheck.ml
+++ b/src/app/base58uncheck/base58uncheck.ml
@@ -1,0 +1,24 @@
+open Core
+
+(* copy paste from base58_check.ml *)
+let coda_alphabet =
+  B58.make_alphabet
+    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+let () =
+  Command.run
+  @@ Command.basic
+       ~summary:"Remove the version bytes and checksums from base58check data"
+  @@
+  let open Command.Let_syntax in
+  let%map_open input = anon ("in-data" %: string) in
+  fun () ->
+    let input_bytes = Bytes.of_string input in
+    let decoded_bytes = B58.decode coda_alphabet input_bytes in
+    (* A base58check string is a single version byte, the payload, then 4 bytes
+       of hash. *)
+    let payload_len = Bytes.length decoded_bytes - 4 - 1 in
+    let output_bytes = Bytes.create payload_len in
+    Bytes.blit ~src:decoded_bytes ~src_pos:1 ~dst:output_bytes ~dst_pos:0
+      ~len:payload_len ;
+    print_endline @@ Bytes.to_string @@ B58.encode coda_alphabet output_bytes

--- a/src/app/base58uncheck/dune
+++ b/src/app/base58uncheck/dune
@@ -1,0 +1,9 @@
+(executable
+ (name base58uncheck)
+ (public_name base58uncheck)
+ (package base58uncheck)
+ (libraries core base58 base58_check)
+ (preprocess (pps ppx_jane))
+ (modes native)
+ )
+

--- a/src/base58uncheck.opam
+++ b/src/base58uncheck.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+


### PR DESCRIPTION
Hacky tool to remove version bytes and checksums from base58check data. I don't think we should merge this.