### PR TITLE
Add password support to tracked accounts

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -40,13 +40,6 @@ let daemon logger =
   let open Cli_lib.Arg_type in
   Command.async ~summary:"Coda daemon"
     (let%map_open conf_dir = Cli_lib.Flag.conf_dir
-     and unsafe_track_propose_key =
-       flag "unsafe-track-propose-key"
-         ~doc:
-           "Your private key will be copied to the internal wallets folder \
-            stripped of its password if it is given using the `propose-key` \
-            flag. (default: don't copy the private key)"
-         no_arg
      and propose_key =
        flag "propose-key"
          ~doc:
@@ -54,13 +47,6 @@ let daemon logger =
             provide both `propose-key` and `propose-public-key`. (default: \
             don't produce blocks)"
          (optional string)
-     and propose_public_key =
-       flag "propose-public-key"
-         ~doc:
-           "PUBLICKEY Public key for the associated private key that is being \
-            tracked by this daemon. You cannot provide both `propose-key` and \
-            `propose-public-key`. (default: don't produce blocks)"
-         (optional public_key_compressed)
      and initial_peers_raw =
        flag "peer"
          ~doc:
@@ -498,54 +484,12 @@ let daemon logger =
            ; communication_port= external_port
            ; client_port }
          in
-         let wallets_disk_location = conf_dir ^/ "wallets" in
-         (* HACK: Until we can properly change propose keys at runtime we'll
-          * suffer by accepting a propose_public_key flag and reloading the wallet
-          * db here to find the keypair for the pubkey *)
          let%bind propose_keypair =
-           match (propose_key, propose_public_key) with
-           | Some _, Some _ ->
-               eprintf
-                 "Error: You cannot provide both `propose-key` and \
-                  `propose-public-key`\n" ;
-               exit 11
-           | Some sk_file, None ->
-               let%bind keypair =
-                 Secrets.Keypair.Terminal_stdin.read_exn sk_file
-               in
-               let%map () =
-                 (* If we wish to track the propose key *)
-                 if unsafe_track_propose_key then
-                   let pk = Public_key.compress keypair.public_key in
-                   let%bind wallets =
-                     Secrets.Wallets.load ~logger
-                       ~disk_location:wallets_disk_location
-                   in
-                   (* Either we already are tracking it *)
-                   match Secrets.Wallets.find wallets ~needle:pk with
-                   | Some _ ->
-                       Deferred.unit
-                   | None ->
-                       (* Or we import it *)
-                       Secrets.Wallets.import_keypair wallets keypair
-                       >>| ignore
-                 else Deferred.unit
-               in
-               Some keypair
-           | None, Some wallet_pk -> (
-               match%bind
-                 Secrets.Wallets.load ~logger
-                   ~disk_location:wallets_disk_location
-                 >>| Secrets.Wallets.find ~needle:wallet_pk
-               with
-               | Some keypair ->
-                   Deferred.Option.return keypair
-               | None ->
-                   eprintf
-                     "Error: This public key was not found in the local \
-                      daemon's wallet database\n" ;
-                   exit 12 )
-           | None, None ->
+           match propose_key with
+           | Some sk_file ->
+               let%map kp = Secrets.Keypair.Terminal_stdin.read_exn sk_file in
+               Some kp
+           | None ->
                return None
          in
          let%bind client_whitelist =

--- a/src/lib/auxiliary_database/transaction_database.ml
+++ b/src/lib/auxiliary_database/transaction_database.ml
@@ -68,6 +68,8 @@ module For_tests = struct
 
   let of_year years = Int64.of_int (years * 365 * 24 * 60 * 60 * 1000)
 
+  let password = lazy (Deferred.Or_error.return (Bytes.of_string ""))
+
   let compress_key_pairs =
     List.map ~f:(fun {Keypair.public_key; _} -> Public_key.compress public_key)
 
@@ -77,8 +79,9 @@ module For_tests = struct
     let%bind wallets = Secrets.Wallets.load ~logger ~disk_location:directory in
     let%map local_wallet_keypairs =
       Deferred.List.init num_wallets ~f:(fun _ ->
-          let%map needle = Secrets.Wallets.generate_new wallets in
-          Option.value_exn (Secrets.Wallets.find wallets ~needle) )
+          let%map needle = Secrets.Wallets.generate_new wallets ~password in
+          let keypair = Secrets.Wallets.find_unlocked wallets ~needle in
+          Option.value_exn keypair )
     in
     let remote_user_keypairs =
       List.init num_foreign ~f:(fun _ -> Keypair.create ())

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -169,7 +169,7 @@ let replace_proposers keys pks =
     List.filter_map pks ~f:(fun pk ->
         let open Option.Let_syntax in
         let%map kps =
-          Coda_lib.wallets keys |> Secrets.Wallets.find ~needle:pk
+          Coda_lib.wallets keys |> Secrets.Wallets.find_unlocked ~needle:pk
         in
         (kps, pk) )
   in

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -544,6 +544,20 @@ module Types = struct
               ~args:Arg.[]
               ~resolve:(fun _ -> Fn.id) ] )
 
+    let unlock_wallet : (Coda_lib.t, Account.key option) typ =
+      obj "UnlockPayload" ~fields:(fun _ ->
+          [ field "publicKey" ~typ:(non_null public_key)
+              ~doc:"Public key of the unlocked account"
+              ~args:Arg.[]
+              ~resolve:(fun _ -> Fn.id) ] )
+
+    let lock_wallet : (Coda_lib.t, Account.key option) typ =
+      obj "LockPayload" ~fields:(fun _ ->
+          [ field "publicKey" ~typ:(non_null public_key)
+              ~doc:"Public key of the unlocked account"
+              ~args:Arg.[]
+              ~resolve:(fun _ -> Fn.id) ] )
+
     let delete_wallet =
       obj "DeleteWalletPayload" ~fields:(fun _ ->
           [ field "publicKey" ~typ:(non_null public_key)
@@ -703,6 +717,28 @@ module Types = struct
           ; fee ~doc:"Fee amount in order to send a stake delegation"
           ; memo ~doc:"Short arbitrary message provided by the sender"
           ; nonce ~doc:"Desired nonce for delegating state" ]
+
+    let add_wallet =
+      obj "AddWalletInput" ~coerce:Fn.id
+        ~fields:
+          [ arg "password" ~doc:"Password used to encrypt the new account"
+              ~typ:(non_null string) ]
+
+    let unlock_wallet =
+      obj "UnlockInput"
+        ~coerce:(fun password pk -> (password, pk))
+        ~fields:
+          [ arg "password" ~doc:"Password for the account to be unlocked"
+              ~typ:(non_null string)
+          ; arg "publicKey"
+              ~doc:"Public key specifying which account to unlock"
+              ~typ:(non_null public_key_arg) ]
+
+    let lock_wallet =
+      obj "LockInput" ~coerce:Fn.id
+        ~fields:
+          [ arg "publicKey" ~doc:"Public key specifying which account to lock"
+              ~typ:(non_null public_key_arg) ]
 
     let delete_wallet =
       obj "DeleteWalletInput" ~coerce:Fn.id
@@ -1163,14 +1199,48 @@ module Mutations = struct
       ~doc:
         "Add a wallet - this will create a new keypair and store it in the \
          daemon"
-      ~typ:
-        (non_null Types.Payload.add_wallet)
-        (* TODO: For now, not including add wallet input *)
-      ~args:Arg.[]
-      ~resolve:(fun {ctx= t; _} () ->
+      ~typ:(non_null Types.Payload.add_wallet)
+      ~args:Arg.[arg "input" ~typ:(non_null Types.Input.add_wallet)]
+      ~resolve:(fun {ctx= t; _} () password ->
         let open Deferred.Let_syntax in
-        let%map pk = Coda_lib.wallets t |> Secrets.Wallets.generate_new in
+        let password =
+          lazy (Deferred.Or_error.return (Bytes.of_string password))
+        in
+        let%map pk =
+          Coda_lib.wallets t |> Secrets.Wallets.generate_new ~password
+        in
         Result.return pk )
+
+  let unlock_wallet =
+    io_field "unlock"
+      ~doc:"Allow transactions to be sent from the unlocked account"
+      ~typ:(non_null Types.Payload.unlock_wallet)
+      ~args:Arg.[arg "input" ~typ:(non_null Types.Input.unlock_wallet)]
+      ~resolve:(fun {ctx= t; _} () (password, pk) ->
+        let password =
+          lazy (Deferred.Or_error.return (Bytes.of_string password))
+        in
+        let open Deferred.Let_syntax in
+        match%map
+          Coda_lib.wallets t |> Secrets.Wallets.unlock ~needle:pk ~password
+        with
+        | Error `Not_found ->
+            Error "Could not find owned account associated with provided key"
+        | Error `Bad_password ->
+            Error "Wrong password provided"
+        | Ok () ->
+            Ok pk )
+
+  let lock_wallet =
+    field "lock"
+      ~doc:"Lock an unlocked account to prevent transaction being sent from it"
+      ~typ:
+        (non_null Types.Payload.lock_wallet)
+        (* TODO: For now, not including add wallet input *)
+      ~args:Arg.[arg "input" ~typ:(non_null Types.Input.lock_wallet)]
+      ~resolve:(fun {ctx= t; _} () pk ->
+        Coda_lib.wallets t |> Secrets.Wallets.lock ~needle:pk ;
+        pk )
 
   let delete_wallet =
     io_field "deleteWallet"
@@ -1237,11 +1307,11 @@ module Mutations = struct
     in
     let%bind sender_kp =
       Result.of_option
-        (Secrets.Wallets.find (Coda_lib.wallets coda) ~needle:from)
+        (Secrets.Wallets.find_unlocked (Coda_lib.wallets coda) ~needle:from)
         ~error:
           (sprintf
-             "Couldn't find the private key for specified `sender`. Do you \
-              own the wallet you're making a %s from?"
+             "Couldn't find an unlocked key for specified `sender`. Did you \
+              unlock the wallet you're making a %s from?"
              kind)
     in
     let%map memo =
@@ -1322,7 +1392,7 @@ module Mutations = struct
     field "setStaking"
       ~doc:
         "Set keys you wish to stake with - silently fails if you pass keys \
-         not tracked in ownedWallets"
+         not unlocked and tracked in ownedWallets"
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.set_staking)]
       ~typ:(non_null Types.Payload.set_staking)
       ~resolve:(fun {ctx= coda; _} () pks ->

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -3,19 +3,36 @@ open Async
 module Secret_keypair = Keypair
 open Signature_lib
 
+(* type key_info = {filename: string; empty_password: bool} *)
+type locked_key = Locked of string | Unlocked of (string * Keypair.t)
+
 (* A simple cache on top of the fs *)
-type t = {cache: Keypair.t Public_key.Compressed.Table.t; path: string}
+type t = {cache: locked_key Public_key.Compressed.Table.t; path: string}
 
-(* TODO: Don't just generate bad passwords *)
-let password = lazy (Deferred.Or_error.return (Bytes.of_string ""))
+let get_privkey_filename public_key =
+  Public_key.Compressed.to_base58_check public_key
 
-let get_path {path; _} public_key =
-  let pubkey_str =
-    (* TODO: Do we need to version this? *)
-    Public_key.Compressed.to_base58_check public_key
-    |> String.tr ~target:'/' ~replacement:'x'
+let get_path {path; cache} public_key =
+  (* TODO: Do we need to version this? *)
+  let filename =
+    Public_key.Compressed.Table.find cache public_key
+    |> Option.map ~f:(fun (Locked file | Unlocked (file, _)) -> file)
+    |> Option.value ~default:(get_privkey_filename public_key)
   in
-  path ^/ pubkey_str
+  path ^/ filename
+
+let decode_public_key key file path logger =
+  match Public_key.Compressed.of_base58_check key with
+  | Ok pk ->
+      Some pk
+  | Error e ->
+      Logger.error logger ~module_:__MODULE__ ~location:__LOC__
+        "Error decoding public key at $path/$file: $error"
+        ~metadata:
+          [ ("file", `String file)
+          ; ("path", `String path)
+          ; ("error", `String (Error.to_string_hum e)) ] ;
+      None
 
 let load ~logger ~disk_location : t Deferred.t =
   let logger =
@@ -26,21 +43,17 @@ let load ~logger ~disk_location : t Deferred.t =
   let%bind files = Sys.readdir path >>| Array.to_list in
   let%bind keypairs =
     Deferred.List.filter_map files ~f:(fun file ->
-        if Filename.check_suffix file ".pub" then return None
-        else
-          match%map
-            Secret_keypair.read ~privkey_path:(path ^/ file) ~password
-          with
-          | Ok keypair ->
-              Some (keypair.public_key |> Public_key.compress, keypair)
-          | Error e ->
-              Logger.error logger ~module_:__MODULE__ ~location:__LOC__
-                "Error reading key pair at $path/$file: $error"
-                ~metadata:
-                  [ ("file", `String file)
-                  ; ("path", `String path)
-                  ; ("error", `String (Error.to_string_hum e)) ] ;
-              None )
+        match String.chop_suffix file ~suffix:".pub" with
+        | Some file_base -> (
+            let%map lines = Reader.file_lines file in
+            match lines with
+            | public_key :: _ ->
+                decode_public_key public_key file path logger
+                |> Option.map ~f:(fun pk -> (pk, Locked file_base))
+            | _ ->
+                None )
+        | None ->
+            return None )
   in
   let%map () = Unix.chmod path ~perm:0o700 in
   let cache =
@@ -52,21 +65,22 @@ let load ~logger ~disk_location : t Deferred.t =
   in
   {cache; path}
 
-(** Generates a new private key file for the given keypair *)
-let import_keypair t keypair : Public_key.Compressed.t Deferred.t =
-  let privkey_path =
-    get_path t (Public_key.compress keypair.Keypair.public_key)
-  in
+(** Generates a new private key file for the given keypair
+  * If no password is provided, an empty one is used *)
+let import_keypair t keypair ~password : Public_key.Compressed.t Deferred.t =
+  let compressed_pk = Public_key.compress keypair.Keypair.public_key in
+  let privkey_path = get_path t compressed_pk in
   let%bind () = Secret_keypair.write_exn keypair ~privkey_path ~password in
   let%map () = Unix.chmod privkey_path ~perm:0o600 in
   let pk = Public_key.compress keypair.public_key in
-  Public_key.Compressed.Table.add_exn t.cache ~key:pk ~data:keypair ;
+  Public_key.Compressed.Table.add_exn t.cache ~key:pk
+    ~data:(Unlocked (get_privkey_filename compressed_pk, keypair)) ;
   pk
 
 (** Generates a new private key file and a keypair *)
-let generate_new t : Public_key.Compressed.t Deferred.t =
+let generate_new t ~password : Public_key.Compressed.t Deferred.t =
   let keypair = Keypair.create () in
-  import_keypair t keypair
+  import_keypair t keypair ~password
 
 let delete ({cache; _} as t : t) (pk : Public_key.Compressed.t) :
     (unit, [`Not_found]) Deferred.Result.t =
@@ -76,12 +90,43 @@ let delete ({cache; _} as t : t) (pk : Public_key.Compressed.t) :
 
 let pks ({cache; _} : t) = Public_key.Compressed.Table.keys cache
 
-let find ({cache; _} : t) ~needle =
+let find_unlocked ({cache; _} : t) ~needle =
   Public_key.Compressed.Table.find cache needle
+  |> Option.bind ~f:(function Locked _ -> None | Unlocked (_, kp) -> Some kp)
+
+let check_locked {cache; _} ~needle =
+  Public_key.Compressed.Table.find cache needle
+  |> Option.map ~f:(function Locked _ -> true | Unlocked _ -> false)
+
+let unlock {cache; path} ~needle ~password =
+  let unlock_keypair = function
+    | Locked file ->
+        Secret_keypair.read ~privkey_path:(path ^/ file) ~password
+        |> Deferred.Result.map_error ~f:(fun _ -> `Bad_password)
+        |> Deferred.Result.map ~f:(fun kp ->
+               Public_key.Compressed.Table.set cache ~key:needle
+                 ~data:(Unlocked (file, kp)) )
+        |> Deferred.Result.ignore
+    | Unlocked _ ->
+        Deferred.Result.return ()
+  in
+  Public_key.Compressed.Table.find cache needle
+  |> Result.of_option ~error:`Not_found
+  |> Deferred.return
+  |> Deferred.Result.bind ~f:unlock_keypair
+
+let lock {cache; _} ~needle =
+  Public_key.Compressed.Table.change cache needle ~f:(function
+    | Some (Unlocked (file, _)) ->
+        Some (Locked file)
+    | k ->
+        k )
 
 let%test_module "wallets" =
   ( module struct
     let logger = Logger.create ()
+
+    let password = lazy (Deferred.Or_error.return (Bytes.of_string ""))
 
     module Set = Public_key.Compressed.Set
 
@@ -89,18 +134,18 @@ let%test_module "wallets" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           File_system.with_temp_dir "/tmp/coda-wallets-test" ~f:(fun path ->
               let%bind wallets = load ~logger ~disk_location:path in
-              let%map pk = generate_new wallets in
+              let%map pk = generate_new wallets ~password in
               let keys = Set.of_list (pks wallets) in
               assert (Set.mem keys pk) ;
-              assert (find wallets ~needle:pk |> Option.is_some) ) )
+              assert (find_unlocked wallets ~needle:pk |> Option.is_some) ) )
 
     let%test_unit "get from existing file system not-scratch" =
       Backtrace.elide := false ;
       Async.Thread_safe.block_on_async_exn (fun () ->
           File_system.with_temp_dir "/tmp/coda-wallets-test" ~f:(fun path ->
               let%bind wallets = load ~logger ~disk_location:path in
-              let%bind pk1 = generate_new wallets in
-              let%bind pk2 = generate_new wallets in
+              let%bind pk1 = generate_new wallets ~password in
+              let%bind pk2 = generate_new wallets ~password in
               let keys = Set.of_list (pks wallets) in
               assert (Set.mem keys pk1 && Set.mem keys pk2) ;
               (* Get wallets again from scratch *)
@@ -112,12 +157,14 @@ let%test_module "wallets" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           File_system.with_temp_dir "/tmp/coda-wallets-test" ~f:(fun path ->
               let%bind wallets = load ~logger ~disk_location:path in
-              let%bind pk = generate_new wallets in
+              let%bind pk = generate_new wallets ~password in
               let keys = Set.of_list (pks wallets) in
               assert (Set.mem keys pk) ;
               match%map delete wallets pk with
               | Ok () ->
-                  assert (Option.is_none @@ find wallets ~needle:pk)
+                  assert (
+                    Option.is_none
+                    @@ Public_key.Compressed.Table.find wallets.cache pk )
               | Error _ ->
                   failwith "unexpected" ) )
 

--- a/src/lib/secrets/wallets.mli
+++ b/src/lib/secrets/wallets.mli
@@ -5,13 +5,28 @@ type t
 
 val load : logger:Logger.t -> disk_location:string -> t Deferred.t
 
-val import_keypair : t -> Keypair.t -> Public_key.Compressed.t Deferred.t
+val import_keypair :
+     t
+  -> Keypair.t
+  -> password:Secret_file.password
+  -> Public_key.Compressed.t Deferred.t
 
-val generate_new : t -> Public_key.Compressed.t Deferred.t
+val generate_new :
+  t -> password:Secret_file.password -> Public_key.Compressed.t Deferred.t
 
 val pks : t -> Public_key.Compressed.t list
 
-val find : t -> needle:Public_key.Compressed.t -> Keypair.t option
+val find_unlocked : t -> needle:Public_key.Compressed.t -> Keypair.t option
+
+val check_locked : t -> needle:Public_key.Compressed.t -> bool option
+
+val unlock :
+     t
+  -> needle:Public_key.Compressed.t
+  -> password:Secret_file.password
+  -> (unit, [`Not_found | `Bad_password]) Deferred.Result.t
+
+val lock : t -> needle:Public_key.Compressed.t -> unit
 
 val get_path : t -> Public_key.Compressed.t -> string
 


### PR DESCRIPTION
Still need to regenerate the schema, fix anything that it breaks, and do some testing, but wanted to get up a PR for early review.

Also might need to add cli commands for locking/unlocking but hopefully those can be in a followup PR.

This contains some breaking changes to the cli:
- removed `-unsafe-track-propose-key`
- removed `-propose-public-key`

High-level design:
- Add `lock` and `unlock` graphql queries
- Interactions that require the private key (sending txns, producing blocks) require the associated key to be unlocked first.