### PR TITLE
handle proposer crashes

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -170,7 +170,7 @@ let daemon logger =
          (optional bool)
      and no_bans =
        let module Expiration = struct
-         [%%expires_after "20190907"]
+         [%%expires_after "20190914"]
        end in
        flag "no-bans" no_arg ~doc:"don't ban peers (**TEMPORARY FOR TESTNET**)"
      and enable_libp2p =

--- a/src/lib/proposer/proposer.ml
+++ b/src/lib/proposer/proposer.ml
@@ -106,11 +106,7 @@ let generate_next_state ~previous_protocol_state ~time_controller
     ~(keypair : Keypair.t) ~proposal_data ~scheduled_time =
   let open Interruptible.Let_syntax in
   let self = Public_key.compress keypair.public_key in
-  let%bind ( diff
-           , next_staged_ledger_hash
-           , ledger_proof_opt
-           , is_new_stack
-           , coinbase_amount ) =
+  let%bind res =
     Interruptible.uninterruptible
       (let open Deferred.Let_syntax in
       let diff =
@@ -118,46 +114,66 @@ let generate_next_state ~previous_protocol_state ~time_controller
             Staged_ledger.create_diff staged_ledger ~self ~logger
               ~transactions_by_fee:transactions ~get_completed_work )
       in
-      let%map ( `Hash_after_applying next_staged_ledger_hash
-              , `Ledger_proof ledger_proof_opt
-              , `Staged_ledger transitioned_staged_ledger
-              , `Pending_coinbase_data (is_new_stack, coinbase_amount) ) =
-        let%map or_error =
-          Staged_ledger.apply_diff_unchecked staged_ledger diff
-        in
-        Or_error.ok_exn or_error
-      in
-      (*staged_ledger remains unchanged and transitioned_staged_ledger is discarded because the external transtion created out of this diff will be applied in Transition_frontier*)
-      ignore
-      @@ Ledger.unregister_mask_exn
-           (Staged_ledger.ledger staged_ledger)
-           (Staged_ledger.ledger transitioned_staged_ledger) ;
+      match%map Staged_ledger.apply_diff_unchecked staged_ledger diff with
+      | Ok
+          ( `Hash_after_applying next_staged_ledger_hash
+          , `Ledger_proof ledger_proof_opt
+          , `Staged_ledger transitioned_staged_ledger
+          , `Pending_coinbase_data (is_new_stack, coinbase_amount) ) ->
+          (*staged_ledger remains unchanged and transitioned_staged_ledger is discarded because the external transtion created out of this diff will be applied in Transition_frontier*)
+          ignore
+          @@ Ledger.unregister_mask_exn
+               (Staged_ledger.ledger staged_ledger)
+               (Staged_ledger.ledger transitioned_staged_ledger) ;
+          Some
+            ( diff
+            , next_staged_ledger_hash
+            , ledger_proof_opt
+            , is_new_stack
+            , coinbase_amount )
+      | Error (Staged_ledger.Staged_ledger_error.Unexpected e) ->
+          raise (Error.to_exn e)
+      | Error e ->
+          Logger.error logger ~module_:__MODULE__ ~location:__LOC__
+            ~metadata:
+              [ ( "error"
+                , `String (Staged_ledger.Staged_ledger_error.to_string e) )
+              ; ( "diff"
+                , Staged_ledger_diff.With_valid_signatures_and_proofs.to_yojson
+                    diff ) ]
+            "Error applying the diff $diff: $error" ;
+          None)
+  in
+  match res with
+  | None ->
+      Interruptible.return None
+  | Some
       ( diff
       , next_staged_ledger_hash
       , ledger_proof_opt
       , is_new_stack
-      , coinbase_amount ))
-  in
-  let%bind protocol_state, consensus_transition_data =
-    lift_sync (fun () ->
-        let previous_ledger_hash =
-          previous_protocol_state |> Protocol_state.blockchain_state
-          |> Blockchain_state.snarked_ledger_hash
-        in
-        let next_ledger_hash =
-          Option.value_map ledger_proof_opt
-            ~f:(fun (proof, _) ->
-              Ledger_proof.statement proof |> Ledger_proof.statement_target )
-            ~default:previous_ledger_hash
-        in
-        let supply_increase =
-          Option.value_map ledger_proof_opt
-            ~f:(fun (proof, _) ->
-              (Ledger_proof.statement proof).supply_increase )
-            ~default:Currency.Amount.zero
-        in
-        let blockchain_state =
-          (* We use the time this proposal was supposed to happen at because
+      , coinbase_amount ) ->
+      let%bind protocol_state, consensus_transition_data =
+        lift_sync (fun () ->
+            let previous_ledger_hash =
+              previous_protocol_state |> Protocol_state.blockchain_state
+              |> Blockchain_state.snarked_ledger_hash
+            in
+            let next_ledger_hash =
+              Option.value_map ledger_proof_opt
+                ~f:(fun (proof, _) ->
+                  Ledger_proof.statement proof |> Ledger_proof.statement_target
+                  )
+                ~default:previous_ledger_hash
+            in
+            let supply_increase =
+              Option.value_map ledger_proof_opt
+                ~f:(fun (proof, _) ->
+                  (Ledger_proof.statement proof).supply_increase )
+                ~default:Currency.Amount.zero
+            in
+            let blockchain_state =
+              (* We use the time this proposal was supposed to happen at because
              if things are slower than expected, we may have entered the next
              slot and putting the **current** timestamp rather than the expected
              one will screw things up.
@@ -165,56 +181,57 @@ let generate_next_state ~previous_protocol_state ~time_controller
              [generate_transition] will log an error if the [current_time] has a
              different slot from the [scheduled_time]
           *)
-          Blockchain_state.create_value ~timestamp:scheduled_time
-            ~snarked_ledger_hash:next_ledger_hash
-            ~staged_ledger_hash:next_staged_ledger_hash
-        in
-        let current_time =
-          Time.now time_controller |> Time.to_span_since_epoch
-          |> Time.Span.to_ms
-        in
-        measure "consensus generate_transition" (fun () ->
-            Consensus_state_hooks.generate_transition ~previous_protocol_state
-              ~blockchain_state ~current_time ~proposal_data
-              ~transactions:
-                ( Staged_ledger_diff.With_valid_signatures_and_proofs
-                  .user_commands diff
-                  :> User_command.t list )
-              ~snarked_ledger_hash:previous_ledger_hash ~supply_increase
-              ~logger ) )
-  in
-  lift_sync (fun () ->
-      measure "making Snark and Internal transitions" (fun () ->
-          let snark_transition =
-            Snark_transition.create_value
-              ?sok_digest:
-                (Option.map ledger_proof_opt ~f:(fun (proof, _) ->
-                     Ledger_proof.sok_digest proof ))
-              ?ledger_proof:
-                (Option.map ledger_proof_opt ~f:(fun (proof, _) ->
-                     Ledger_proof.underlying_proof proof ))
-              ~supply_increase:
-                (Option.value_map ~default:Currency.Amount.zero
-                   ~f:(fun (proof, _) ->
-                     (Ledger_proof.statement proof).supply_increase )
-                   ledger_proof_opt)
-              ~blockchain_state:
-                (Protocol_state.blockchain_state protocol_state)
-              ~consensus_transition:consensus_transition_data ~proposer:self
-              ~coinbase:coinbase_amount ()
-          in
-          let internal_transition =
-            Internal_transition.create ~snark_transition
-              ~prover_state:
-                (Consensus.Data.Proposal_data.prover_state proposal_data)
-              ~staged_ledger_diff:(Staged_ledger_diff.forget diff)
-          in
-          let witness =
-            { Pending_coinbase_witness.pending_coinbases=
-                Staged_ledger.pending_coinbase_collection staged_ledger
-            ; is_new_stack }
-          in
-          Some (protocol_state, internal_transition, witness) ) )
+              Blockchain_state.create_value ~timestamp:scheduled_time
+                ~snarked_ledger_hash:next_ledger_hash
+                ~staged_ledger_hash:next_staged_ledger_hash
+            in
+            let current_time =
+              Time.now time_controller |> Time.to_span_since_epoch
+              |> Time.Span.to_ms
+            in
+            measure "consensus generate_transition" (fun () ->
+                Consensus_state_hooks.generate_transition
+                  ~previous_protocol_state ~blockchain_state ~current_time
+                  ~proposal_data
+                  ~transactions:
+                    ( Staged_ledger_diff.With_valid_signatures_and_proofs
+                      .user_commands diff
+                      :> User_command.t list )
+                  ~snarked_ledger_hash:previous_ledger_hash ~supply_increase
+                  ~logger ) )
+      in
+      lift_sync (fun () ->
+          measure "making Snark and Internal transitions" (fun () ->
+              let snark_transition =
+                Snark_transition.create_value
+                  ?sok_digest:
+                    (Option.map ledger_proof_opt ~f:(fun (proof, _) ->
+                         Ledger_proof.sok_digest proof ))
+                  ?ledger_proof:
+                    (Option.map ledger_proof_opt ~f:(fun (proof, _) ->
+                         Ledger_proof.underlying_proof proof ))
+                  ~supply_increase:
+                    (Option.value_map ~default:Currency.Amount.zero
+                       ~f:(fun (proof, _) ->
+                         (Ledger_proof.statement proof).supply_increase )
+                       ledger_proof_opt)
+                  ~blockchain_state:
+                    (Protocol_state.blockchain_state protocol_state)
+                  ~consensus_transition:consensus_transition_data
+                  ~proposer:self ~coinbase:coinbase_amount ()
+              in
+              let internal_transition =
+                Internal_transition.create ~snark_transition
+                  ~prover_state:
+                    (Consensus.Data.Proposal_data.prover_state proposal_data)
+                  ~staged_ledger_diff:(Staged_ledger_diff.forget diff)
+              in
+              let witness =
+                { Pending_coinbase_witness.pending_coinbases=
+                    Staged_ledger.pending_coinbase_collection staged_ledger
+                ; is_new_stack }
+              in
+              Some (protocol_state, internal_transition, witness) ) )
 
 let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
     ~transaction_resource_pool ~time_controller ~keypairs
@@ -395,84 +412,89 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                             Breadcrumb.build ~logger ~verifier ~trust_system
                               ~parent:crumb ~transition ~sender:None
                           in
-                          let breadcrumb =
-                            Result.map_error breadcrumb_result ~f:(fun err ->
-                                let exn name =
-                                  Error.to_exn
-                                    (Error.of_string
-                                       (sprintf
-                                          "Error building breadcrumb from \
-                                           proposed transition: %s"
-                                          name))
-                                in
-                                match err with
-                                | `Fatal_error e ->
-                                    exn
-                                      (sprintf "fatal error -- %s"
-                                         (Exn.to_string e))
-                                | `Invalid_staged_ledger_diff e ->
-                                    exn
-                                      (sprintf
-                                         "invalid staged ledger diff -- %s"
-                                         (Error.to_string_hum e))
-                                | `Invalid_staged_ledger_hash e ->
-                                    exn
-                                      (sprintf
-                                         "invalid staged ledger hash -- %s"
-                                         (Error.to_string_hum e)) )
-                            |> Result.ok_exn
+                          let exn name =
+                            raise
+                              (Error.to_exn
+                                 (Error.of_string
+                                    (sprintf
+                                       "Error building breadcrumb from \
+                                        proposed transition: %s"
+                                       name)))
                           in
-                          let metadata =
-                            [ ( "state_hash"
-                              , State_hash.to_yojson transition_hash ) ]
-                          in
-                          Logger.info logger ~module_:__MODULE__
-                            ~location:__LOC__
-                            !"Submitting newly produced block $state_hash to \
-                              the transition frontier controller"
-                            ~metadata ;
-                          Coda_metrics.(
-                            Counter.inc_one Proposer.blocks_proposed) ;
-                          let%bind () =
-                            Strict_pipe.Writer.write transition_writer
-                              breadcrumb
-                          in
-                          Logger.debug logger ~module_:__MODULE__
-                            ~location:__LOC__ ~metadata
-                            "Waiting for transition $state_hash to be \
-                             inserted into frontier" ;
-                          Deferred.choose
-                            [ Deferred.choice
-                                (Transition_frontier.wait_for_transition
-                                   frontier transition_hash)
-                                (Fn.const `Transition_accepted)
-                            ; Deferred.choice
-                                ( Time.Timeout.create time_controller
-                                    (* We allow up to 15 seconds for the transition to make its way from the transition_writer to the frontier.
+                          match breadcrumb_result with
+                          | Error (`Fatal_error e) ->
+                              exn
+                                (sprintf "fatal error -- %s" (Exn.to_string e))
+                          | Error (`Invalid_staged_ledger_hash e) ->
+                              exn
+                                (sprintf "Invalid staged ledger hash -- %s"
+                                   (Error.to_string_hum e))
+                          | Error (`Invalid_staged_ledger_diff e) ->
+                              (*Unexpected errors from staged_ledger are captured in `Fatal_error*)
+                              Logger.error logger ~module_:__MODULE__
+                                ~location:__LOC__
+                                ~metadata:
+                                  [ ( "diff"
+                                    , Staged_ledger_diff.to_yojson
+                                        staged_ledger_diff ) ]
+                                !"Error building breadcrumb from proposed \
+                                  transition. Invalid staged ledger diff -- %s"
+                                (Error.to_string_hum e) ;
+                              return ()
+                          | Ok breadcrumb -> (
+                              let metadata =
+                                [ ( "state_hash"
+                                  , State_hash.to_yojson transition_hash ) ]
+                              in
+                              Logger.info logger ~module_:__MODULE__
+                                ~location:__LOC__
+                                !"Submitting newly produced block $state_hash \
+                                  to the transition frontier controller"
+                                ~metadata ;
+                              Coda_metrics.(
+                                Counter.inc_one Proposer.blocks_proposed) ;
+                              let%bind () =
+                                Strict_pipe.Writer.write transition_writer
+                                  breadcrumb
+                              in
+                              Logger.debug logger ~module_:__MODULE__
+                                ~location:__LOC__ ~metadata
+                                "Waiting for transition $state_hash to be \
+                                 inserted into frontier" ;
+                              Deferred.choose
+                                [ Deferred.choice
+                                    (Transition_frontier.wait_for_transition
+                                       frontier transition_hash)
+                                    (Fn.const `Transition_accepted)
+                                ; Deferred.choice
+                                    ( Time.Timeout.create time_controller
+                                        (* We allow up to 15 seconds for the transition to make its way from the transition_writer to the frontier.
                                   This value is chosen to be reasonably generous. In theory, this should not take terribly long. But long
                                   cycles do happen in our system, and with medium curves those long cycles can be substantial. *)
-                                    (Time.Span.of_ms 20000L)
-                                    ~f:(Fn.const ())
-                                |> Time.Timeout.to_deferred )
-                                (Fn.const `Timed_out) ]
-                          >>| function
-                          | `Transition_accepted ->
-                              Logger.info logger ~module_:__MODULE__
-                                ~location:__LOC__ ~metadata
-                                "Generated transition $state_hash was \
-                                 accepted into transition frontier"
-                          | `Timed_out ->
-                              let str =
-                                "Timed out waiting for generated transition \
-                                 $state_hash to enter transition frontier. \
-                                 Continuing to produce new blocks anyway. \
-                                 This may mean your CPU is overloaded. \
-                                 Consider disabling `-run-snark-worker` if \
-                                 it's configured."
-                              in
-                              (* FIXME #3167: this should be fatal, and more importantly, shouldn't happen. *)
-                              Logger.error logger ~module_:__MODULE__
-                                ~location:__LOC__ ~metadata "%s" str ) )) )
+                                        (Time.Span.of_ms 20000L)
+                                        ~f:(Fn.const ())
+                                    |> Time.Timeout.to_deferred )
+                                    (Fn.const `Timed_out) ]
+                              >>| function
+                              | `Transition_accepted ->
+                                  Logger.info logger ~module_:__MODULE__
+                                    ~location:__LOC__ ~metadata
+                                    "Generated transition $state_hash was \
+                                     accepted into transition frontier"
+                              | `Timed_out ->
+                                  let str =
+                                    "Timed out waiting for generated \
+                                     transition $state_hash to enter \
+                                     transition frontier. Continuing to \
+                                     produce new blocks anyway. This may mean \
+                                     your CPU is overloaded. Consider \
+                                     disabling `-run-snark-worker` if it's \
+                                     configured."
+                                  in
+                                  (* FIXME #3167: this should be fatal, and more importantly, shouldn't happen. *)
+                                  Logger.error logger ~module_:__MODULE__
+                                    ~location:__LOC__ ~metadata "%s" str ) ) ))
+            )
       in
       let proposal_supervisor = Singleton_supervisor.create ~task:propose in
       let scheduler = Singleton_scheduler.create time_controller in

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -27,9 +27,12 @@ module type S = sig
 
   val get_unchecked :
        Staged_ledger_diff.With_valid_signatures_and_proofs.t
-    -> Transaction.t list
-       * Transaction_snark_work.t list
-       * Currency.Amount.t list
+    -> ( Transaction.t list
+         * Transaction_snark_work.t list
+         * int
+         * Currency.Amount.t list
+       , Error.t )
+       result
 
   val get_transactions :
     Staged_ledger_diff.t -> (Transaction.t list, Error.t) result
@@ -65,7 +68,7 @@ type t =
   { transactions: Transaction.t list
   ; work: Transaction_snark_work.t list
   ; user_commands_count: int
-  ; coinbases: Coinbase.t list }
+  ; coinbases: Currency.Amount.t list }
 
 (*A Coinbase is a single transaction that accommodates the coinbase amount
     and a fee transfer for the work required to add the coinbase. Unlike a
@@ -205,60 +208,43 @@ let create_fee_transfers completed_works delta public_key coinbase_fts =
       |> Fee_transfer.of_single_list )
   |> to_staged_ledger_or_error
 
-let get_individual_info coinbase_parts (proposer : Public_key.Compressed.t)
-    user_commands completed_works =
+let get_individual_info coinbase_parts proposer user_commands completed_works =
   let open Result.Let_syntax in
-  let%map user_commands, coinbase, transactions =
-    let open Result.Let_syntax in
-    let%bind user_commands =
-      let%map user_commands' =
-        List.fold_until user_commands ~init:[]
-          ~f:(fun acc t ->
-            match User_command.check t with
-            | Some t ->
-                Continue (t :: acc)
-            | None ->
-                Stop (Error (Error.Bad_signature t)) )
-          ~finish:(fun acc -> Ok acc)
-      in
-      List.rev user_commands'
-    in
-    let%bind coinbase = create_coinbase coinbase_parts proposer in
-    let coinbase_fts =
-      List.concat_map coinbase ~f:(fun cb ->
-          Option.value_map cb.fee_transfer ~default:[] ~f:(fun ft -> [ft]) )
-    in
-    let%bind coinbase_work_fees =
-      sum_fees coinbase_fts ~f:snd |> to_staged_ledger_or_error
-    in
-    let completed_works_others =
-      List.filter completed_works ~f:(fun {Transaction_snark_work.prover; _} ->
-          not (Public_key.Compressed.equal proposer prover) )
-    in
-    let%bind delta =
-      fee_remainder user_commands completed_works_others coinbase_work_fees
-    in
-    let%map fee_transfers =
-      create_fee_transfers completed_works_others delta proposer
-        (coinbase_fts : Fee_transfer.Single.t list)
-    in
-    let transactions =
-      List.map user_commands ~f:(fun t -> Transaction.User_command t)
-      @ List.map coinbase ~f:(fun t -> Transaction.Coinbase t)
-      @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
-    in
-    (user_commands, coinbase, transactions)
+  let%bind coinbase_parts =
+    O1trace.measure "create_coinbase" (fun () ->
+        create_coinbase coinbase_parts proposer )
+  in
+  let coinbase_fts =
+    List.concat_map coinbase_parts ~f:(fun cb ->
+        Option.value_map cb.fee_transfer ~default:[] ~f:(fun ft -> [ft]) )
+  in
+  let coinbase_work_fees = sum_fees coinbase_fts ~f:snd |> Or_error.ok_exn in
+  let txn_works_others =
+    List.filter completed_works ~f:(fun {Transaction_snark_work.prover; _} ->
+        not (Public_key.Compressed.equal proposer prover) )
+  in
+  let%bind delta =
+    fee_remainder user_commands txn_works_others coinbase_work_fees
+  in
+  let%map fee_transfers =
+    create_fee_transfers txn_works_others delta proposer coinbase_fts
+  in
+  let transactions =
+    List.map user_commands ~f:(fun t -> Transaction.User_command t)
+    @ List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
+    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
   in
   { transactions
   ; work= completed_works
   ; user_commands_count= List.length user_commands
-  ; coinbases= coinbase }
+  ; coinbases= List.map coinbase_parts ~f:(fun Coinbase.{amount; _} -> amount)
+  }
 
 open Staged_ledger_diff
 
-let get t =
+let get' (t : With_valid_signatures.t) =
   let apply_pre_diff_with_at_most_two
-      (t1 : Pre_diff_with_at_most_two_coinbase.t) =
+      (t1 : With_valid_signatures.pre_diff_with_at_most_two_coinbase) =
     let coinbase_parts =
       match t1.coinbase with
       | Zero ->
@@ -272,7 +258,7 @@ let get t =
       t1.completed_works
   in
   let apply_pre_diff_with_at_most_one
-      (t2 : Pre_diff_with_at_most_one_coinbase.t) =
+      (t2 : With_valid_signatures.pre_diff_with_at_most_one_coinbase) =
     let coinbase_added =
       match t2.coinbase with Zero -> `Zero | One x -> `One x
     in
@@ -291,77 +277,18 @@ let get t =
   ( p1.transactions @ p2.transactions
   , p1.work @ p2.work
   , p1.user_commands_count + p2.user_commands_count
-  , List.map (p1.coinbases @ p2.coinbases) ~f:(fun Coinbase.{amount; _} ->
-        amount ) )
+  , p1.coinbases @ p2.coinbases )
 
-let ok_exn' (t : ('a, Error.t) Result.t) =
-  match t with Ok x -> x | Error e -> Core.Error.raise (Error.to_error e)
-
-let get_individual_diff_unchecked coinbase_parts proposer user_commands
-    completed_works =
-  let txn_works = List.map ~f:Transaction_snark_work.forget completed_works in
-  let coinbase_parts =
-    O1trace.measure "create_coinbase" (fun () ->
-        ok_exn' (create_coinbase coinbase_parts proposer) )
-  in
-  let coinbase_fts =
-    List.concat_map coinbase_parts ~f:(fun cb ->
-        Option.value_map cb.fee_transfer ~default:[] ~f:(fun ft -> [ft]) )
-  in
-  let coinbase_work_fees = sum_fees coinbase_fts ~f:snd |> Or_error.ok_exn in
-  let txn_works_others =
-    List.filter txn_works ~f:(fun {Transaction_snark_work.prover; _} ->
-        not (Public_key.Compressed.equal proposer prover) )
-  in
-  let delta =
-    ok_exn' (fee_remainder user_commands txn_works_others coinbase_work_fees)
-  in
-  let fee_transfers =
-    ok_exn' (create_fee_transfers txn_works_others delta proposer coinbase_fts)
-  in
-  let transactions =
-    List.map user_commands ~f:(fun t -> Transaction.User_command t)
-    @ List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
-    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
-  in
-  ( transactions
-  , txn_works
-  , List.map coinbase_parts ~f:(fun Coinbase.{amount; _} -> amount) )
+let get t =
+  match validate_user_commands t ~check:User_command.check with
+  | Ok diff ->
+      get' diff
+  | Error uc ->
+      Error (Error.Bad_signature uc)
 
 let get_unchecked (t : With_valid_signatures_and_proofs.t) =
-  let apply_pre_diff_with_at_most_two
-      (pre_diff1 :
-        With_valid_signatures_and_proofs.pre_diff_with_at_most_two_coinbase) =
-    let coinbase_parts =
-      match pre_diff1.coinbase with
-      | Zero ->
-          `Zero
-      | One x ->
-          `One x
-      | Two x ->
-          `Two x
-    in
-    get_individual_diff_unchecked coinbase_parts t.creator
-      pre_diff1.user_commands pre_diff1.completed_works
-  in
-  let apply_pre_diff_with_at_most_one
-      (pre_diff2 :
-        With_valid_signatures_and_proofs.pre_diff_with_at_most_one_coinbase) =
-    let coinbase_added =
-      match pre_diff2.coinbase with Zero -> `Zero | One x -> `One x
-    in
-    get_individual_diff_unchecked coinbase_added t.creator
-      pre_diff2.user_commands pre_diff2.completed_works
-  in
-  let data1, work1, coinbases1 =
-    apply_pre_diff_with_at_most_two (fst t.diff)
-  in
-  let data2, work2, coinbases2 =
-    Option.value_map
-      ~f:(fun d -> apply_pre_diff_with_at_most_one d)
-      (snd t.diff) ~default:([], [], [])
-  in
-  (data1 @ data2, work1 @ work2, coinbases1 @ coinbases2)
+  let t = forget_proof_checks t in
+  get' t
 
 let get_transactions (sl_diff : t) =
   let open Result.Let_syntax in

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -51,12 +51,6 @@ module T = struct
           Error.to_string_hum e
 
     let to_error = Fn.compose Error.of_string to_string
-
-    let to_or_error = function
-      | Ok s ->
-          Ok s
-      | Error e ->
-          Or_error.error_string (to_string e)
   end
 
   let to_staged_ledger_or_error = function
@@ -618,9 +612,7 @@ module T = struct
           (Staged_ledger_error.Pre_diff
              (Pre_diff_info.Error.Coinbase_error "More than two coinbase parts"))
 
-  (* N.B.: we don't expose apply_diff_unverified
-     in For_tests only, we expose apply apply_unverified, which calls apply_diff_unverified *)
-  let apply_diff ~logger ~verifier t (sl_diff : Staged_ledger_diff.t) =
+  let apply_diff ~logger t pre_diff_info =
     let open Deferred.Result.Let_syntax in
     let max_throughput =
       Int.pow 2
@@ -633,16 +625,7 @@ module T = struct
     in
     let new_mask = Ledger.Mask.create () in
     let new_ledger = Ledger.register_mask t.ledger new_mask in
-    let pre_diff_info =
-      Result.map_error ~f:(fun error -> Staged_ledger_error.Pre_diff error)
-      @@ Pre_diff_info.get sl_diff
-    in
-    let%bind transactions, works, user_commands_count, coinbases =
-      Deferred.return pre_diff_info
-    in
-    Coda_metrics.(
-      Gauge.set Snark_work.completed_snark_work_last_block
-        (Float.of_int (List.length works))) ;
+    let transactions, works, user_commands_count, coinbases = pre_diff_info in
     let%bind is_new_stack, data, stack_update =
       update_coinbase_stack_and_get_data t.scan_state new_ledger
         t.pending_coinbase_collection transactions
@@ -668,7 +651,6 @@ module T = struct
                    slots required work_count)))
       else Deferred.return (Ok ())
     in
-    let%bind () = check_completed_works ~logger ~verifier t.scan_state works in
     let%bind () = Deferred.return (check_zero_fee_excess t.scan_state data) in
     let%bind res_opt, scan_state' =
       let r =
@@ -683,27 +665,14 @@ module T = struct
           in
           Logger.error logger ~module_:__MODULE__ ~location:__LOC__
             ~metadata:
-              [ ("staged_ledger_diff", Staged_ledger_diff.to_yojson sl_diff)
-              ; ( "scan_state"
+              [ ( "scan_state"
                 , `String (Scan_state.snark_job_list_json t.scan_state) )
               ; ("data", data_json) ]
-            !"Unexpected error when applying the diff $staged_ledger_diff, \
-              data $data to the scan_state $scan_state: %s\n\
+            !"Unexpected error when applying diff data $data to the \
+              scan_state $scan_state: %s\n\
               %!"
             (Error.to_string_hum e) ) ;
       Deferred.return (to_staged_ledger_or_error r)
-    in
-    let () =
-      try
-        Coda_metrics.(
-          Gauge.set Snark_work.scan_state_snark_work
-            (Float.of_int
-               (List.length (Scan_state.all_work_pairs_exn scan_state'))))
-      with exn ->
-        Logger.error logger ~module_:__MODULE__ ~location:__LOC__
-          ~metadata:[("error", `String (Exn.to_string exn))]
-          !"Error when getting all work pairs from scan state: $error" ;
-        Exn.reraise exn "Error when getting all work pairs from scan state"
     in
     let%bind updated_pending_coinbase_collection' =
       update_pending_coinbase_collection t.pending_coinbase_collection
@@ -741,67 +710,44 @@ module T = struct
     , `Staged_ledger new_staged_ledger
     , `Pending_coinbase_data (is_new_stack, coinbase_amount) )
 
-  let apply t witness ~logger = apply_diff t witness ~logger
+  let apply t witness ~logger ~verifier =
+    let open Deferred.Result.Let_syntax in
+    let work = Staged_ledger_diff.completed_works witness in
+    Coda_metrics.(
+      Gauge.set Snark_work.completed_snark_work_last_block
+        (Float.of_int @@ List.length work)) ;
+    let%bind () = check_completed_works ~logger ~verifier t.scan_state work in
+    let%bind prediff =
+      Result.map_error ~f:(fun error -> Staged_ledger_error.Pre_diff error)
+      @@ Pre_diff_info.get witness
+      |> Deferred.return
+    in
+    let%map res = apply_diff t prediff ~logger in
+    let _, _, `Staged_ledger new_staged_ledger, _ = res in
+    let () =
+      try
+        Coda_metrics.(
+          Gauge.set Snark_work.scan_state_snark_work
+            (Float.of_int
+               (List.length
+                  (Scan_state.all_work_pairs_exn new_staged_ledger.scan_state))))
+      with exn ->
+        Logger.error logger ~module_:__MODULE__ ~location:__LOC__
+          ~metadata:[("error", `String (Exn.to_string exn))]
+          !"Error when getting all work pairs from scan state: $error" ;
+        Exn.reraise exn "Error when getting all work pairs from scan state"
+    in
+    res
 
   let apply_diff_unchecked t
       (sl_diff : Staged_ledger_diff.With_valid_signatures_and_proofs.t) =
-    let open Deferred.Or_error.Let_syntax in
-    let new_mask = Ledger.Mask.create () in
-    let transactions, works, coinbases = Pre_diff_info.get_unchecked sl_diff in
-    let new_ledger = Ledger.register_mask t.ledger new_mask in
-    let%bind is_new_stack, data, updated_coinbase_stack =
-      let open Deferred.Let_syntax in
-      let%bind x =
-        update_coinbase_stack_and_get_data t.scan_state new_ledger
-          t.pending_coinbase_collection transactions
-      in
-      Staged_ledger_error.to_or_error x |> Deferred.return
+    let open Deferred.Result.Let_syntax in
+    let%bind prediff =
+      Result.map_error ~f:(fun error -> Staged_ledger_error.Pre_diff error)
+      @@ Pre_diff_info.get_unchecked sl_diff
+      |> Deferred.return
     in
-    let slots = List.length data in
-    let work_count = List.length works in
-    let required_pairs =
-      Scan_state.work_statements_for_new_diff t.scan_state
-    in
-    let%bind () =
-      let required = List.length required_pairs in
-      if
-        work_count < required
-        && List.length data
-           > Scan_state.free_space t.scan_state - required + work_count
-      then
-        Deferred.return
-          (Or_error.errorf
-             !"Insufficient number of transaction snark work (slots \
-               occupying: %d)  required %d, got %d"
-             slots required work_count)
-      else Deferred.return (Ok ())
-    in
-    let res_opt, scan_state' =
-      Or_error.ok_exn
-        (Scan_state.fill_work_and_enqueue_transactions t.scan_state data works)
-    in
-    let%bind coinbase_amount =
-      coinbase_for_blockchain_snark coinbases
-      |> Staged_ledger_error.to_or_error |> Deferred.return
-    in
-    let%map update_pending_coinbase_collection' =
-      update_pending_coinbase_collection t.pending_coinbase_collection
-        updated_coinbase_stack ~is_new_stack ~ledger_proof:res_opt
-      |> Staged_ledger_error.to_or_error |> Deferred.return
-    in
-    Or_error.ok_exn
-      (verify_scan_state_after_apply
-         (Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root new_ledger))
-         scan_state') ;
-    let new_staged_ledger =
-      { scan_state= scan_state'
-      ; ledger= new_ledger
-      ; pending_coinbase_collection= update_pending_coinbase_collection' }
-    in
-    ( `Hash_after_applying (hash new_staged_ledger)
-    , `Ledger_proof res_opt
-    , `Staged_ledger new_staged_ledger
-    , `Pending_coinbase_data (is_new_stack, coinbase_amount) )
+    apply_diff t prediff ~logger:(Logger.null ())
 
   module Resources = struct
     module Discarded = struct
@@ -1171,7 +1117,7 @@ module T = struct
                 Zero
           in
           (* We have to reverse here because we only know they work in THIS order *)
-          { Staged_ledger_diff.With_valid_signatures_and_proofs.user_commands=
+          { Staged_ledger_diff.Pre_diff_one.user_commands=
               Sequence.to_list_rev res.user_commands_rev
           ; completed_works= Sequence.to_list_rev res.completed_work_rev
           ; coinbase= to_at_most_one res.coinbase } )

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -102,10 +102,11 @@ val apply_diff_unchecked :
      t
   -> Staged_ledger_diff.With_valid_signatures_and_proofs.t
   -> ( [`Hash_after_applying of Staged_ledger_hash.t]
-     * [`Ledger_proof of (Ledger_proof.t * Transaction.t list) option]
-     * [`Staged_ledger of t]
-     * [`Pending_coinbase_data of bool * Currency.Amount.t] )
-     Deferred.Or_error.t
+       * [`Ledger_proof of (Ledger_proof.t * Transaction.t list) option]
+       * [`Staged_ledger of t]
+       * [`Pending_coinbase_data of bool * Currency.Amount.t]
+     , Staged_ledger_error.t )
+     Deferred.Result.t
 
 module For_tests : sig
   val materialized_snarked_ledger_hash :

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -137,9 +137,14 @@ struct
                , `Ledger_proof ledger_proof_opt
                , `Staged_ledger _
                , `Pending_coinbase_data _ ) =
-        Staged_ledger.apply_diff_unchecked parent_staged_ledger
-          staged_ledger_diff
-        |> Deferred.Or_error.ok_exn
+        match%bind
+          Staged_ledger.apply_diff_unchecked parent_staged_ledger
+            staged_ledger_diff
+        with
+        | Ok r ->
+            return r
+        | Error e ->
+            failwith (Staged_ledger.Staged_ledger_error.to_string e)
       in
       let previous_transition =
         Transition_frontier.Breadcrumb.validated_transition parent_breadcrumb

--- a/src/lib/trust_system/record.ml
+++ b/src/lib/trust_system/record.ml
@@ -34,7 +34,7 @@ end) : S = struct
 
   let bans_disabled =
     let module Expiration = struct
-      [%%expires_after "20190907"]
+      [%%expires_after "20190914"]
     end in
     ref false
 


### PR DESCRIPTION
Not crashing proposers when the following staged ledger errors occur: 
 1. `Non_zero_fee_excess`
 2. `Invalid_proof`
 3. `Pre_diff of Pre_diff_info.Error.t`
 4. `Insufficient_work`

Instead, log the error, drop the block, and continue. 

Proper handling of each of those errors is tracked in #3366

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #3350 ?
Closes #3347 ?
