### PR TITLE
Refactor SNARK bundles to use One_or_two library

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -170,7 +170,7 @@ let daemon logger =
          (optional bool)
      and no_bans =
        let module Expiration = struct
-         [%%expires_after "20190907"]
+         [%%expires_after "20190914"]
        end in
        flag "no-bans" no_arg ~doc:"don't ban peers (**TEMPORARY FOR TESTNET**)"
      and enable_libp2p =

--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -306,7 +306,7 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
                 , `String
                     (sprintf !"%{sexp:Snark_worker.Work.Spec.t}" work.spec) )
               ] ;
-          List.iter work.metrics ~f:(fun (total, tag) ->
+          One_or_two.iter work.metrics ~f:(fun (total, tag) ->
               match tag with
               | `Merge ->
                   Perf_histograms.add_span ~name:"snark_worker_merge_time"

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -347,7 +347,7 @@ module Types = struct
             ~typ:(non_null @@ list @@ non_null int)
             ~args:Arg.[]
             ~resolve:(fun _ {Transaction_snark_work.Info.work_ids; _} ->
-              work_ids ) ] )
+              One_or_two.to_list work_ids ) ] )
 
   let blockchain_state =
     obj "BlockchainState" ~fields:(fun _ ->

--- a/src/lib/coda_intf/transition_frontier_intf.ml
+++ b/src/lib/coda_intf/transition_frontier_intf.ml
@@ -177,7 +177,8 @@ module type Transition_frontier_extensions_intf = sig
     with type transition_frontier_diff := Diff.t
 
   module Work : sig
-    type t = Transaction_snark.Statement.t list [@@deriving sexp, yojson]
+    type t = Transaction_snark.Statement.t One_or_two.t
+    [@@deriving sexp, yojson]
 
     module Stable :
       sig

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -487,13 +487,13 @@ let request_work t =
         None
   in
   let fee = snark_work_fee t in
-  let instances, seen_jobs =
+  let instances_opt, seen_jobs =
     Work_selection_method.work ~logger:t.config.logger ~fee
       ~snark_pool:(snark_pool t) sl (seen_jobs t)
   in
   set_seen_jobs t seen_jobs ;
-  if List.is_empty instances then None
-  else Some {Snark_work_lib.Work.Spec.instances; fee}
+  Option.map instances_opt ~f:(fun instances ->
+      {Snark_work_lib.Work.Spec.instances; fee} )
 
 let start t =
   Proposer.run ~logger:t.config.logger ~verifier:t.processes.verifier

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -114,3 +114,8 @@ include Prod
 include Debug
 
 [%%endif]
+
+module For_tests = struct
+  let mk_dummy_proof statement =
+    create ~statement ~sok_digest:Sok_message.Digest.default ~proof:Proof.dummy
+end

--- a/src/lib/ledger_proof/ledger_proof.mli
+++ b/src/lib/ledger_proof/ledger_proof.mli
@@ -19,3 +19,7 @@ include S with type t = Prod.t
 include S with type t = Debug.t
 
 [%%endif]
+
+module For_tests : sig
+  val mk_dummy_proof : Transaction_snark.Statement.t -> t
+end

--- a/src/lib/network_pool/dune
+++ b/src/lib/network_pool/dune
@@ -3,7 +3,7 @@
  (public_name network_pool)
  (inline_tests)
  (library_flags -linkall)
- (libraries core async pipe_lib transition_frontier quickcheck_lib)
+ (libraries async core one_or_two pipe_lib quickcheck_lib transition_frontier)
  (preprocessor_deps "../../config.mlh")
  (preprocess (pps ppx_base ppx_coda ppx_let ppx_assert ppx_pipebang ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx -conditional))
  (synopsis

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -104,11 +104,12 @@ module type Snark_resource_pool_intf = sig
   val add_snark :
        t
     -> work:work
-    -> proof:ledger_proof list
+    -> proof:ledger_proof One_or_two.t
     -> fee:Fee_with_prover.t
     -> [`Rebroadcast | `Don't_rebroadcast]
 
-  val request_proof : t -> work -> ledger_proof list Priced_proof.t option
+  val request_proof :
+    t -> work -> ledger_proof One_or_two.t Priced_proof.t option
 
   val snark_pool_json : t -> Yojson.Safe.json
 
@@ -127,7 +128,8 @@ module type Snark_pool_diff_intf = sig
   module Stable : sig
     module V1 : sig
       type t =
-        | Add_solved_work of work * ledger_proof list Priced_proof.Stable.V1.t
+        | Add_solved_work of
+            work * ledger_proof One_or_two.Stable.V1.t Priced_proof.Stable.V1.t
       [@@deriving sexp, to_yojson, bin_io, version]
     end
 

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -36,7 +36,8 @@ end)
       module T = struct
         type t =
           | Add_solved_work of
-              Work.Stable.V1.t * Ledger_proof.t list Priced_proof.Stable.V1.t
+              Work.Stable.V1.t
+              * Ledger_proof.t One_or_two.Stable.V1.t Priced_proof.Stable.V1.t
         [@@deriving bin_io, sexp, to_yojson, version]
       end
 
@@ -59,7 +60,7 @@ end)
   (* bin_io omitted *)
   type t = Stable.Latest.t =
     | Add_solved_work of
-        Work.Stable.V1.t * Ledger_proof.t list Priced_proof.Stable.V1.t
+        Work.Stable.V1.t * Ledger_proof.t One_or_two.t Priced_proof.Stable.V1.t
   [@@deriving sexp, to_yojson]
 
   let compact_json = function

--- a/src/lib/one_or_two/intfs.ml
+++ b/src/lib/one_or_two/intfs.ml
@@ -1,11 +1,20 @@
 type 'a t = [`One of 'a | `Two of 'a * 'a]
 
+(** One_or_two operations in a two-parameter monad. *)
+module type Monadic2 = sig
+  type ('a, 'e) m
+
+  val sequence : ('a, 'e) m t -> ('a t, 'e) m
+
+  val map : 'a t -> f:('a -> ('b, 'e) m) -> ('b t, 'e) m
+
+  val fold :
+    'a t -> init:'accum -> f:('accum -> 'a -> ('accum, 'e) m) -> ('accum, 'e) m
+end
+
+(** One_or_two operations in a single parameter monad. *)
 module type Monadic = sig
   type 'a m
 
-  val sequence : 'a m t -> 'a t m
-
-  val map : 'a t -> f:('a -> 'b m) -> 'b t m
-
-  val fold : 'a t -> init:'accum -> f:('accum -> 'a -> 'accum m) -> 'accum m
+  include Monadic2 with type ('a, 'e) m := 'a m
 end

--- a/src/lib/one_or_two/one_or_two.mli
+++ b/src/lib/one_or_two/one_or_two.mli
@@ -37,6 +37,9 @@ val fold_until :
   -> 'a t
   -> 'final
 
+module Deferred_result :
+  Intfs.Monadic2 with type ('a, 'e) m := ('a, 'e) Result.t Deferred.t
+
 module Deferred : Intfs.Monadic with type 'a m := 'a Deferred.t
 
 module Option : Intfs.Monadic with type 'a m := 'a option

--- a/src/lib/parallel_scan/dune
+++ b/src/lib/parallel_scan/dune
@@ -3,7 +3,7 @@
  (public_name parallel_scan)
  (inline_tests)
  (library_flags -linkall)
- (libraries pipe_lib coda_digestif core async async_extra sgn non_empty_list state_or_error)
+ (libraries async async_extra coda_digestif core non_empty_list pipe_lib sgn state_or_error)
  (preprocess
   (pps ppx_jane ppx_coda lens.ppx_deriving ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "Parallel scan over an infinite stream (incremental map-reduce)"))

--- a/src/lib/snark_work_lib/dune
+++ b/src/lib/snark_work_lib/dune
@@ -3,7 +3,7 @@
  (public_name snark_work_lib)
  (library_flags -linkall)
  (inline_tests)
- (libraries core_kernel currency signature_lib transaction_snark)
+ (libraries core_kernel currency one_or_two signature_lib transaction_snark)
  (preprocess
   (pps ppx_jane ppx_deriving_yojson bisect_ppx ppx_coda -- -conditional))
  (synopsis "Snark work types"))

--- a/src/lib/snark_work_lib/work.ml
+++ b/src/lib/snark_work_lib/work.ml
@@ -64,7 +64,8 @@ module Spec = struct
     module V1 = struct
       module T = struct
         type 'single t =
-          {instances: 'single list; fee: Currency.Fee.Stable.V1.t}
+          { instances: 'single One_or_two.Stable.V1.t
+          ; fee: Currency.Fee.Stable.V1.t }
         [@@deriving bin_io, fields, sexp, version]
       end
 
@@ -75,7 +76,7 @@ module Spec = struct
   end
 
   type 'single t = 'single Stable.Latest.t =
-    {instances: 'single list; fee: Currency.Fee.t}
+    {instances: 'single One_or_two.t; fee: Currency.Fee.t}
   [@@deriving fields, sexp]
 end
 
@@ -84,8 +85,10 @@ module Result = struct
     module V1 = struct
       module T = struct
         type ('spec, 'single) t =
-          { proofs: 'single list
-          ; metrics: (Core.Time.Stable.Span.V1.t * [`Transition | `Merge]) list
+          { proofs: 'single One_or_two.Stable.V1.t
+          ; metrics:
+              (Core.Time.Stable.Span.V1.t * [`Transition | `Merge])
+              One_or_two.Stable.V1.t
           ; spec: 'spec
           ; prover: Signature_lib.Public_key.Compressed.Stable.V1.t }
         [@@deriving bin_io, fields, version]
@@ -98,11 +101,9 @@ module Result = struct
   end
 
   type ('spec, 'single) t = ('spec, 'single) Stable.Latest.t =
-    { proofs: 'single list
-    ; metrics: (Time.Span.t * [`Transition | `Merge]) list
+    { proofs: 'single One_or_two.t
+    ; metrics: (Time.Span.t * [`Transition | `Merge]) One_or_two.t
     ; spec: 'spec
     ; prover: Signature_lib.Public_key.Compressed.t }
   [@@deriving fields]
 end
-
-let proofs_per_work = 2

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -417,20 +417,16 @@ module T = struct
       Scan_state.k_work_pairs_for_new_diff scan_state ~k:work_count
     in
     let check job_proofs prover message =
-      let open Deferred.Let_syntax in
-      Deferred.List.find_map job_proofs ~f:(fun (job, proof) ->
-          match%map verify ~logger ~verifier ~message job proof prover with
-          | Ok () ->
-              None
-          | Error e ->
-              Some e )
+      One_or_two.Deferred_result.map job_proofs ~f:(fun (job, proof) ->
+          verify ~logger ~verifier ~message job proof prover )
     in
     let open Deferred.Let_syntax in
     let%map result =
       Deferred.List.find_map (List.zip_exn job_pairs completed_works)
         ~f:(fun (jobs, work) ->
           let message = Sok_message.create ~fee:work.fee ~prover:work.prover in
-          check (List.zip_exn jobs work.proofs) work.prover message )
+          Deferred.map ~f:Result.error
+          @@ check (One_or_two.zip_exn jobs work.proofs) work.prover message )
     in
     Option.value_map result ~default:(Ok ()) ~f:(fun e -> Error e)
 
@@ -1283,7 +1279,7 @@ module T = struct
           | Some cw_checked ->
               Continue
                 ( Sequence.append seq (Sequence.singleton cw_checked)
-                , List.length cw_checked.proofs + count )
+                , One_or_two.length cw_checked.proofs + count )
           | None ->
               Stop (seq, count) )
         ~finish:Fn.id
@@ -1433,14 +1429,14 @@ let%test_module "test" =
         Transaction_snark_work.Statement.t -> Public_key.Compressed.t =
      fun stmts ->
       let prover_seed =
-        List.fold stmts ~init:"P" ~f:(fun p stmt ->
+        One_or_two.fold stmts ~init:"P" ~f:(fun p stmt ->
             p ^ Frozen_ledger_hash.to_bytes stmt.target )
       in
       Quickcheck.random_value ~seed:(`Deterministic prover_seed)
         Public_key.Compressed.gen
 
-    let proofs stmts : Ledger_proof.t list =
-      List.map stmts ~f:(fun statement ->
+    let proofs stmts : Ledger_proof.t One_or_two.t =
+      One_or_two.map stmts ~f:(fun statement ->
           Ledger_proof.create ~statement ~sok_digest:Sok_message.Digest.default
             ~proof:Proof.dummy )
 
@@ -1914,13 +1910,9 @@ let%test_module "test" =
           (fun cmds_left _count_opt cmds_this_iter proofs_available_left ->
             let work_list : Transaction_snark_work.Statement.t list =
               let spec_list = Sl.all_work_pairs_exn !sl in
-              List.map spec_list ~f:(fun (s1, s2_opt) ->
-                  let stmt1 = Snark_work_lib.Work.Single.Spec.statement s1 in
-                  let stmt2 =
-                    Option.value_map s2_opt ~default:[] ~f:(fun s ->
-                        [Snark_work_lib.Work.Single.Spec.statement s] )
-                  in
-                  stmt1 :: stmt2 )
+              List.map spec_list ~f:(fun specs ->
+                  One_or_two.map specs
+                    ~f:Snark_work_lib.Work.Single.Spec.statement )
             in
             let proofs_available_this_iter =
               List.hd_exn proofs_available_left

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -140,13 +140,9 @@ val of_scan_state_pending_coinbases_and_snarked_ledger :
 
 val all_work_pairs_exn :
      t
-  -> ( ( Transaction.t
-       , Transaction_witness.t
-       , Ledger_proof.t )
-       Snark_work_lib.Work.Single.Spec.t
-     * ( Transaction.t
-       , Transaction_witness.t
-       , Ledger_proof.t )
-       Snark_work_lib.Work.Single.Spec.t
-       option )
+  -> ( Transaction.t
+     , Transaction_witness.t
+     , Ledger_proof.t )
+     Snark_work_lib.Work.Single.Spec.t
+     One_or_two.t
      list

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -84,10 +84,6 @@ module Staged_undos : sig
   val apply : t -> Ledger.t -> unit Or_error.t
 end
 
-module Bundle : sig
-  type 'a t = 'a list
-end
-
 val staged_undos : t -> Staged_undos.t
 
 val empty : unit -> t
@@ -118,17 +114,17 @@ val statement_of_job : Available_job.t -> Transaction_snark.Statement.t option
 val snark_job_list_json : t -> string
 
 (** All the proof bundles *)
-val all_work_statements : t -> Transaction_snark.Statement.t Bundle.t list
+val all_work_statements : t -> Transaction_snark.Statement.t One_or_two.t list
 
 (** Required proof bundles for a certain number of slots *)
-val required_work_pairs : t -> slots:int -> Available_job.t Bundle.t list
+val required_work_pairs : t -> slots:int -> Available_job.t One_or_two.t list
 
 (**K proof bundles*)
-val k_work_pairs_for_new_diff : t -> k:int -> Available_job.t Bundle.t list
+val k_work_pairs_for_new_diff : t -> k:int -> Available_job.t One_or_two.t list
 
 (** All the proof bundles for 2**transaction_capacity_log2 slots that can be used up in one diff *)
 val work_statements_for_new_diff :
-  t -> Transaction_snark.Statement.t Bundle.t list
+  t -> Transaction_snark.Statement.t One_or_two.t list
 
 (** True if the latest tree is full and transactions would be added on to a new tree *)
 val next_on_new_tree : t -> bool
@@ -136,15 +132,11 @@ val next_on_new_tree : t -> bool
 (** All the proof bundles for snark workers*)
 val all_work_pairs_exn :
      t
-  -> ( ( Transaction.t
-       , Transaction_witness.t
-       , Ledger_proof.t )
-       Snark_work_lib.Work.Single.Spec.t
-     * ( Transaction.t
-       , Transaction_witness.t
-       , Ledger_proof.t )
-       Snark_work_lib.Work.Single.Spec.t
-       option )
+  -> ( Transaction.t
+     , Transaction_witness.t
+     , Ledger_proof.t )
+     Snark_work_lib.Work.Single.Spec.t
+     One_or_two.t
      list
 
 module Constants : Constants_intf.S

--- a/src/lib/transaction_snark_work/dune
+++ b/src/lib/transaction_snark_work/dune
@@ -1,5 +1,5 @@
 (library
   (name transaction_snark_work)
   (public_name transaction_snark_work)
-  (libraries core_kernel coda_base transaction_snark ledger_proof)
+  (libraries core_kernel coda_base ledger_proof one_or_two transaction_snark)
   (preprocess (pps ppx_jane ppx_coda ppx_deriving_yojson)))

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -1,16 +1,13 @@
 open Core_kernel
-open Async_kernel
 open Module_version
 open Currency
 open Signature_lib
-
-let proofs_length = 2
 
 module Statement = struct
   module Stable = struct
     module V1 = struct
       module T = struct
-        type t = Transaction_snark.Statement.Stable.V1.t list
+        type t = Transaction_snark.Statement.Stable.V1.t One_or_two.Stable.V1.t
         [@@deriving bin_io, sexp, hash, compare, yojson, version]
       end
 
@@ -36,14 +33,15 @@ module Statement = struct
 
   include Hashable.Make (Stable.Latest)
 
-  let gen =
-    Quickcheck.Generator.list_with_length proofs_length
-      Transaction_snark.Statement.gen
+  let gen = One_or_two.gen Transaction_snark.Statement.gen
 
   let compact_json t =
-    `List (List.map ~f:(fun s -> `Int (Transaction_snark.Statement.hash s)) t)
+    `List
+      ( One_or_two.map ~f:(fun s -> `Int (Transaction_snark.Statement.hash s)) t
+      |> One_or_two.to_list )
 
-  let work_ids t : int list = List.map t ~f:Transaction_snark.Statement.hash
+  let work_ids t : int One_or_two.t =
+    One_or_two.map t ~f:Transaction_snark.Statement.hash
 end
 
 module Info = struct
@@ -52,7 +50,7 @@ module Info = struct
       module T = struct
         type t =
           { statements: Statement.Stable.V1.t
-          ; work_ids: int list
+          ; work_ids: int One_or_two.Stable.V1.t
           ; fee: Fee.Stable.V1.t
           ; prover: Public_key.Compressed.Stable.V1.t }
         [@@deriving sexp, to_yojson, bin_io, version]
@@ -77,7 +75,7 @@ module Info = struct
   (* bin_io omitted *)
   type t = Stable.Latest.t =
     { statements: Statement.Stable.V1.t
-    ; work_ids: int list
+    ; work_ids: int One_or_two.t
     ; fee: Fee.Stable.V1.t
     ; prover: Public_key.Compressed.Stable.V1.t }
   [@@deriving to_yojson, sexp]
@@ -89,7 +87,7 @@ module T = struct
       module T = struct
         type t =
           { fee: Fee.Stable.V1.t
-          ; proofs: Ledger_proof.Stable.V1.t list
+          ; proofs: Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
           ; prover: Public_key.Compressed.Stable.V1.t }
         [@@deriving sexp, to_yojson, bin_io, version]
       end
@@ -112,13 +110,15 @@ module T = struct
 
   (* bin_io omitted *)
   type t = Stable.Latest.t =
-    {fee: Fee.t; proofs: Ledger_proof.t list; prover: Public_key.Compressed.t}
+    { fee: Fee.t
+    ; proofs: Ledger_proof.t One_or_two.t
+    ; prover: Public_key.Compressed.t }
   [@@deriving to_yojson, sexp]
 
   let info t =
-    let statements = List.map t.proofs ~f:Ledger_proof.statement in
+    let statements = One_or_two.map t.proofs ~f:Ledger_proof.statement in
     { Info.statements
-    ; work_ids= List.map statements ~f:Transaction_snark.Statement.hash
+    ; work_ids= One_or_two.map statements ~f:Transaction_snark.Statement.hash
     ; fee= t.fee
     ; prover= t.prover }
 end

--- a/src/lib/transaction_snark_work/transaction_snark_work.mli
+++ b/src/lib/transaction_snark_work/transaction_snark_work.mli
@@ -3,7 +3,7 @@ open Currency
 open Signature_lib
 
 module Statement : sig
-  type t = Transaction_snark.Statement.t list [@@deriving yojson, sexp]
+  type t = Transaction_snark.Statement.t One_or_two.t [@@deriving yojson, sexp]
 
   include Hashable.S with type t := t
 
@@ -21,13 +21,13 @@ module Statement : sig
 
   val compact_json : t -> Yojson.Safe.json
 
-  val work_ids : t -> int list
+  val work_ids : t -> int One_or_two.t
 end
 
 module Info : sig
   type t =
     { statements: Statement.Stable.V1.t
-    ; work_ids: int list
+    ; work_ids: int One_or_two.Stable.V1.t
     ; fee: Fee.Stable.V1.t
     ; prover: Public_key.Compressed.Stable.V1.t }
   [@@deriving to_yojson, sexp]
@@ -48,7 +48,9 @@ end
     *)
 
 type t =
-  {fee: Fee.t; proofs: Ledger_proof.t list; prover: Public_key.Compressed.t}
+  { fee: Fee.t
+  ; proofs: Ledger_proof.t One_or_two.t
+  ; prover: Public_key.Compressed.t }
 [@@deriving sexp, to_yojson]
 
 val fee : t -> Fee.t
@@ -67,7 +69,9 @@ type unchecked = t
 
 module Checked : sig
   type nonrec t = t =
-    {fee: Fee.t; proofs: Ledger_proof.t list; prover: Public_key.Compressed.t}
+    { fee: Fee.t
+    ; proofs: Ledger_proof.t One_or_two.t
+    ; prover: Public_key.Compressed.t }
   [@@deriving sexp, to_yojson]
 
   module Stable : module type of Stable
@@ -76,5 +80,3 @@ module Checked : sig
 end
 
 val forget : Checked.t -> t
-
-val proofs_length : int

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -122,7 +122,7 @@ struct
           Transaction_snark_work.Checked.
             { fee= Fee.of_int 1
             ; proofs=
-                List.map stmts ~f:(fun statement ->
+                One_or_two.map stmts ~f:(fun statement ->
                     Ledger_proof.create ~statement
                       ~sok_digest:Sok_message.Digest.default ~proof:Proof.dummy
                 )

--- a/src/lib/trust_system/record.ml
+++ b/src/lib/trust_system/record.ml
@@ -34,7 +34,7 @@ end) : S = struct
 
   let bans_disabled =
     let module Expiration = struct
-      [%%expires_after "20190907"]
+      [%%expires_after "20190914"]
     end in
     ref false
 

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -29,7 +29,8 @@ module Test_inputs = struct
 
   module Snark_pool = struct
     module T = struct
-      type t = Transaction_snark.Statement.Stable.Latest.t list
+      type t =
+        Transaction_snark.Statement.Stable.Latest.t One_or_two.Stable.Latest.t
       [@@deriving bin_io, hash, compare, sexp]
     end
 
@@ -56,20 +57,7 @@ module Test_inputs = struct
 
     let work = Fn.id
 
-    let chunks_of xs ~n = List.groupi xs ~break:(fun i _ _ -> i mod n = 0)
-
-    let paired ls =
-      let pairs = chunks_of ls ~n:2 in
-      List.map pairs ~f:(fun js ->
-          match js with
-          | [j] ->
-              (work j, None)
-          | [j1; j2] ->
-              (work j1, Some (work j2))
-          | _ ->
-              failwith "error pairing jobs" )
-
-    let all_work_pairs_exn (t : t) = paired t
+    let all_work_pairs_exn = One_or_two.group_list
   end
 end
 

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -32,7 +32,7 @@ module type Inputs_intf = sig
 
     val get_completed_work :
          t
-      -> Transaction_snark.Statement.t list
+      -> Transaction_snark.Statement.t One_or_two.t
       -> Transaction_snark_work.t option
   end
 
@@ -41,15 +41,11 @@ module type Inputs_intf = sig
 
     val all_work_pairs_exn :
          t
-      -> ( ( Transaction.t
-           , Transaction_witness.t
-           , Ledger_proof.t )
-           Snark_work_lib.Work.Single.Spec.t
-         * ( Transaction.t
-           , Transaction_witness.t
-           , Ledger_proof.t )
-           Snark_work_lib.Work.Single.Spec.t
-           option )
+      -> ( Transaction.t
+         , Transaction_witness.t
+         , Ledger_proof.t )
+         Snark_work_lib.Work.Single.Spec.t
+         One_or_two.t
          list
   end
 end
@@ -74,67 +70,35 @@ module type Lib_intf = sig
          , Transaction_witness.t
          , Ledger_proof.t )
          Snark_work_lib.Work.Single.Spec.t
-         * ( Transaction.t
-           , Transaction_witness.t
-           , Ledger_proof.t )
-           Snark_work_lib.Work.Single.Spec.t
-           option
+         One_or_two.t
       -> t
   end
-
-  val pair_to_list :
-       ( Transaction.t
-       , Transaction_witness.t
-       , Ledger_proof.t )
-       Snark_work_lib.Work.Single.Spec.t
-       * ( Transaction.t
-         , Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-         option
-    -> ( Transaction.t
-       , Transaction_witness.t
-       , Ledger_proof.t )
-       Snark_work_lib.Work.Single.Spec.t
-       list
 
   val get_expensive_work :
        snark_pool:Snark_pool.t
     -> fee:Fee.t
-    -> ( ( Transaction.t
-         , Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-       * ( Transaction.t
-         , Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-         option )
+    -> ( Transaction.t
+       , Transaction_witness.t
+       , Ledger_proof.t )
+       Snark_work_lib.Work.Single.Spec.t
+       One_or_two.t
        list
-    -> ( ( Transaction.t
-         , Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-       * ( Transaction.t
-         , Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-         option )
+    -> ( Transaction.t
+       , Transaction_witness.t
+       , Ledger_proof.t )
+       Snark_work_lib.Work.Single.Spec.t
+       One_or_two.t
        list
 
   val all_works :
        logger:Logger.t
     -> Staged_ledger.t
     -> State.t
-    -> ( ( Transaction.t
-         , Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-       * ( Transaction.t
-         , Transaction_witness.t
-         , Ledger_proof.t )
-         Snark_work_lib.Work.Single.Spec.t
-         option )
+    -> ( Transaction.t
+       , Transaction_witness.t
+       , Ledger_proof.t )
+       Snark_work_lib.Work.Single.Spec.t
+       One_or_two.t
        list
 
   module For_tests : sig
@@ -145,7 +109,7 @@ module type Lib_intf = sig
          , Transaction_witness.t
          , Ledger_proof.t )
          Snark_work_lib.Work.Single.Spec.t
-         list
+         One_or_two.t
       -> bool
   end
 end
@@ -165,7 +129,7 @@ module type Selection_method_intf = sig
     -> logger:Logger.t
     -> staged_ledger
     -> State.t
-    -> work list * State.t
+    -> work One_or_two.t option * State.t
 end
 
 module type Make_selection_method_intf = functor

--- a/src/lib/work_selector/random.ml
+++ b/src/lib/work_selector/random.ml
@@ -9,11 +9,11 @@ struct
     let unseen_jobs = Lib.all_works staged_ledger state ~logger in
     match Lib.get_expensive_work ~snark_pool ~fee unseen_jobs with
     | [] ->
-        ([], state)
+        (None, state)
     | expensive_work ->
         let i = Random.int (List.length expensive_work) in
         let x = List.nth_exn expensive_work i in
-        (Lib.pair_to_list x, Lib.State.set state x)
+        (Some x, Lib.State.set state x)
 end
 
 let%test_module "test" =

--- a/src/lib/work_selector/sequence.ml
+++ b/src/lib/work_selector/sequence.ml
@@ -7,9 +7,9 @@ struct
     let unseen_jobs = Lib.all_works staged_ledger state ~logger in
     match Lib.get_expensive_work ~snark_pool ~fee unseen_jobs with
     | [] ->
-        ([], state)
+        (None, state)
     | x :: _ ->
-        (Lib.pair_to_list x, Lib.State.set state x)
+        (Some x, Lib.State.set state x)
 end
 
 let%test_module "test" =


### PR DESCRIPTION
Transaction SNARKs and associated data always come in bundles of one or two.
Prior to this, we either used a list or a pair like `'a * 'a option` to express
this. I've replaced all of those with One_or_two.t, which buys us type safety,
self documenting code, and saves us ~60 lines of code due to reducing
redundancy.

Unit tests pass, we'll see what happens when CI runs the integration tests.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: