### PR TITLE
[WIP] script to enforce ppx order for versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -225,7 +225,7 @@ jobs:
     build-artifacts--testnet_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         environment:
             DUNE_PROFILE: testnet_postake_medium_curves
         steps:
@@ -267,7 +267,7 @@ jobs:
     test-unit--test_postake_snarkless_unittest:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -305,7 +305,7 @@ jobs:
     test-unit--dev:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -343,7 +343,7 @@ jobs:
     test-unit--test_postake_snarkless_medium_curves_unit_test:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -359,7 +359,7 @@ jobs:
     test-unit--dev_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -375,7 +375,7 @@ jobs:
     test--fake_hash:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -389,7 +389,7 @@ jobs:
     test--test_postake:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -406,7 +406,7 @@ jobs:
     test--test_postake_bootstrap:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -423,7 +423,7 @@ jobs:
     test--test_postake_catchup:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -437,7 +437,7 @@ jobs:
     test--test_postake_delegation:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -451,7 +451,7 @@ jobs:
     test--test_postake_five_even_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -465,7 +465,7 @@ jobs:
     test--test_postake_five_even_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -479,7 +479,7 @@ jobs:
     test--test_postake_holy_grail:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -496,7 +496,7 @@ jobs:
     test--test_postake_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -513,7 +513,7 @@ jobs:
     test--test_postake_split:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -527,7 +527,7 @@ jobs:
     test--test_postake_split_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -562,7 +562,7 @@ jobs:
     test--test_postake_three_proposers:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -576,7 +576,7 @@ jobs:
     test--test_postake_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -593,7 +593,7 @@ jobs:
     test--test_postake_delegation_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -607,7 +607,7 @@ jobs:
     test--test_postake_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -626,7 +626,7 @@ jobs:
     test--test_postake_snarkless_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -643,7 +643,7 @@ jobs:
     test--test_postake_split_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -657,7 +657,7 @@ jobs:
     test--test_postake_split_snarkless_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -692,7 +692,7 @@ jobs:
     test--test_postake_txns_medium_curves:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -57,7 +57,7 @@ jobs:
 
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -231,7 +231,7 @@ jobs:
         resource_class: large
         {%- endif %}
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         environment:
             DUNE_PROFILE: {{profile}}
         steps:
@@ -282,7 +282,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -323,7 +323,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -342,7 +342,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:
@@ -361,7 +361,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+            - image: codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
         steps:
             - checkout
             - run:

--- a/README-dev.md
+++ b/README-dev.md
@@ -57,7 +57,7 @@ of the repo.
 
 * Pull down developer container image  (~2GB download, go stretch your legs)
 
-`docker pull codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83`
+`docker pull codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d`
 
 * Create local builder image
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM codaprotocol/coda:toolchain-6b64dedbb6e27f0cc57228f1b44aaa87da489e83
+FROM codaprotocol/coda:toolchain-d39bcf204b75266bbbeec7620ebf036d1083752d
 
 ENV OPAM_DIR             "/home/opam/.opam/4.07"
 ENV PATH                 "${OPAM_DIR}/bin:$PATH"

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -17,6 +17,7 @@ RUN sudo apt-get update && sudo apt-get install --yes \
     pandoc \
     patchelf \
     python \
+    python-pip \
     perl \
     pkg-config \
     python-jinja2 \
@@ -25,6 +26,8 @@ RUN sudo apt-get update && sudo apt-get install --yes \
     libbz2-dev
 
 RUN sudo gem install deb-s3
+
+RUN sudo pip install sexpdata
 
 # Google Cloud tools
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \

--- a/scripts/enforce-ppx-order.py
+++ b/scripts/enforce-ppx-order.py
@@ -19,7 +19,16 @@ pps = sexpdata.loads ('pps')
 no_preprocessing = sexpdata.loads ('no_preprocessing')
 
 ppx_static_checks = sexpdata.loads ('ppx_static_checks')
+ppx_register_version = sexpdata.loads ('ppx_register_version')
 ppx_versioning = sexpdata.loads ('ppx_coda')
+
+def ppx_not_found (dune,ppx) :
+    print ("In dune file " + dune + ", the preprocessing clause does not contain " + (sexpdata.dumps (ppx)))
+    exit (1)
+
+def bad_ppx_order (dune,ppx1,ppx2) :
+    print ("In dune file " + dune + ", in the preprocessing clause, " + (sexpdata.dumps (ppx1)) + " does not precede " + (sexpdata.dumps (ppx2)))
+    exit (2)
 
 for dune in dunes :
     with open (dune) as fp :
@@ -40,18 +49,21 @@ for dune in dunes :
                             try :
                                 static_checks_ndx = ppxs.index (ppx_static_checks)
                             except :
-                                print ("In dune file " + dune + ", did not find ppx " + (sexpdata.dumps (ppx_static_checks)))
-                                exit (1)
+                                ppx_not_found (dune,ppx_static_checks)
+                            try :
+                                register_version_ndx = ppxs.index (ppx_register_version)
+                            except :
+                                ppx_not_found (dune,ppx_register_version)
                             try :
                                 versioning_ndx = ppxs.index (ppx_versioning)
                             except :
-                                print ("In dune file " + dune + ", did not find ppx " + (sexpdata.dumps (ppx_versioning)))
-                                exit (1)
-                            if not (static_checks_ndx < versioning_ndx) :
-                                print ("In dune file " + dune + ", in preprocessing clause, " + (sexpdata.dumps (ppx_static_checks)) + " does not precede " + (sexpdata.dumps (ppx_versioning)))
-                                exit (1)
+                                ppx_not_found (dune,ppx_versioning)
+                            if not (static_checks_ndx < register_version_ndx) :
+                                bad_ppx_order (dune,ppx_static_checks,ppx_register_version)
+                            if not (register_version_ndx < versioning_ndx) :
+                                bad_ppx_order (dune,ppx_register_version,ppx_versioning)
                         else :
-                            print ("In dune file " + dune + ", in library preprocessing clause, expected pps or no-preprocessing subclause in preprocess clause, got: " + str(subclause))
+                            print ("In dune file " + dune + ", in the library preprocessing clause, expected pps or no-preprocessing subclause in preprocess clause, got: " + str(subclause))
                             exit (1)
 
                           

--- a/scripts/enforce-ppx-order.py
+++ b/scripts/enforce-ppx-order.py
@@ -51,7 +51,7 @@ for dune in dunes :
                             # if no preprocessing, don't have to worry about order of ppxs
                             continue
                         elif sexpdata.car (subclause) == pps :
-                            # if there is preprocessing, static checks before versioning, and both must occur
+                            # if there is preprocessing, static checks before version registration before versioning, and all three must occur
                             ppxs = sexpdata.cdr (subclause)
                             static_checks_ndx = get_ppx_ndx (dune,ppxs,ppx_static_checks)
                             register_version_ndx = get_ppx_ndx (dune,ppxs,ppx_register_version)

--- a/scripts/enforce-ppx-order.py
+++ b/scripts/enforce-ppx-order.py
@@ -64,6 +64,7 @@ for dune in dunes :
                                 bad_ppx_order (dune,ppx_register_version,ppx_versioning)
                         else :
                             print ("In dune file " + dune + ", in the library preprocessing clause, expected pps or no-preprocessing subclause in preprocess clause, got: " + str(subclause))
+                            global exit_code
                             exit_code = 1
 
 exit (exit_code)

--- a/scripts/enforce-ppx-order.py
+++ b/scripts/enforce-ppx-order.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+
+# In dune files, whenever there's preprocessing, the static enforcement ppx appears before the versioning ppx, because the
+# former checks for occurrences of the latter, so we don't want it expanded away
+
+import subprocess
+import string
+import sexpdata
+
+dune_string = subprocess.check_output(['find','src/lib','-name','dune'])
+
+dunes_raw = string.split (dune_string,'\n')
+
+dunes = list(filter(lambda s : len(s) > 0,dunes_raw))
+
+library = sexpdata.loads ('library')
+preprocess = sexpdata.loads ('preprocess')
+pps = sexpdata.loads ('pps')
+no_preprocessing = sexpdata.loads ('no_preprocessing')
+
+ppx_static_checks = sexpdata.loads ('ppx_static_checks')
+ppx_versioning = sexpdata.loads ('ppx_coda')
+
+for dune in dunes :
+    with open (dune) as fp :
+        # wrap in parens to get list of top-level clauses
+        sexps = sexpdata.loads ('(' + fp.read () + ')')
+        for sexp in sexps :
+            if isinstance (sexp,list) and len (sexp) > 0 and sexpdata.car (sexp) == library :
+                clauses = sexpdata.cdr (sexp)
+                for clause in clauses :
+                    if sexpdata.car (clause) == preprocess :
+                        subclause = sexpdata.car (sexpdata.cdr (clause))
+                        if subclause == no_preprocessing :
+                            # if no preprocessing, don't have to worry about order of ppxs
+                            continue
+                        elif sexpdata.car (subclause) == pps :
+                            # if there is preprocessing, static checks before versioning, and both must occur
+                            ppxs = sexpdata.cdr (subclause)
+                            try :
+                                static_checks_ndx = ppxs.index (ppx_static_checks)
+                            except :
+                                print ("In dune file " + dune + ", did not find ppx " + (sexpdata.dumps (ppx_static_checks)))
+                                exit (1)
+                            try :
+                                versioning_ndx = ppxs.index (ppx_versioning)
+                            except :
+                                print ("In dune file " + dune + ", did not find ppx " + (sexpdata.dumps (ppx_versioning)))
+                                exit (1)
+                            if not (static_checks_ndx < versioning_ndx) :
+                                print ("In dune file " + dune + ", in preprocessing clause, " + (sexpdata.dumps (ppx_static_checks)) + " does not precede " + (sexpdata.dumps (ppx_versioning)))
+                                exit (1)
+                        else :
+                            print ("In dune file " + dune + ", in library preprocessing clause, expected pps or no-preprocessing subclause in preprocess clause, got: " + str(subclause))
+                            exit (1)
+
+                          
+
+                              
+                
+            
+            
+
+      
+      
+
+    
+


### PR DESCRIPTION
When RFC 0024 is implemented, we'll have two ppxs: one to expand the versioning and registration boilerplate, another to check that we're not calling `deriving bin_io` anywhere, and that there's no versioning withing functor bodies. The latter one must run before the former expands into `deriving bin_io` uses.

This Python script enforces that whenever there's preprocessing, both ppxs must appear, and in order.

The actual ppx module names may change, just change the names in this script.

Note: it's OK if a module has no preprocessing clause, or specifies `no_preprocessing`.

The script only looks in `src/lib` dune files currently, since that's where any versioning should be taking place.

