### PR TITLE
Remove versioning for envelope

### DIFF
--- a/src/lib/envelope/envelope.ml
+++ b/src/lib/envelope/envelope.ml
@@ -1,83 +1,40 @@
 open Core
-open Module_version
 
 module Sender = struct
-  module Stable = struct
-    module V1 = struct
-      module T = struct
-        type t = Local | Remote of Core.Unix.Inet_addr.Stable.V1.t
-        [@@deriving sexp, bin_io, compare, version]
-      end
-
-      include T
-
-      let equal sender1 sender2 = Int.equal (compare sender1 sender2) 0
-
-      let to_yojson t : Yojson.Safe.json =
-        match t with
-        | Local ->
-            `String "Local"
-        | Remote inet_addr ->
-            `Assoc [("Remote", `String (Unix.Inet_addr.to_string inet_addr))]
-
-      let of_yojson (json : Yojson.Safe.json) : (t, string) Result.t =
-        match json with
-        | `String "Local" ->
-            Ok Local
-        | `Assoc [("Remote", `String addr)] ->
-            Ok (Remote (Unix.Inet_addr.of_string addr))
-        | _ ->
-            Error "Expected JSON representing envelope sender"
-
-      include Registration.Make_latest_version (T)
-    end
-
-    module Latest = V1
-
-    module Module_decl = struct
-      let name = "envelope_sender"
-
-      type latest = Latest.t
-    end
-
-    module Registrar = Registration.Make (Module_decl)
-    module Registered_V1 = Registrar.Register (V1)
-  end
-
-  (* bin_io intentionally omitted in deriving list *)
-  type t = Stable.Latest.t = Local | Remote of Unix.Inet_addr.Stable.V1.t
+  type t = Local | Remote of Unix.Inet_addr.Stable.V1.t
   [@@deriving sexp, compare]
 
-  [%%define_locally
-  Stable.Latest.(to_yojson, of_yojson, equal)]
+  let equal sender1 sender2 = Int.equal (compare sender1 sender2) 0
+
+  let to_yojson t : Yojson.Safe.json =
+    match t with
+    | Local ->
+        `String "Local"
+    | Remote inet_addr ->
+        `Assoc [("Remote", `String (Unix.Inet_addr.to_string inet_addr))]
+
+  let of_yojson (json : Yojson.Safe.json) : (t, string) Result.t =
+    match json with
+    | `String "Local" ->
+        Ok Local
+    | `Assoc [("Remote", `String addr)] ->
+        Ok (Remote (Unix.Inet_addr.of_string addr))
+    | _ ->
+        Error "Expected JSON representing envelope sender"
 end
 
 module Incoming = struct
-  module Stable = struct
-    module V1 = struct
-      module T = struct
-        type 'a t = {data: 'a; sender: Sender.Stable.V1.t}
-        [@@deriving eq, sexp, bin_io, yojson, version]
-      end
+  type 'a t = {data: 'a; sender: Sender.t} [@@deriving eq, sexp, yojson]
 
-      include T
-    end
+  let sender t = t.sender
 
-    module Latest = V1
-  end
+  let data t = t.data
 
-  (* bin_io intentionally omitted *)
-  type 'a t = 'a Stable.Latest.t [@@deriving eq, sexp, yojson]
+  let wrap ~data ~sender = {data; sender}
 
-  let sender t = t.Stable.Latest.sender
-
-  let data t = t.Stable.Latest.data
-
-  let wrap ~data ~sender = Stable.Latest.{data; sender}
-
-  let map ~f t = Stable.Latest.{t with data= f t.data}
+  let map ~f t = {t with data= f t.data}
 
   let local data =
     let sender = Sender.Local in
-    Stable.Latest.{data; sender}
+    {data; sender}
 end

--- a/src/lib/envelope/envelope.mli
+++ b/src/lib/envelope/envelope.mli
@@ -1,30 +1,12 @@
 open Core
 
 module Sender : sig
-  module Stable : sig
-    module V1 : sig
-      type t = Local | Remote of Unix.Inet_addr.Stable.V1.t
-      [@@deriving sexp, bin_io, eq, yojson, version]
-    end
-
-    module Latest = V1
-  end
-
-  type t = Stable.Latest.t = Local | Remote of Unix.Inet_addr.Stable.V1.t
+  type t = Local | Remote of Unix.Inet_addr.Stable.V1.t
   [@@deriving sexp, eq, yojson]
 end
 
 module Incoming : sig
-  module Stable : sig
-    module V1 : sig
-      type 'a t = {data: 'a; sender: Sender.Stable.V1.t}
-      [@@deriving eq, sexp, bin_io, yojson, version]
-    end
-
-    module Latest = V1
-  end
-
-  type 'a t = 'a Stable.Latest.t [@@deriving eq, sexp, yojson]
+  type 'a t = {data: 'a; sender: Sender.t} [@@deriving eq, sexp, yojson]
 
   val sender : 'a t -> Sender.t
 


### PR DESCRIPTION
Envelopes are created on message receipt, not when sent, so they're not serializable, hence `Envelope` does not need versioning.

Closes #2361.