### PR TITLE
Use default if CODA_TIME_OFFSET undefined

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -613,7 +613,7 @@ let daemon logger =
          let trust_system = Trust_system.create ~db_dir:trust_dir in
          trace_database_initialization "trust_system" __LOC__ trust_dir ;
          let time_controller =
-           Block_time.Controller.create Block_time.Controller.basic
+           Block_time.Controller.create @@ Block_time.Controller.basic ~logger
          in
          let initial_propose_keypairs =
            propose_keypair |> Option.to_list |> Keypair.Set.of_list

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -431,7 +431,7 @@ module T = struct
           trace_database_initialization "external_transition_database" __LOC__
             external_transition_database_dir ;
           let time_controller =
-            Block_time.Controller.create Block_time.Controller.basic
+            Block_time.Controller.create (Block_time.Controller.basic ~logger)
           in
           let propose_keypair =
             Option.map proposer ~f:(fun i ->

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -115,7 +115,7 @@ let run_test () : unit Deferred.t =
         Auxiliary_database.External_transition_database.create ~logger
           external_transition_database_dir
       in
-      let time_controller = Block_time.Controller.(create basic) in
+      let time_controller = Block_time.Controller.(create @@ basic ~logger) in
       let consensus_local_state =
         Consensus.Data.Local_state.create
           (Public_key.Compressed.Set.singleton

--- a/src/lib/auxiliary_database/transaction_database.ml
+++ b/src/lib/auxiliary_database/transaction_database.ml
@@ -109,7 +109,7 @@ module For_tests = struct
     let time_gen =
       let time_now =
         Block_time.Time.to_span_since_epoch
-          (Block_time.Time.now Block_time.Time.Controller.basic)
+          (Block_time.Time.now @@ Block_time.Time.Controller.basic ~logger)
       in
       let time_max = Block_time.Time.Span.to_ms time_now in
       let time_min = Int64.(time_max - of_year 5) in

--- a/src/lib/coda_base/block_time.ml
+++ b/src/lib/coda_base/block_time.ml
@@ -43,10 +43,19 @@ module Time = struct
 
     let create offset = offset
 
-    let basic =
+    let basic ~logger =
       lazy
-        ( Core_kernel.Time.Span.of_int_sec @@ Int.of_string
-        @@ Unix.getenv "CODA_TIME_OFFSET" )
+        (let offset =
+           match Core.Sys.getenv "CODA_TIME_OFFSET" with
+           | Some tm ->
+               Int.of_string tm
+           | None ->
+               Logger.info logger ~module_:__MODULE__ ~location:__LOC__
+                 "Environment variable CODA_TIME_OFFSET not found, using \
+                  default of 0" ;
+               0
+         in
+         Core_kernel.Time.Span.of_int_sec offset)
 
     [%%else]
 
@@ -54,7 +63,7 @@ module Time = struct
 
     let create () = ()
 
-    let basic = ()
+    let basic ~logger:_ = ()
 
     [%%endif]
   end

--- a/src/lib/coda_base/block_time.ml
+++ b/src/lib/coda_base/block_time.ml
@@ -50,7 +50,7 @@ module Time = struct
            | Some tm ->
                Int.of_string tm
            | None ->
-               Logger.info logger ~module_:__MODULE__ ~location:__LOC__
+               Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
                  "Environment variable CODA_TIME_OFFSET not found, using \
                   default of 0" ;
                0

--- a/src/lib/coda_base/block_time.mli
+++ b/src/lib/coda_base/block_time.mli
@@ -14,7 +14,7 @@ module Time : sig
 
     val create : t -> t
 
-    val basic : t
+    val basic : logger:Logger.t -> t
   end
 
   module Stable : sig

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -159,7 +159,7 @@ struct
       in
       let next_blockchain_state =
         Blockchain_state.create_value
-          ~timestamp:(Block_time.now Block_time.Controller.basic)
+          ~timestamp:(Block_time.now Block_time.Controller.basic ~logger)
           ~snarked_ledger_hash:next_ledger_hash
           ~staged_ledger_hash:next_staged_ledger_hash
       in

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -159,7 +159,7 @@ struct
       in
       let next_blockchain_state =
         Blockchain_state.create_value
-          ~timestamp:(Block_time.now Block_time.Controller.basic ~logger)
+          ~timestamp:(Block_time.now @@ Block_time.Controller.basic ~logger)
           ~snarked_ledger_hash:next_ledger_hash
           ~staged_ledger_hash:next_staged_ledger_hash
       in

--- a/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
+++ b/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
@@ -29,7 +29,7 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
 
     let trust_system = Trust_system.null ()
 
-    let time_controller = Block_time.Controller.basic
+    let time_controller = Block_time.Controller.basic ~logger
 
     let timeout_duration = Block_time.Span.of_ms 200L
 


### PR DESCRIPTION
Use default of 0 and log that fact if `CODA_TIME_OFFSET` is undefined.

Use `Core.Sys.getenv`, which returns an option, instead of `Unix.getenv`, which raises an exception, which we weren't handling.

Closes #3336.