### PR TITLE
Use shadowed bin_io functions

### DIFF
--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -12,7 +12,8 @@ module Stable = struct
     end
 
     include T
-    include Module_version.Registration.Make_latest_version (T)
+    module Registered = Module_version.Registration.Make_latest_version (T)
+    include Registered
 
     let is_valid {proposer= _; amount; fee_transfer} =
       match fee_transfer with
@@ -22,8 +23,12 @@ module Stable = struct
           Currency.Amount.(of_fee fee <= amount)
 
     (* check validity when deserializing *)
-    include Binable.Of_binable
-              (T)
+    include Binable.Of_binable (struct
+                (* use shadowed bin_io functions *)
+                type nonrec t = t
+
+                include Registered
+              end)
               (struct
                 type nonrec t = t
 


### PR DESCRIPTION
In `coinbase.ml`, we use `Binable.Of_binable` to insert a validity guard in `bin_io` functions. We were passing the unregistered `bin_io` functions, so the registration had no effect.

Use the functions that come from registration instead.

Closes #3388.