### PR TITLE
Daemon expiry in configs

### DIFF
--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -5,5 +5,5 @@
   (modes native)
   (libraries init tests)
   (preprocessor_deps ../../../config.mlh)
-  (preprocess (pps ppx_coda ppx_jane))
+  (preprocess (pps ppx_coda ppx_let ppx_sexp_conv ppx_optcomp))
   (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli true]
+
+[%%define daemon_expiry "never"]

--- a/src/config/dev_frontend.mlh
+++ b/src/config/dev_frontend.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data true]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_bootstrap.mlh
+++ b/src/config/test_postake_bootstrap.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_delegation.mlh
+++ b/src/config/test_postake_delegation.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_delegation_medium_curves.mlh
+++ b/src/config/test_postake_delegation_medium_curves.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_five_even_snarkless.mlh
+++ b/src/config/test_postake_five_even_snarkless.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_snarkless_medium_curves_unit_test.mlh
+++ b/src/config/test_postake_snarkless_medium_curves_unit_test.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_snarkless_unittest.mlh
+++ b/src/config/test_postake_snarkless_unittest.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_split_snarkless.mlh
+++ b/src/config/test_postake_split_snarkless.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_split_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_split_snarkless_medium_curves.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_three_proposers.mlh
+++ b/src/config/test_postake_three_proposers.mlh
@@ -20,3 +20,4 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_txns.mlh
+++ b/src/config/test_postake_txns.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/test_postake_txns_medium_curves.mlh
+++ b/src/config/test_postake_txns_medium_curves.mlh
@@ -20,3 +20,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -21,3 +21,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/testnet_postake_many_proposers.mlh
+++ b/src/config/testnet_postake_many_proposers.mlh
@@ -21,3 +21,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/testnet_postake_many_proposers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_proposers_medium_curves.mlh
@@ -21,3 +21,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -27,3 +27,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -21,3 +21,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -22,3 +22,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -21,3 +21,5 @@
 [%%define mock_frontend_data false]
 
 [%%define new_cli false]
+
+[%%define daemon_expiry "never"]


### PR DESCRIPTION
Add a new field `daemon_expiry` to configs. It can be "never", or a date/time in the same format as we use for genesis timestamps.

If it's not "never", on startup, log the fact that the daemon will expire. The daemon shuts down with an `exit 0` at the appointed hour, logging the expiry.

Closes #3398.
