### PR TITLE
Set up unlock modal on wallet in sidebar

### DIFF
--- a/frontend/wallet/src/render/components/Modal.re
+++ b/frontend/wallet/src/render/components/Modal.re
@@ -44,6 +44,16 @@ module Styles = {
       height(`percent(100.)),
       backgroundColor(Theme.Colors.modalDisableBgAlpha(0.67)),
     ]);
+
+  let default =
+    style([
+      margin(`auto),
+      width(`rem(22.)),
+      display(`flex),
+      flexDirection(`column),
+      alignItems(`center),
+      justifyContent(`center),
+    ]);
 };
 
 module Binding = {

--- a/frontend/wallet/src/render/components/RequestCodaModal.re
+++ b/frontend/wallet/src/render/components/RequestCodaModal.re
@@ -3,14 +3,6 @@ open Tc;
 module Styles = {
   open Css;
 
-  let modalBody =
-    style([
-      display(`flex),
-      flexDirection(`column),
-      alignItems(`center),
-      justifyContent(`center),
-    ]);
-
   let bodyMargin = style([margin(`rem(1.0)), width(`percent(100.))]);
 
   let publicKey =
@@ -36,7 +28,7 @@ let make = (~wallets, ~setModalState) => {
     Bindings.Navigator.Clipboard.writeTextTask(PublicKey.toString(wallet))
     |> Task.perform(~f=() => setModalState(_ => false));
   <Modal title="Request Coda" onRequestClose={() => setModalState(_ => false)}>
-    <div className=Styles.modalBody>
+    <div className=Modal.Styles.default>
       <div className=Styles.bodyMargin>
         <Dropdown
           label="To"

--- a/frontend/wallet/src/render/components/TextField.re
+++ b/frontend/wallet/src/render/components/TextField.re
@@ -161,6 +161,7 @@ let make =
       ~value,
       ~label,
       ~mono=false,
+      ~type_="text",
       ~button=React.null,
       ~placeholder=?,
       ~disabled=false,
@@ -170,7 +171,7 @@ let make =
     <Spacer width=0.5 />
     <input
       className={mono ? Styles.inputMono : Styles.input}
-      type_="text"
+      type_
       onChange={e => onChange(ReactEvent.Form.target(e)##value)}
       value
       ?placeholder

--- a/frontend/wallet/src/render/components/UnlockModal.re
+++ b/frontend/wallet/src/render/components/UnlockModal.re
@@ -1,18 +1,18 @@
-// TODO: Add validation that the wallet name isn't already in use
-
 [@react.component]
-let make = (~walletName, ~setModalState, ~onSubmit) => {
-  <Modal title="Add Wallet" onRequestClose={() => setModalState(_ => None)}>
+let make = (~wallet, ~password, ~setModalState, ~onSubmit) => {
+  <Modal title="Unlock Wallet" onRequestClose={() => setModalState(_ => None)}>
     <div className=Modal.Styles.default>
-      <Alert
-        kind=`Info
-        message="You can change the name or delete the wallet later."
-      />
+      <p className=Theme.Text.Body.regular>
+        {React.string("Please enter password for ")}
+        <WalletName pubkey=wallet />
+        {React.string(".")}
+      </p>
       <Spacer height=1. />
       <TextField
-        label="Name"
+        label="Pass"
+        type_="password"
         onChange={value => setModalState(_ => Some(value))}
-        value=walletName
+        value=password
       />
       <Spacer height=1.5 />
       <div className=Css.(style([display(`flex)]))>
@@ -26,7 +26,7 @@ let make = (~walletName, ~setModalState, ~onSubmit) => {
           label="Create"
           style=Button.Green
           onClick={_ => {
-            onSubmit(walletName);
+            onSubmit(password);
             setModalState(_ => None);
           }}
         />

--- a/frontend/wallet/src/render/views/walletlist/WalletItem.re
+++ b/frontend/wallet/src/render/views/walletlist/WalletItem.re
@@ -49,7 +49,7 @@ let make = (~wallet: Wallet.t) => {
       PublicKey.equal(activeWallet, wallet.publicKey)
     )
     |> Option.withDefault(~default=false);
-
+  let (modalState, setModalState) = React.useState(() => None);
   <div
     className={
       switch (isActive) {
@@ -58,15 +58,25 @@ let make = (~wallet: Wallet.t) => {
       }
     }
     onClick={_ =>
-      ReasonReact.Router.push(
-        "/wallet/" ++ PublicKey.uriEncode(wallet.publicKey),
-      )
-    }>
-    <WalletName pubkey={wallet.publicKey} />
-    <div className=Styles.balance>
+      // ReasonReact.Router.push(
+      //   "/wallet/" ++ PublicKey.uriEncode(wallet.publicKey),
+      // )
+      ()}>
+    <div className=Styles.balance onClick={_ => setModalState(_ => Some(""))}>
+      <WalletName pubkey={wallet.publicKey} />
       {ReasonReact.string(
          {js|■ |js} ++ Int64.to_string(wallet.balance##total),
        )}
     </div>
+    {switch (modalState) {
+     | None => React.null
+     | Some(password) =>
+       <UnlockModal
+         password
+         setModalState
+         wallet={wallet.publicKey}
+         onSubmit={_ => setModalState(_ => None)}
+       />
+     }}
   </div>;
 };


### PR DESCRIPTION

<img width="1072" alt="Screen Shot 2019-09-11 at 3 24 45 PM" src="https://user-images.githubusercontent.com/12700801/64739903-52c8db00-d4a8-11e9-8c5a-96c12a72d3dd.png">

Refactored modal styles to reduce code duplication, added to Textfield option to specify input type, added Unlock Wallet modal 