### PR TITLE
Add commands to new accounts cli section

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -774,6 +774,33 @@
           "possibleTypes": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ReloadWalletsPayload",
+          "description": null,
+          "fields": [
+            {
+              "name": "success",
+              "description": "True when the reload was successful",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "DeleteWalletInput",
           "description": null,
@@ -1202,6 +1229,22 @@
                 "ofType": {
                   "kind": "OBJECT",
                   "name": "DeleteWalletPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "reloadWallets",
+              "description": "Reload wallet information from disk",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ReloadWalletsPayload",
                   "ofType": null
                 }
               },
@@ -2509,6 +2552,18 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locked",
+              "description": "True if locked, false if unlocked, null if the account isn't tracked by the queried daemon",
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/src/app/cli/src/init/graphql_client.ml
+++ b/src/app/cli/src/init/graphql_client.ml
@@ -2,7 +2,12 @@ open Core
 open Async
 open Signature_lib
 
-let query query_obj port =
+let query_or_error
+    (query_obj :
+      < parse: Yojson.Basic.json -> 'response
+      ; query: string
+      ; variables: Yojson.Basic.json
+      ; .. >) port : 'response Deferred.Or_error.t =
   let uri_string = "http://localhost:" ^ string_of_int port ^ "/graphql" in
   let variables_string = Yojson.Basic.to_string query_obj#variables in
   let body_string =
@@ -25,9 +30,12 @@ let query query_obj port =
     |> Yojson.Basic.Util.member "data"
     |> query_obj#parse
   in
-  match%bind Deferred.Or_error.try_with ~extract_exn:true get_result with
-  | Ok e ->
-      return e
+  Deferred.Or_error.try_with ~extract_exn:true get_result
+
+let query query_obj port =
+  match%bind query_or_error query_obj port with
+  | Ok r ->
+      Deferred.return r
   | Error e ->
       eprintf
         "Error connecting to daemon. You might need to start it, or specify a \
@@ -43,8 +51,7 @@ module Encoders = struct
 
   let uint32 value = `String (Unsigned.UInt32.to_string value)
 
-  let public_key public_key =
-    Yojson.Safe.to_basic @@ Public_key.Compressed.to_yojson public_key
+  let public_key value = `String (Public_key.Compressed.to_base58_check value)
 end
 
 module Decoders = struct

--- a/src/app/cli/src/init/graphql_client.ml
+++ b/src/app/cli/src/init/graphql_client.ml
@@ -67,17 +67,52 @@ module Decoders = struct
     Yojson.Basic.Util.to_string json |> Unsigned.UInt64.of_string
 end
 
-module Get_wallet =
+module Get_wallets =
 [%graphql
 {|
-query getWallet {
+query {
   ownedWallets {
     public_key: publicKey @bsDecoder(fn: "Decoders.public_key")
+    locked
     balance {
       total @bsDecoder(fn: "Decoders.uint64")
     }
   }
 }
+|}]
+
+module Add_wallet =
+[%graphql
+{|
+mutation ($password: String) {
+  addWallet(input: {password: $password}) {
+    public_key: publicKey @bsDecoder(fn: "Decoders.public_key")
+  }
+}
+|}]
+
+module Unlock_wallet =
+[%graphql
+{|
+mutation ($password: String, $public_key: PublicKey) {
+  unlockWallet(input: {password: $password, publicKey: $public_key }) {
+    public_key: publicKey @bsDecoder(fn: "Decoders.public_key")
+  }
+}
+|}]
+
+module Lock_wallet =
+[%graphql
+{|
+mutation ($public_key: PublicKey) {
+  lockWallet(input: {publicKey: $public_key }) {
+    public_key: publicKey @bsDecoder(fn: "Decoders.public_key")
+  }
+}
+|}]
+
+module Reload_wallets = [%graphql {|
+mutation { reloadWallets { success } }
 |}]
 
 module Snark_pool =

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -34,7 +34,7 @@ let port =
     (Command.Param.optional Arg_type.int16)
 
 let rest_port =
-  Command.Param.flag "--rest-port"
+  Command.Param.flag "rest-port"
     ~doc:
       (Printf.sprintf "PORT Client to daemon rest server (default: %d)"
          Port.default_rest)

--- a/src/lib/secrets/wallets.ml
+++ b/src/lib/secrets/wallets.ml
@@ -34,36 +34,39 @@ let decode_public_key key file path logger =
           ; ("error", `String (Error.to_string_hum e)) ] ;
       None
 
-let load ~logger ~disk_location : t Deferred.t =
+let reload ~logger {cache; path} : unit Deferred.t =
   let logger =
     Logger.extend logger [("wallets_context", `String "Wallets.get")]
   in
-  let path = disk_location ^/ "store" in
+  Public_key.Compressed.Table.clear cache ;
   let%bind () = File_system.create_dir path in
   let%bind files = Sys.readdir path >>| Array.to_list in
-  let%bind keypairs =
-    Deferred.List.filter_map files ~f:(fun file ->
+  let%bind () =
+    Deferred.List.iter files ~f:(fun file ->
         match String.chop_suffix file ~suffix:".pub" with
         | Some sk_filename -> (
             let%map lines = Reader.file_lines (path ^/ file) in
             match lines with
             | public_key :: _ ->
                 decode_public_key public_key file path logger
-                |> Option.map ~f:(fun pk -> (pk, Locked sk_filename))
+                |> Option.iter ~f:(fun pk ->
+                       ignore
+                       @@ Public_key.Compressed.Table.add cache ~key:pk
+                            ~data:(Locked sk_filename) )
             | _ ->
-                None )
+                () )
         | None ->
-            return None )
+            return () )
   in
-  let%map () = Unix.chmod path ~perm:0o700 in
-  let cache =
-    match Public_key.Compressed.Table.of_alist keypairs with
-    | `Ok m ->
-        m
-    | `Duplicate_key _ ->
-        failwith "impossible"
+  Unix.chmod path ~perm:0o700
+
+let load ~logger ~disk_location =
+  let t =
+    { cache= Public_key.Compressed.Table.create ()
+    ; path= disk_location ^/ "store" }
   in
-  {cache; path}
+  let%map () = reload ~logger t in
+  t
 
 let import_keypair_helper t keypair write_keypair =
   let compressed_pk = Public_key.compress keypair.Keypair.public_key in

--- a/src/lib/secrets/wallets.mli
+++ b/src/lib/secrets/wallets.mli
@@ -5,6 +5,8 @@ type t
 
 val load : logger:Logger.t -> disk_location:string -> t Deferred.t
 
+val reload : logger:Logger.t -> t -> unit Deferred.t
+
 val import_keypair :
      t
   -> Keypair.t


### PR DESCRIPTION
First commit:
- Add `reloadWallets` mutation
- Add `locked` field to wallet
- Small refactor to secrets/wallets.ml to allow you to "reload" wallets

Second commit:
- Add ability for graphql_client to return the result of a query so that you can optionally ignore errors
- Fix bug in Encoder for public key

Third commit:
- Add commands to accounts section of the cli. These use graphql and have corresponding additions to the list of queries in `graphql_client.ml`

Usable example of the new commands:
```
avery@mbp $ coda account list
😢 You have no wallets!
You can make a new one using `coda accounts create`
avery@mbp $ coda account create
Password for new private key file: 
Again to confirm: 

👝 Added new account!
Public key: 8QnLXcjiXHe4jsEx2stzSs9j4J5jXPuGTzCD7P2wtAk1AkNFT6SfgsHzJYAxWsDW8z
avery@mbp $ coda account list
Wallet #1:
  Public key: 8QnLXcjiXHe4jsEx2stzSs9j4J5jXPuGTzCD7P2wtAk1AkNFT6SfgsHzJYAxWsDW8z
  Balance: 0
  Locked: true
avery@mbp $ coda accounts unlock -public-key 8QnLWRTR6nMmq59zdkky5hHvj9AMf2SBzXAzhf4beoTYi8R3JCLfw9GeFCBsyznFMq
Password to unlock account: 

🔓 Unlocked account!
Public key: 8QnLWRTR6nMmq59zdkky5hHvj9AMf2SBzXAzhf4beoTYi8R3JCLfw9GeFCBsyznFMq
avery@mbp $ coda account list
Wallet #1:
  Public key: 8QnLXcjiXHe4jsEx2stzSs9j4J5jXPuGTzCD7P2wtAk1AkNFT6SfgsHzJYAxWsDW8z
  Balance: 0
  Locked: false
avery@mbp $ coda accounts lock -public-key 8QnLWRTR6nMmq59zdkky5hHvj9AMf2SBzXAzhf4beoTYi8R3JCLfw9GeFCBsyznFMq
🔒 Locked account!
Public key: 8QnLWRTR6nMmq59zdkky5hHvj9AMf2SBzXAzhf4beoTYi8R3JCLfw9GeFCBsyznFMq
```