### PR TITLE
Remove from seen_jobs after receiving snark work

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -314,8 +314,7 @@ let setup_local_server ?(client_whitelist = []) ?rest_server_port
               | `Transition ->
                   Perf_histograms.add_span ~name:"snark_worker_transition_time"
                     total ) ;
-          Network_pool.Snark_pool.add_completed_work (Coda_lib.snark_pool coda)
-            work ) ]
+          Coda_lib.add_work coda work ) ]
   in
   Option.iter rest_server_port ~f:(fun rest_server_port ->
       trace_task "REST server" (fun () ->

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -42,6 +42,8 @@ val set_snark_work_fee : t -> Currency.Fee.t -> unit
 
 val request_work : t -> Snark_worker.Work.Spec.t option
 
+val add_work : t -> Snark_worker.Work.Result.t -> unit Deferred.t
+
 val best_staged_ledger : t -> Staged_ledger.t Participating_state.t
 
 val best_ledger : t -> Ledger.t Participating_state.t

--- a/src/lib/work_selector/intf.ml
+++ b/src/lib/work_selector/intf.ml
@@ -64,6 +64,17 @@ module type Lib_intf = sig
   module State : sig
     include State_intf
 
+    val remove_old_assignments : t -> logger:Logger.t -> t
+
+    val remove :
+         t
+      -> ( Transaction.t
+         , Transaction_witness.t
+         , Ledger_proof.t )
+         Snark_work_lib.Work.Single.Spec.t
+         One_or_two.t
+      -> t
+
     val set :
          t
       -> ( Transaction.t
@@ -91,8 +102,7 @@ module type Lib_intf = sig
        list
 
   val all_works :
-       logger:Logger.t
-    -> Staged_ledger.t
+       Staged_ledger.t
     -> State.t
     -> ( Transaction.t
        , Transaction_witness.t
@@ -122,6 +132,8 @@ module type Selection_method_intf = sig
   type work
 
   module State : State_intf
+
+  val remove : State.t -> work One_or_two.t -> State.t
 
   val work :
        snark_pool:snark_pool

--- a/src/lib/work_selector/random.ml
+++ b/src/lib/work_selector/random.ml
@@ -6,7 +6,8 @@ module Make
 struct
   let work ~snark_pool ~fee ~logger (staged_ledger : Inputs.Staged_ledger.t)
       (state : Lib.State.t) =
-    let unseen_jobs = Lib.all_works staged_ledger state ~logger in
+    let state = Lib.State.remove_old_assignments state ~logger in
+    let unseen_jobs = Lib.all_works staged_ledger state in
     match Lib.get_expensive_work ~snark_pool ~fee unseen_jobs with
     | [] ->
         (None, state)
@@ -14,6 +15,8 @@ struct
         let i = Random.int (List.length expensive_work) in
         let x = List.nth_exn expensive_work i in
         (Some x, Lib.State.set state x)
+
+  let remove = Lib.State.remove
 end
 
 let%test_module "test" =

--- a/src/lib/work_selector/sequence.ml
+++ b/src/lib/work_selector/sequence.ml
@@ -4,12 +4,15 @@ module Make
 struct
   let work ~snark_pool ~fee ~logger (staged_ledger : Inputs.Staged_ledger.t)
       (state : Lib.State.t) =
-    let unseen_jobs = Lib.all_works staged_ledger state ~logger in
+    let state = Lib.State.remove_old_assignments state ~logger in
+    let unseen_jobs = Lib.all_works staged_ledger state in
     match Lib.get_expensive_work ~snark_pool ~fee unseen_jobs with
     | [] ->
         (None, state)
     | x :: _ ->
         (Some x, Lib.State.set state x)
+
+  let remove = Lib.State.remove
 end
 
 let%test_module "test" =


### PR DESCRIPTION
`seen_jobs` which keeps track of the work assigned was not being updated upon receiving completed work causing it to grow indefinitely.
Manually tested by running daemon

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
