### PR TITLE
Fake accounts for testnet_postake genesis ledger

### DIFF
--- a/src/config/ledger_depth/full.mlh
+++ b/src/config/ledger_depth/full.mlh
@@ -1,2 +1,2 @@
 [%%define ledger_depth 30]
-[%%define fake_accounts_target 1000000000]
+[%%define fake_accounts_target 20]

--- a/src/config/ledger_depth/full.mlh
+++ b/src/config/ledger_depth/full.mlh
@@ -1,1 +1,2 @@
 [%%define ledger_depth 30]
+[%%define fake_accounts_target 1000000000]

--- a/src/config/ledger_depth/full.mlh
+++ b/src/config/ledger_depth/full.mlh
@@ -1,2 +1,2 @@
 [%%define ledger_depth 30]
-[%%define fake_accounts_target 20]
+[%%define fake_accounts_target 50]

--- a/src/config/ledger_depth/small.mlh
+++ b/src/config/ledger_depth/small.mlh
@@ -1,1 +1,2 @@
 [%%define ledger_depth 10]
+[%%define fake_accounts_target 1024]

--- a/src/config/ledger_depth/small.mlh
+++ b/src/config/ledger_depth/small.mlh
@@ -1,2 +1,2 @@
 [%%define ledger_depth 10]
-[%%define fake_accounts_target 1024]
+[%%define fake_accounts_target 20]

--- a/src/config/ledger_depth/small.mlh
+++ b/src/config/ledger_depth/small.mlh
@@ -1,2 +1,2 @@
 [%%define ledger_depth 10]
-[%%define fake_accounts_target 20]
+[%%define fake_accounts_target 50]

--- a/src/config/ledger_depth/tiny.mlh
+++ b/src/config/ledger_depth/tiny.mlh
@@ -1,2 +1,2 @@
 [%%define ledger_depth 6]
-[%%define fake_accounts_target 64]
+[%%define fake_accounts_target 20]

--- a/src/config/ledger_depth/tiny.mlh
+++ b/src/config/ledger_depth/tiny.mlh
@@ -1,1 +1,2 @@
 [%%define ledger_depth 6]
+[%%define fake_accounts_target 64]

--- a/src/config/ledger_depth/tiny.mlh
+++ b/src/config/ledger_depth/tiny.mlh
@@ -1,2 +1,2 @@
 [%%define ledger_depth 6]
-[%%define fake_accounts_target 20]
+[%%define fake_accounts_target 50]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,4 +1,5 @@
 [%%define ledger_depth 11]
+[%%define fake_accounts_target 20]
 [%%import "config/curve/medium.mlh"]
 [%%import "config/coinbase/standard.mlh"]
 [%%import "config/scan_state/point1tps.mlh"]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,5 +1,5 @@
 [%%define ledger_depth 11]
-[%%define fake_accounts_target 20]
+[%%define fake_accounts_target 50]
 [%%import "config/curve/medium.mlh"]
 [%%import "config/coinbase/standard.mlh"]
 [%%import "config/scan_state/point1tps.mlh"]

--- a/src/lib/genesis_ledger/dune
+++ b/src/lib/genesis_ledger/dune
@@ -1,6 +1,6 @@
 (library
   (public_name genesis_ledger)
   (name genesis_ledger)
-  (libraries core_kernel coda_base)
+  (libraries core_kernel coda_base signature_lib)
   (preprocessor_deps "../../config.mlh")
-  (preprocess (pps ppx_optcomp)))
+  (preprocess (pps ppx_coda ppx_optcomp ppx_let)))

--- a/src/lib/genesis_ledger/fake_accounts.ml
+++ b/src/lib/genesis_ledger/fake_accounts.ml
@@ -1,0 +1,15 @@
+(* fake_accounts.ml -- generate fake accounts for testnet *)
+
+open Core_kernel
+open Signature_lib
+
+let make_account pk balance =
+  Functor.Without_private.{pk; balance; delegate= None}
+
+let balance_gen = Quickcheck.Generator.of_list (List.range 100 20000)
+
+let gen =
+  let open Quickcheck.Let_syntax in
+  let%bind balance = balance_gen in
+  let%map pk = Public_key.Compressed.gen in
+  make_account pk balance

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -1,6 +1,16 @@
 [%%import
 "../../config.mlh"]
 
+[%%inject
+"ledger_depth", ledger_depth]
+
+[%%inject
+"fake_accounts_target", fake_accounts_target]
+
+let _ =
+  if Base.Int.(fake_accounts_target > pow 2 ledger_depth) then
+    failwith "Genesis_ledger: fake_accounts_target >= 2**ledger_depth"
+
 [%%if
 defined genesis_ledger]
 

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -1,8 +1,15 @@
+[%%import
+"../../config.mlh"]
+
+open Core_kernel
 open Functor.Without_private
 module Public_key = Signature_lib.Public_key
 
+[%%inject
+"fake_accounts_target", fake_accounts_target]
+
 include Make (struct
-  let accounts =
+  let real_accounts =
     [ { pk=
           Public_key.Compressed.of_base58_check_exn
             "tNcihhTPEQLJVkQYXXe9NjqWctZq5GXLGRKBh9CVeUMasWMb4imdxPD9r9fGh883Np3XixeGARbe9dCW43RqMt9UZvvmXrAaHDMjuFYyn5UJHg6XwGfyiBBYLAc6PxYMqJfGWCJKDd1Boo"
@@ -366,4 +373,11 @@ include Make (struct
             (Public_key.Compressed.of_base58_check_exn
                "tNciKu2s74n6JTSZTpyMcZ7on2pNQvizz7RnY8gsE23ThH61Gmsi7vxmECLjARzHCkXQQdZTYM7Ufz6xW3jdkGBdAvbLzj2gKvpJFRB38qUW7t1UWti2VSKTaxtRmFtCQC64o8xknA3xBk")
       } ]
+
+  let fake_accounts =
+    let open Quickcheck in
+    random_value
+      (Generator.list_with_length fake_accounts_target Fake_accounts.gen)
+
+  let accounts = real_accounts @ fake_accounts
 end)

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -376,8 +376,10 @@ include Make (struct
 
   let fake_accounts =
     let open Quickcheck in
-    random_value
-      (Generator.list_with_length fake_accounts_target Fake_accounts.gen)
+    random_value ~seed:(`Deterministic "fake accounts for testnet postake")
+      (Generator.list_with_length
+         (fake_accounts_target - List.length real_accounts)
+         Fake_accounts.gen)
 
   let accounts = real_accounts @ fake_accounts
 end)


### PR DESCRIPTION
Generate fake accounts for genesis ledgers.

There's a general mechanism to do this via a Quickcheck generator, `Fake_accounts.gen`. Currently, it's used in `Testnet_postake_ledger`.

The number of fake accounts is a new config parameter, `fake_accounts_target`. There's a load-time check in `Genesis_ledger` that this value is no greater than `2**ledger_depth`. The parameter has been added to the `ledger_depth/*.mlh` files, and to `testnet_postake_medium_curves`.

For that last configuration, the ledger depth is 11, so the  number of fake accounts could be, in theory, as much as `2**11 = 2048`. Unfortunately, that choice generates a compile-time error:
```
 "unhandled exception in Async scheduler"
 ("unhandled exception"
  ((monitor.ml.Error
    ( "Snarky.Checked_runner.Runtime_error(_, _, _, _)\
     \n\
     \nEncountered an error while evaluating the checked computation:\
     \n  \"Assert_failure lib/coda_base/ledger.ml:191:4\"\
     \n\
     \nLabel stack trace:\
     \nmain: File \"lib/coda_base/transition_system.ml\", line 143, characters 4-3183\
     \n\
     \n\
     \nRaised at file \"lib/coda_base/ledger.ml\", line 191, characters 4-28\
     \nCalled from file \"list.ml\", line 106, characters 12-15\
     \nCalled from file \"src/list0.ml\" (inlined), line 26, characters 40-75\
     \nCalled from file \"lib/genesis_ledger/functor.ml\", line 21, characters 7-126\
     \nCalled from file \"camlinternalLazy.ml\", line 27, characters 17-27\
     \nRe-raised at file \"camlinternalLazy.ml\", line 34, characters 4-11\
```
In this PR, we use 20 as the number of fake accounts. If this PR is merged, I'll create an issue to track down the failure when larger numbers are used.
