### PR TITLE
Record async backtraces; set expiry to Tuesday, 10-8-2019 14:00 PDT

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -550,6 +550,8 @@ let daemon logger =
              [%of_sexp: Unix.Inet_addr.Blocking_sexp.t list]
            >>| Or_error.ok
          in
+         Async_kernel.Async_kernel_scheduler.(
+           set_record_backtraces (t ()) true) ;
          Stream.iter
            (Async_kernel.Async_kernel_scheduler.(
               long_cycles_with_context @@ t ())

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -29,4 +29,4 @@
 
 [%%define new_cli false]
 
-[%%define daemon_expiry "never"]
+[%%define daemon_expiry "2019-10-08 14:00:00-07:00"]


### PR DESCRIPTION
Enable backtrace recording for `Async`.  Tested by building, running daemon, examining log file.

Use daemon expiration date.