### PR TITLE
Remove async backtraces, improve time formatting

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -550,24 +550,12 @@ let daemon logger =
              [%of_sexp: Unix.Inet_addr.Blocking_sexp.t list]
            >>| Or_error.ok
          in
-         Async_kernel.Async_kernel_scheduler.(
-           set_record_backtraces (t ()) true) ;
          Stream.iter
-           (Async_kernel.Async_kernel_scheduler.(
-              long_cycles_with_context @@ t ())
+           (Async.Scheduler.long_cycles
               ~at_least:(sec 0.5 |> Time_ns.Span.of_span_float_round_nearest))
-           ~f:(fun (span, ctx) ->
-             let tm = Time_ns.Span.to_string span in
-             (* see if backtraces reveal anything about long async cycles *)
-             let metadata =
-               [ ("tm", `String tm)
-               ; ( "backtraces"
-                 , `List
-                     (List.map ctx.backtrace_history ~f:(fun bt ->
-                          `String (Backtrace.to_string bt) )) ) ]
-             in
+           ~f:(fun span ->
              Logger.warn logger ~module_:__MODULE__ ~location:__LOC__
-               "Long async cycle %s" tm ~metadata ) ;
+               "Long async cycle, %0.01f seconds" (Time_ns.Span.to_sec span) ) ;
          let trace_database_initialization typ location =
            Logger.trace logger "Creating %s at %s" ~module_:__MODULE__
              ~location typ

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -554,7 +554,7 @@ let daemon logger =
            (Async.Scheduler.long_cycles
               ~at_least:(sec 0.5 |> Time_ns.Span.of_span_float_round_nearest))
            ~f:(fun span ->
-             Logger.warn logger ~module_:__MODULE__ ~location:__LOC__
+             Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
                "Long async cycle, %0.01f seconds" (Time_ns.Span.to_sec span) ) ;
          let trace_database_initialization typ location =
            Logger.trace logger "Creating %s at %s" ~module_:__MODULE__


### PR DESCRIPTION
Remove the async backtraces, which were not providing useful information, just a lot of entries relating to the scheduler internals.

Also, print just one decimal digit of precision for the long cycle times; the extra digits we were printing are unneeded and, if I might say, unsightly.

