### PR TITLE
Make bot errors readable

### DIFF
--- a/frontend/bot/src/Coda.re
+++ b/frontend/bot/src/Coda.re
@@ -54,7 +54,7 @@ let unlock = (~publicKey, ~password) => {
            `Error,
            "Unlock failed for %s, error: %s",
            publicKey,
-           Js.String.make(e),
+           Graphql.combinedErrorToString(e),
          )
        | NotFound => log(`Error, "Got 'NotFound' unlocking %s", publicKey)
        }

--- a/frontend/bot/src/Echo.re
+++ b/frontend/bot/src/Echo.re
@@ -48,7 +48,7 @@ let sendEcho = (echoKey, fee, {from: userKey, amount}) =>
              Int64.to_string(amount),
              echoKey,
              userKey,
-             Js.String.make(e),
+             Graphql.combinedErrorToString(e),
            )
          | NotFound =>
            // Shouldn't happen
@@ -103,7 +103,7 @@ let start = (echoKey, fee) => {
          log(
            `Error,
            "Error retrieving new block. Message: %s",
-           Js.String.make(e),
+           Graphql.combinedErrorToString(e),
          )
        | NotFound =>
          // Shouldn't happen

--- a/frontend/bot/src/Faucet.re
+++ b/frontend/bot/src/Faucet.re
@@ -32,13 +32,9 @@ let sendFaucetCoda = (userId, msg, pk) => {
            log(`Info, "Sent (to %s): %s", pk, id);
            Messages.faucetSentNotification(~id);
          | Error(error) =>
-           log(
-             `Error,
-             "Send failed (to %s), error: %s",
-             pk,
-             Js.String.make(error),
-           );
-           Messages.faucetFailNotification(~error);
+           let msg = Graphql.combinedErrorToString(error);
+           log(`Error, "Send failed (to %s), error: %s", pk, msg);
+           Messages.faucetFailNotification(~error=msg);
          | NotFound =>
            // Shouldn't happen
            log(`Error, "Got 'NotFound' sending to %s", pk);

--- a/frontend/bot/src/Graphql.re
+++ b/frontend/bot/src/Graphql.re
@@ -50,3 +50,24 @@ module Encoders = {
   let publicKey = s => s |> Js.Json.string;
   let int64 = s => s |> Int64.to_string |> Js.Json.string;
 };
+
+let combinedErrorToString = (e: UrqlCombinedError.combinedError) => {
+  switch (e) {
+  | {networkError: Some(e)} =>
+    let default = Js.String.make(e);
+    let message = Belt.Option.getWithDefault(Js.Exn.message(e), default);
+    "[Network: " ++ message ++ "]";
+  | {graphqlErrors: Some(errors)} =>
+    Array.to_list(errors)
+    |> List.map(e => {
+         let msg =
+           Belt.Option.getWithDefault(
+             Js.Nullable.toOption(UrqlCombinedError.messageGet(e)),
+             "Unknown error",
+           );
+         "[GraphQL: " ++ msg ++ "]";
+       })
+    |> String.concat(", ")
+  | _ => "[Unknown error]"
+  };
+};

--- a/frontend/bot/src/Repeater.re
+++ b/frontend/bot/src/Repeater.re
@@ -24,7 +24,7 @@ let start = (~fromKey, ~toKey, ~amount, ~fee, ~timeout) => {
                "Send failed (from %s to %s), error: %s",
                fromKey,
                toKey,
-               Js.String.make(e),
+               Graphql.combinedErrorToString(e),
              )
            | NotFound =>
              // Shouldn't happen


### PR DESCRIPTION
The issues with the faucet this week highlighted an issue with how the bot formats errors. Namely:

```
I failed to send you some coda just now :sob:
Please try again later!
Error: Error: Internal Server Error,,[object Response]
```

This is because reason-urql's combinedError type doesn't expose a toString() function. I opened a PR to expose a formatted version of the message (https://github.com/FormidableLabs/reason-urql/pull/105) but in the meantime, we can use a custom one which is very similar (defined in `Graphql.combinedErrorToString`).

Hopefully this improves the debug-ability of the bot.