### PR TITLE
Registration of async shutdown handlers

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -482,4 +482,5 @@ You might be trying to connect to a different network version, or need to troubl
         Logger.info logger ~module_:__MODULE__ ~location:__LOC__
           !"Coda process was interrupted by $signal"
           ~metadata:[("signal", `String (to_string signal))] ;
-        Stdlib.exit 130 ))
+        (* causes async shutdown and at_exit handlers to run *)
+        Async.shutdown 130 ))

--- a/src/lib/exit_handlers/dune
+++ b/src/lib/exit_handlers/dune
@@ -2,6 +2,6 @@
  (name exit_handlers)
  (public_name exit_handlers)
  (library_flags -linkall)
- (libraries core_kernel logger)
- (preprocess (no_preprocessing))
+ (libraries core_kernel async_kernel async_unix logger)
+ (preprocess (pps ppx_let))
  (synopsis "Exit handlers"))


### PR DESCRIPTION
Add new function `register_async_shutdown_handler`.

Tested with:
 - handler that returns `Deferred.unit`
 - handler that raises an exception
The registration and execution of both handlers was logged, and the exception logged.

Verified that these handlers, and the ordinary exit handlers run on both Ctl-C and `client stop-daemon`. The exit code is 130 for Ctl-C and 0 for `stop-daemon`.
