### PR TITLE
Expose more information in Sparse_ledger error messages

### DIFF
--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -214,7 +214,19 @@ end = struct
           let go_right = ith_bit idx i in
           if go_right then go (i - 1) r else go (i - 1) l
       | _ ->
-          failwith "Sparse_ledger.get: Bad index"
+          let expected_kind = if i < 0 then "n account" else " node" in
+          let kind =
+            match tree with
+            | Account _ ->
+                "n account"
+            | Hash _ ->
+                " hash"
+            | Node _ ->
+                " node"
+          in
+          failwithf
+            "Spare_ledger.get: Bad index %i. Expected a%s, but got a%s." idx
+            expected_kind kind ()
     in
     go (depth - 1) tree
 
@@ -230,7 +242,19 @@ end = struct
           in
           Node (Hash.merge ~height:i (hash l) (hash r), l, r)
       | _ ->
-          failwith "Sparse_ledger.set: Bad index"
+          let expected_kind = if i < 0 then "n account" else " node" in
+          let kind =
+            match tree with
+            | Account _ ->
+                "n account"
+            | Hash _ ->
+                " hash"
+            | Node _ ->
+                " node"
+          in
+          failwithf
+            "Spare_ledger.set: Bad index %i. Expected a%s, but got a%s." idx
+            expected_kind kind ()
     in
     {t with tree= go (t.depth - 1) t.tree}
 
@@ -240,9 +264,9 @@ end = struct
       else
         match tree with
         | Poly.Tree.Account _ ->
-            failwith "Sparse_ledger.path: Bad depth"
+            failwithf "Sparse_ledger.path: Bad depth at index %i." idx ()
         | Hash _ ->
-            failwith "Sparse_ledger.path: Dead end"
+            failwithf "Sparse_ledger.path: Dead end at index %i." idx ()
         | Node (_, l, r) ->
             let go_right = ith_bit idx i in
             if go_right then go (`Right (hash l) :: acc) (i - 1) r

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -256,7 +256,7 @@ end = struct
           failwithf
             "Spare_ledger.set: Bad index %i. Expected a%s, but got a%s at \
              depth %i."
-            idx expected_kind kind (depth - i) ()
+            idx expected_kind kind (t.depth - i) ()
     in
     {t with tree= go (t.depth - 1) t.tree}
 

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -225,8 +225,9 @@ end = struct
                 " node"
           in
           failwithf
-            "Spare_ledger.get: Bad index %i. Expected a%s, but got a%s." idx
-            expected_kind kind ()
+            "Spare_ledger.get: Bad index %i. Expected a%s, but got a%s at \
+             depth %i."
+            idx expected_kind kind (depth - i) ()
     in
     go (depth - 1) tree
 
@@ -253,8 +254,9 @@ end = struct
                 " node"
           in
           failwithf
-            "Spare_ledger.set: Bad index %i. Expected a%s, but got a%s." idx
-            expected_kind kind ()
+            "Spare_ledger.set: Bad index %i. Expected a%s, but got a%s at \
+             depth %i."
+            idx expected_kind kind (depth - i) ()
     in
     {t with tree= go (t.depth - 1) t.tree}
 


### PR DESCRIPTION
This PR tweaks the error messages in `Sparse_ledger` to expose the index and information about the kind of node that was found when there is a mismatch.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: