### PR TITLE
Cleaning up some broken links on the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The [Developer docs](https://codaprotocol.com/docs/developers/) contain all the 
 #### Quick Links:
 * [Developer readme](README-dev.md)
 * [Compiling from source and and running a node](docs/demo.md)
-* [Directory structure](frontend/website/docs/directory-structure.md)
-* [Lifecycle of a payment](docs/architecture/lifecycle-payment.md)
+* [Directory structure](frontend/website/docs/developers/directory-structure.md)
+* [Lifecycle of a payment](frontend/website/docs/architecture/lifecycle-payment.md)
 
 
 ## Community


### PR DESCRIPTION
Looks like some docs got moved around and the README links were dead.  Cleaned them up so they're like new!

Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

Explain your changes here.

Explain how you tested your changes here.

Checklist:

- [x] Tests were added for the new behavior
- [x] All tests pass (CI will check this if you didn't)
- [x] Serialized types are in stable-versioned modules
- [x] Does this close issues? List them:

Closes #0000
Closes #0000
