### PR TITLE
trivial: remove unused import

### DIFF
--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -9,7 +9,6 @@ import (
 	p2p "github.com/libp2p/go-libp2p"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	host "github.com/libp2p/go-libp2p-core/host"
-	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	routing "github.com/libp2p/go-libp2p-core/routing"
 	discovery "github.com/libp2p/go-libp2p-discovery"


### PR DESCRIPTION
broken compile -- this fixes

```
codanet
# codanet
./codanet.go:12:2: imported and not used: "github.com/libp2p/go-libp2p-core/network"
```
