### PR TITLE
TPS goal times 10

### DIFF
--- a/src/config/scan_state/1tps.mlh
+++ b/src/config/scan_state/1tps.mlh
@@ -1,3 +1,4 @@
 [%%define scan_state_with_tps_goal true]
-[%%define scan_state_tps_goal 1]
+(* 1TPS * 10 *)
+[%%define scan_state_tps_goal_x10 10]
 [%%define scan_state_work_delay 2]

--- a/src/config/scan_state/standard.mlh
+++ b/src/config/scan_state/standard.mlh
@@ -1,2 +1,3 @@
+[%%define scan_state_with_tps_goal false]
 [%%define scan_state_transaction_capacity_log_2 7]
 [%%define scan_state_work_delay 2]

--- a/src/lib/snark_params/scan_state_constants.ml
+++ b/src/lib/snark_params/scan_state_constants.ml
@@ -10,8 +10,6 @@
    use the config boolean scan_state_with_tps_goal to distinguish those cases
 *)
 
-open Core_kernel
-
 module type S = Scan_state_constants_intf.S
 
 [%%inject
@@ -19,6 +17,8 @@ module type S = Scan_state_constants_intf.S
 
 [%%if
 scan_state_with_tps_goal]
+
+open Core_kernel
 
 [%%inject
 "tps_goal_x10", scan_state_tps_goal_x10]

--- a/src/lib/snark_params/scan_state_constants.ml
+++ b/src/lib/snark_params/scan_state_constants.ml
@@ -4,10 +4,13 @@
 (* in the config files, we either have:
 
     - a work_delay and transaction_capacity_log_2, or
-    - a work_delay and a tps_goal, allowing us to calculate transaction_capacity_log_2
+    - a work_delay and a tps_goal_x10 (transactions per second times 10), allowing us to calculate
+       transaction_capacity_log_2
 
    use the config boolean scan_state_with_tps_goal to distinguish those cases
 *)
+
+open Core_kernel
 
 module type S = Scan_state_constants_intf.S
 
@@ -18,14 +21,18 @@ module type S = Scan_state_constants_intf.S
 scan_state_with_tps_goal]
 
 [%%inject
-"tps_goal", scan_state_tps_goal]
+"tps_goal_x10", scan_state_tps_goal_x10]
 
 [%%inject
 "block_window_duration", block_window_duration]
 
 let max_coinbases = 2
 
-let max_user_commands_per_block = tps_goal * block_window_duration / 1000
+(* block_window_duration is in milliseconds, so divide by 1000
+   divide by 10 again because we have tps * 10
+ *)
+let max_user_commands_per_block =
+  tps_goal_x10 * block_window_duration / (1000 * 10)
 
 let transaction_capacity_log_2 =
   1 + Int.ceil_log2 (max_user_commands_per_block + max_coinbases)


### PR DESCRIPTION
Instead of specifying an integer TPS goal, specify TPS * 10 goal, so we can try TPSs of 1.5, 2.5, etc.

Note: when building locally for `testnet_postake_medium_curves`, I got an error, not certain whether related to this fix:
```
  \n  \"Spare_ledger.get: Bad index 0. Expected a node, but got a hash at depth 10.\")\
```
Update: seems to build in CI, so not sure why I got this failure.
