### PR TITLE
Use .dockerenv, not CODA_DOCKER

### DIFF
--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -8,9 +8,6 @@ ARG OCAML_VERSION=4.07.1
 ARG OPAMKEEPBUILDDIR=false
 ARG OPAMREUSEBUILDDIR=false
 
-# for scripts to be run only in Docker
-ENV CODA_DOCKER=true
-
 # OS package dependencies
 RUN sudo apt-get update && sudo apt-get install --yes \
     cmake \

--- a/scripts/update-opam-in-docker.sh
+++ b/scripts/update-opam-in-docker.sh
@@ -2,7 +2,7 @@
 
 # update OPAM packages, including pinned ones
 
-if [ -z $CODA_DOCKER ] ; then
+if [ ! -f /.dockerenv ]; then
     echo `basename $0` "can run only inside Coda Docker image"
     exit 1
 fi


### PR DESCRIPTION
When running a Docker image, there's a file `/.dockerenv`.

The script `update-opam-in-docker.sh` can use that, instead of `CODA_DOCKER`.

Remove that env variable from `Docker-toolchain`, since it's no longer needed. The image isn't rebuilt here, since nothing else has changed.
