### PR TITLE
Wrap Process.wait in Monitor.try_with

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -100,22 +100,33 @@ module Snark_worker = struct
                ~shutdown_on_disconnect:false )
     in
     don't_wait_for
-      ( match%bind Process.wait snark_worker_process with
-      | Ok () ->
-          Logger.info logger "Snark worker process died" ~module_:__MODULE__
-            ~location:__LOC__ ;
-          Ivar.fill kill_ivar () ;
-          Deferred.unit
-      | Error (`Exit_non_zero non_zero_error) ->
-          Logger.fatal logger
-            !"Snark worker process died with a nonzero error %i"
-            non_zero_error ~module_:__MODULE__ ~location:__LOC__ ;
-          raise (Snark_worker_error non_zero_error)
-      | Error (`Signal signal) ->
+      ( match%bind
+          Monitor.try_with (fun () -> Process.wait snark_worker_process)
+        with
+      | Ok signal_or_error -> (
+        match signal_or_error with
+        | Ok () ->
+            Logger.info logger "Snark worker process died" ~module_:__MODULE__
+              ~location:__LOC__ ;
+            Ivar.fill kill_ivar () ;
+            Deferred.unit
+        | Error (`Exit_non_zero non_zero_error) ->
+            Logger.fatal logger
+              !"Snark worker process died with a nonzero error %i"
+              non_zero_error ~module_:__MODULE__ ~location:__LOC__ ;
+            raise (Snark_worker_error non_zero_error)
+        | Error (`Signal signal) ->
+            Logger.info logger
+              !"Snark worker died with signal %{sexp:Signal.t}. Aborting daemon"
+              signal ~module_:__MODULE__ ~location:__LOC__ ;
+            raise (Snark_worker_signal_interrupt signal) )
+      | Error exn ->
           Logger.info logger
-            !"Snark worker died with signal %{sexp:Signal.t}. Aborting daemon"
-            signal ~module_:__MODULE__ ~location:__LOC__ ;
-          raise (Snark_worker_signal_interrupt signal) ) ;
+            !"Exception when waiting for snark worker process to terminate: \
+              $exn"
+            ~module_:__MODULE__ ~location:__LOC__
+            ~metadata:[("exn", `String (Exn.to_string exn))] ;
+          Deferred.unit ) ;
     Logger.trace logger
       !"Created snark worker with pid: %i"
       ~module_:__MODULE__ ~location:__LOC__


### PR DESCRIPTION
@jkrauska observed a `no child processes` error caused by a `waitpid` with `NOHANG`, caught by the outer Async monitor, crashing the daemon.

`Process.wait` calls `waitpid`, and can raise. Wrapped a couple of these in `Monitor.try_with`: one in the integration test code, and one in `Coda_lib` for snark workers (probably the one @jkrauska observed).

There are also such calls in Kademlia code, in `Coda_net2`, and in the `testone` app. I didn't modify those, since they're not the causes of the crash as far as I can see.