### PR TITLE
Kinds for child processes

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -629,7 +629,7 @@ let daemon logger =
              external_transition_database_dir
          in
          (* log terminated child processes *)
-         let pids = Child_processes.Termination.create_pid_set () in
+         let pids = Child_processes.Termination.create_pid_table () in
          let rec terminated_child_loop () =
            match
              try Unix.wait_nohang `Any

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -397,7 +397,7 @@ module T = struct
             ; ("port", `Int addrs_and_ports.communication_port) ]
           ()
       in
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let%bind () =
         Option.value_map trace_dir
           ~f:(fun d ->

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -79,7 +79,7 @@ let print_heartbeat logger =
 
 let run_test () : unit Deferred.t =
   let logger = Logger.create () in
-  let pids = Child_processes.Termination.create_pid_set () in
+  let pids = Child_processes.Termination.create_pid_table () in
   setup_time_offsets () ;
   print_heartbeat logger |> don't_wait_for ;
   Parallel.init_master () ;

--- a/src/lib/child_processes/dune
+++ b/src/lib/child_processes/dune
@@ -1,4 +1,5 @@
 (library
   (name child_processes)
   (public_name child_processes)
+  (preprocess (pps ppx_deriving.show))
   (libraries core_kernel async logger))

--- a/src/lib/child_processes/termination.ml
+++ b/src/lib/child_processes/termination.ml
@@ -4,17 +4,24 @@
 
 open Async
 open Core_kernel
+include Hashable.Make_binable (Pid)
 
-type t = Pid.Hash_set.t
+type process_kind = Prover | Verifier [@@deriving show {with_path= false}]
 
-let create_pid_set () = Pid.Hash_set.create ()
+type t = process_kind Pid.Table.t
 
-let register_process t process = Hash_set.add t (Process.pid process)
+let create_pid_table () = Pid.Table.create ()
+
+let register_process t process kind =
+  Pid.Table.add_exn t ~key:(Process.pid process) ~data:kind
 
 let check_terminated_child t child_pid logger =
-  if Hash_set.mem t child_pid then (
+  if Pid.Table.mem t child_pid then (
+    let kind = Pid.Table.find_exn t child_pid in
     Logger.error logger ~module_:__MODULE__ ~location:__LOC__
-      "Child process with pid $child_pid has terminated; terminating parent \
-       process $pid"
-      ~metadata:[("child_pid", `Int (Pid.to_int child_pid))] ;
+      "Child process of kind $process_kind with pid $child_pid has \
+       terminated; terminating parent process $pid"
+      ~metadata:
+        [ ("child_pid", `Int (Pid.to_int child_pid))
+        ; ("process_kind", `String (show_process_kind kind)) ] ;
     Core_kernel.exit 99 )

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -459,7 +459,7 @@ let%test_module "random set test" =
         let open Deferred.Let_syntax in
         let%bind verifier =
           Verifier.create ~logger
-            ~pids:(Child_processes.Termination.create_pid_set ())
+            ~pids:(Child_processes.Termination.create_pid_table ())
         in
         let config = config verifier in
         let resource_pool =
@@ -602,7 +602,7 @@ let%test_module "random set test" =
           in
           let%bind verifier =
             Verifier.create ~logger
-              ~pids:(Child_processes.Termination.create_pid_set ())
+              ~pids:(Child_processes.Termination.create_pid_table ())
           in
           let config = config verifier in
           let network_pool =
@@ -671,7 +671,7 @@ let%test_module "random set test" =
             in
             let%bind verifier =
               Verifier.create ~logger
-                ~pids:(Child_processes.Termination.create_pid_set ())
+                ~pids:(Child_processes.Termination.create_pid_table ())
             in
             let config = config verifier in
             let network_pool =
@@ -716,7 +716,7 @@ let%test_module "random set test" =
           let open Deferred.Let_syntax in
           let%bind verifier =
             Verifier.create ~logger
-              ~pids:(Child_processes.Termination.create_pid_set ())
+              ~pids:(Child_processes.Termination.create_pid_table ())
           in
           let config = config verifier in
           let network_pool =

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -32,7 +32,7 @@ let%test_module "network pool test" =
       Async.Thread_safe.block_on_async_exn (fun () ->
           let%bind verifier =
             Verifier.create ~logger
-              ~pids:(Child_processes.Termination.create_pid_set ())
+              ~pids:(Child_processes.Termination.create_pid_table ())
           in
           let config = config verifier in
           let network_pool =
@@ -86,7 +86,7 @@ let%test_module "network pool test" =
         in
         let%bind verifier =
           Verifier.create ~logger
-            ~pids:(Child_processes.Termination.create_pid_set ())
+            ~pids:(Child_processes.Termination.create_pid_table ())
         in
         let config = config verifier in
         let network_pool =

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -246,9 +246,12 @@ let create ~logger ~pids =
       ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:() ()
   in
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__
-    "Daemon started prover process with pid $prover_pid"
-    ~metadata:[("prover_pid", `Int (Process.pid process |> Pid.to_int))] ;
-  Child_processes.Termination.register_process pids process ;
+    "Daemon started process of kind $process_kind with pid $prover_pid"
+    ~metadata:
+      [ ("prover_pid", `Int (Process.pid process |> Pid.to_int))
+      ; ( "process_kind"
+        , `String Child_processes.Termination.(show_process_kind Prover) ) ] ;
+  Child_processes.Termination.(register_process pids process Prover) ;
   File_system.dup_stdout process ;
   File_system.dup_stderr process ;
   {connection; process}

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1545,7 +1545,7 @@ let%test_module "test" =
      fun init_state cmds cmd_iters sl ?(expected_proof_count = None) test_mask
          provers stmt_to_work ->
       let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let%map total_ledger_proofs =
         iter_cmds_acc cmds cmd_iters 0
           (fun cmds_left count_opt cmds_this_iter proof_count ->
@@ -1765,7 +1765,7 @@ let%test_module "test" =
         ~f:(fun (ledger_init_state, cmds, iters) ->
           async_with_ledgers ledger_init_state (fun sl _test_mask ->
               let logger = Logger.null () in
-              let pids = Child_processes.Termination.create_pid_set () in
+              let pids = Child_processes.Termination.create_pid_table () in
               let%map checked =
                 iter_cmds_acc cmds iters true
                   (fun _cmds_left _count_opt cmds_this_iter checked ->
@@ -1815,7 +1815,7 @@ let%test_module "test" =
 
     let%test_unit "Snarked ledger" =
       let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       Quickcheck.test (gen_below_capacity ()) ~trials:20
         ~f:(fun (ledger_init_state, cmds, iters) ->
           async_with_ledgers ledger_init_state (fun sl _test_mask ->
@@ -1873,7 +1873,7 @@ let%test_module "test" =
         -> unit Deferred.t =
      fun init_state cmds cmd_iters proofs_available sl test_mask provers ->
       let logger = Logger.null () in
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let%map proofs_available_left =
         iter_cmds_acc cmds cmd_iters proofs_available
           (fun cmds_left _count_opt cmds_this_iter proofs_available_left ->

--- a/src/lib/transition_frontier_controller_tests/test_bootstrap_controller.ml
+++ b/src/lib/transition_frontier_controller_tests/test_bootstrap_controller.ml
@@ -47,7 +47,7 @@ let%test_module "Bootstrap Controller" =
         Bootstrap_controller.For_tests.Transition_cache.create ()
       in
       let num_breadcrumbs = (Transition_frontier.max_length * 2) + 2 in
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let network =
         Network.create_stub ~logger
           ~ip_table:(Hashtbl.create (module Unix.Inet_addr))
@@ -162,7 +162,7 @@ let%test_module "Bootstrap Controller" =
 
     let%test_unit "reconstruct staged_ledgers using \
                    of_scan_state_and_snarked_ledger" =
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let num_breadcrumbs = 10 in
       let accounts = Genesis_ledger.accounts in
       heartbeat_flag := true ;
@@ -236,7 +236,7 @@ let%test_module "Bootstrap Controller" =
       Backtrace.elide := false ;
       heartbeat_flag := true ;
       Printexc.record_backtrace true ;
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let num_breadcrumbs = 10 in
       Thread_safe.block_on_async_exn (fun () ->
           print_heartbeat hb_logger |> don't_wait_for ;
@@ -276,7 +276,7 @@ let%test_module "Bootstrap Controller" =
       Backtrace.elide := false ;
       heartbeat_flag := true ;
       Printexc.record_backtrace true ;
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let num_breadcrumbs = (2 * max_length) + Consensus.Constants.delta + 2 in
       Thread_safe.block_on_async_exn (fun () ->
           print_heartbeat hb_logger |> don't_wait_for ;
@@ -311,7 +311,7 @@ let%test_module "Bootstrap Controller" =
     let%test "when eagerly syncing to multiple nodes, you should sync to the \
               node with the highest transition_frontier" =
       heartbeat_flag := true ;
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let unsynced_peer_num_breadcrumbs = 6 in
       let unsynced_peers_accounts =
         List.take Genesis_ledger.accounts
@@ -357,7 +357,7 @@ let%test_module "Bootstrap Controller" =
       Backtrace.elide := false ;
       Printexc.record_backtrace true ;
       heartbeat_flag := true ;
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let small_peer_num_breadcrumbs = 6 in
       let large_peer_num_breadcrumbs = small_peer_num_breadcrumbs * 2 in
       let source_accounts = [List.hd_exn Genesis_ledger.accounts] in
@@ -414,7 +414,7 @@ let%test_module "Bootstrap Controller" =
 
     let%test "`on_transition` should deny outdated transitions" =
       heartbeat_flag := true ;
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       let num_breadcrumbs = 10 in
       Thread_safe.block_on_async_exn (fun () ->
           print_heartbeat hb_logger |> don't_wait_for ;

--- a/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
+++ b/src/lib/transition_frontier_controller_tests/test_catchup_scheduler.ml
@@ -29,7 +29,7 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
 
     let hb_logger = Logger.create ()
 
-    let pids = Child_processes.Termination.create_pid_set ()
+    let pids = Child_processes.Termination.create_pid_table ()
 
     let trust_system = Trust_system.null ()
 

--- a/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
+++ b/src/lib/transition_frontier_controller_tests/test_ledger_catchup.ml
@@ -109,7 +109,7 @@ let%test_module "Ledger catchup" =
     let%test "catchup to a peer" =
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       heartbeat_flag := true ;
       Thread_safe.block_on_async_exn (fun () ->
           print_heartbeat hb_logger |> don't_wait_for ;
@@ -144,7 +144,7 @@ let%test_module "Ledger catchup" =
 
     let%test "peers can provide transitions with length between max_length to \
               2 * max_length" =
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       heartbeat_flag := true ;
       Thread_safe.block_on_async_exn (fun () ->
           print_heartbeat hb_logger |> don't_wait_for ;
@@ -194,7 +194,7 @@ let%test_module "Ledger catchup" =
 
     let%test "catchup would be successful even if the parent transition is \
               already in the frontier" =
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       heartbeat_flag := true ;
       Thread_safe.block_on_async_exn (fun () ->
           print_heartbeat hb_logger |> don't_wait_for ;
@@ -224,7 +224,7 @@ let%test_module "Ledger catchup" =
           res )
 
     let%test "catchup would fail if one of the parent transition fails" =
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       heartbeat_flag := true ;
       let catchup_job_reader, catchup_job_writer =
         Strict_pipe.create (Buffered (`Capacity 10, `Overflow Crash))
@@ -305,7 +305,7 @@ let%test_module "Ledger catchup" =
 
     let%test_unit "catchup won't be blocked by transitions that are still \
                    under processing" =
-      let pids = Child_processes.Termination.create_pid_set () in
+      let pids = Child_processes.Termination.create_pid_table () in
       heartbeat_flag := true ;
       let catchup_job_reader, catchup_job_writer =
         Strict_pipe.create (Buffered (`Capacity 10, `Overflow Crash))

--- a/src/lib/transition_frontier_controller_tests/test_sync_handler.ml
+++ b/src/lib/transition_frontier_controller_tests/test_sync_handler.ml
@@ -20,7 +20,7 @@ let%test_module "Sync_handler" =
 
     let hb_logger = Logger.create ()
 
-    let pids = Child_processes.Termination.create_pid_set ()
+    let pids = Child_processes.Termination.create_pid_table ()
 
     let trust_system = Trust_system.null ()
 

--- a/src/lib/transition_frontier_controller_tests/test_transaction_status.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transaction_status.ml
@@ -21,7 +21,7 @@ let%test_module "transaction_status" =
 
     let hb_logger = Logger.create ()
 
-    let pids = Child_processes.Termination.create_pid_set ()
+    let pids = Child_processes.Termination.create_pid_table ()
 
     let trust_system = Trust_system.null ()
 

--- a/src/lib/transition_frontier_controller_tests/test_transition_frontier.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transition_frontier.ml
@@ -31,7 +31,7 @@ let%test_module "Root_history and Transition_frontier" =
 
     let hb_logger = Logger.create ()
 
-    let pids = Child_processes.Termination.create_pid_set ()
+    let pids = Child_processes.Termination.create_pid_table ()
 
     let trust_system = Trust_system.null ()
 

--- a/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
@@ -25,7 +25,7 @@ let%test_module "Transition Frontier Persistence" =
 
     let hb_logger = Logger.create ()
 
-    let pids = Child_processes.Termination.create_pid_set ()
+    let pids = Child_processes.Termination.create_pid_table ()
 
     let trust_system = Trust_system.null ()
 

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -123,9 +123,12 @@ let create ~logger ~pids =
       ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:() ()
   in
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__
-    "Daemon started verifier process with pid $verifier_pid"
-    ~metadata:[("verifier_pid", `Int (Process.pid process |> Pid.to_int))] ;
-  Child_processes.Termination.register_process pids process ;
+    "Daemon started process of kind $process_kind with pid $verifier_pid"
+    ~metadata:
+      [ ("verifier_pid", `Int (Process.pid process |> Pid.to_int))
+      ; ( "process_kind"
+        , `String Child_processes.Termination.(show_process_kind Verifier) ) ] ;
+  Child_processes.Termination.(register_process pids process Verifier) ;
   File_system.dup_stdout process ;
   File_system.dup_stderr process ;
   connection


### PR DESCRIPTION
Associate a "kind" for child processes that are registered to terminate the daemon. Current kinds are `Verifier` and `Prover`.

Closes #3566.

Sample log entries:
```
{"timestamp":"2019-10-04 20:24:34.658280Z","level":"Info","source":{"module":"Prover","location":"File \"lib/prover/prover.ml\", line 248, characters 51-58"},"message":"Daemon started process of kind $process_kind with pid $prover_pid","metadata":{"pid":22050,"process_kind":"Prover","prover_pid":22130}}
```
and
```
{"timestamp":"2019-10-04 20:25:34.045796Z","level":"Error","source":{"module":"Child_processes__Termination","location":"File \"lib/child_processes/termination.ml\", line 21, characters 54-61"},"message":"Child process of kind $process_kind with pid $child_pid has terminated; terminating parent process $pid","metadata":{"child_pid":22130,"pid":22050,"process_kind":"Prover"}}
```
