### PR TITLE
Wait for snark worker termination in integration tests

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -221,7 +221,7 @@ let replace_snark_worker_key = Snark_worker.replace_key
 
 let snark_worker_key = Snark_worker.get_key
 
-let stop_snark_worker = Snark_worker.stop
+let stop_snark_worker = Snark_worker.stop ~should_wait_kill:true
 
 let best_tip_opt t =
   let open Option.Let_syntax in


### PR DESCRIPTION
There's a race condition in the integration tests when the snark worker process is terminated via an RPC call. The node dies before it can return an RPC result.

The failure looks like:
```
exn!!!! (monitor.ml.Error
exn!!!!  ((rpc_error (Connection_closed ("EOF or connection closed")))
exn!!!!   (connection_description ("Client connected via TCP" (f79fc044f6c5 34103)))
exn!!!!   (rpc_tag stop_snark_worker) (rpc_version 0))
```
This is an attempt to fix the error by waiting for the snark worker termination.

Closes #3231.