### PR TITLE
Try-with for stop_snark_worker RPC in disconnect

### DIFF
--- a/src/app/cli/src/tests/coda_archive_node_test.ml
+++ b/src/app/cli/src/tests/coda_archive_node_test.ml
@@ -48,7 +48,7 @@ let main () =
          ~f:(fun {With_hash.hash; _} -> hash))
   in
   assert (Hash_set.equal observed_hashset stored_state_hashes) ;
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async

--- a/src/app/cli/src/tests/coda_batch_payment_test.ml
+++ b/src/app/cli/src/tests/coda_batch_payment_test.ml
@@ -32,7 +32,7 @@ let main () =
   let%bind () =
     Coda_worker_testnet.Payments.assert_retrievable_payments testnet payments
   in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async ~summary:"Test batch payments" (Async.Command.Spec.return main)

--- a/src/app/cli/src/tests/coda_block_production_test.ml
+++ b/src/app/cli/src/tests/coda_block_production_test.ml
@@ -12,7 +12,7 @@ let main () =
       Cli_lib.Arg_type.Sequence ~max_concurrent_connections:None
   in
   let%bind () = after (Time.Span.of_sec 30.) in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async ~summary:"Test that blocks get produced"

--- a/src/app/cli/src/tests/coda_bootstrap_test.ml
+++ b/src/app/cli/src/tests/coda_bootstrap_test.ml
@@ -40,7 +40,7 @@ let main () =
   (* TODO: one of the previous_statuses should be `Bootstrap. The broadcast pip 
     coda.transition_frontier never gets set to None *)
   assert (Hash_set.mem previous_status `Synced) ;
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async ~summary:"Test that triggers bootstrap once"

--- a/src/app/cli/src/tests/coda_change_snark_worker_test.ml
+++ b/src/app/cli/src/tests/coda_change_snark_worker_test.ml
@@ -94,7 +94,7 @@ let main () =
     Option.value_exn opt
   in
   let%bind () = after (Time.Span.of_sec 30.) in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async

--- a/src/app/cli/src/tests/coda_delegation_test.ml
+++ b/src/app/cli/src/tests/coda_delegation_test.ml
@@ -126,7 +126,7 @@ let main () =
     "Saw $delegatee_proposal_count blocks proposed by delegatee"
     ~metadata:[("delegatee_proposal_count", `Int !delegatee_proposal_count)] ;
   heartbeat_flag := false ;
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async

--- a/src/app/cli/src/tests/coda_five_nodes_test.ml
+++ b/src/app/cli/src/tests/coda_five_nodes_test.ml
@@ -19,7 +19,7 @@ let main () =
       Cli_lib.Arg_type.Sequence ~max_concurrent_connections:None
   in
   let%bind () = after (Time.Span.of_min 10.) in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async ~summary:"Test that five nodes work"

--- a/src/app/cli/src/tests/coda_long_fork.ml
+++ b/src/app/cli/src/tests/coda_long_fork.ml
@@ -26,7 +26,7 @@ let main n waiting_time () =
       ~duration:(Time.Span.of_ms (2 * epoch_duration |> Float.of_int))
   in
   let%bind () = after (Time.Span.of_sec (waiting_time |> Float.of_int)) in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   let open Command.Let_syntax in

--- a/src/app/cli/src/tests/coda_peers_test.ml
+++ b/src/app/cli/src/tests/coda_peers_test.ml
@@ -41,7 +41,7 @@ let main () =
                   ))
                (S.of_list expected_peers) ) ))
   in
-  Deferred.List.iter workers ~f:Coda_process.disconnect
+  Deferred.List.iter workers ~f:(Coda_process.disconnect ~logger)
 
 let command =
   Command.async

--- a/src/app/cli/src/tests/coda_receipt_chain_test.ml
+++ b/src/app/cli/src/tests/coda_receipt_chain_test.ml
@@ -8,12 +8,13 @@ let name = "coda-receipt-chain-test"
 let lift = Deferred.map ~f:Option.some
 
 (* TODO: This should completely kill the coda daemon for a worker *)
-let restart_node worker ~config =
-  let%bind () = Coda_process.disconnect worker in
+let restart_node worker ~config ~logger =
+  let%bind () = Coda_process.disconnect worker ~logger in
   Coda_process.spawn_exn config
 
 let main () =
   let open Keypair in
+  let logger = Logger.create () in
   let largest_account_keypair =
     Genesis_ledger.largest_account_keypair_exn ()
   in
@@ -50,7 +51,7 @@ let main () =
       fee User_command_memo.dummy
   in
   let receipt_chain_hash = Or_error.ok_exn receipt_chain_hash in
-  let%bind restarted_worker = restart_node ~config worker in
+  let%bind restarted_worker = restart_node ~config worker ~logger in
   let%bind proof =
     Coda_process.prove_receipt_exn restarted_worker receipt_chain_hash
       receipt_chain_hash
@@ -61,7 +62,7 @@ let main () =
       receipt_chain_hash
   in
   assert result ;
-  Deferred.List.iter workers ~f:Coda_process.disconnect
+  Deferred.List.iter workers ~f:(Coda_process.disconnect ~logger)
 
 let command =
   Command.async ~summary:"Test that peers can prove sent payments"

--- a/src/app/cli/src/tests/coda_restart_node_test.ml
+++ b/src/app/cli/src/tests/coda_restart_node_test.ml
@@ -27,7 +27,7 @@ let main () =
   in
   let%bind () = after (Time.Span.of_min 2.) in
   heartbeat_flag := false ;
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async ~summary:"Test of stopping, waiting, then starting a node"

--- a/src/app/cli/src/tests/coda_restarts_and_txns_holy_grail.ml
+++ b/src/app/cli/src/tests/coda_restarts_and_txns_holy_grail.ml
@@ -49,7 +49,7 @@ let main n () =
   in
   (* settle for a few more min *)
   let%bind () = after (Time.Span.of_min 1.) in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   let open Command.Let_syntax in

--- a/src/app/cli/src/tests/coda_shared_prefix_multiproposer_test.ml
+++ b/src/app/cli/src/tests/coda_shared_prefix_multiproposer_test.ml
@@ -23,7 +23,7 @@ let main n enable_payments () =
         ~keypairs ~n:3
     else after (Time.Span.of_min 3.)
   in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   let open Command.Let_syntax in

--- a/src/app/cli/src/tests/coda_shared_prefix_test.ml
+++ b/src/app/cli/src/tests/coda_shared_prefix_test.ml
@@ -13,7 +13,7 @@ let main who_proposes () =
       Cli_lib.Arg_type.Sequence ~max_concurrent_connections:None
   in
   let%bind () = after (Time.Span.of_sec 30.) in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   let open Command.Let_syntax in

--- a/src/app/cli/src/tests/coda_shared_state_test.ml
+++ b/src/app/cli/src/tests/coda_shared_state_test.ml
@@ -22,7 +22,7 @@ let main () =
     Coda_worker_testnet.Payments.send_several_payments testnet ~node:0
       ~keypairs ~n:3
   in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async ~summary:"Test that workers share states"

--- a/src/app/cli/src/tests/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/tests/coda_transitive_peers_test.ml
@@ -48,8 +48,8 @@ let main () =
       (S.of_list
          (peers |> List.map ~f:Network_peer.Peer.to_discovery_host_and_port))
       (S.of_list expected_peers) ) ;
-  let%bind () = Coda_process.disconnect worker in
-  Deferred.List.iter workers ~f:Coda_process.disconnect
+  let%bind () = Coda_process.disconnect worker ~logger in
+  Deferred.List.iter workers ~f:(Coda_process.disconnect ~logger)
 
 let command =
   Command.async

--- a/src/app/cli/src/tests/coda_txns_and_restart_non_proposers.ml
+++ b/src/app/cli/src/tests/coda_txns_and_restart_non_proposers.ml
@@ -46,7 +46,7 @@ let main () =
   in
   (* settle for a few more min *)
   let%bind () = after (Time.Span.of_min 1.) in
-  Coda_worker_testnet.Api.teardown testnet
+  Coda_worker_testnet.Api.teardown testnet ~logger
 
 let command =
   Command.async ~summary:"only restart non-proposers"

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -117,7 +117,7 @@ module Api = struct
           in
           t.status.(i) <- `On (`Synced user_cmds_under_inspection) )
 
-  let stop t i =
+  let stop t i ~logger =
     ( match t.status.(i) with
     | `On (`Synced user_cmds_under_inspection) ->
         Hashtbl.iter user_cmds_under_inspection ~f:(fun {passed_root; _} ->
@@ -131,7 +131,7 @@ module Api = struct
       else Deferred.bind (Condition.wait lock) ~f:wait_for_no_rpcs
     in
     let%bind () = wait_for_no_rpcs () in
-    Coda_process.disconnect t.workers.(i)
+    Coda_process.disconnect t.workers.(i) ~logger
 
   let run_user_command t i (sk : Private_key.t) fee ~body =
     let open Deferred.Option.Let_syntax in
@@ -192,8 +192,9 @@ module Api = struct
     ignore @@ new_block t i key ;
     new_user_command t i key
 
-  let teardown t =
-    Deferred.Array.iteri ~how:`Parallel t.workers ~f:(fun i _ -> stop t i)
+  let teardown t ~logger =
+    Deferred.Array.iteri ~how:`Parallel t.workers ~f:(fun i _ ->
+        stop t i ~logger )
 
   let setup_bootstrap_signal t i =
     let signal = Ivar.create () in
@@ -657,7 +658,7 @@ end = struct
     let%bind () = after (Time.Span.of_sec 5.) in
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__ "Stopping node %d"
       node ;
-    let%bind () = Api.stop testnet node in
+    let%bind () = Api.stop testnet node ~logger in
     let%bind () = after duration in
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__
       "Triggering restart on %d" node ;
@@ -667,7 +668,7 @@ end = struct
     let%bind () = after (Time.Span.of_sec 5.) in
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__ "Stopping node %d"
       node ;
-    let%bind () = Api.stop testnet node in
+    let%bind () = Api.stop testnet node ~logger in
     let signal = Api.setup_catchup_signal testnet node in
     let%bind () = Ivar.read signal in
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__
@@ -678,7 +679,7 @@ end = struct
     let%bind () = after (Time.Span.of_sec 5.) in
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__ "Stopping node %d"
       node ;
-    let%bind () = Api.stop testnet node in
+    let%bind () = Api.stop testnet node ~logger in
     let signal = Api.setup_bootstrap_signal testnet node in
     let%bind () = Ivar.read signal in
     Logger.info logger ~module_:__MODULE__ ~location:__LOC__


### PR DESCRIPTION
Use `Monitor.try_with` for the `stop_snark_worker` RPC in `Coda_process.disconnect` used for integration tests.

Log any error, also the error when the connected node terminates.

Closes #3231.