### PR TITLE
Update snarky for dummy proofs

### DIFF
--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -70,10 +70,10 @@ module Keys = struct
 
     let dummy =
       { step=
-          Tick_backend.Verification_key.dummy
+          Tick_backend.Verification_key.get_dummy
             ~input_size:Coda_base.Transition_system.step_input_size
       ; wrap=
-          Tock_backend.Bowe_gabizon.Verification_key.dummy
+          Tock_backend.Bowe_gabizon.Verification_key.get_dummy
             ~input_size:Wrap_input.size }
 
     let load ({step; wrap} : Location.t) =

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -267,12 +267,13 @@ module Verification_keys = struct
 
   let dummy : t =
     let groth16 =
-      Tick_backend.Verification_key.dummy
+      Tick_backend.Verification_key.get_dummy
         ~input_size:(Tick.Data_spec.size (tick_input ()))
     in
     { merge= groth16
     ; base= groth16
-    ; wrap= Tock_backend.Verification_key.dummy ~input_size:Wrap_input.size }
+    ; wrap= Tock_backend.Verification_key.get_dummy ~input_size:Wrap_input.size
+    }
 end
 
 module Keys0 = struct


### PR DESCRIPTION
Snarky added `Proof.get_dummy`, which is a stable value that can be used in serialization tests.

Update the Snarky submodule commit to be able to access that.