### PR TITLE
Fix bug where epoch was used instead of slot

### DIFF
--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -391,7 +391,7 @@ module Types = struct
         ; field "slot" ~doc:"Slot in which this block was created"
             ~typ:(non_null uint32)
             ~args:Arg.[]
-            ~resolve:(fun _ t -> curr_epoch t)
+            ~resolve:(fun _ t -> curr_slot t)
         ; field "epoch" ~doc:"Epoch in which this block was created"
             ~typ:(non_null uint32)
             ~args:Arg.[]


### PR DESCRIPTION
As discussed here: https://discordapp.com/channels/484437221055922177/601215883939020852/631905317600362509

This resolves the issue where epoch was being used incorrectly for slot.
