### PR TITLE
Don't pin ppx_optcomp in scripts

### DIFF
--- a/scripts/pin-external-packages.sh
+++ b/scripts/pin-external-packages.sh
@@ -2,7 +2,7 @@
 
 # update and pin packages, used by CI
 
-PACKAGES="ocaml-sodium rpc_parallel ocaml-extlib digestif ocaml-extlib ppx_optcomp async_kernel coda_base58 graphql_ppx"
+PACKAGES="ocaml-sodium rpc_parallel ocaml-extlib digestif ocaml-extlib async_kernel coda_base58 graphql_ppx"
 
 git package sync && git package update --init --recursive
 

--- a/scripts/update-opam-in-docker.sh
+++ b/scripts/update-opam-in-docker.sh
@@ -33,7 +33,7 @@ function uptodate () {
 }
 
 # submodules
-for pkg in async_kernel digestif graphql_ppx ocaml-extlib ppx_optcomp rpc_parallel ; do
+for pkg in async_kernel digestif graphql_ppx ocaml-extlib rpc_parallel ; do
     CURRENT_COMMIT=$(git submodule status src/external/$pkg | awk '{print $1}')
     DOCKER_COMMIT=$(cat ~opam/opam-repository/$pkg.commit)
     if [ $CURRENT_COMMIT != $DOCKER_COMMIT ] ; then


### PR DESCRIPTION
We're not pinning `ppx_optcomp` in the Docker toolchain image; I don't have it pinned locally, and my builds work. @nholland94 says it's not meant to be pinned.

So the `update-opam-in-docker.sh` and `pin-external-packages.sh` scripts should also not pin it.

There are a couple of references to `ppx_optcomp` in the Docker toolchain build that remove the `.git` file and create a hash. Those are harmless, I believe, and @enolan will likely remove those in an upcoming PR.


