### PR TITLE
TRIVIAL: revert to testnet ledger

### DIFF
--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -17,7 +17,7 @@
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
-[%%define genesis_ledger "seared_kobe"]
+[%%define genesis_ledger "testnet_postake"]
 
 [%%define genesis_state_timestamp "2019-10-08 09:00:00-07:00"]
 [%%define block_window_duration 180000]


### PR DESCRIPTION
smoketest and other standalone testnets need the normal ledger
