### PR TITLE
[HOTFIX] Divide frontier update and disable expensive metrics

### DIFF
--- a/src/lib/non_empty_list/dune
+++ b/src/lib/non_empty_list/dune
@@ -1,5 +1,5 @@
 (library
   (name non_empty_list)
   (public_name non_empty_list)
-  (libraries core_kernel)
+  (libraries core_kernel async_kernel)
   (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq)))

--- a/src/lib/non_empty_list/non_empty_list.ml
+++ b/src/lib/non_empty_list/non_empty_list.ml
@@ -81,3 +81,8 @@ let min_elt ~compare (x, xs) =
 let max_elt ~compare (x, xs) =
   Option.value_map ~default:x (List.max_elt ~compare xs) ~f:(fun maximum ->
       if compare x maximum > 0 then x else maximum )
+
+let rec iter_deferred (x, xs) ~f =
+  let open Async_kernel in
+  let%bind () = f x in
+  match xs with [] -> return () | h :: t -> iter_deferred (h, t) ~f

--- a/src/lib/non_empty_list/non_empty_list.mli
+++ b/src/lib/non_empty_list/non_empty_list.mli
@@ -67,3 +67,8 @@ val take : 'a t -> int -> 'a t option
 val min_elt : compare:('a -> 'a -> int) -> 'a t -> 'a
 
 val max_elt : compare:('a -> 'a -> int) -> 'a t -> 'a
+
+val iter_deferred :
+     'a t
+  -> f:('a -> unit Async_kernel.Deferred.t)
+  -> unit Async_kernel.Deferred.t

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -581,20 +581,9 @@ struct
     t.root <- new_root_hash ;
     (* TODO: these metrics are too expensive to compute in this way, but it should be ok for beta *)
     (*
-    let num_finalized_staged_txns =
-      Breadcrumb.user_commands new_root |> List.length |> Float.of_int
-    in
     let root_snarked_ledger_accounts =
       Ledger.Db.to_list t.root_snarked_ledger
     in
-    *)
-    (*
-    Coda_metrics.(
-      Gauge.set Transition_frontier.recently_finalized_staged_txns
-        num_finalized_staged_txns) ;
-    Coda_metrics.(
-      Counter.inc Transition_frontier.finalized_staged_txns
-        num_finalized_staged_txns) ;
     Coda_metrics.(
       Gauge.set Transition_frontier.root_snarked_ledger_accounts
         (Float.of_int @@ List.length root_snarked_ledger_accounts)) ;
@@ -605,6 +594,15 @@ struct
              ~f:(fun sum account ->
                sum + Currency.Balance.to_int account.balance ) )) ;
     *)
+    let num_finalized_staged_txns =
+      Breadcrumb.user_commands new_root |> List.length |> Float.of_int
+    in
+    Coda_metrics.(
+      Gauge.set Transition_frontier.recently_finalized_staged_txns
+        num_finalized_staged_txns) ;
+    Coda_metrics.(
+      Counter.inc Transition_frontier.finalized_staged_txns
+        num_finalized_staged_txns) ;
     Coda_metrics.(Counter.inc_one Transition_frontier.root_transitions) ;
     let consensus_state = Breadcrumb.consensus_state new_root in
     let blockchain_length =

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -894,12 +894,13 @@ struct
                     Ledger.Maskable.register_mask db_casted
                       (Ledger.Mask.create ())
                   in
+                  let%bind () = Async.Scheduler.yield () in
                   let%bind () =
                     Non_empty_list.iter_deferred txns ~f:(fun txn ->
-                        let%map () = Async.Scheduler.yield () in
-                        ignore
-                          ( Ledger.apply_transaction db_mask txn
-                          |> Or_error.ok_exn ) )
+                        return
+                        @@ ignore
+                             ( Ledger.apply_transaction db_mask txn
+                             |> Or_error.ok_exn ) )
                   in
                   let%bind () = Async.Scheduler.yield () in
                   Ledger.commit db_mask ;


### PR DESCRIPTION
This hotfix aims to address some of the issues we have been seeing on the latest testnet, the root cause of which we currently believe to be the extremely long async cycles we are observing. Based on log activity, I have evidence to believe the long async cycles are caused when the root of the transition frontier is moved. This PR does two things to help remediate this: it splits the process of moving the transition frontier root up into multiple deferred's, and it disables some very expensive metrics we were computing when moving the root (sorry @yourbuddyconner, I'll get them back in soon).

I have 1 major concern with this PR, which is that I don't know exactly what would happen if the transition frontier is queried while it is in the middle of updating a root. Implementing a read lock on the transition frontier is too large in scope for a hotfix, so this is basically the only thing we can try right now. I would appreciate some input from other engineers to see whether or not this hotfix is worth trying, or if we should just shutdown the current testnet and focus on longer term solutions.

The existing issue https://github.com/CodaProtocol/coda/issues/2850 documents the work needed to fix the expensive metrics to be collected in O(1) instead of O(n) wrt # of accounts.