### PR TITLE
Fix the possibility of introducing a null for sync status

### DIFF
--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -138,8 +138,7 @@ module Types = struct
   let sync_status : ('context, Sync_status.t option) typ =
     enum "SyncStatus" ~doc:"Sync status of daemon"
       ~values:
-        (List.init (Sync_status.max + 1) ~f:(fun i ->
-             let status = Option.value_exn (Sync_status.of_enum i) in
+        (List.map Sync_status.all ~f:(fun status ->
              enum_value
                (String.map ~f:Char.uppercase @@ Sync_status.to_string status)
                ~value:status ))

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -138,11 +138,11 @@ module Types = struct
   let sync_status : ('context, Sync_status.t option) typ =
     enum "SyncStatus" ~doc:"Sync status of daemon"
       ~values:
-        [ enum_value "BOOTSTRAP" ~value:`Bootstrap
-        ; enum_value "SYNCED" ~value:`Synced
-        ; enum_value "OFFLINE" ~value:`Offline
-        ; enum_value "CONNECTING" ~value:`Connecting
-        ; enum_value "LISTENING" ~value:`Listening ]
+        (List.init (Sync_status.max + 1) ~f:(fun i ->
+             let status = Option.value_exn (Sync_status.of_enum i) in
+             enum_value
+               (String.map ~f:Char.uppercase @@ Sync_status.to_string status)
+               ~value:status ))
 
   let transaction_status : ('context, Transaction_status.State.t option) typ =
     enum "TransactionStatus" ~doc:"Status of a transaction"

--- a/src/lib/sync_status/dune
+++ b/src/lib/sync_status/dune
@@ -4,5 +4,5 @@
  (inline_tests)
  (libraries core_kernel currency signature_lib)
  (preprocess
-  (pps ppx_jane ppx_coda ppx_deriving_yojson))
+  (pps ppx_jane ppx_coda ppx_deriving_yojson ppx_deriving.enum))
  (synopsis "Different kinds of status for Coda "))

--- a/src/lib/sync_status/dune
+++ b/src/lib/sync_status/dune
@@ -4,5 +4,5 @@
  (inline_tests)
  (libraries core_kernel currency signature_lib)
  (preprocess
-  (pps ppx_jane ppx_coda ppx_deriving_yojson ppx_deriving.enum))
+  (pps ppx_jane ppx_coda ppx_deriving_yojson ppx_enumerate))
  (synopsis "Different kinds of status for Coda "))

--- a/src/lib/sync_status/sync_status.ml
+++ b/src/lib/sync_status/sync_status.ml
@@ -46,7 +46,7 @@ module Stable = struct
     module T = struct
       type t =
         [`Connecting | `Listening | `Offline | `Bootstrap | `Synced | `Catchup]
-      [@@deriving bin_io, version, sexp, hash, compare, equal, enum]
+      [@@deriving bin_io, version, sexp, hash, compare, equal, enumerate]
 
       let to_yojson = to_yojson
     end
@@ -59,7 +59,7 @@ module Stable = struct
 end
 
 type t = [`Connecting | `Listening | `Offline | `Bootstrap | `Synced | `Catchup]
-[@@deriving sexp, hash, equal, enum]
+[@@deriving sexp, hash, equal, enumerate]
 
 include Hashable.Make (Stable.Latest.T)
 

--- a/src/lib/sync_status/sync_status.ml
+++ b/src/lib/sync_status/sync_status.ml
@@ -46,7 +46,7 @@ module Stable = struct
     module T = struct
       type t =
         [`Connecting | `Listening | `Offline | `Bootstrap | `Synced | `Catchup]
-      [@@deriving bin_io, version, sexp, hash, compare, equal]
+      [@@deriving bin_io, version, sexp, hash, compare, equal, enum]
 
       let to_yojson = to_yojson
     end
@@ -59,7 +59,7 @@ module Stable = struct
 end
 
 type t = [`Connecting | `Listening | `Offline | `Bootstrap | `Synced | `Catchup]
-[@@deriving sexp, hash, equal]
+[@@deriving sexp, hash, equal, enum]
 
 include Hashable.Make (Stable.Latest.T)
 


### PR DESCRIPTION
@figitaki mentioned that sync status could return a null, even though the type is a non-null. This should not happen. However, it is happening because we do not include `Catchup` as a sync status for Graphql. This PR addresses this type of inconsistency once and for all. I created a little program using ppx_deriving.enum to make sure that the Graphql type of Sync_status matches with the actual Sync_status type.

Now, the Catchup status will be shown:

<img width="330" alt="Screenshot 2019-10-14 14 50 43" src="https://user-images.githubusercontent.com/10444402/66785787-23d0cb00-ee93-11e9-9ae7-7816a44b2f52.png">


Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

