### PR TITLE
Wallet: adds active and focus button styles 

### DIFF
--- a/frontend/wallet/src/render/components/Button.re
+++ b/frontend/wallet/src/render/components/Button.re
@@ -34,6 +34,14 @@ module Styles = {
           backgroundColor(Theme.Colors.marineAlpha(1.)),
           color(white),
         ]),
+        focus([
+          backgroundColor(Theme.Colors.marineAlpha(1.)),
+          color(white),
+        ]),
+        active([
+          backgroundColor(Theme.Colors.marineAlpha(1.)),
+          color(white),
+        ]),
       ]),
     ]);
 
@@ -44,6 +52,8 @@ module Styles = {
         backgroundColor(Theme.Colors.serpentine),
         color(white),
         hover([backgroundColor(Theme.Colors.jungle)]),
+        focus([backgroundColor(Theme.Colors.jungle)]),
+        active([backgroundColor(Theme.Colors.jungle)]),
       ]),
     ]);
 
@@ -54,6 +64,8 @@ module Styles = {
         backgroundColor(Theme.Colors.roseBud),
         color(white),
         hover([backgroundColor(Theme.Colors.yeezy)]),
+        focus([backgroundColor(Theme.Colors.yeezy)]),
+        active([backgroundColor(Theme.Colors.yeezy)]),
       ]),
     ]);
 
@@ -64,6 +76,8 @@ module Styles = {
         backgroundColor(Theme.Colors.slateAlpha(0.05)),
         color(Theme.Colors.midnight),
         hover([backgroundColor(Theme.Colors.slateAlpha(0.2))]),
+        focus([backgroundColor(Theme.Colors.slateAlpha(0.2))]),
+        active([backgroundColor(Theme.Colors.slateAlpha(0.2))]),
       ]),
     ]);
 

--- a/frontend/wallet/src/render/components/Button.re
+++ b/frontend/wallet/src/render/components/Button.re
@@ -30,18 +30,9 @@ module Styles = {
       style([
         backgroundColor(Theme.Colors.marineAlpha(0.1)),
         color(Theme.Colors.marineAlpha(1.)),
-        hover([
-          backgroundColor(Theme.Colors.marineAlpha(1.)),
-          color(white),
-        ]),
-        focus([
-          backgroundColor(Theme.Colors.marineAlpha(1.)),
-          color(white),
-        ]),
-        active([
-          backgroundColor(Theme.Colors.marineAlpha(1.)),
-          color(white),
-        ]),
+        hover([backgroundColor(Theme.Colors.marine), color(white)]),
+        focus([backgroundColor(Theme.Colors.marine), color(white)]),
+        active([backgroundColor(Theme.Colors.marine), color(white)]),
       ]),
     ]);
 

--- a/frontend/wallet/src/render/components/TextField.re
+++ b/frontend/wallet/src/render/components/TextField.re
@@ -37,6 +37,10 @@ module Styles = {
       border(`px(2), `solid, Theme.Colors.roseBud),
       borderRadius(`rem(0.25)),
       flexGrow(1.),
+      selector(
+        ":focus-within",
+        [border(`px(2), `solid, Theme.Colors.hyperlink)],
+      ),
     ]);
   let label =
     merge([


### PR DESCRIPTION
Uses hover state currently on active and focus states for buttons (will have to revisit for design) 
