### PR TITLE
Script to enforce ppx_coda always used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,9 @@ jobs:
             - run:
                   name: Check CODEOWNERS file format
                   command: ./scripts/lint_codeowners.sh
-
+            - run:
+                  name: Require ppx_coda preprocessing for linting
+                  command: ./scripts/require-ppx-coda.py
     update-branch-protection:
         docker:
             - image: python:3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
     build-archive:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
               environment: 
                 CODA_DOCKER: true
                 HASURA_PORT: 8080
@@ -91,7 +91,7 @@ jobs:
                   command: ls && ./scripts/archive/make_hasura_configurations.sh     
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -262,7 +262,7 @@ jobs:
     build-artifacts--testnet_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -311,7 +311,7 @@ jobs:
     test-unit--test_postake_snarkless_unittest:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -349,7 +349,7 @@ jobs:
     test-unit--dev:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -387,7 +387,7 @@ jobs:
     test-unit--dev_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -403,7 +403,7 @@ jobs:
     test--fake_hash:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -417,7 +417,7 @@ jobs:
     test--test_postake:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -434,7 +434,7 @@ jobs:
     test--test_postake_bootstrap:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -451,7 +451,7 @@ jobs:
     test--test_postake_catchup:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -465,7 +465,7 @@ jobs:
     test--test_postake_delegation:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -479,7 +479,7 @@ jobs:
     test--test_postake_five_even_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -493,7 +493,7 @@ jobs:
     test--test_postake_five_even_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -507,7 +507,7 @@ jobs:
     test--test_postake_holy_grail:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -524,7 +524,7 @@ jobs:
     test--test_postake_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -541,7 +541,7 @@ jobs:
     test--test_postake_split:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -555,7 +555,7 @@ jobs:
     test--test_postake_split_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -590,7 +590,7 @@ jobs:
     test--test_postake_three_proposers:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -604,7 +604,7 @@ jobs:
     test--test_postake_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -621,7 +621,7 @@ jobs:
     test--test_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -640,7 +640,7 @@ jobs:
     test--test_postake_snarkless_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -657,7 +657,7 @@ jobs:
     test--test_postake_split_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -61,7 +61,7 @@ jobs:
 
     build-archive:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
               environment: 
                 CODA_DOCKER: true
                 HASURA_PORT: 8080
@@ -91,7 +91,7 @@ jobs:
                   command: ls && ./scripts/archive/make_hasura_configurations.sh     
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -268,7 +268,7 @@ jobs:
         resource_class: large
         {%- endif %}
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -326,7 +326,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -367,7 +367,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -386,7 +386,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:
@@ -405,7 +405,7 @@ jobs:
     test--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -109,7 +109,9 @@ jobs:
             - run:
                   name: Check CODEOWNERS file format
                   command: ./scripts/lint_codeowners.sh
-
+            - run:
+                  name: Require ppx_coda preprocessing for linting
+                  command: ./scripts/require-ppx-coda.py
     update-branch-protection:
         docker:
             - image: python:3

--- a/README-dev.md
+++ b/README-dev.md
@@ -57,7 +57,7 @@ of the repo.
 
 * Pull down developer container image  (~2GB download, go stretch your legs)
 
-`docker pull codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41`
+`docker pull codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17`
 
 * Create local builder image
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+FROM codaprotocol/coda:toolchain-0b4ea6c4f8e5ba17bf5965dca7c74759442bff17
 
 # same as in Dockerfile-toolchain
 ARG OCAML_VERSION=4.07.1

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -28,9 +28,12 @@ RUN sudo apt-get update && sudo apt-get install --yes \
     perl \
     pkg-config \
     python-jinja2 \
+    python-pip \
     rubygems \
     zlib1g-dev \
     libbz2-dev
+
+RUN sudo pip install sexpdata
 
 RUN sudo gem install deb-s3
 
@@ -49,7 +52,7 @@ RUN cd /rocksdb && sudo make static_lib PORTABLE=1 -j$(nproc) && sudo cp librock
 RUN sudo git clone https://github.com/CodaProtocol/coda /coda
 
 # submodules
-RUN for pkg in async_kernel digestif graphql_ppx ocaml-extlib ppx_optcomp rpc_parallel ; do \
+RUN for pkg in async_kernel digestif graphql_ppx ocaml-extlib rpc_parallel ; do \
       # remove leading "-" indicating uninitialized
       cd /coda && sudo bash -c "git submodule status src/external/$pkg | awk '{print \$1}' | sed s/-// > ~opam/opam-repository/$pkg.commit" ; \
     done
@@ -95,7 +98,7 @@ ADD /src/external/async_kernel /async_kernel
 ADD /src/external/graphql_ppx /graphql_ppx
 
 # Remove .git files for submodules
-RUN for pkg in async_kernel digestif graphql_ppx ocaml-extlib ppx_optcomp rpc_parallel ; do \
+RUN for pkg in async_kernel digestif graphql_ppx ocaml-extlib rpc_parallel ; do \
       sudo rm -f /$pkg/.git ; \
     done
 

--- a/scripts/require-ppx-coda.py
+++ b/scripts/require-ppx-coda.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+
+# In dune files, require preprocessing by ppx_coda, so that the version syntax linter is always run
+
+import subprocess
+import string
+import sexpdata
+
+dune_string = subprocess.check_output(['find','src','-name','dune'])
+
+dunes_raw = string.split (dune_string,'\n')
+
+# filter out dunes where we don't require linting
+def dunes_ok (dune) :
+  path = dune.split ('/')
+  path_prefix2 = path[1:2]
+  path_prefix3 = path[1:3]
+  return (not (path_prefix2 == ['_build'] or path_prefix2 == ['external'] or
+               path_prefix3 == ['lib', 'snarky'] or path_prefix3 == ['lib', 'ppx_coda']))
+
+dunes = list(filter(lambda s : len(s) > 0 and dunes_ok (s),dunes_raw))
+
+library = sexpdata.loads ('library')
+preprocess = sexpdata.loads ('preprocess')
+pps = sexpdata.loads ('pps')
+no_preprocessing = sexpdata.loads ('no_preprocessing')
+
+ppx_lint = sexpdata.loads ('ppx_coda')
+
+exit_code = 0
+
+def ppx_error (dune,ppx) :
+    print ("In dune file " + dune + ", the preprocessing clause does not contain " + (sexpdata.dumps (ppx)) + ", or is missing")
+    global exit_code
+    exit_code = 1
+
+def get_ppx_ndx (dune,ppxs,ppx) :
+    try :
+        ppxs.index (ppx)
+    except :
+        ppx_error (dune,ppx)
+
+for dune in dunes :
+    with open (dune) as fp :
+        # wrap in parens to get list of top-level clauses
+        sexps = sexpdata.loads ('(' + fp.read () + ')')
+        for sexp in sexps :
+            if isinstance (sexp,list) and len (sexp) > 0 and sexpdata.car (sexp) == library :
+                clauses = sexpdata.cdr (sexp)
+                for clause in clauses :
+                    if sexpdata.car (clause) == preprocess :
+                        subclause = sexpdata.car (sexpdata.cdr (clause))
+                        if subclause == no_preprocessing :
+                            # error if no preprocessing explicitly
+                            ppx_error (dune,ppx_lint)
+                        elif sexpdata.car (subclause) == pps :
+                            # if there is preprocessing, static checks before version registration before versioning, and all three must occur
+                            ppxs = sexpdata.cdr (subclause)
+                            lint_ppx_ndx = get_ppx_ndx (dune,ppxs,ppx_lint)
+                            if (lint_ppx_ndx == None) :
+                                continue
+                        else :
+                            # error if no preprocessing implicitly
+                            ppx_error (dune,ppx_lint)
+
+exit (exit_code)

--- a/scripts/require-ppx-coda.py
+++ b/scripts/require-ppx-coda.py
@@ -8,17 +8,17 @@ import sexpdata
 
 dune_string = subprocess.check_output(['find','src','-name','dune'])
 
-dunes_raw = string.split (dune_string,'\n')
+dune_paths_raw = string.split (dune_string,'\n')
 
-# filter out dunes where we don't require linting
-def dunes_ok (dune) :
+# filter out dune paths where we don't require linting
+def dune_paths_ok (dune) :
   path = dune.split ('/')
   path_prefix2 = path[1:2]
   path_prefix3 = path[1:3]
   return (not (path_prefix2 == ['_build'] or path_prefix2 == ['external'] or
                path_prefix3 == ['lib', 'snarky'] or path_prefix3 == ['lib', 'ppx_coda']))
 
-dune_paths = list(filter(lambda s : len(s) > 0 and dunes_ok (s),dunes_raw))
+dune_paths = list(filter(lambda s : len(s) > 0 and dune_paths_ok (s),dune_paths_raw))
 
 library = sexpdata.loads ('library')
 preprocess = sexpdata.loads ('preprocess')

--- a/scripts/require-ppx-coda.py
+++ b/scripts/require-ppx-coda.py
@@ -54,11 +54,8 @@ for dune in dunes :
                             # error if no preprocessing explicitly
                             ppx_error (dune,ppx_lint)
                         elif sexpdata.car (subclause) == pps :
-                            # if there is preprocessing, static checks before version registration before versioning, and all three must occur
                             ppxs = sexpdata.cdr (subclause)
                             lint_ppx_ndx = get_ppx_ndx (dune,ppxs,ppx_lint)
-                            if (lint_ppx_ndx == None) :
-                                continue
                         else :
                             # error if no preprocessing implicitly
                             ppx_error (dune,ppx_lint)

--- a/src/app/archive/lib/dune
+++ b/src/app/archive/lib/dune
@@ -4,5 +4,5 @@
   (libraries core async coda_base coda_transition graphql_client_lib)
   (inline_tests)
   (preprocessor_deps ../archive_graphql_schema.json)
-  (preprocess (pps ppx_jane graphql_ppx -- -schema src/app/archive/archive_graphql_schema.json))
+  (preprocess (pps ppx_coda ppx_jane graphql_ppx -- -schema src/app/archive/archive_graphql_schema.json))
   )

--- a/src/app/website/stationary/src/dune
+++ b/src/app/website/stationary/src/dune
@@ -4,5 +4,5 @@
  (library_flags -linkall)
  (libraries core async)
  (preprocess
-  (pps ppx_jane))
+  (pps ppx_coda ppx_jane))
  (synopsis "Library for html"))

--- a/src/lib/best_tip_prover/dune
+++ b/src/lib/best_tip_prover/dune
@@ -1,5 +1,5 @@
 (library
   (name best_tip_prover)
   (public_name best_tip_prover)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries core_kernel coda_intf coda_base transition_frontier consensus transition_chain_prover))

--- a/src/lib/bignum_bigint/dune
+++ b/src/lib/bignum_bigint/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core fold_lib async async_extra bignum)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Bignum's bigint re-exported as Bignum_bigint"))

--- a/src/lib/bowe_gabizon_hash/dune
+++ b/src/lib/bowe_gabizon_hash/dune
@@ -1,7 +1,7 @@
 (library
   (name bowe_gabizon_hash)
   (public_name bowe_gabizon_hash)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     core_kernel ))

--- a/src/lib/cache_dir/dune
+++ b/src/lib/cache_dir/dune
@@ -2,4 +2,4 @@
  (name cache_dir)
  (public_name cache_dir)
  (libraries core async)
- (preprocess no_preprocessing))
+ (preprocess (pps ppx_coda)))

--- a/src/lib/cache_lib/dune
+++ b/src/lib/cache_lib/dune
@@ -3,4 +3,4 @@
   (public_name cache_lib)
   (inline_tests)
   (libraries async_kernel core_kernel logger)
-  (preprocess (pps ppx_base ppx_let ppx_custom_printf ppx_inline_test ppx_optcomp)))
+  (preprocess (pps ppx_coda ppx_base ppx_let ppx_custom_printf ppx_inline_test ppx_optcomp)))

--- a/src/lib/cached/dune
+++ b/src/lib/cached/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core storage async)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Cache computation results on disk"))

--- a/src/lib/child_processes/dune
+++ b/src/lib/child_processes/dune
@@ -1,5 +1,5 @@
 (library
   (name child_processes)
   (public_name child_processes)
-  (preprocess (pps ppx_deriving.show))
+  (preprocess (pps ppx_coda ppx_deriving.show))
   (libraries core_kernel async logger))

--- a/src/lib/chunked_triples/dune
+++ b/src/lib/chunked_triples/dune
@@ -2,5 +2,5 @@
   (name chunked_triples)
   (public_name chunked_triples)
   (libraries core tuple_lib)
-  (preprocess (pps ppx_jane bisect_ppx -conditional))
+  (preprocess (pps ppx_coda ppx_jane bisect_ppx -conditional))
   (inline_tests))

--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -6,6 +6,6 @@
  (libraries core async_unix sodium ppx_deriving_yojson.runtime yojson
    coda_base daemon_rpcs secrets work_selector graphql_client_lib)
  (preprocess
-  (pps ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
     -conditional))
  (synopsis "Library to communicate with Coda as cli as the front-end"))

--- a/src/lib/cli_lib/dune
+++ b/src/lib/cli_lib/dune
@@ -6,6 +6,6 @@
  (libraries core async_unix sodium ppx_deriving_yojson.runtime yojson
    coda_base daemon_rpcs secrets work_selector graphql_client_lib)
  (preprocess
-  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
     -conditional))
  (synopsis "Library to communicate with Coda as cli as the front-end"))

--- a/src/lib/coda_compile_config/dune
+++ b/src/lib/coda_compile_config/dune
@@ -2,4 +2,4 @@
   (name coda_compile_config)
   (public_name coda_compile_config)
   (libraries currency)
-  (preprocess (pps ppx_base ppx_optcomp)))
+  (preprocess (pps ppx_coda ppx_base ppx_optcomp)))

--- a/src/lib/coda_debug/dune
+++ b/src/lib/coda_debug/dune
@@ -4,4 +4,4 @@
  (libraries core_kernel)
  (flags :standard -short-paths)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_coda ppx_jane)))

--- a/src/lib/coda_graphql/dune
+++ b/src/lib/coda_graphql/dune
@@ -6,4 +6,4 @@
     async core cohttp graphql-async graphql-cohttp
     ; libs
     auxiliary_database coda_base coda_commands coda_lib)
-  (preprocess (pps ppx_jane)))
+  (preprocess (pps ppx_coda ppx_jane)))

--- a/src/lib/coda_incremental/dune
+++ b/src/lib/coda_incremental/dune
@@ -1,5 +1,6 @@
 (library
  (name coda_incremental)
  (public_name coda_incremental)
+ (preprocess (pps ppx_coda))
  (libraries incremental pipe_lib)
  )

--- a/src/lib/coda_lib/dune
+++ b/src/lib/coda_lib/dune
@@ -10,5 +10,5 @@
   sync_handler transition_router otp_lib snark_worker
   participating_state transaction_status)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving.make bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving.make bisect_ppx -- -conditional))
  (synopsis "Coda gut layer"))

--- a/src/lib/coda_metrics/dune
+++ b/src/lib/coda_metrics/dune
@@ -2,4 +2,4 @@
   (name coda_metrics)
   (public_name coda_metrics)
   (libraries async prometheus cohttp cohttp-async logger)
-  (preprocess (pps ppx_jane)))
+  (preprocess (pps ppx_coda ppx_jane)))

--- a/src/lib/coda_net2/dune
+++ b/src/lib/coda_net2/dune
@@ -3,4 +3,4 @@
  (public_name coda_net2)
  (libraries core async network_peer file_system yojson coda_digestif pipe_lib envelope logger base58)
  (inline_tests)
- (preprocess (pps ppx_jane ppx_let ppx_deriving_yojson)))
+ (preprocess (pps ppx_coda ppx_jane ppx_let ppx_deriving_yojson)))

--- a/src/lib/coda_version/dune
+++ b/src/lib/coda_version/dune
@@ -1,5 +1,6 @@
 (library
  (name coda_version)
+ (preprocess (pps ppx_coda))
  (public_name coda_version))
 
 (rule

--- a/src/lib/codable/dune
+++ b/src/lib/codable/dune
@@ -4,5 +4,5 @@
   (library_flags (-linkall))
   (inline_tests)
   (libraries core_kernel ppx_deriving_yojson.runtime yojson base58_check)
-  (preprocess (pps ppx_jane ppx_deriving_yojson bisect_ppx -conditional))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving_yojson bisect_ppx -conditional))
   (synopsis "Extension of Yojson to make it easy for a type to derive yojson"))

--- a/src/lib/command_line_tests/dune
+++ b/src/lib/command_line_tests/dune
@@ -3,5 +3,5 @@
   (public_name command_line_tests)
   (inline_tests)
   (libraries core async)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   )

--- a/src/lib/crs/dune
+++ b/src/lib/crs/dune
@@ -1,6 +1,7 @@
 (library
  (name crs)
  (public_name crs)
+ (preprocess (pps ppx_coda))
  (library_flags -linkall)
  (libraries coda_digestif)
  (synopsis "Common random string generation library"))

--- a/src/lib/crypto_params/chunk_table/dune
+++ b/src/lib/crypto_params/chunk_table/dune
@@ -2,4 +2,4 @@
   (name chunk_table)
   (public_name crypto_params.chunk_table)
   (libraries curve_choice)
-  (preprocess (pps ppx_coda ppx_jane)))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane)))

--- a/src/lib/crypto_params/chunk_table/dune
+++ b/src/lib/crypto_params/chunk_table/dune
@@ -2,4 +2,4 @@
   (name chunk_table)
   (public_name crypto_params.chunk_table)
   (libraries curve_choice)
-  (preprocess (pps ppx_jane)))
+  (preprocess (pps ppx_coda ppx_jane)))

--- a/src/lib/crypto_params/dune
+++ b/src/lib/crypto_params/dune
@@ -16,7 +16,7 @@
   random_oracle
   tuple_lib)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Cryptographic parameters"))
 
 (rule

--- a/src/lib/curve_choice/dune
+++ b/src/lib/curve_choice/dune
@@ -3,4 +3,4 @@
  (public_name curve_choice)
  (libraries snarkette snarky)
  (preprocess
-  (pps ppx_jane)))
+  (pps ppx_coda ppx_jane)))

--- a/src/lib/daemon_rpcs/dune
+++ b/src/lib/daemon_rpcs/dune
@@ -6,6 +6,6 @@
  (libraries core async coda_base ppx_deriving_yojson.runtime yojson
    perf_histograms consensus sync_status transaction_status)
  (preprocess
-  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_deriving.eq ppx_deriving.make
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving_yojson ppx_deriving.eq ppx_deriving.make
     bisect_ppx -- -conditional))
  (synopsis "Lib powering the client interactions with the daemon"))

--- a/src/lib/daemon_rpcs/dune
+++ b/src/lib/daemon_rpcs/dune
@@ -6,6 +6,6 @@
  (libraries core async coda_base ppx_deriving_yojson.runtime yojson
    perf_histograms consensus sync_status transaction_status)
  (preprocess
-  (pps ppx_jane ppx_deriving_yojson ppx_deriving.eq ppx_deriving.make
+  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_deriving.eq ppx_deriving.make
     bisect_ppx -- -conditional))
  (synopsis "Lib powering the client interactions with the daemon"))

--- a/src/lib/debug_assert/dune
+++ b/src/lib/debug_assert/dune
@@ -1,6 +1,7 @@
 (library
  (name debug_assert)
   (public_name debug_assert)
+  (preprocess (pps ppx_coda))
   (libraries async_kernel)
   (synopsis "Debug assertion library")
  )

--- a/src/lib/direction/dune
+++ b/src/lib/direction/dune
@@ -4,5 +4,5 @@
  (library_flags -linkall)
  (libraries core)
  (preprocess
-  (pps ppx_jane ppx_deriving ppx_deriving.eq))
+  (pps ppx_coda ppx_jane ppx_deriving ppx_deriving.eq))
  (synopsis "Representation of direction in a binary tree"))

--- a/src/lib/distributed_dsl/dune
+++ b/src/lib/distributed_dsl/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries logger core pipe_lib async async_extra)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving.enum ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving.enum ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Distributed DSL"))

--- a/src/lib/dummy_values/dune
+++ b/src/lib/dummy_values/dune
@@ -5,7 +5,7 @@
  (libraries crypto_params snarky)
  (ppx_runtime_libraries base)
  (preprocess
-  (pps ppx_jane ppxlib.metaquot ppxlib.runner)))
+  (pps ppx_coda ppx_jane ppxlib.metaquot ppxlib.runner)))
 
 (rule
  (targets dummy_values.ml)

--- a/src/lib/dyn_array/dune
+++ b/src/lib/dyn_array/dune
@@ -5,6 +5,6 @@
  (inline_tests)
  (libraries core extlib)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis
    "dyn_array has the same capabilities as Core's DynArray and it is also serializable"))

--- a/src/lib/empty_hashes/dune
+++ b/src/lib/empty_hashes/dune
@@ -1,6 +1,7 @@
 (library
   (name empty_hashes)
   (public_name empty_hashes)
+  (preprocess (pps ppx_coda))
   (library_flags (-linkall))
   (libraries core immutable_array )
    )

--- a/src/lib/exit_handlers/dune
+++ b/src/lib/exit_handlers/dune
@@ -3,5 +3,5 @@
  (public_name exit_handlers)
  (library_flags -linkall)
  (libraries core_kernel async_kernel async_unix logger)
- (preprocess (pps ppx_let))
+ (preprocess (pps ppx_coda ppx_let))
  (synopsis "Exit handlers"))

--- a/src/lib/file_system/dune
+++ b/src/lib/file_system/dune
@@ -4,5 +4,5 @@
  (library_flags -linkall)
  (libraries core async)
  (preprocess
-  (pps ppx_jane))
+  (pps ppx_coda ppx_jane))
  (synopsis "Interface to make system calls to the Unix file system"))

--- a/src/lib/global_signer_private_key/dune
+++ b/src/lib/global_signer_private_key/dune
@@ -6,5 +6,5 @@
  (inline_tests)
  (libraries core_kernel signature_lib)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "fold types"))

--- a/src/lib/group_map/dune
+++ b/src/lib/group_map/dune
@@ -1,7 +1,7 @@
 (library
   (name group_map)
   (public_name group_map)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     snarkette ; This is actually just needed in tests

--- a/src/lib/group_map/dune
+++ b/src/lib/group_map/dune
@@ -1,7 +1,7 @@
 (library
   (name group_map)
   (public_name group_map)
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     snarkette ; This is actually just needed in tests

--- a/src/lib/hash_prefixes/dune
+++ b/src/lib/hash_prefixes/dune
@@ -1,4 +1,5 @@
 (library
   (name hash_prefixes)
   (public_name hash_prefixes)
+  (preprocess (pps ppx_coda))
   )

--- a/src/lib/immutable_array/dune
+++ b/src/lib/immutable_array/dune
@@ -1,5 +1,6 @@
 (library
  (name immutable_array)
  (public_name immutable_array)
+ (preprocess (pps ppx_coda))
  (library_flags -linkall)
  (synopsis "Access only array utility"))

--- a/src/lib/interruptible/dune
+++ b/src/lib/interruptible/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core async)
  (preprocess
-  (pps ppx_jane ppx_deriving.std bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.std bisect_ppx -- -conditional))
  (synopsis "Interruptible monad (deferreds, that can be triggered to cancel)"))

--- a/src/lib/kademlia/dune
+++ b/src/lib/kademlia/dune
@@ -7,5 +7,5 @@
  (libraries core logger pipe_lib async async_extra file_system
    network_peer trust_system ctypes ctypes.foreign)
  (preprocess
-  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane bisect_ppx -- -conditional))
  (synopsis "Kademlia DHT -- only being used for its membership"))

--- a/src/lib/kademlia/dune
+++ b/src/lib/kademlia/dune
@@ -7,5 +7,5 @@
  (libraries core logger pipe_lib async async_extra file_system
    network_peer trust_system ctypes ctypes.foreign)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Kademlia DHT -- only being used for its membership"))

--- a/src/lib/key_value_database/dune
+++ b/src/lib/key_value_database/dune
@@ -3,5 +3,5 @@
   (public_name key_value_database)
   (library_flags (-linkall))
   (libraries core_kernel)
-  (preprocess (pps ppx_jane))
+  (preprocess (pps ppx_coda ppx_jane))
   (synopsis "Collection of key-value databases used in Coda"))

--- a/src/lib/keys_lib/dune
+++ b/src/lib/keys_lib/dune
@@ -6,5 +6,5 @@
  (libraries core async coda_base snark_keys blockchain_snark
    transaction_snark)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "SNARK keys"))

--- a/src/lib/ledger_catchup/dune
+++ b/src/lib/ledger_catchup/dune
@@ -1,7 +1,7 @@
 (library
   (name ledger_catchup)
   (public_name ledger_catchup)
-  (preprocess (pps ppx_jane) )
+  (preprocess (pps ppx_coda ppx_jane) )
   (libraries
     async_kernel
     non_empty_list 

--- a/src/lib/linked_tree/dune
+++ b/src/lib/linked_tree/dune
@@ -1,7 +1,7 @@
 (library
   (name linked_tree)
   (public_name linked_tree)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries
     core
     coda_numbers

--- a/src/lib/lite_compat/dune
+++ b/src/lib/lite_compat/dune
@@ -12,5 +12,5 @@
       genesis_ledger
       lite_compat_algebra
     )
-   (preprocess (pps ppx_jane ppxlib.runner))
+   (preprocess (pps ppx_coda ppx_jane ppxlib.runner))
    (modes native))

--- a/src/lib/logger/dune
+++ b/src/lib/logger/dune
@@ -5,6 +5,6 @@
  (inline_tests)
  (libraries core async yojson ppx_deriving_yojson.runtime re2 logproc_lib)
  (preprocess
-  (pps ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx --
     -conditional))
  (synopsis "Logging library"))

--- a/src/lib/logproc_lib/dune
+++ b/src/lib/logproc_lib/dune
@@ -3,5 +3,5 @@
   (public_name logproc_lib)
   (modules filter interpolator)
   (libraries core yojson angstrom re2)
-  (preprocess (pps ppx_jane ppx_deriving.std))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.std))
   (inline_tests))

--- a/src/lib/merkle_ledger/dune
+++ b/src/lib/merkle_ledger/dune
@@ -6,5 +6,5 @@
    dyn_array merkle_address direction rocks key_value_database empty_hashes module_version
    visualization non_empty_list)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson))
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson))
  (synopsis "Implementation of different account databases"))

--- a/src/lib/merkle_ledger/dune
+++ b/src/lib/merkle_ledger/dune
@@ -6,5 +6,5 @@
    dyn_array merkle_address direction rocks key_value_database empty_hashes module_version
    visualization non_empty_list)
  (preprocess
-  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson))
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson))
  (synopsis "Implementation of different account databases"))

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -4,7 +4,7 @@
  (library_flags -linkall)
  (libraries core merkle_ledger merkle_mask coda_base signature_lib extlib)
  (preprocess
-  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson bisect_ppx -- -conditional))
  (inline_tests
   (libraries rocks))
  (synopsis "Testing account databases"))

--- a/src/lib/merkle_ledger_tests/dune
+++ b/src/lib/merkle_ledger_tests/dune
@@ -4,7 +4,7 @@
  (library_flags -linkall)
  (libraries core merkle_ledger merkle_mask coda_base signature_lib extlib)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson bisect_ppx -- -conditional))
  (inline_tests
   (libraries rocks))
  (synopsis "Testing account databases"))

--- a/src/lib/merkle_list_prover/dune
+++ b/src/lib/merkle_list_prover/dune
@@ -1,5 +1,5 @@
 (library
 (name merkle_list_prover)
   (public_name merkle_list_prover)
-  (preprocess (pps ppx_jane))
+  (preprocess (pps ppx_coda ppx_jane))
   (libraries core_kernel))

--- a/src/lib/merkle_list_verifier/dune
+++ b/src/lib/merkle_list_verifier/dune
@@ -1,5 +1,5 @@
 (library
 (name merkle_list_verifier)
   (public_name merkle_list_verifier)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries core_kernel non_empty_list))

--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -5,5 +5,5 @@
  (libraries core debug_assert bitstring integers immutable_array
    dyn_array merkle_ledger merkle_address yojson visualization)
  (preprocess
-  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_jane ppx_deriving.eq ppx_deriving.show))
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving_yojson ppx_jane ppx_deriving.eq ppx_deriving.show))
  (synopsis "Implementation of Merkle tree masks"))

--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -5,5 +5,5 @@
  (libraries core debug_assert bitstring integers immutable_array
    dyn_array merkle_ledger merkle_address yojson visualization)
  (preprocess
-  (pps ppx_jane ppx_deriving_yojson ppx_jane ppx_deriving.eq ppx_deriving.show))
+  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_jane ppx_deriving.eq ppx_deriving.show))
  (synopsis "Implementation of Merkle tree masks"))

--- a/src/lib/o1trace/dune
+++ b/src/lib/o1trace/dune
@@ -4,4 +4,4 @@
   (libraries async core webkit_trace_event)
   (synopsis "Basic event tracing")
   (preprocessor_deps "../../config.mlh")
-  (preprocess (pps ppx_optcomp)))
+  (preprocess (pps ppx_coda ppx_optcomp)))

--- a/src/lib/otp_lib/dune
+++ b/src/lib/otp_lib/dune
@@ -3,4 +3,4 @@
   (public_name otp_lib)
   (inline_tests)
   (libraries core_kernel async_kernel pipe_lib)
-  (preprocess (pps ppx_jane)))
+  (preprocess (pps ppx_coda ppx_jane)))

--- a/src/lib/outside_pedersen_image/dune
+++ b/src/lib/outside_pedersen_image/dune
@@ -3,7 +3,7 @@
   (public_name outside_pedersen_image)
   (libraries snark_params)
   (preprocess
-    (pps ppx_jane ppxlib.metaquot)))
+    (pps ppx_coda ppx_jane ppxlib.metaquot)))
 
 (rule
   (targets outside_pedersen_image.ml)

--- a/src/lib/parallel/dune
+++ b/src/lib/parallel/dune
@@ -4,5 +4,5 @@
  (library_flags -linkall)
  (libraries core async rpc_parallel)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq))
+  (pps ppx_coda ppx_jane ppx_deriving.eq))
  (synopsis "Template code to run programs that rely Rpc_parallel.Expert"))

--- a/src/lib/participating_state/dune
+++ b/src/lib/participating_state/dune
@@ -1,4 +1,5 @@
 (library
   (name participating_state)
   (public_name participating_state)
+  (preprocess (pps ppx_coda))
   (libraries core_kernel))

--- a/src/lib/pedersen_lib/dune
+++ b/src/lib/pedersen_lib/dune
@@ -1,5 +1,5 @@
 (library
   (name pedersen_lib)
   (public_name pedersen_lib)
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_deriving_yojson))
   (libraries tuple_lib fold_lib core_kernel))

--- a/src/lib/pedersen_lib/dune
+++ b/src/lib/pedersen_lib/dune
@@ -1,5 +1,5 @@
 (library
   (name pedersen_lib)
   (public_name pedersen_lib)
-  (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
   (libraries tuple_lib fold_lib core_kernel))

--- a/src/lib/perf_histograms/dune
+++ b/src/lib/perf_histograms/dune
@@ -6,6 +6,6 @@
  (inline_tests)
  (libraries coda_metrics core async core_kernel yojson ppx_deriving_yojson.runtime)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
     -conditional))
  (synopsis "Performance monitoring with histograms"))

--- a/src/lib/perf_histograms/dune
+++ b/src/lib/perf_histograms/dune
@@ -6,6 +6,6 @@
  (inline_tests)
  (libraries coda_metrics core async core_kernel yojson ppx_deriving_yojson.runtime)
  (preprocess
-  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
     -conditional))
  (synopsis "Performance monitoring with histograms"))

--- a/src/lib/pipe_lib/dune
+++ b/src/lib/pipe_lib/dune
@@ -3,4 +3,4 @@
   (inline_tests)
   (public_name pipe_lib)
   (libraries core_kernel async o1trace logger)
-  (preprocess (pps ppx_jane ppx_deriving.make)))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.make)))

--- a/src/lib/pokolog/dune
+++ b/src/lib/pokolog/dune
@@ -1,7 +1,7 @@
 (library
   (name pokolog)
   (public_name pokolog)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries
     snarky
     core_kernel ))

--- a/src/lib/pokolog/dune
+++ b/src/lib/pokolog/dune
@@ -1,7 +1,7 @@
 (library
   (name pokolog)
   (public_name pokolog)
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq))
   (libraries
     snarky
     core_kernel ))

--- a/src/lib/ppx_util/dune
+++ b/src/lib/ppx_util/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core ppxlib)
  (preprocess
-  (pps bisect_ppx ppx_jane ppxlib.metaquot ppxlib.runner -- -conditional))
+  (pps ppx_coda bisect_ppx ppx_jane ppxlib.metaquot ppxlib.runner -- -conditional))
  (synopsis "PPX utilities"))

--- a/src/lib/precomputed_values/dune
+++ b/src/lib/precomputed_values/dune
@@ -4,7 +4,7 @@
  (libraries crypto_params dummy_values snarky snark_keys coda_base)
  (ppx_runtime_libraries base)
  (preprocess
-  (pps ppx_jane ppxlib.metaquot ppxlib.runner)))
+  (pps ppx_coda ppx_jane ppxlib.metaquot ppxlib.runner)))
 
 (rule
  (targets precomputed_values.ml)

--- a/src/lib/proposer/dune
+++ b/src/lib/proposer/dune
@@ -9,5 +9,5 @@
    prover transaction_snark_scan_state transition_frontier
    network_pool unix_timestamp otp_lib transition_chain_prover)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Coda block proposer"))

--- a/src/lib/prover/dune
+++ b/src/lib/prover/dune
@@ -3,4 +3,4 @@
   (public_name prover)
   (libraries async core rpc_parallel coda_base coda_state coda_transition blockchain_snark keys_lib precomputed_values child_processes)
   (preprocessor_deps "../../config.mlh")
-  (preprocess (pps ppx_jane)))
+  (preprocess (pps ppx_coda ppx_jane)))

--- a/src/lib/prover/dune
+++ b/src/lib/prover/dune
@@ -3,4 +3,4 @@
   (public_name prover)
   (libraries async core rpc_parallel coda_base coda_state coda_transition blockchain_snark keys_lib precomputed_values child_processes)
   (preprocessor_deps "../../config.mlh")
-  (preprocess (pps ppx_coda ppx_jane)))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane)))

--- a/src/lib/quickcheck_lib/dune
+++ b/src/lib/quickcheck_lib/dune
@@ -3,4 +3,4 @@
   (public_name quickcheck_lib)
   (libraries core_kernel currency rose_tree)
   (inline_tests)
-  (preprocess (pps ppx_jane)))
+  (preprocess (pps ppx_coda ppx_jane)))

--- a/src/lib/rc_pool/dune
+++ b/src/lib/rc_pool/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries snark_params core_kernel)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "A pool for reference-counting large things"))

--- a/src/lib/receipt_chain_database_lib/dune
+++ b/src/lib/receipt_chain_database_lib/dune
@@ -4,6 +4,6 @@
   (library_flags (-linkall))
   (libraries core key_value_database ppx_deriving_yojson.runtime yojson)
   (inline_tests)
-  (preprocess (pps bisect_ppx -conditional ppx_jane ppx_deriving.eq ppx_deriving_yojson ppx_fields_conv))
+  (preprocess (pps ppx_coda bisect_ppx -conditional ppx_jane ppx_deriving.eq ppx_deriving_yojson ppx_fields_conv))
   (synopsis "A library that contains a database that records sent payments for an individual account and generates a proof of a payment.
   Also, the library contains a verifier that proves the correctness of the proof of payments"))

--- a/src/lib/receipt_chain_database_lib/dune
+++ b/src/lib/receipt_chain_database_lib/dune
@@ -4,6 +4,6 @@
   (library_flags (-linkall))
   (libraries core key_value_database ppx_deriving_yojson.runtime yojson)
   (inline_tests)
-  (preprocess (pps ppx_coda bisect_ppx -conditional ppx_jane ppx_deriving.eq ppx_deriving_yojson ppx_fields_conv))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings bisect_ppx -conditional ppx_jane ppx_deriving.eq ppx_deriving_yojson ppx_fields_conv))
   (synopsis "A library that contains a database that records sent payments for an individual account and generates a proof of a payment.
   Also, the library contains a verifier that proves the correctness of the proof of payments"))

--- a/src/lib/rocksdb/dune
+++ b/src/lib/rocksdb/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core rocks key_value_database file_system)
  (preprocess
-  (pps ppx_jane))
+  (pps ppx_coda ppx_jane))
  (synopsis "RocksDB Database module"))

--- a/src/lib/rose_tree/dune
+++ b/src/lib/rose_tree/dune
@@ -2,4 +2,4 @@
   (name rose_tree)
   (public_name rose_tree)
   (libraries core_kernel async_kernel non_empty_list)
-  (preprocess (pps ppx_jane ppx_deriving_yojson)))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving_yojson)))

--- a/src/lib/secrets/dune
+++ b/src/lib/secrets/dune
@@ -6,6 +6,6 @@
  (libraries core async_unix sodium ppx_deriving_yojson.runtime yojson
    coda_base daemon_rpcs)
  (preprocess
-  (pps ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
     -conditional))
  (synopsis "Managing secrets including passwords and keypairs"))

--- a/src/lib/sha256_lib/dune
+++ b/src/lib/sha256_lib/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core coda_digestif snark_params)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "SNARK keys"))

--- a/src/lib/snark_bits/dune
+++ b/src/lib/snark_bits/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries fold_lib core_kernel snarky)
  (preprocess
-  (pps ppx_snarky ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_snarky ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "Snark parameters"))

--- a/src/lib/snark_keys/dune
+++ b/src/lib/snark_keys/dune
@@ -3,7 +3,7 @@
  (public_name snark_keys)
  (libraries async transaction_snark dummy_values blockchain_snark core)
  (preprocess
-  (pps ppx_jane ppxlib.runner ppx_deriving_yojson)))
+  (pps ppx_coda ppx_jane ppxlib.runner ppx_deriving_yojson)))
 
 (rule
  (targets snark_keys.ml)

--- a/src/lib/snark_keys/remove_snark_keys_trigger/dune
+++ b/src/lib/snark_keys/remove_snark_keys_trigger/dune
@@ -2,7 +2,7 @@
  (name remove_snark_keys_trigger)
  ; Remove keys when snarky gets recompiled
  (libraries snarky)
- (preprocess no_preprocessing))
+ (preprocess (pps ppx_coda)))
 
 (rule
  (targets remove_keys_trigger.ml)

--- a/src/lib/snarkette/dune
+++ b/src/lib/snarkette/dune
@@ -3,5 +3,5 @@
   (name snarkette)
   (public_name snarkette)
   (libraries tuple_lib fold_lib num core_kernel )
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_deriving_yojson))
   (js_of_ocaml (flags +nat.js)))

--- a/src/lib/snarkette/dune
+++ b/src/lib/snarkette/dune
@@ -3,5 +3,5 @@
   (name snarkette)
   (public_name snarkette)
   (libraries tuple_lib fold_lib num core_kernel )
-  (preprocess (pps ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
   (js_of_ocaml (flags +nat.js)))

--- a/src/lib/snarky_blake2/dune
+++ b/src/lib/snarky_blake2/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_blake2)
   (public_name snarky_blake2)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     snarky

--- a/src/lib/snarky_curves/dune
+++ b/src/lib/snarky_curves/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_curves)
   (public_name snarky_curves)
-  (preprocess (pps ppx_snarky ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_snarky ppx_jane ppx_deriving.eq))
   (libraries
     snarky_field_extensions
     snarky

--- a/src/lib/snarky_field_extensions/dune
+++ b/src/lib/snarky_field_extensions/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_field_extensions)
   (public_name snarky_field_extensions)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries
     snarky
     snarkette

--- a/src/lib/snarky_group_map/dune
+++ b/src/lib/snarky_group_map/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_group_map)
   (public_name snarky_group_map)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     group_map

--- a/src/lib/snarky_integer/dune
+++ b/src/lib/snarky_integer/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_integer)
   (public_name snarky_integer)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     snarky

--- a/src/lib/snarky_log/dune
+++ b/src/lib/snarky_log/dune
@@ -1,4 +1,5 @@
 (library
  (name snarky_log)
  (public_name snarky_log)
+ (preprocess (pps ppx_coda))
  (libraries yojson snarky webkit_trace_event))

--- a/src/lib/snarky_pairing/dune
+++ b/src/lib/snarky_pairing/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_pairing)
   (public_name snarky_pairing)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries
     sgn_type
     snarky_field_extensions

--- a/src/lib/snarky_taylor/dune
+++ b/src/lib/snarky_taylor/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_taylor)
   (public_name snarky_taylor)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     snarky

--- a/src/lib/snarky_verifier/dune
+++ b/src/lib/snarky_verifier/dune
@@ -1,7 +1,7 @@
 (library
   (name snarky_verifier)
   (public_name snarky_verifier)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries
     sgn_type
     snarky_curves

--- a/src/lib/sponge/dune
+++ b/src/lib/sponge/dune
@@ -1,7 +1,7 @@
 (library
   (name sponge)
   (public_name sponge)
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     core_kernel ))

--- a/src/lib/sponge/dune
+++ b/src/lib/sponge/dune
@@ -1,7 +1,7 @@
 (library
   (name sponge)
   (public_name sponge)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     core_kernel ))

--- a/src/lib/sponge_params/dune
+++ b/src/lib/sponge_params/dune
@@ -1,7 +1,7 @@
 (library
   (name sponge_params)
   (public_name sponge_params)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     curve_choice ))

--- a/src/lib/storage/dune
+++ b/src/lib/storage/dune
@@ -5,5 +5,5 @@
  (library_flags -linkall)
  (libraries core async async_extra logger)
  (preprocess
-  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane bisect_ppx -- -conditional))
  (synopsis "Storage module checksums data and stores it"))

--- a/src/lib/storage/dune
+++ b/src/lib/storage/dune
@@ -5,5 +5,5 @@
  (library_flags -linkall)
  (libraries core async async_extra logger)
  (preprocess
-  (pps ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Storage module checksums data and stores it"))

--- a/src/lib/sync_handler/dune
+++ b/src/lib/sync_handler/dune
@@ -1,5 +1,5 @@
 (library
   (name sync_handler)
   (public_name sync_handler)
-  (preprocess (pps ppx_jane))
+  (preprocess (pps ppx_coda ppx_jane))
   (libraries async_kernel core_kernel coda_intf coda_base transition_frontier syncable_ledger merkle_address consensus best_tip_prover))

--- a/src/lib/test_util/dune
+++ b/src/lib/test_util/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries snark_params fold_lib core_kernel snarky)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "test utils"))

--- a/src/lib/time_simulator/dune
+++ b/src/lib/time_simulator/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries coda_intf)
  (preprocess
-  (pps ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.eq bisect_ppx -- -conditional))
  (synopsis "Time simulator. Time moves faster if nothing is happening."))

--- a/src/lib/transition_chain_prover/dune
+++ b/src/lib/transition_chain_prover/dune
@@ -1,5 +1,5 @@
 (library
   (name transition_chain_prover)
   (public_name transition_chain_prover)
-  (preprocess (pps ppx_jane))
+  (preprocess (pps ppx_coda ppx_jane))
   (libraries core_kernel coda_intf coda_base transition_frontier merkle_list_prover))

--- a/src/lib/transition_chain_verifier/dune
+++ b/src/lib/transition_chain_verifier/dune
@@ -1,5 +1,5 @@
 (library
   (name transition_chain_verifier)
   (public_name transition_chain_verifier)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries core_kernel coda_base coda_state merkle_list_verifier))

--- a/src/lib/transition_frontier_controller/dune
+++ b/src/lib/transition_frontier_controller/dune
@@ -1,4 +1,5 @@
 (library
   (name transition_frontier_controller)
   (public_name transition_frontier_controller)
+  (preprocess (pps ppx_coda))
   (libraries core_kernel consensus coda_intf coda_base syncable_ledger merkle_address merkle_mask sync_handler transition_handler genesis_ledger kademlia coda_networking ledger_catchup))

--- a/src/lib/transition_frontier_persistence/dune
+++ b/src/lib/transition_frontier_persistence/dune
@@ -2,4 +2,4 @@
   (name transition_frontier_persistence)
   (public_name transition_frontier_persistence)
   (libraries coda_base core async rocksdb coda_intf signature_lib consensus storage transition_frontier yojson rpc_parallel)
-  (preprocess (pps ppx_jane ppx_deriving.eq ppx_bin_prot ppx_deriving_yojson)))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_bin_prot ppx_deriving_yojson)))

--- a/src/lib/transition_frontier_persistence/dune
+++ b/src/lib/transition_frontier_persistence/dune
@@ -2,4 +2,4 @@
   (name transition_frontier_persistence)
   (public_name transition_frontier_persistence)
   (libraries coda_base core async rocksdb coda_intf signature_lib consensus storage transition_frontier yojson rpc_parallel)
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_bin_prot ppx_deriving_yojson)))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_bin_prot ppx_deriving_yojson)))

--- a/src/lib/transition_handler/dune
+++ b/src/lib/transition_handler/dune
@@ -2,4 +2,4 @@
   (name transition_handler)
   (public_name transition_handler)
   (libraries coda_metrics perf_histograms core_kernel transition_frontier consensus coda_intf rose_tree pipe_lib otp_lib coda_base cache_lib)
-  (preprocess (pps ppx_jane)))
+  (preprocess (pps ppx_coda ppx_jane)))

--- a/src/lib/transition_router/dune
+++ b/src/lib/transition_router/dune
@@ -1,7 +1,7 @@
 (library
   (name transition_router)
   (public_name transition_router)
-  (preprocess (pps ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries
     core
     async

--- a/src/lib/unix_timestamp/dune
+++ b/src/lib/unix_timestamp/dune
@@ -1,5 +1,6 @@
 (library
  (name unix_timestamp)
  (public_name unix_timestamp)
+ (preprocess (pps ppx_coda))
  (library_flags -linkall)
  (libraries core_kernel))

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -3,4 +3,4 @@
   (public_name verifier)
   (libraries core_kernel async_kernel rpc_parallel coda_base coda_state blockchain_snark snark_keys snark_params ledger_proof logger child_processes)
   (preprocessor_deps "../../config.mlh")
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson)))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -3,4 +3,4 @@
   (public_name verifier)
   (libraries core_kernel async_kernel rpc_parallel coda_base coda_state blockchain_snark snark_keys snark_params ledger_proof logger child_processes)
   (preprocessor_deps "../../config.mlh")
-  (preprocess (pps ppx_jane ppx_deriving.std ppx_deriving_yojson)))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/visualization/dune
+++ b/src/lib/visualization/dune
@@ -2,4 +2,4 @@
   (name visualization)
   (public_name visualization)
   (libraries core async ocamlgraph yojson)
-  (preprocess (pps ppx_jane ppx_deriving_yojson)))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving_yojson)))

--- a/src/lib/vrf_lib/dune
+++ b/src/lib/vrf_lib/dune
@@ -5,7 +5,7 @@
  (library_flags -linkall)
  (libraries core snarky snarky_curves test_util)
  (preprocess
-  (pps ppx_coda ppx_coda ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda -lint-version-syntax-warnings ppx_coda ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
  (modules integrated standalone)
  (synopsis "VRF instantiation"))
 

--- a/src/lib/vrf_lib/dune
+++ b/src/lib/vrf_lib/dune
@@ -5,7 +5,7 @@
  (library_flags -linkall)
  (libraries core snarky snarky_curves test_util)
  (preprocess
-  (pps ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_coda ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
  (modules integrated standalone)
  (synopsis "VRF instantiation"))
 
@@ -17,5 +17,5 @@
  (libraries core snarky snarky_curves test_util signature_lib snark_params
    vrf_lib coda_base random_oracle fold_lib)
  (preprocess
-  (pps ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_coda ppx_jane ppx_bench ppx_deriving.eq bisect_ppx -- -conditional))
  (modules integrated_test))

--- a/src/lib/web_client_pipe/dune
+++ b/src/lib/web_client_pipe/dune
@@ -5,6 +5,6 @@
  (inline_tests)
  (libraries core async pipe_lib logger web_request)
  (preprocess
-  (pps ppx_jane ppx_deriving.std bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane ppx_deriving.std bisect_ppx -- -conditional))
  (synopsis
    "Transforming Coda data such that it can be easy for the Web Client to process"))

--- a/src/lib/web_request/dune
+++ b/src/lib/web_request/dune
@@ -1,5 +1,6 @@
 (library
  (name web_request)
   (public_name web_request)
+  (preprocess (pps ppx_coda))
   (libraries core async)
   (synopsis "Web tools that are used to send put requests"))

--- a/src/lib/webkit_trace_event/dune
+++ b/src/lib/webkit_trace_event/dune
@@ -1,5 +1,6 @@
 (library
  (name webkit_trace_event)
   (public_name webkit_trace_event)
+  (preprocess (pps ppx_coda))
   (libraries core async)
   (synopsis "Binary and JSON output of WebKit trace events"))


### PR DESCRIPTION
The version syntax linter in #3633 only works if `ppx_coda` is used to preprocess a file.

The script in this PR is added to the `lint` step of CI to make sure that every `dune` file contains `ppx_coda` in its list of preprocessors, except for those in `src/external`, `src/lib/snarky`, and, of course, in `src/lib/ppx_coda` (and the `src/_build` directory, if you've already built).

The existing `dune` files have been updated to include `ppx_coda` where they did not already do 
so.

Update: I'll need to build the docker image to install the Python sexplib library. Done.
