### PR TITLE
versioned ppx for Account

### DIFF
--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -287,7 +287,7 @@ module T = struct
 
     let new_block =
       C.create_pipe ~f:new_block_impl ~name:"new_block"
-        ~bin_input:[%bin_type_class: Account.Stable.V1.key]
+        ~bin_input:[%bin_type_class: Account.Key.Stable.V1.t]
         ~bin_output:
           [%bin_type_class:
             ( Auxiliary_database.Filtered_external_transition.Stable.V1.t

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -7,20 +7,16 @@ open Let_syntax
 open Currency
 open Snark_bits
 open Fold_lib
-open Module_version
 
 module Index = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      module T = struct
-        type t = int [@@deriving bin_io, to_yojson, sexp, version]
-      end
+      type t = int [@@deriving bin_io, to_yojson, sexp, version]
 
-      include T
+      let to_latest = Fn.id
     end
-
-    module Latest = V1
-  end
+  end]
 
   type t = Stable.Latest.t [@@deriving to_yojson, sexp]
 
@@ -55,24 +51,19 @@ end
 module Nonce = Account_nonce
 
 module Poly = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      module T = struct
-        type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'state_hash) t =
-          { public_key: 'pk
-          ; balance: 'amount
-          ; nonce: 'nonce
-          ; receipt_chain_hash: 'receipt_chain_hash
-          ; delegate: 'pk
-          ; voting_for: 'state_hash }
-        [@@deriving sexp, bin_io, eq, compare, hash, yojson, version]
-      end
-
-      include T
+      type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'state_hash) t =
+        { public_key: 'pk
+        ; balance: 'amount
+        ; nonce: 'nonce
+        ; receipt_chain_hash: 'receipt_chain_hash
+        ; delegate: 'pk
+        ; voting_for: 'state_hash }
+      [@@deriving sexp, bin_io, eq, compare, hash, yojson, version]
     end
-
-    module Latest = V1
-  end
+  end]
 
   type ('pk, 'amount, 'nonce, 'receipt_chain_hash, 'state_hash) t =
         ( 'pk
@@ -90,49 +81,43 @@ module Poly = struct
   [@@deriving sexp, eq, compare, hash, yojson]
 end
 
-module Stable = struct
-  module V1 = struct
-    module T = struct
-      type key = Public_key.Compressed.Stable.V1.t
+module Key = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = Public_key.Compressed.Stable.V1.t
       [@@deriving sexp, bin_io, eq, hash, compare, yojson]
 
-      type t =
-        ( Public_key.Compressed.Stable.V1.t
-        , Balance.Stable.V1.t
-        , Nonce.Stable.V1.t
-        , Receipt.Chain_hash.Stable.V1.t
-        , State_hash.Stable.V1.t )
-        Poly.Stable.V1.t
-      [@@deriving sexp, bin_io, eq, hash, compare, yojson, version]
+      let to_latest = Fn.id
     end
+  end]
+end
 
-    include T
-    include Registration.Make_latest_version (T)
+type key = Key.Stable.Latest.t [@@deriving sexp, eq, hash, compare, yojson]
+
+[%%versioned
+module Stable = struct
+  module V1 = struct
+    type t =
+      ( Public_key.Compressed.Stable.V1.t
+      , Balance.Stable.V1.t
+      , Nonce.Stable.V1.t
+      , Receipt.Chain_hash.Stable.V1.t
+      , State_hash.Stable.V1.t )
+      Poly.Stable.V1.t
+    [@@deriving sexp, bin_io, eq, hash, compare, yojson, version]
+
+    let to_latest = Fn.id
 
     let public_key (t : t) : key = t.public_key
   end
-
-  (* module version registration *)
-
-  module Latest = V1
-
-  module Module_decl = struct
-    let name = "coda_base_account"
-
-    type latest = Latest.t
-  end
-
-  module Registrar = Registration.Make (Module_decl)
-  module Registered_V1 = Registrar.Register (V1)
-end
+end]
 
 (* bin_io, version omitted *)
 type t = Stable.Latest.t [@@deriving sexp, eq, hash, compare]
 
 [%%define_locally
 Stable.Latest.(public_key)]
-
-type key = Stable.Latest.key [@@deriving sexp, eq, hash, compare, yojson]
 
 type var =
   ( Public_key.Compressed.var

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -12,7 +12,7 @@ module Index = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = int [@@deriving bin_io, to_yojson, sexp, version]
+      type t = int [@@deriving to_yojson, sexp]
 
       let to_latest = Fn.id
     end
@@ -61,7 +61,7 @@ module Poly = struct
         ; receipt_chain_hash: 'receipt_chain_hash
         ; delegate: 'pk
         ; voting_for: 'state_hash }
-      [@@deriving sexp, bin_io, eq, compare, hash, yojson, version]
+      [@@deriving sexp, eq, compare, hash, yojson]
     end
   end]
 
@@ -86,7 +86,7 @@ module Key = struct
   module Stable = struct
     module V1 = struct
       type t = Public_key.Compressed.Stable.V1.t
-      [@@deriving sexp, bin_io, eq, hash, compare, yojson]
+      [@@deriving sexp, eq, hash, compare, yojson]
 
       let to_latest = Fn.id
     end
@@ -105,7 +105,7 @@ module Stable = struct
       , Receipt.Chain_hash.Stable.V1.t
       , State_hash.Stable.V1.t )
       Poly.Stable.V1.t
-    [@@deriving sexp, bin_io, eq, hash, compare, yojson, version]
+    [@@deriving sexp, eq, hash, compare, yojson]
 
     let to_latest = Fn.id
 

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -7,7 +7,7 @@ module Account = struct
   type t = Coda_base.Account.Stable.V1.t
   [@@deriving bin_io, sexp, eq, compare, hash, yojson]
 
-  type key = Coda_base.Account.Stable.V1.key
+  type key = Coda_base.Account.Key.Stable.V1.t
   [@@deriving bin_io, sexp, eq, compare, hash]
 
   (* use Account items needed *)


### PR DESCRIPTION
Use the new `[%%versioned` ppx instead of manual registration of versioned modules.

The type `V1.key` was `bin_io` and should have been versioned, but wasn't, fixed here.

Because registration is done via the ppx, we don't have to import `Module_version`, and we don't need the `T` modules inside `Vn` modules.

First of many such PRs to come.