### PR TITLE
Jemalloc for develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
     build-archive:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
               environment: 
                 CODA_DOCKER: true
                 HASURA_PORT: 8080
@@ -91,7 +91,7 @@ jobs:
                   command: ls && ./scripts/archive/make_hasura_configurations.sh     
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -260,7 +260,7 @@ jobs:
     build-artifacts--testnet_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -309,7 +309,7 @@ jobs:
     test-unit--test_postake_snarkless_unittest:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -347,7 +347,7 @@ jobs:
     test-unit--dev:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -385,7 +385,7 @@ jobs:
     test-unit--dev_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -401,7 +401,7 @@ jobs:
     test--fake_hash:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -415,7 +415,7 @@ jobs:
     test--test_postake:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -432,7 +432,7 @@ jobs:
     test--test_postake_bootstrap:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -449,7 +449,7 @@ jobs:
     test--test_postake_catchup:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -463,7 +463,7 @@ jobs:
     test--test_postake_delegation:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -477,7 +477,7 @@ jobs:
     test--test_postake_five_even_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -491,7 +491,7 @@ jobs:
     test--test_postake_five_even_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -505,7 +505,7 @@ jobs:
     test--test_postake_holy_grail:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -522,7 +522,7 @@ jobs:
     test--test_postake_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -539,7 +539,7 @@ jobs:
     test--test_postake_split:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -553,7 +553,7 @@ jobs:
     test--test_postake_split_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -588,7 +588,7 @@ jobs:
     test--test_postake_three_proposers:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -602,7 +602,7 @@ jobs:
     test--test_postake_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -619,7 +619,7 @@ jobs:
     test--test_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -638,7 +638,7 @@ jobs:
     test--test_postake_snarkless_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -655,7 +655,7 @@ jobs:
     test--test_postake_split_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
 
     build-archive:
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
               environment: 
                 CODA_DOCKER: true
                 HASURA_PORT: 8080
@@ -91,7 +91,7 @@ jobs:
                   command: ls && ./scripts/archive/make_hasura_configurations.sh     
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -262,7 +262,7 @@ jobs:
     build-artifacts--testnet_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -311,7 +311,7 @@ jobs:
     test-unit--test_postake_snarkless_unittest:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -349,7 +349,7 @@ jobs:
     test-unit--dev:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -387,7 +387,7 @@ jobs:
     test-unit--dev_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -403,7 +403,7 @@ jobs:
     test--fake_hash:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -417,7 +417,7 @@ jobs:
     test--test_postake:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -434,7 +434,7 @@ jobs:
     test--test_postake_bootstrap:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -451,7 +451,7 @@ jobs:
     test--test_postake_catchup:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -465,7 +465,7 @@ jobs:
     test--test_postake_delegation:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -479,7 +479,7 @@ jobs:
     test--test_postake_five_even_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -493,7 +493,7 @@ jobs:
     test--test_postake_five_even_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -507,7 +507,7 @@ jobs:
     test--test_postake_holy_grail:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -524,7 +524,7 @@ jobs:
     test--test_postake_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -541,7 +541,7 @@ jobs:
     test--test_postake_split:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -555,7 +555,7 @@ jobs:
     test--test_postake_split_snarkless:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -590,7 +590,7 @@ jobs:
     test--test_postake_three_proposers:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -604,7 +604,7 @@ jobs:
     test--test_postake_txns:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -621,7 +621,7 @@ jobs:
     test--test_postake_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -640,7 +640,7 @@ jobs:
     test--test_postake_snarkless_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -657,7 +657,7 @@ jobs:
     test--test_postake_split_medium_curves:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -61,7 +61,7 @@ jobs:
 
     build-archive:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
               environment: 
                 CODA_DOCKER: true
                 HASURA_PORT: 8080
@@ -91,7 +91,7 @@ jobs:
                   command: ls && ./scripts/archive/make_hasura_configurations.sh     
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -266,7 +266,7 @@ jobs:
         resource_class: large
         {%- endif %}
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -324,7 +324,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -365,7 +365,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -384,7 +384,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:
@@ -403,7 +403,7 @@ jobs:
     test--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+            - image: codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
         steps:
             - checkout
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -61,7 +61,7 @@ jobs:
 
     build-archive:
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
               environment: 
                 CODA_DOCKER: true
                 HASURA_PORT: 8080
@@ -91,7 +91,7 @@ jobs:
                   command: ls && ./scripts/archive/make_hasura_configurations.sh     
     lint:
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -268,7 +268,7 @@ jobs:
         resource_class: large
         {%- endif %}
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -326,7 +326,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -367,7 +367,7 @@ jobs:
     test-unit--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run: ulimit -c unlimited
@@ -386,7 +386,7 @@ jobs:
     test--{{profile}}:
         resource_class: large
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:
@@ -405,7 +405,7 @@ jobs:
     test--{{profile}}:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-FIXME
+            - image: codaprotocol/coda:toolchain-03e9ed5771ebca91003ce50fb246640f3d5ff061
         steps:
             - checkout
             - run:

--- a/README-dev.md
+++ b/README-dev.md
@@ -57,7 +57,7 @@ of the repo.
 
 * Pull down developer container image  (~2GB download, go stretch your legs)
 
-`docker pull codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41`
+`docker pull codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad`
 
 * Create local builder image
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM codaprotocol/coda:toolchain-843753c21e4a97f3d583f1cb251b50135f396d41
+FROM codaprotocol/coda:toolchain-49b82f20eecac055b45df0626d50a2d098b950ad
 
 # same as in Dockerfile-toolchain
 ARG OCAML_VERSION=4.07.1

--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -17,6 +17,7 @@ RUN sudo apt-get update && sudo apt-get install --yes \
     libffi-dev \
     libgmp-dev \
     libgmp3-dev \
+    libjemalloc-dev \
     libprocps-dev \
     libsodium-dev \
     libssl-dev \

--- a/scripts/macos-setup-brew.sh
+++ b/scripts/macos-setup-brew.sh
@@ -3,7 +3,7 @@ set -eu
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-NEEDED_PACKAGES="gpatch opam cmake gmp pkg-config openssl libffi libsodium boost zlib libomp bash"
+NEEDED_PACKAGES="bash boost cmake gmp gpatch jemalloc libffi libomp libsodium opam openssl pkg-config zlib"
 echo "Needed:  ${NEEDED_PACKAGES}"
 
 CURRENT_PACKAGES=$(brew list | xargs)

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -32,7 +32,7 @@ Version: ${VERSION}
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: libssl1.1, libprocps6, libgmp10, libffi6, libgomp1, miniupnpc, coda-discovery
+Depends: coda-kademlia, libffi6, libgmp10, libgomp1, libjemalloc1, libprocps6, libssl1.1, miniupnpc
 License: Apache-2.0
 Homepage: https://codaprotocol.com/
 Maintainer: o(1)Labs <build@o1labs.org>
@@ -116,7 +116,7 @@ Version: ${VERSION}
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: libssl1.1, libprocps6, libgmp10, libffi6, libgomp1, miniupnpc, coda-discovery
+Depends: libssl1.1, libprocps6, libgmp10, libffi6, libgomp1, miniupnpc, coda-kademlia
 License: Apache-2.0
 Homepage: https://codaprotocol.com/
 Maintainer: o(1)Labs <build@o1labs.org>

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -32,7 +32,7 @@ Version: ${VERSION}
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: coda-kademlia, libffi6, libgmp10, libgomp1, libjemalloc1, libprocps6, libssl1.1, miniupnpc
+Depends: coda-discovery, libffi6, libgmp10, libgomp1, libjemalloc1, libprocps6, libssl1.1, miniupnpc
 License: Apache-2.0
 Homepage: https://codaprotocol.com/
 Maintainer: o(1)Labs <build@o1labs.org>
@@ -116,7 +116,7 @@ Version: ${VERSION}
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: libssl1.1, libprocps6, libgmp10, libffi6, libgomp1, miniupnpc, coda-kademlia
+Depends: coda-discovery, libffi6, libgmp10, libgomp1, libjemalloc1, libprocps6, libssl1.1, miniupnpc
 License: Apache-2.0
 Homepage: https://codaprotocol.com/
 Maintainer: o(1)Labs <build@o1labs.org>

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -391,12 +391,12 @@ let daemon logger =
               Jemalloc.get_memory_stats ()
             in
             Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-              "Jemalloc memory statistics"
+              "Jemalloc memory statistics (in bytes)"
               ~metadata:
-                [ ("active", `Int active)
-                ; ("resident", `Int resident)
-                ; ("allocated", `Int allocated)
-                ; ("mapped", `Int mapped) ]
+                [ ("active", `Int (active * 1024))
+                ; ("resident", `Int (resident * 1024))
+                ; ("allocated", `Int (allocated * 1024))
+                ; ("mapped", `Int (mapped * 1024)) ]
           in
           let rec loop () =
             log_stats "before major gc" ;

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -386,7 +386,17 @@ let daemon logger =
                 ; ("heap_chunks", `Int stat.heap_chunks)
                 ; ("max_heap_size", `Int (stat.top_heap_words * bytes_per_word))
                 ; ("live_size", `Int (stat.live_words * bytes_per_word))
-                ; ("live_blocks", `Int stat.live_blocks) ]
+                ; ("live_blocks", `Int stat.live_blocks) ] ;
+            let {Jemalloc.active; resident; allocated; mapped} =
+              Jemalloc.get_memory_stats ()
+            in
+            Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
+              "Jemalloc memory statistics"
+              ~metadata:
+                [ ("active", `Int active)
+                ; ("resident", `Int resident)
+                ; ("allocated", `Int allocated)
+                ; ("mapped", `Int mapped) ]
           in
           let rec loop () =
             log_stats "before major gc" ;

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -3,7 +3,7 @@
   (name coda)
   (public_name coda)
   (modes native)
-  (libraries init tests child_processes)
+  (libraries init tests child_processes jemalloc)
   (preprocessor_deps ../../../config.mlh)
   (preprocess (pps ppx_coda ppx_let ppx_sexp_conv ppx_optcomp))
   (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/dune
+++ b/src/dune
@@ -5,4 +5,4 @@
   (action (copy config/config.mlh config.mlh)))
 
 (env
-  (_ (flags (:standard -short-paths -w @a-4-29-40-41-42-44-45-48-58-59-60))))
+  (_ (flags (:standard -short-paths -cclib -ljemalloc -w @a-4-29-40-41-42-44-45-48-58-59-60))))

--- a/src/lib/coda_metrics/coda_metrics.ml
+++ b/src/lib/coda_metrics/coda_metrics.ml
@@ -131,9 +131,13 @@ module Runtime = struct
 
   let start_time = Core.Time.now ()
 
-  let current = ref (Gc.stat ())
+  let current_gc = ref (Gc.stat ())
 
-  let update () = current := Gc.stat ()
+  let current_jemalloc = ref (Jemalloc.get_memory_stats ())
+
+  let update () =
+    current_gc := Gc.stat () ;
+    current_jemalloc := Jemalloc.get_memory_stats ()
 
   let simple_metric ~metric_type ~help name fn =
     let name = Printf.sprintf "%s_%s_%s" namespace subsystem name in
@@ -150,59 +154,81 @@ module Runtime = struct
 
   let ocaml_gc_major_words =
     simple_metric ~metric_type:Counter "ocaml_gc_major_words"
-      (fun () -> !current.Gc.Stat.major_words)
+      (fun () -> !current_gc.Gc.Stat.major_words)
       ~help:
         "Number of words allocated in the major heap since the program was \
          started."
 
   let ocaml_gc_minor_collections =
     simple_metric ~metric_type:Counter "ocaml_gc_minor_collections"
-      (fun () -> float_of_int !current.Gc.Stat.minor_collections)
+      (fun () -> float_of_int !current_gc.Gc.Stat.minor_collections)
       ~help:
         "Number of minor collection cycles completed since the program was \
          started."
 
   let ocaml_gc_major_collections =
     simple_metric ~metric_type:Counter "ocaml_gc_major_collections"
-      (fun () -> float_of_int !current.Gc.Stat.major_collections)
+      (fun () -> float_of_int !current_gc.Gc.Stat.major_collections)
       ~help:
         "Number of major collection cycles completed since the program was \
          started."
 
   let ocaml_gc_heap_words =
     simple_metric ~metric_type:Gauge "ocaml_gc_heap_words"
-      (fun () -> float_of_int !current.Gc.Stat.heap_words)
+      (fun () -> float_of_int !current_gc.Gc.Stat.heap_words)
       ~help:"Total size of the major heap, in words."
 
   let ocaml_gc_compactions =
     simple_metric ~metric_type:Counter "ocaml_gc_compactions"
-      (fun () -> float_of_int !current.Gc.Stat.compactions)
+      (fun () -> float_of_int !current_gc.Gc.Stat.compactions)
       ~help:"Number of heap compactions since the program was started."
 
   let ocaml_gc_top_heap_words =
     simple_metric ~metric_type:Counter "ocaml_gc_top_heap_words"
-      (fun () -> float_of_int !current.Gc.Stat.top_heap_words)
+      (fun () -> float_of_int !current_gc.Gc.Stat.top_heap_words)
       ~help:"Maximum size reached by the major heap, in words."
 
   let ocaml_gc_live_words =
     simple_metric ~metric_type:Counter "ocaml_gc_live_words"
-      (fun () -> float_of_int !current.Gc.Stat.live_words)
+      (fun () -> float_of_int !current_gc.Gc.Stat.live_words)
       ~help:"Live words allocated by the GC."
 
   let ocaml_gc_free_words =
     simple_metric ~metric_type:Counter "ocaml_gc_free_words"
-      (fun () -> float_of_int !current.Gc.Stat.free_words)
+      (fun () -> float_of_int !current_gc.Gc.Stat.free_words)
       ~help:"Words freed by the GC."
 
   let ocaml_gc_largest_free =
     simple_metric ~metric_type:Counter "ocaml_gc_largest_free"
-      (fun () -> float_of_int !current.Gc.Stat.largest_free)
+      (fun () -> float_of_int !current_gc.Gc.Stat.largest_free)
       ~help:"Size of the largest block freed by the GC."
 
   let ocaml_gc_stack_size =
     simple_metric ~metric_type:Counter "ocaml_gc_stack_size"
-      (fun () -> float_of_int !current.Gc.Stat.stack_size)
+      (fun () -> float_of_int !current_gc.Gc.Stat.stack_size)
       ~help:"Current stack size."
+
+  let jemalloc_active_bytes =
+    simple_metric ~metric_type:Gauge "jemalloc_active_bytes"
+      (fun () -> float_of_int @@ (1024 * !current_jemalloc.active))
+      ~help:"active memory in bytes"
+
+  let jemalloc_resident_bytes =
+    simple_metric ~metric_type:Gauge "jemalloc_resident_bytes"
+      (fun () -> float_of_int @@ (1024 * !current_jemalloc.resident))
+      ~help:
+        "resident memory in bytes (may be zero depending on jemalloc compile \
+         options)"
+
+  let jemalloc_allocated_bytes =
+    simple_metric ~metric_type:Gauge "jemalloc_allocated_bytes"
+      (fun () -> float_of_int @@ (1024 * !current_jemalloc.allocated))
+      ~help:"memory allocated to heap objects in bytes"
+
+  let jemalloc_mapped_bytes =
+    simple_metric ~metric_type:Gauge "jemalloc_mapped_bytes"
+      (fun () -> float_of_int @@ (1024 * !current_jemalloc.mapped))
+      ~help:"memory mapped into process address space in bytes"
 
   let process_cpu_seconds_total =
     simple_metric ~metric_type:Counter "process_cpu_seconds_total" Sys.time
@@ -226,6 +252,10 @@ module Runtime = struct
     ; ocaml_gc_free_words
     ; ocaml_gc_largest_free
     ; ocaml_gc_stack_size
+    ; jemalloc_active_bytes
+    ; jemalloc_resident_bytes
+    ; jemalloc_allocated_bytes
+    ; jemalloc_mapped_bytes
     ; process_cpu_seconds_total
     ; process_uptime_ms_total ]
 

--- a/src/lib/coda_metrics/dune
+++ b/src/lib/coda_metrics/dune
@@ -1,5 +1,5 @@
 (library
   (name coda_metrics)
   (public_name coda_metrics)
-  (libraries async prometheus cohttp cohttp-async logger)
+  (libraries async cohttp cohttp-async logger jemalloc prometheus)
   (preprocess (pps ppx_jane)))

--- a/src/opam.export
+++ b/src/opam.export
@@ -102,6 +102,7 @@ installed: [
   "integers.0.2.2"
   "ipaddr.3.1.0"
   "jane-street-headers.v0.12.0"
+  "jemalloc.0.2"
   "jbuilder.transition"
   "js_of_ocaml.3.3.0"
   "js_of_ocaml-compiler.3.3.0"


### PR DESCRIPTION
Use Jemalloc in place of glibc malloc and collect stats from it. This improves overall memory use by a lot: the proportional set size is 3.4gb on my test machine with 3h19m uptime, while a node on seared-kobe with 3h11m of uptime is using 5.3gb. It also makes the program less leaky over time, due to reduced heap fragmentation. It may or may not still leak, it's been hard to keep a node up for long enough to tell a clear trend.