### PR TITLE
Versioned ppx in Priced_proof

### DIFF
--- a/src/lib/network_pool/priced_proof.ml
+++ b/src/lib/network_pool/priced_proof.ml
@@ -1,17 +1,13 @@
+open Core_kernel
 open Coda_base
 
+[%%versioned
 module Stable = struct
   module V1 = struct
-    module T = struct
-      type 'proof t = {proof: 'proof; fee: Fee_with_prover.Stable.V1.t}
-      [@@deriving bin_io, compare, fields, sexp, version, yojson]
-    end
-
-    include T
+    type 'proof t = {proof: 'proof; fee: Fee_with_prover.Stable.V1.t}
+    [@@deriving compare, fields, sexp, yojson]
   end
-
-  module Latest = V1
-end
+end]
 
 type 'proof t = 'proof Stable.Latest.t =
   {proof: 'proof; fee: Fee_with_prover.Stable.V1.t}


### PR DESCRIPTION
`%%versioned` in `Priced_proof`.

There are other versioned modules in `Network_pool`, but they're in functors, and so should be hoisted out, before we apply the ppx.