### PR TITLE
Enable the wallet to build on linux

### DIFF
--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -69,7 +69,7 @@
       "bundle/**/*",
       "public/**/*"
     ],
-    "productName": "Coda Wallet",
+    "productName": "CodaWallet",
     "compression": "store",
     "dmg": {
       "contents": [
@@ -86,6 +86,7 @@
       ]
     },
     "linux": {
+      "executableName": "coda-wallet",
       "target": [
         "AppImage"
       ]

--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -87,8 +87,7 @@
     },
     "linux": {
       "target": [
-        "AppImage",
-        "deb"
+        "AppImage"
       ]
     },
     "win": {

--- a/frontend/wallet/src/main/DaemonProcess.re
+++ b/frontend/wallet/src/main/DaemonProcess.re
@@ -142,17 +142,7 @@ module CodaProcess = {
       switch (Js.Dict.get(ChildProcess.Process.env, "GRAPHQL_BACKEND")) {
       | Some("faker") => Process.start(fakerCommand(~port))
       | _ =>
-        /* Workaround for https://github.com/CodaProtocol/coda/issues/2667
-           Remove the config deletion when it is resolved.  */
-        let transitionFrontierPath =
-          ProjectRoot.resource ^/ codaPath ^/ "config/transition_frontier";
-
-        Printf.fprintf(stderr, "Deleting %s\n%!", transitionFrontierPath);
-        Bindings.ChildProcess.execSync(
-          "rm",
-          [|"-rf", transitionFrontierPath|],
-        );
-        Process.start(codaCommand(~port, ~extraArgs=args |> Array.fromList));
+        Process.start(codaCommand(~port, ~extraArgs=args |> Array.fromList))
       };
     };
 };

--- a/frontend/wallet/src/main/DaemonProcess.re
+++ b/frontend/wallet/src/main/DaemonProcess.re
@@ -24,7 +24,7 @@ let codaCommand = (~port, ~extraArgs) => {
           "-rest-port",
           Js.Int.toString(port),
           "-config-directory",
-          ProjectRoot.resource ^/ codaPath ^/ "config",
+          ProjectRoot.userData ^/ "coda" ^/ "config",
         |],
       ),
     env: ChildProcess.Process.env,
@@ -46,7 +46,7 @@ let fakerCommand = (~port) => {
   env: ChildProcess.Process.env,
 };
 
-[@bs.module "os"] external tmpdir : unit => string = "";
+[@bs.module "os"] external tmpdir: unit => string = "";
 
 module Process = {
   let start = (command: Command.t) => {

--- a/frontend/wallet/src/render/Theme.re
+++ b/frontend/wallet/src/render/Theme.re
@@ -20,7 +20,8 @@ module Colors = {
 
   let bgColor = white;
 
-  let bgColorElectronWindow = "#00E9E9E9";
+  // Linux doesn't support transparency
+  let bgColorElectronWindow = "#FFE9E9E9";
 
   let savilleAlpha = a => `rgba((61, 88, 120, a));
   let saville = savilleAlpha(1.);


### PR DESCRIPTION
AppImage building successfully on ubuntu and running against apt-get daemon.
Not building deb for now. Had to change the coda-config dir as appimage mounts are read-only.

Tested on ubuntu and arch with at least moderate success.

Future work: Built the appimage in CI.