### PR TITLE
Fix metadata.peer in trust to differentiate from communications

### DIFF
--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -117,7 +117,7 @@ struct
       in
       Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
         ~metadata:([("peer_id", Peer_id.to_yojson peer)] @ action_metadata)
-        "%s trust for peer $peer due to action %s. New trust is %f." verb
+        "%s trust for peer $peer_id due to %s. New trust is %f." verb
         action_fmt simple_new.trust
     in
     let%map () =
@@ -131,7 +131,7 @@ struct
                   , `String (Time.to_string_abs expiration ~zone:Time.Zone.utc)
                   ) ]
               @ action_metadata )
-            "Banning peer $peer until $expiration because it %s" action_fmt ;
+            "Banning peer $peer_id until $expiration due to %s" action_fmt ;
           if Option.is_some db then (
             Coda_metrics.Gauge.inc_one Coda_metrics.Trust_system.banned_peers ;
             Strict_pipe.Writer.write bans_writer (peer, expiration) )

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -116,7 +116,7 @@ struct
         else "Decreasing"
       in
       Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-        ~metadata:([("peer_ip", Peer_id.to_yojson peer)] @ action_metadata)
+        ~metadata:([("peer_id", Peer_id.to_yojson peer)] @ action_metadata)
         "%s trust for peer $peer due to action %s. New trust is %f." verb
         action_fmt simple_new.trust
     in
@@ -126,7 +126,7 @@ struct
           Logger.faulty_peer_without_punishment logger ~module_:__MODULE__
             ~location:__LOC__
             ~metadata:
-              ( [ ("peer_ip", Peer_id.to_yojson peer)
+              ( [ ("peer_id", Peer_id.to_yojson peer)
                 ; ( "expiration"
                   , `String (Time.to_string_abs expiration ~zone:Time.Zone.utc)
                   ) ]

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -116,7 +116,7 @@ struct
         else "Decreasing"
       in
       Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-        ~metadata:([("peer", Peer_id.to_yojson peer)] @ action_metadata)
+        ~metadata:([("peer_ip", Peer_id.to_yojson peer)] @ action_metadata)
         "%s trust for peer $peer due to action %s. New trust is %f." verb
         action_fmt simple_new.trust
     in
@@ -126,7 +126,7 @@ struct
           Logger.faulty_peer_without_punishment logger ~module_:__MODULE__
             ~location:__LOC__
             ~metadata:
-              ( [ ("peer", Peer_id.to_yojson peer)
+              ( [ ("peer_ip", Peer_id.to_yojson peer)
                 ; ( "expiration"
                   , `String (Time.to_string_abs expiration ~zone:Time.Zone.utc)
                   ) ]


### PR DESCRIPTION
Closes #3418 

In trust layer peers are only known by IP.
In communications peers are known by IP and other metadata (gossip and discovery ports).

This change adjusts how trust layer describes bans to use a new metadata keyword peer_id, which is more usable in this context and doesn't overload the other representation of peer used by other parts of the code.