### PR TITLE
Hotfix/friday feedback

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -167,7 +167,7 @@ let daemon logger =
      and disable_libp2p =
        flag "disable-libp2p-discovery" no_arg ~doc:"Disable libp2p discovery"
      and discovery_port =
-       flag "discoery-port" (optional int)
+       flag "discovery-port" (optional int)
          ~doc:"PORT Port to use for peer-to-peer discovery (default: 28675)"
      and enable_old_discovery =
        flag "enable-old-discovery" no_arg

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -164,20 +164,20 @@ let daemon logger =
            "true|false Log transaction-pool diff received from peers \
             (default: false)"
          (optional bool)
-     and enable_libp2p =
-       flag "libp2p-discovery" no_arg ~doc:"Use libp2p for peer discovery"
-     and libp2p_port =
-       flag "libp2p-port" (optional int)
-         ~doc:"PORT Port to use for libp2p (default: 28675)"
-     and disable_haskell =
-       flag "disable-old-discovery" no_arg
-         ~doc:"Disable the old discovery mechanism"
+     and disable_libp2p =
+       flag "disable-libp2p-discovery" no_arg ~doc:"Disable libp2p discovery"
+     and discovery_port =
+       flag "discoery-port" (optional int)
+         ~doc:"PORT Port to use for peer-to-peer discovery (default: 28675)"
+     and enable_old_discovery =
+       flag "enable-old-discovery" no_arg
+         ~doc:"Enable the old Haskell Kademlia discovery"
      and libp2p_keypair =
-       flag "libp2p-keypair" (optional string)
+       flag "discovery-keypair" (optional string)
          ~doc:
-           "KEYPAIR Keypair (generated from `coda advanced \
-            generate-libp2p-keypair`) to use with libp2p (default: generate \
-            new keypair)"
+           "PUBKEY,PRIVKEY,PEERID Keypair (generated from `coda advanced \
+            generate-libp2p-keypair`) to use with libp2p discovery (default: \
+            generate new temporary keypair)"
      and libp2p_peers_raw =
        flag "peer"
          ~doc:
@@ -472,9 +472,9 @@ let daemon logger =
            or_from_config YJ.Util.to_int_option "rest-port"
              ~default:Port.default_rest rest_server_port
          in
-         let libp2p_port =
-           or_from_config YJ.Util.to_int_option "libp2p-port"
-             ~default:Port.default_libp2p libp2p_port
+         let discovery_port =
+           or_from_config YJ.Util.to_int_option "discovery-port"
+             ~default:Port.default_discovery discovery_port
          in
          let snark_work_fee_flag =
            let json_to_currency_fee_option json =
@@ -529,7 +529,7 @@ let daemon logger =
                        (YJ.Util.convert_each YJ.Util.to_string))
                     "peers" None ~default:[] ]
          in
-         let discovery_port = external_port + 1 in
+         let old_discovery_port = external_port + 1 in
          if enable_tracing then Coda_tracing.start conf_dir |> don't_wait_for ;
          let%bind initial_peers_cleaned_lists =
            (* for each provided peer, lookup all its addresses *)
@@ -583,10 +583,10 @@ let daemon logger =
          let addrs_and_ports : Kademlia.Node_addrs_and_ports.t =
            { external_ip
            ; bind_ip
-           ; discovery_port
+           ; discovery_port= old_discovery_port
            ; communication_port= external_port
            ; client_port
-           ; libp2p_port }
+           ; libp2p_port= discovery_port }
          in
          let%bind propose_keypair =
            match propose_key with
@@ -672,8 +672,8 @@ let daemon logger =
                ; addrs_and_ports
                ; trust_system
                ; log_gossip_heard
-               ; enable_libp2p
-               ; disable_haskell
+               ; enable_libp2p= not disable_libp2p
+               ; disable_haskell= not enable_old_discovery
                ; libp2p_keypair
                ; libp2p_peers=
                    List.map ~f:Coda_net2.Multiaddr.of_string libp2p_peers_raw

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -20,13 +20,12 @@ let net_configs n =
         let discovery_port = base + 1 in
         let libp2p_port = base + 2 in
         let client_port = 20000 + i in
-        Kademlia.Node_addrs_and_ports.
-          { external_ip= ip
-          ; bind_ip= ip
-          ; discovery_port
-          ; communication_port
-          ; libp2p_port
-          ; client_port } )
+        { Kademlia.Node_addrs_and_ports.external_ip= ip
+        ; bind_ip= ip
+        ; discovery_port
+        ; communication_port
+        ; libp2p_port
+        ; client_port } )
   in
   let all_peers =
     List.map addrs_and_ports_list

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -66,16 +66,13 @@ func MakeHelper(ctx context.Context, listenOn []ma.Multiaddr, externalAddr ma.Mu
 	logger := logging.Logger("codanet.Helper")
 	dso := dsb.DefaultOptions
 
-	bp := path.Join(statedir, strconv.Itoa(os.Getpid()))
-	os.MkdirAll(bp, 0700)
-
-	ds, err := dsb.NewDatastore(path.Join(statedir, strconv.Itoa(os.Getpid()), "libp2p-peerstore-v0"), &dso)
+	ds, err := dsb.NewDatastore(path.Join(statedir, "libp2p-peerstore-v0"), &dso)
 	if err != nil {
 		return nil, err
 	}
 
 	dsoDht := dsb.DefaultOptions
-	dsDht, err := dsb.NewDatastore(path.Join(statedir, strconv.Itoa(os.Getpid()), "libp2p-dht-v0"), &dsoDht)
+	dsDht, err := dsb.NewDatastore(path.Join(statedir, "libp2p-dht-v0"), &dsoDht)
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/libp2p_helper/src/gen_keys/libp2p_priv_to_pub.go
+++ b/src/app/libp2p_helper/src/gen_keys/libp2p_priv_to_pub.go
@@ -1,0 +1,27 @@
+package main
+import (
+        crypto "github.com/libp2p/go-libp2p-crypto"
+        b58 "github.com/mr-tron/base58/base58"
+        "os"
+    )
+
+func main() {
+    if len(os.Args) != 2 {
+        println("usage: libp2p-priv-to-pub PRIVKEY_BASE58_STRING");
+    }
+    privk_enc := os.Args[1]
+    privk_raw, err := b58.Decode(privk_enc)
+    if err != nil { panic(err); }
+
+    priv, err := crypto.UnmarshalPrivateKey(privk_raw)
+    if err != nil { panic(err); }
+
+    pub := priv.GetPublic()
+
+    pubk_raw, err := crypto.MarshalPublicKey(pub)
+    if err != nil { panic(err); }
+
+    pubk_enc := b58.Encode(pubk_raw)
+
+    println(pubk_enc)
+}

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -415,6 +415,10 @@ let get_status ~flag t =
         Coda_lib.net t |> Coda_networking.net2 >>= Coda_net2.me
         >>| Coda_net2.Keypair.to_peerid >>| Coda_net2.PeerID.to_string)
   in
+  let addrs_and_ports =
+    Kademlia.Node_addrs_and_ports.to_display
+      (Coda_lib.config t).net_config.gossip_net_params.addrs_and_ports
+  in
   { Daemon_rpcs.Types.Status.num_accounts
   ; sync_status
   ; blockchain_length
@@ -437,7 +441,8 @@ let get_status ~flag t =
   ; consensus_time_now
   ; consensus_mechanism
   ; consensus_configuration
-  ; libp2p_peer_id }
+  ; libp2p_peer_id
+  ; addrs_and_ports }
 
 let clear_hist_status ~flag t = Perf_histograms.wipe () ; get_status ~flag t
 

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -409,6 +409,12 @@ let get_status ~flag t =
       | `Check_again time ->
           sprintf "None this epoch… checking at %s" (str time) )
   in
+  let libp2p_peer_id =
+    Option.value ~default:"<not connected to libp2p>"
+      Option.(
+        Coda_lib.net t |> Coda_networking.net2 >>= Coda_net2.me
+        >>| Coda_net2.Keypair.to_peerid >>| Coda_net2.PeerID.to_string)
+  in
   { Daemon_rpcs.Types.Status.num_accounts
   ; sync_status
   ; blockchain_length
@@ -430,7 +436,8 @@ let get_status ~flag t =
   ; next_proposal
   ; consensus_time_now
   ; consensus_mechanism
-  ; consensus_configuration }
+  ; consensus_configuration
+  ; libp2p_peer_id }
 
 let clear_hist_status ~flag t = Perf_histograms.wipe () ; get_status ~flag t
 

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -221,6 +221,16 @@ module Types = struct
                ~slot_duration:nn_int ~epoch_duration:nn_int
                ~acceptable_network_delay:nn_int )
 
+    let addrs_and_ports :
+        (_, Kademlia.Node_addrs_and_ports.Display.Stable.V1.t option) typ =
+      obj "AddrsAndPorts" ~fields:(fun _ ->
+          let open Reflection.Shorthand in
+          List.rev
+          @@ Kademlia.Node_addrs_and_ports.Display.Stable.V1.Fields.fold
+               ~init:[] ~external_ip:nn_string ~bind_ip:nn_string
+               ~discovery_port:nn_int ~client_port:nn_int ~libp2p_port:nn_int
+               ~communication_port:nn_int )
+
     let t : (_, Daemon_rpcs.Types.Status.t option) typ =
       obj "DaemonStatus" ~fields:(fun _ ->
           let open Reflection.Shorthand in
@@ -237,6 +247,7 @@ module Types = struct
                  (id ~typ:Schema.(non_null @@ list (non_null string)))
                ~histograms:(id ~typ:histograms) ~consensus_time_best_tip:string
                ~consensus_time_now:nn_string ~consensus_mechanism:nn_string
+               ~addrs_and_ports:(id ~typ:(non_null addrs_and_ports))
                ~libp2p_peer_id:nn_string
                ~consensus_configuration:
                  (id ~typ:(non_null consensus_configuration))

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -237,6 +237,7 @@ module Types = struct
                  (id ~typ:Schema.(non_null @@ list (non_null string)))
                ~histograms:(id ~typ:histograms) ~consensus_time_best_tip:string
                ~consensus_time_now:nn_string ~consensus_mechanism:nn_string
+               ~libp2p_peer_id:nn_string
                ~consensus_configuration:
                  (id ~typ:(non_null consensus_configuration))
                ~highest_block_length_received:nn_int )

--- a/src/lib/coda_intf/network_intf.ml
+++ b/src/lib/coda_intf/network_intf.ml
@@ -109,6 +109,8 @@ module type Network_intf = sig
 
   val banned_until : ban_notification -> Time.t
 
+  val net2 : t -> Coda_net2.net option
+
   module Gossip_net : sig
     module Config : Gossip_net.Config_intf
   end

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -719,17 +719,30 @@ module Keypair = struct
   let secret_key_base58 {secret; _} = to_b58_data secret
 
   let to_string {secret; public; peer_id} =
-    String.concat ~sep:";" [to_b58_data secret; to_b58_data public; peer_id]
+    String.concat ~sep:"," [to_b58_data secret; to_b58_data public; peer_id]
 
   let of_string s =
-    match String.split s ~on:';' with
-    | [secret_b58; public_b58; peer_id] ->
-        let open Or_error.Let_syntax in
-        let%map secret = of_b58_data (`String secret_b58)
-        and public = of_b58_data (`String public_b58) in
-        {secret; public; peer_id}
-    | _ ->
-        Or_error.errorf "%s is not a valid Keypair.to_string output" s
+    let with_semicolon =
+      match String.split s ~on:';' with
+      | [secret_b58; public_b58; peer_id] ->
+          let open Or_error.Let_syntax in
+          let%map secret = of_b58_data (`String secret_b58)
+          and public = of_b58_data (`String public_b58) in
+          {secret; public; peer_id}
+      | _ ->
+          Or_error.errorf "%s is not a valid Keypair.to_string output" s
+    in
+    let with_comma =
+      match String.split s ~on:',' with
+      | [secret_b58; public_b58; peer_id] ->
+          let open Or_error.Let_syntax in
+          let%map secret = of_b58_data (`String secret_b58)
+          and public = of_b58_data (`String public_b58) in
+          {secret; public; peer_id}
+      | _ ->
+          Or_error.errorf "%s is not a valid Keypair.to_string output" s
+    in
+    if Or_error.is_error with_semicolon then with_comma else with_semicolon
 
   let to_peerid {peer_id; _} = peer_id
 end

--- a/src/lib/coda_net2/coda_net2.mli
+++ b/src/lib/coda_net2/coda_net2.mli
@@ -60,7 +60,7 @@ module Keypair : sig
   (** Securely generate a new keypair. *)
   val random : net -> t Deferred.t
 
-  (** Formats this keypair to a ;-separated list of public key, secret key, and peer_id. *)
+  (** Formats this keypair to a comma-separated list of public key, secret key, and peer_id. *)
   val to_string : t -> string
 
   (** Undo [to_string t].
@@ -81,7 +81,7 @@ end
   Some example multiaddrs:
 
   - [/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC]
-  - [/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234]
+  - [/ip4/127.0.0.1/tcp/1234/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC]
   - [/ip6/2601:9:4f81:9700:803e:ca65:66e8:c21]
  *)
 module Multiaddr : sig

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -555,6 +555,8 @@ module Make (Inputs : Inputs_intf) = struct
     let sender = Envelope.Sender.Remote inet_addr in
     Envelope.Incoming.wrap ~data ~sender
 
+  let net2 t = Gossip_net.net2 t.gossip_net
+
   let create (config : Config.t)
       ~(get_staged_ledger_aux_and_pending_coinbases_at_hash :
             State_hash.t Envelope.Incoming.t

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -250,6 +250,8 @@ module Types = struct
           |> digest_entries ~title:""
         in
         map_entry "Consensus configuration" ~f:render
+
+      let libp2p_peer_id = string_entry "Libp2p PeerID"
     end
 
     type t =
@@ -272,7 +274,8 @@ module Types = struct
       ; next_proposal: string option
       ; consensus_time_now: string
       ; consensus_mechanism: string
-      ; consensus_configuration: Consensus.Configuration.t }
+      ; consensus_configuration: Consensus.Configuration.t
+      ; libp2p_peer_id: string }
     [@@deriving to_yojson, bin_io, fields]
 
     let entries (s : t) =
@@ -287,7 +290,7 @@ module Types = struct
         ~state_hash ~commit_id ~conf_dir ~peers ~user_commands_sent
         ~snark_worker ~propose_pubkeys ~histograms ~consensus_time_best_tip
         ~consensus_time_now ~consensus_mechanism ~consensus_configuration
-        ~next_proposal ~snark_work_fee
+        ~next_proposal ~snark_work_fee ~libp2p_peer_id
       |> List.filter_map ~f:Fn.id
 
     let to_text (t : t) =

--- a/src/lib/daemon_rpcs/daemon_rpcs.ml
+++ b/src/lib/daemon_rpcs/daemon_rpcs.ml
@@ -251,6 +251,21 @@ module Types = struct
         in
         map_entry "Consensus configuration" ~f:render
 
+      let addrs_and_ports =
+        let render conf =
+          let fmt_field name op field = (name, op (Field.get field conf)) in
+          Kademlia.Node_addrs_and_ports.Display.Stable.V1.Fields.to_list
+            ~external_ip:(fmt_field "External IP" Fn.id)
+            ~bind_ip:(fmt_field "Bind IP" Fn.id)
+            ~discovery_port:(fmt_field "Haskell Kademlia port" string_of_int)
+            ~client_port:(fmt_field "Client port" string_of_int)
+            ~libp2p_port:(fmt_field "Discovery (libp2p) port" string_of_int)
+            ~communication_port:(fmt_field "External port" string_of_int)
+          |> List.map ~f:(fun (s, v) -> ("\t" ^ s, v))
+          |> digest_entries ~title:""
+        in
+        map_entry "Addresses and ports" ~f:render
+
       let libp2p_peer_id = string_entry "Libp2p PeerID"
     end
 
@@ -275,6 +290,7 @@ module Types = struct
       ; consensus_time_now: string
       ; consensus_mechanism: string
       ; consensus_configuration: Consensus.Configuration.t
+      ; addrs_and_ports: Kademlia.Node_addrs_and_ports.Display.Stable.V1.t
       ; libp2p_peer_id: string }
     [@@deriving to_yojson, bin_io, fields]
 
@@ -290,7 +306,7 @@ module Types = struct
         ~state_hash ~commit_id ~conf_dir ~peers ~user_commands_sent
         ~snark_worker ~propose_pubkeys ~histograms ~consensus_time_best_tip
         ~consensus_time_now ~consensus_mechanism ~consensus_configuration
-        ~next_proposal ~snark_work_fee ~libp2p_peer_id
+        ~next_proposal ~snark_work_fee ~addrs_and_ports ~libp2p_peer_id
       |> List.filter_map ~f:Fn.id
 
     let to_text (t : t) =

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -134,6 +134,8 @@ module type S = sig
   val high_connectivity_signal : t -> unit Ivar.t
 
   val peers_by_ip : t -> Unix.Inet_addr.t -> Peer.t list
+
+  val net2 : t -> Coda_net2.net option
 end
 
 module Make (Message : Message_intf) : S with type msg := Message.msg = struct
@@ -503,6 +505,8 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
   let send_ban_notification t banned_peer banned_until =
     Linear_pipe.write_without_pushback t.ban_notification_writer
       {banned_peer; banned_until}
+
+  let net2 t = t.libp2p_membership
 
   let create (config : Config.t)
       (implementation_list : Host_and_port.t Rpc.Implementation.t list) =

--- a/src/lib/gossip_net/gossip_net.ml
+++ b/src/lib/gossip_net/gossip_net.ml
@@ -151,7 +151,7 @@ module Make (Message : Message_intf) : S with type msg := Message.msg = struct
 
     let add {set; high_connectivity_signal} value =
       Hash_set.add set value ;
-      if Hash_set.length set >= 8 then
+      if Hash_set.length set >= 4 then
         Ivar.fill_if_empty high_connectivity_signal ()
 
     let remove {set; _} value = Hash_set.remove set value

--- a/src/lib/kademlia/dune
+++ b/src/lib/kademlia/dune
@@ -7,5 +7,5 @@
  (libraries core logger pipe_lib async async_extra file_system
    network_peer trust_system ctypes ctypes.foreign)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Kademlia DHT -- only being used for its membership"))

--- a/src/lib/kademlia/node_addrs_and_ports.ml
+++ b/src/lib/kademlia/node_addrs_and_ports.ml
@@ -8,7 +8,33 @@ type t =
   ; client_port: int
   ; libp2p_port: int
   ; communication_port: int }
-[@@deriving bin_io]
+[@@deriving bin_io, fields]
+
+module Display = struct
+  module Stable = struct
+    module V1 = struct
+      type t =
+        { external_ip: string
+        ; bind_ip: string
+        ; discovery_port: int
+        ; client_port: int
+        ; libp2p_port: int
+        ; communication_port: int }
+      [@@deriving fields, yojson, bin_io]
+    end
+  end
+end
+
+let to_display (t : t) =
+  Display.Stable.V1.
+    { external_ip= Unix.Inet_addr.to_string t.external_ip
+    ; bind_ip= Unix.Inet_addr.to_string t.bind_ip
+    ; discovery_port= t.discovery_port
+    ; client_port= t.client_port
+    ; libp2p_port= t.libp2p_port
+    ; communication_port= t.communication_port }
+
+let to_yojson = Fn.compose Display.Stable.V1.to_yojson to_display
 
 let to_peer : t -> Peer.t = function
   | {external_ip; discovery_port; communication_port; _} ->

--- a/src/lib/transition_frontier_controller_tests/stubs.ml
+++ b/src/lib/transition_frontier_controller_tests/stubs.ml
@@ -666,6 +666,8 @@ struct
     let transaction_pool_diffs _ = failwith "stub"
 
     let snark_pool_diffs _ = failwith "stub"
+
+    let net2 _ = None
   end
 
   module Network_builder = struct

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -97,7 +97,7 @@ module Make (Inputs : Inputs_intf) = struct
     trace_recurring "bootstrap controller" (fun () ->
         upon
           (let%bind () =
-             let connectivity_time_uppperbound = 15.0 in
+             let connectivity_time_uppperbound = 60.0 in
              let high_connectivity_deferred =
                Ivar.read (Network.high_connectivity network)
              in
@@ -109,7 +109,7 @@ module Make (Inputs : Inputs_intf) = struct
                  then
                    Logger.info logger
                      !"Will start bootstrapping without connecting with too \
-                       many peers"
+                       many peers ($num_peers connected)"
                      ~metadata:
                        [ ( "num peers"
                          , `Int (List.length @@ Network.peers network) )


### PR DESCRIPTION
CLI changes:

    -discovery-port for the libp2p port
    -discovery-keypair instead of -libp2p-keypair (generate command doesn't change)
    -disable-libp2p-discovery to turn it off
    -enable-old-discovery to turn that back on

Discovery keypairs are now comma-separated. It will continue to accept
both syntaxes but the semicolon one is prone to errors in shell scripts
and was definitely a mistake.

libp2p helper state is now persistent. It should remember at least the IP<->pubkey mapping. [Routing table persistence](https://github.com/libp2p/go-libp2p-kad-dht/pull/383) in their DHT is a WIP.

libp2p peer ID is included in status commands + graphql.

the high connectivity watermark is 4 peers instead of 8. additionally we wait up to 60 seconds for that instead of 15. 