### PR TITLE
Functored the inputs for Key-value database

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -616,7 +616,7 @@ let daemon logger =
          let transition_frontier_location =
            conf_dir ^/ "transition_frontier"
          in
-         let trust_system = Trust_system.create ~db_dir:trust_dir in
+         let trust_system = Trust_system.create trust_dir in
          trace_database_initialization "trust_system" __LOC__ trust_dir ;
          let time_controller =
            Block_time.Controller.create @@ Block_time.Controller.basic ~logger
@@ -658,7 +658,7 @@ let daemon logger =
          let receipt_chain_dir_name = conf_dir ^/ "receipt_chain" in
          let%bind () = Async.Unix.mkdir ~p:() receipt_chain_dir_name in
          let receipt_chain_database =
-           Receipt_chain_database.create ~directory:receipt_chain_dir_name
+           Receipt_chain_database.create receipt_chain_dir_name
          in
          trace_database_initialization "receipt_chain_database" __LOC__
            receipt_chain_dir_name ;

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -424,11 +424,11 @@ module T = struct
               ~location typ
           in
           let receipt_chain_database =
-            Receipt_chain_database.create ~directory:receipt_chain_dir_name
+            Receipt_chain_database.create receipt_chain_dir_name
           in
           trace_database_initialization "receipt_chain_database" __LOC__
             receipt_chain_dir_name ;
-          let trust_system = Trust_system.create ~db_dir:trust_dir in
+          let trust_system = Trust_system.create trust_dir in
           trace_database_initialization "trust_system" __LOC__ trust_dir ;
           let transaction_database =
             Auxiliary_database.Transaction_database.create ~logger

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -98,7 +98,7 @@ let run_test () : unit Deferred.t =
           typ
       in
       let%bind trust_dir = Async.Unix.mkdtemp (temp_conf_dir ^/ "trust_db") in
-      let trust_system = Trust_system.create ~db_dir:trust_dir in
+      let trust_system = Trust_system.create trust_dir in
       trace_database_initialization "trust_system" __LOC__ trust_dir ;
       let%bind receipt_chain_dir_name =
         Async.Unix.mkdtemp (temp_conf_dir ^/ "receipt_chain")
@@ -106,7 +106,7 @@ let run_test () : unit Deferred.t =
       trace_database_initialization "receipt_chain_database" __LOC__
         receipt_chain_dir_name ;
       let receipt_chain_database =
-        Receipt_chain_database.create ~directory:receipt_chain_dir_name
+        Receipt_chain_database.create receipt_chain_dir_name
       in
       let%bind transaction_database_dir =
         Async.Unix.mkdtemp (temp_conf_dir ^/ "transaction_database")

--- a/src/lib/auxiliary_database/external_transition_database.ml
+++ b/src/lib/auxiliary_database/external_transition_database.ml
@@ -47,7 +47,7 @@ let add_user_blocks (pagination : Pagination.t)
     state_hash external_transition time
 
 let create ~logger directory =
-  let database = Database.create ~directory in
+  let database = Database.create directory in
   let pagination = Pagination.create () in
   List.iter (Database.to_alist database) ~f:(fun (hash, (block_data, time)) ->
       add_user_blocks pagination ({With_hash.hash; data= block_data}, time) ) ;

--- a/src/lib/auxiliary_database/transaction_database.ml
+++ b/src/lib/auxiliary_database/transaction_database.ml
@@ -28,7 +28,7 @@ struct
       transaction transaction date
 
   let create ~logger directory =
-    let database = Database.create ~directory in
+    let database = Database.create directory in
     let pagination = Pagination.create () in
     List.iter (Database.to_alist database) ~f:(add_user_transaction pagination) ;
     {database; pagination; logger}

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -13,7 +13,8 @@ module Ledger_inner = struct
 
   module Location_at_depth = Location0
 
-  module Kvdb : Intf.Key_value_database = Rocksdb.Database
+  module Kvdb : Intf.Key_value_database with type config := string =
+    Rocksdb.Database
 
   module Storage_locations : Intf.Storage_locations = struct
     let key_value_db_dir = "coda_key_value_db"

--- a/src/lib/kademlia/membership.ml
+++ b/src/lib/kademlia/membership.ml
@@ -692,7 +692,7 @@ let%test_module "Tests" =
       at_exit (fun () -> Sys.command_exn @@ "rm -rf '" ^ tmpdir ^ "'") ;
       tmpdir
 
-    let create_trust_system () = Trust_system.create ~db_dir:(get_temp_dir ())
+    let create_trust_system () = Trust_system.create (get_temp_dir ())
 
     let%test_unit "connect" =
       (* This flakes 1 in 20 times, so try a couple times if it fails *)

--- a/src/lib/key_value_database/key_value_database.ml
+++ b/src/lib/key_value_database/key_value_database.ml
@@ -42,9 +42,11 @@ module Intf = struct
 
     type value
 
+    type config
+
     module M : Monad.S
 
-    val create : directory:string -> t
+    val create : config -> t
 
     val close : t -> unit
 
@@ -79,7 +81,8 @@ module Make_mock
   Intf.Mock
   with type t = Value.t Key.Table.t
    and type key := Key.t
-   and type value := Value.t = struct
+   and type value := Value.t
+   and type config := unit = struct
   type t = Value.t Key.Table.t
 
   let to_sexp t ~key_sexp ~value_sexp =
@@ -88,7 +91,7 @@ module Make_mock
            [%sexp_of: Sexp.t * Sexp.t] (key_sexp key, value_sexp value) )
     |> [%sexp_of: Sexp.t list]
 
-  let create ~directory:_ = Key.Table.create ()
+  let create _ = Key.Table.create ()
 
   let get t ~key = Key.Table.find t key
 

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -5,7 +5,7 @@ module type Inputs_intf = sig
 
   module Location : Location_intf.S
 
-  module Kvdb : Intf.Key_value_database
+  module Kvdb : Intf.Key_value_database with type config := string
 
   module Storage_locations : Intf.Storage_locations
 end
@@ -56,7 +56,7 @@ module Make (Inputs : Inputs_intf) :
       | Some name ->
           name
     in
-    let kvdb = Kvdb.create ~directory in
+    let kvdb = Kvdb.create directory in
     {uuid; kvdb}
 
   let close {uuid= _; kvdb} = Kvdb.close kvdb

--- a/src/lib/merkle_ledger/intf.ml
+++ b/src/lib/merkle_ledger/intf.ml
@@ -65,11 +65,14 @@ end
 module type Key_value_database = sig
   type t [@@deriving sexp]
 
+  type config
+
   include
     Key_value_database.Intf.Ident
     with type t := t
      and type key := Bigstring.t
      and type value := Bigstring.t
+     and type config := config
 
   val get_uuid : t -> Uuid.t
 

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -127,7 +127,8 @@ end
 
 module Intf = Merkle_ledger.Intf
 
-module In_memory_kvdb : Intf.Key_value_database = struct
+module In_memory_kvdb : Intf.Key_value_database with type config := string =
+struct
   module Bigstring_frozen = struct
     module T = struct
       include Bigstring.Stable.V1
@@ -157,7 +158,7 @@ module In_memory_kvdb : Intf.Key_value_database = struct
 
   let get_uuid t = t.uuid
 
-  let create ~directory:_ =
+  let create _ =
     {uuid= Uuid_unix.create (); table= Bigstring_frozen.Table.create ()}
 
   let close _ = ()

--- a/src/lib/receipt_chain_database/intf.ml
+++ b/src/lib/receipt_chain_database/intf.ml
@@ -23,9 +23,11 @@ open Coda_base
 module type S = sig
   type t
 
+  type config
+
   module M : Key_value_database.Monad.S
 
-  val create : directory:string -> t
+  val create : config -> t
 
   (** [prove t ~proving_receipt ~resulting_receipt] will provide a proof of a
       `proving_receipt` hash up to an underlying `resulting_receipt` hash. The

--- a/src/lib/receipt_chain_database/receipt_chain_database.mli
+++ b/src/lib/receipt_chain_database/receipt_chain_database.mli
@@ -11,7 +11,7 @@ module Make
                      and type key := Receipt.Chain_hash.t
                      and type value := Tree_node.t
                      and type config := Config.t) :
-  Intf.S with module M := Monad and type input := Config.t
+  Intf.S with module M := Monad and type config := Config.t
 
 (* A Rocksdb version of the receipt_chain_database *)
 module Rocksdb :
@@ -23,4 +23,4 @@ module Rocksdb :
 include
   Intf.S
   with module M := Key_value_database.Monad.Ident
-   and type input := string
+   and type config := string

--- a/src/lib/receipt_chain_database/receipt_chain_database.mli
+++ b/src/lib/receipt_chain_database/receipt_chain_database.mli
@@ -3,17 +3,24 @@ open Coda_base
 module Tree_node : Intf.Tree_node
 
 module Make
-    (Monad : Key_value_database.Monad.S)
+    (Monad : Key_value_database.Monad.S) (Config : sig
+        type t
+    end)
     (Key_value_db : Key_value_database.Intf.S
                     with module M := Monad
                      and type key := Receipt.Chain_hash.t
-                     and type value := Tree_node.t) :
-  Intf.S with module M := Monad
+                     and type value := Tree_node.t
+                     and type config := Config.t) :
+  Intf.S with module M := Monad and type input := Config.t
 
 (* A Rocksdb version of the receipt_chain_database *)
 module Rocksdb :
   Key_value_database.Intf.Ident
   with type key := Receipt.Chain_hash.t
    and type value := Tree_node.t
+   and type config := string
 
-include Intf.S with module M := Key_value_database.Monad.Ident
+include
+  Intf.S
+  with module M := Key_value_database.Monad.Ident
+   and type input := string

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -10,7 +10,7 @@ end
 
 include T
 
-let create ~directory =
+let create directory =
   let opts = Rocks.Options.create () in
   Rocks.Options.set_create_if_missing opts true ;
   {uuid= Uuid_unix.create (); db= Rocks.open_db ~opts directory}
@@ -86,7 +86,7 @@ let%test_unit "to_alist (of_alist l) = l" =
             List.sort kvs ~compare:[%compare: string * string]
             |> List.map ~f:(fun (k, v) -> (s k, s v))
           in
-          let db = create ~directory in
+          let db = create directory in
           List.iter sorted ~f:(fun (key, data) -> set db ~key ~data) ;
           let alist =
             List.sort (to_alist db)

--- a/src/lib/rocksdb/serializable.ml
+++ b/src/lib/rocksdb/serializable.ml
@@ -1,32 +1,9 @@
 open Core_kernel
 
-module type S = sig
-  include Key_value_database.Intf.Ident
-
-  module T : sig
-    type nonrec t = t
-  end
-
-  module Batch : sig
-    type t
-
-    val get : t -> key:key -> value option
-
-    val set : t -> key:key -> data:value -> unit
-
-    val remove : t -> key:key -> unit
-
-    val with_batch : T.t -> f:(t -> 'a) -> 'a
-  end
-end
-
-module Make (Key : Binable.S) (Value : Binable.S) :
-  Key_value_database.Intf.Ident
-  with type key := Key.t
-   and type value := Value.t = struct
+module Make (Key : Binable.S) (Value : Binable.S) = struct
   type t = Database.t
 
-  let create ~directory = Database.create ~directory
+  let create directory = Database.create directory
 
   let close = Database.close
 
@@ -84,7 +61,7 @@ module GADT = struct
       type nonrec t = t
     end
 
-    val create : directory:string -> t
+    val create : string -> t
 
     val close : t -> unit
 
@@ -134,7 +111,7 @@ module GADT = struct
         Database.remove t ~key:(bin_key_dump key)
     end
 
-    let create ~directory = Database.create ~directory
+    let create directory = Database.create directory
 
     let close = Database.close
 

--- a/src/lib/rocksdb/serializable.ml
+++ b/src/lib/rocksdb/serializable.ml
@@ -1,6 +1,11 @@
 open Core_kernel
 
-module Make (Key : Binable.S) (Value : Binable.S) = struct
+module Make (Key : Binable.S) (Value : Binable.S) : 
+  Key_value_database.Intf.S 
+    with module M := Key_value_database.Monad.Ident 
+    and type key := Key.t
+    and type value := Value.t
+    and type config := string = struct
   type t = Database.t
 
   let create directory = Database.create directory

--- a/src/lib/rocksdb/serializable.ml
+++ b/src/lib/rocksdb/serializable.ml
@@ -1,11 +1,11 @@
 open Core_kernel
 
-module Make (Key : Binable.S) (Value : Binable.S) : 
-  Key_value_database.Intf.S 
-    with module M := Key_value_database.Monad.Ident 
-    and type key := Key.t
-    and type value := Value.t
-    and type config := string = struct
+module Make (Key : Binable.S) (Value : Binable.S) :
+  Key_value_database.Intf.S
+  with module M := Key_value_database.Monad.Ident
+   and type key := Key.t
+   and type value := Value.t
+   and type config := string = struct
   type t = Database.t
 
   let create directory = Database.create directory

--- a/src/lib/test/dune
+++ b/src/lib/test/dune
@@ -1,5 +1,0 @@
-(executable
-  (name test)
-  (modules test)
-  (libraries graphql-cohttp graphql-async coda_graphql coda_digestif)
-  (modes native))

--- a/src/lib/test/test.ml
+++ b/src/lib/test/test.ml
@@ -1,4 +1,0 @@
-let _ =
-  Coda_graphql.result_of_exn (fun x -> x) Coda_graphql.schema ~error:`Error
-
-let () = print_endline "help"

--- a/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
@@ -125,7 +125,7 @@ let%test_module "Transition Frontier Persistence" =
         with_persistence ~logger ~pids ~directory_name ~f:(fun (frontier, t) ->
             let create_breadcrumb =
               gen_breadcrumb ~logger ~pids ~trust_system
-                ~accounts_with_secret_keys:Genesis_ledger.accounts
+                Genesis_ledger.accounts
               |> Quickcheck.random_value
             in
             let root = Transition_frontier.root frontier in

--- a/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_controller_tests/test_transition_frontier_persistence.ml
@@ -125,7 +125,7 @@ let%test_module "Transition Frontier Persistence" =
         with_persistence ~logger ~pids ~directory_name ~f:(fun (frontier, t) ->
             let create_breadcrumb =
               gen_breadcrumb ~logger ~pids ~trust_system
-                Genesis_ledger.accounts
+                ~accounts_with_secret_keys:Genesis_ledger.accounts
               |> Quickcheck.random_value
             in
             let root = Transition_frontier.root frontier in

--- a/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
+++ b/src/lib/transition_frontier_persistence/transition_frontier_persistence.ml
@@ -194,9 +194,7 @@ module Make (Inputs : Intf.Main_inputs) = struct
         Blockchain_state.staged_ledger_hash @@ blockchain_state protocol_state)
 
   let with_database ~directory_name ~f =
-    let transition_storage =
-      Transition_storage.create ~directory:directory_name
-    in
+    let transition_storage = Transition_storage.create directory_name in
     let%map result = f transition_storage in
     Transition_storage.close transition_storage ;
     result

--- a/src/lib/transition_frontier_persistence/worker.ml
+++ b/src/lib/transition_frontier_persistence/worker.ml
@@ -21,7 +21,7 @@ module Make (Inputs : Intf.Worker_inputs) :
       | Some name ->
           name
     in
-    let transition_storage = Transition_storage.create ~directory in
+    let transition_storage = Transition_storage.create directory in
     {transition_storage; logger}
 
   let close {transition_storage; _} =

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -20,16 +20,31 @@ let max_rate secs =
      ban threshold (-1) *)
   1. -. (Record.decay_rate ** interval)
 
-module Make0 (Peer_id : sig
-  type t [@@deriving sexp, to_yojson]
-end) (Now : sig
-  val now : unit -> Time.t
-end)
-(Db : Key_value_database.Intf.Ident
-      with type key := Peer_id.t
-       and type value := Record.t)
-(Action : Action_intf) =
-struct
+module type Input_intf = sig
+  module Peer_id : sig
+    type t [@@deriving sexp, to_yojson]
+  end
+
+  module Now : sig
+    val now : unit -> Time.t
+  end
+
+  module Config : sig
+    type t
+  end
+
+  module Db :
+    Key_value_database.Intf.Ident
+    with type key := Peer_id.t
+     and type value := Record.t
+     and type config := Config.t
+
+  module Action : Action_intf
+end
+
+module Make0 (Inputs : Input_intf) = struct
+  open Inputs
+
   type t =
     { db: Db.t option
           (* This is an option to allow using a fake trust system in tests. This is
@@ -45,9 +60,9 @@ struct
 
   module Record_inst = Record.Make (Now)
 
-  let create ~db_dir =
+  let create db_dir =
     let reader, writer = Strict_pipe.create Strict_pipe.Synchronous in
-    { db= Some (Db.create ~directory:db_dir)
+    { db= Some (Db.create db_dir)
     ; bans_reader= reader
     ; bans_writer= writer
     ; actions_writers= [] }
@@ -190,7 +205,13 @@ let%test_module "peer_trust" =
       let to_log t = (string_of_sexp @@ sexp_of_t t, [])
     end
 
-    module Peer_trust_test = Make0 (Peer_id) (Mock_now) (Db) (Action)
+    module Peer_trust_test = Make0 (struct
+      module Peer_id = Peer_id
+      module Now = Mock_now
+      module Config = Unit
+      module Db = Db
+      module Action = Action
+    end)
 
     (* We want to check the output of the pipe in these tests, but it's
        synchronous, so we need to read from it in a different "thread",
@@ -203,7 +224,7 @@ let%test_module "peer_trust" =
       ban_pipe_out := []
 
     let setup_mock_db () =
-      let res = Peer_trust_test.create ~db_dir:"fake" in
+      let res = Peer_trust_test.create () in
       don't_wait_for
       @@ Strict_pipe.Reader.iter_without_pushback res.bans_reader ~f:(fun v ->
              ban_pipe_out := v :: !ban_pipe_out ) ;
@@ -354,13 +375,18 @@ let%test_module "peer_trust" =
               failwith "wrong number of actions written to pipe" )
   end )
 
-module Make =
-  Make0 (struct
-      include Unix.Inet_addr.Blocking_sexp
+module Make (Action : Action_intf) = Make0 (struct
+  module Peer_id = struct
+    include Unix.Inet_addr.Blocking_sexp
 
-      let to_yojson x = `String (Unix.Inet_addr.to_string x)
-    end)
-    (struct
-      let now = Time.now
-    end)
-    (Rocksdb.Serializable.Make (Unix.Inet_addr.Blocking_sexp) (Record))
+    let to_yojson x = `String (Unix.Inet_addr.to_string x)
+  end
+
+  module Now = struct
+    let now = Time.now
+  end
+
+  module Config = String
+  module Db = Rocksdb.Serializable.Make (Unix.Inet_addr.Blocking_sexp) (Record)
+  module Action = Action
+end)

--- a/src/lib/trust_system/peer_trust.mli
+++ b/src/lib/trust_system/peer_trust.mli
@@ -45,7 +45,7 @@ module Make (Action : Action_intf) : sig
 
   (** Set up the trust system. Pass the directory to store the trust database
       in. *)
-  val create : db_dir:string -> t
+  val create : string -> t
 
   (** Get a fake trust system, for tests. *)
   val null : unit -> t


### PR DESCRIPTION
- Some instances of Key-value database now need an input of an integer,
so the constructor inputs of the database are now functored
- This made some of the tests cleaner as the client does not have to
input a string value for databases that didn't require a string
- Refactored functor inputs for peer_trust.ml so that it fits to our
coding style

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
