### PR TITLE
%%versioned many daemon RPC types

### DIFF
--- a/src/lib/signature_lib/keypair.ml
+++ b/src/lib/signature_lib/keypair.ml
@@ -14,8 +14,7 @@ end]
 
 module T = struct
   type t = Stable.Latest.t =
-    { public_key: Public_key.Stable.V1.t
-    ; private_key: Private_key.Stable.V1.t sexp_opaque }
+    {public_key: Public_key.t; private_key: Private_key.t sexp_opaque}
   [@@deriving sexp]
 
   let compare {public_key= pk1; private_key= _}

--- a/src/lib/signature_lib/keypair.mli
+++ b/src/lib/signature_lib/keypair.mli
@@ -11,9 +11,8 @@ module Stable : sig
   module Latest = V1
 end
 
-type t = Stable.V1.t =
-  { public_key: Public_key.Stable.V1.t
-  ; private_key: Private_key.Stable.V1.t sexp_opaque }
+type t = Stable.Latest.t =
+  {public_key: Public_key.t; private_key: Private_key.t sexp_opaque}
 [@@deriving sexp, compare]
 
 include Comparable.S with type t := t

--- a/src/lib/signature_lib/keypair.mli
+++ b/src/lib/signature_lib/keypair.mli
@@ -5,14 +5,15 @@ module Stable : sig
     type t =
       { public_key: Public_key.Stable.V1.t
       ; private_key: Private_key.Stable.V1.t sexp_opaque }
-    [@@deriving sexp, bin_io]
+    [@@deriving sexp, bin_io, version]
   end
 
   module Latest = V1
 end
 
 type t = Stable.V1.t =
-  {public_key: Public_key.t; private_key: Private_key.t sexp_opaque}
+  { public_key: Public_key.Stable.V1.t
+  ; private_key: Private_key.Stable.V1.t sexp_opaque }
 [@@deriving sexp, compare]
 
 include Comparable.S with type t := t


### PR DESCRIPTION
Apply `%%version` to many daemon RPC types. Some are not done, because they rely on a number of other `bin_io` types that need versioning. The linter will remind us to do those.

This is part of the program of versioning all types with `bin_io`.

Removed the definitions of `type error`, which were not used.

Partially addresses #3667: Many of the linter warnings are removed, a number remain.