### PR TITLE
Next proposal status supports time offsets

### DIFF
--- a/src/lib/coda_base/block_time.ml
+++ b/src/lib/coda_base/block_time.ml
@@ -115,6 +115,8 @@ module Time = struct
     let to_time_ns_span s =
       Time_ns.Span.of_ms (Int64.to_float (UInt64.to_int64 s))
 
+    let to_string_hum s = to_time_ns_span s |> Time_ns.Span.to_string_hum
+
     let to_ms = UInt64.to_int64
 
     let of_ms = UInt64.of_int64
@@ -136,6 +138,8 @@ module Time = struct
     let ( >= ) = UInt64.( >= )
 
     let min = UInt64.min
+
+    let zero = UInt64.zero
   end
 
   include Comparable.Make (Stable.Latest)

--- a/src/lib/coda_base/block_time.mli
+++ b/src/lib/coda_base/block_time.mli
@@ -58,6 +58,8 @@ module Time : sig
 
     val to_time_ns_span : t -> Core.Time_ns.Span.t
 
+    val to_string_hum : t -> string
+
     val to_ms : t -> Int64.t
 
     val of_ms : Int64.t -> t
@@ -79,6 +81,8 @@ module Time : sig
     val ( >= ) : t -> t -> bool
 
     val min : t -> t -> t
+
+    val zero : t
   end
 
   val field_var_to_unpacked :

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -285,8 +285,9 @@ let get_status ~flag t =
   let snark_work_fee = Currency.Fee.to_int @@ Coda_lib.snark_work_fee t in
   let propose_pubkeys = Coda_lib.propose_public_keys t in
   let consensus_mechanism = Consensus.name in
+  let time_controller = (Coda_lib.config t).time_controller in
   let consensus_time_now =
-    Consensus.time_hum (Block_time.now (Coda_lib.config t).time_controller)
+    Consensus.time_hum (Block_time.now time_controller)
   in
   let consensus_configuration = Consensus.Configuration.t in
   let r = Perf_histograms.report in
@@ -393,10 +394,10 @@ let get_status ~flag t =
   in
   let next_proposal =
     let str time =
-      let open Time in
-      let time = Int64.to_float time |> Span.of_ms |> of_span_since_epoch in
-      let diff = diff time (now ()) in
-      if Span.(zero < diff) then sprintf "in %s" (Time.Span.to_string_hum diff)
+      let open Block_time in
+      let since_epoch_time = time |> Span.of_ms |> of_span_since_epoch in
+      let diff = diff since_epoch_time (now time_controller) in
+      if Span.(zero < diff) then sprintf "in %s" (Span.to_string_hum diff)
       else "Computing next proposal state..."
     in
     Option.map (Coda_lib.next_proposal t) ~f:(function


### PR DESCRIPTION
`Next proposal` in coda client status didn't obey time offsets because it used Core time instead of Block_time. Now it will obey the time offsets.