### PR TITLE
Build libp2p in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ jobs:
         docker:
             - image: python:3
         steps:
-            - checkout
             - run:
                 name: Install dependencies
                 command: pip install --user requests jinja2
@@ -129,6 +128,7 @@ jobs:
         docker:
             - image: nixos/nix
         steps:
+            - checkout
             - run:
                 name: Install cachix
                 command: nix-env -iA cachix -f https://cachix.org/api/v1/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,20 @@ jobs:
                   name: Update branch protection rule from test configuration
                   command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status
 
+    build-auxiliary:
+        docker:
+            - image: nixos/nix
+        steps:
+            - run:
+                name: Install cachix
+                command: nix-env -iA cachix -f https://cachix.org/api/v1/install
+            - run:
+                name: Build libp2p_helper using cachix
+                command: |
+                    cachix use codaprotocol
+                    cd src/app/libp2p_helper
+                    nix-build default.nix
+
     build-macos:
       # only run when there's a 'release' tag
       # filters:
@@ -677,6 +691,7 @@ workflows:
     coda_parallel:
         jobs:
             - lint
+            - build-auxiliary
             - update-branch-protection:
                 filters:
                   branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,7 @@ jobs:
         docker:
             - image: python:3
         steps:
+            - checkout
             - run:
                 name: Install dependencies
                 command: pip install --user requests jinja2

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -116,7 +116,6 @@ jobs:
         docker:
             - image: python:3
         steps:
-            - checkout
             - run:
                 name: Install dependencies
                 command: pip install --user requests jinja2
@@ -129,6 +128,7 @@ jobs:
         docker:
             - image: nixos/nix
         steps:
+            - checkout
             - run:
                 name: Install cachix
                 command: nix-env -iA cachix -f https://cachix.org/api/v1/install

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -116,6 +116,7 @@ jobs:
         docker:
             - image: python:3
         steps:
+            - checkout
             - run:
                 name: Install dependencies
                 command: pip install --user requests jinja2

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -124,6 +124,20 @@ jobs:
                   name: Update branch protection rule from test configuration
                   command: ./scripts/test.py required-status >required_status && cat required_status && ./scripts/update_branch_rule.py required_status
 
+    build-auxiliary:
+        docker:
+            - image: nixos/nix
+        steps:
+            - run:
+                name: Install cachix
+                command: nix-env -iA cachix -f https://cachix.org/api/v1/install
+            - run:
+                name: Build libp2p_helper using cachix
+                command: |
+                    cachix use codaprotocol
+                    cd src/app/libp2p_helper
+                    nix-build default.nix
+
     build-macos:
       # only run when there's a 'release' tag
       # filters:
@@ -431,6 +445,7 @@ workflows:
     coda_parallel:
         jobs:
             - lint
+            - build-auxiliary
             - update-branch-protection:
                 filters:
                   branches:


### PR DESCRIPTION
We've had several issues deploying because libp2p_helper is only built in prod. We should enforce that it builds every PR.