### PR TITLE
Wallet: Add log link to tray

### DIFF
--- a/frontend/wallet/src/main/App.re
+++ b/frontend/wallet/src/main/App.re
@@ -1,6 +1,9 @@
 open BsElectron;
 open Tc;
 
+[@bs.module "electron"][@bs.scope "shell"][@bs.val]
+external openItem: string => unit = "openItem";
+
 let createTray = dispatch => {
   let t = AppTray.get();
   let trayItems =
@@ -24,6 +27,12 @@ let createTray = dispatch => {
         Label("Settings"),
         ~accelerator="CmdOrCtrl+,",
         ~click=() => AppWindow.deepLink({path: Route.Settings, dispatch}),
+        (),
+      ),
+      make(
+        Label("View logs"),
+        ~accelerator="CmdOrCtrl+L",
+        ~click=() => openItem(DaemonProcess.Process.logfileName),
         (),
       ),
       make(Separator, ()),

--- a/frontend/wallet/src/main/DaemonProcess.re
+++ b/frontend/wallet/src/main/DaemonProcess.re
@@ -49,9 +49,9 @@ let fakerCommand = (~port) => {
 [@bs.module "os"] external tmpdir: unit => string = "";
 
 module Process = {
+  let logfileName = tmpdir() ++ "/daemon.log";
   let start = (command: Command.t) => {
     let {Command.executable, args} = command;
-    let logfileName = tmpdir() ++ "/daemon.log";
     print_endline(
       {j|Starting $executable with $args. Logging to `$logfileName`|j},
     );


### PR DESCRIPTION
Adds a link to view wallet logs from the tray.
<img width="186" alt="Screen Shot 2019-10-24 at 5 51 26 PM" src="https://user-images.githubusercontent.com/1709621/67535318-ea644080-f686-11e9-8e7a-572a09e2aec4.png">
