### PR TITLE
Fix units in jemalloc stats

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -400,10 +400,10 @@ let daemon logger =
             Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
               "Jemalloc memory statistics (in bytes)"
               ~metadata:
-                [ ("active", `Int (active * 1024))
-                ; ("resident", `Int (resident * 1024))
-                ; ("allocated", `Int (allocated * 1024))
-                ; ("mapped", `Int (mapped * 1024)) ]
+                [ ("active", `Int active)
+                ; ("resident", `Int resident)
+                ; ("allocated", `Int allocated)
+                ; ("mapped", `Int mapped) ]
           in
           let rec loop () =
             log_stats "before major gc" ;

--- a/src/lib/coda_metrics/coda_metrics.ml
+++ b/src/lib/coda_metrics/coda_metrics.ml
@@ -218,24 +218,24 @@ module Runtime = struct
 
   let jemalloc_active_bytes =
     simple_metric ~metric_type:Gauge "jemalloc_active_bytes"
-      (fun () -> float_of_int @@ (1024 * !current_jemalloc.active))
+      (fun () -> float_of_int !current_jemalloc.active)
       ~help:"active memory in bytes"
 
   let jemalloc_resident_bytes =
     simple_metric ~metric_type:Gauge "jemalloc_resident_bytes"
-      (fun () -> float_of_int @@ (1024 * !current_jemalloc.resident))
+      (fun () -> float_of_int !current_jemalloc.resident)
       ~help:
         "resident memory in bytes (may be zero depending on jemalloc compile \
          options)"
 
   let jemalloc_allocated_bytes =
     simple_metric ~metric_type:Gauge "jemalloc_allocated_bytes"
-      (fun () -> float_of_int @@ (1024 * !current_jemalloc.allocated))
+      (fun () -> float_of_int !current_jemalloc.allocated)
       ~help:"memory allocated to heap objects in bytes"
 
   let jemalloc_mapped_bytes =
     simple_metric ~metric_type:Gauge "jemalloc_mapped_bytes"
-      (fun () -> float_of_int @@ (1024 * !current_jemalloc.mapped))
+      (fun () -> float_of_int !current_jemalloc.mapped)
       ~help:"memory mapped into process address space in bytes"
 
   let process_cpu_seconds_total =


### PR DESCRIPTION
I got confused before about which things were kilobytes and which were bytes. It's right now.