### PR TITLE
Displaying proof in external_transition

### DIFF
--- a/src/lib/auxiliary_database/filtered_external_transition.ml
+++ b/src/lib/auxiliary_database/filtered_external_transition.ml
@@ -48,7 +48,8 @@ module Stable = struct
       { creator: Public_key.Compressed.Stable.V1.t
       ; protocol_state: Protocol_state.Stable.V1.t
       ; transactions: Transactions.Stable.V1.t
-      ; snark_jobs: Transaction_snark_work.Info.Stable.V1.t list }
+      ; snark_jobs: Transaction_snark_work.Info.Stable.V1.t list
+      ; proof: Proof.Stable.V1.t }
 
     let to_latest = Fn.id
   end
@@ -58,7 +59,8 @@ type t = Stable.Latest.t =
   { creator: Public_key.Compressed.t
   ; protocol_state: Protocol_state.t
   ; transactions: Transactions.t
-  ; snark_jobs: Transaction_snark_work.Info.t list }
+  ; snark_jobs: Transaction_snark_work.Info.t list
+  ; proof: Proof.t }
 
 let participants {transactions= {user_commands; fee_transfers; _}; creator; _}
     =
@@ -144,4 +146,7 @@ let of_transition tracked_participants external_transition =
       (Staged_ledger_diff.completed_works staged_ledger_diff)
       ~f:Transaction_snark_work.info
   in
-  {creator; protocol_state; transactions; snark_jobs}
+  let proof =
+    External_transition.Validated.protocol_state_proof external_transition
+  in
+  {creator; protocol_state; transactions; snark_jobs; proof}

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -667,6 +667,46 @@ module Types = struct
             ~resolve:(fun _ {coinbase; _} -> Currency.Amount.to_uint64 coinbase)
         ] )
 
+  let protocol_state_proof : (Coda_lib.t, Proof.t option) typ =
+    let display_g1_elem (g1 : Crypto_params.Tick_backend.Inner_curve.t) =
+      let x, y = Crypto_params.Tick_backend.Inner_curve.to_affine_exn g1 in
+      List.map [x; y] ~f:Crypto_params.Tick0.Field.to_string
+    in
+    let display_g2_elem (g2 : Curve_choice.Tock_full.G2.t) =
+      let open Curve_choice.Tock_full in
+      let x, y = G2.to_affine_exn g2 in
+      let to_string (fqe : Fqe.t) =
+        let vector = Fqe.to_vector fqe in
+        List.init (Fq.Vector.length vector) ~f:(fun i ->
+            (* TODO: visually display string better *)
+            let string_value =
+              Binable.to_string (module Fq) (Fq.Vector.get vector i)
+            in
+            string_value )
+      in
+      List.map [x; y] ~f:to_string
+    in
+    let string_list_field ~resolve =
+      field
+        ~typ:(non_null @@ list (non_null string))
+        ~args:Arg.[]
+        ~resolve:(fun _ (proof : Proof.t) -> display_g1_elem (resolve proof))
+    in
+    let string_list_list_field ~resolve =
+      field
+        ~typ:(non_null @@ list (non_null @@ list @@ non_null string))
+        ~args:Arg.[]
+        ~resolve:(fun _ (proof : Proof.t) -> display_g2_elem (resolve proof))
+    in
+    obj "protocolStateProof" ~fields:(fun _ ->
+        [ string_list_field "a" ~resolve:(fun (proof : Proof.t) -> proof.a)
+        ; string_list_list_field "b" ~resolve:(fun (proof : Proof.t) -> proof.b)
+        ; string_list_field "c" ~resolve:(fun (proof : Proof.t) -> proof.c)
+        ; string_list_list_field "delta_prime"
+            ~resolve:(fun (proof : Proof.t) -> proof.delta_prime)
+        ; string_list_field "z" ~resolve:(fun (proof : Proof.t) ->
+              proof.z ) ] )
+
   let block :
       ( Coda_lib.t
       , (Filtered_external_transition.t, State_hash.t) With_hash.t option )
@@ -692,6 +732,11 @@ module Types = struct
         ; field "protocolState" ~typ:(non_null protocol_state)
             ~args:Arg.[]
             ~resolve:(fun _ {With_hash.data; _} -> data.protocol_state)
+        ; field "protocolStateProof"
+            ~typ:(non_null protocol_state_proof)
+            ~doc:"Snark proof of blockchain state"
+            ~args:Arg.[]
+            ~resolve:(fun _ {With_hash.data; _} -> data.proof)
         ; field "transactions" ~typ:(non_null transactions)
             ~args:Arg.[]
             ~resolve:(fun _ {With_hash.data; _} -> data.transactions)

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -678,11 +678,8 @@ module Types = struct
       let to_string (fqe : Fqe.t) =
         let vector = Fqe.to_vector fqe in
         List.init (Fq.Vector.length vector) ~f:(fun i ->
-            (* TODO: visually display string better *)
-            let string_value =
-              Binable.to_string (module Fq) (Fq.Vector.get vector i)
-            in
-            string_value )
+            let fq = Fq.Vector.get vector i in
+            Crypto_params.Tick0.Field.to_string fq )
       in
       List.map [x; y] ~f:to_string
     in
@@ -704,8 +701,8 @@ module Types = struct
         ; string_list_field "c" ~resolve:(fun (proof : Proof.t) -> proof.c)
         ; string_list_list_field "delta_prime"
             ~resolve:(fun (proof : Proof.t) -> proof.delta_prime)
-        ; string_list_field "z" ~resolve:(fun (proof : Proof.t) ->
-              proof.z ) ] )
+        ; string_list_field "z" ~resolve:(fun (proof : Proof.t) -> proof.z) ]
+    )
 
   let block :
       ( Coda_lib.t


### PR DESCRIPTION
Used the following query to test out the output:
```
query MyQuery {
  blocks(first: 2) {
    nodes {
      protocolStateProof {
        a
        b
        c
        delta_prime
        z
      }
    }
  }
}

```
```
{
  "data": {
    "blocks": {
      "nodes": [
        {
          "protocolStateProof": {
            "a": [
              "361147348322508534178922229981124815550694634710568970777845228804322874214018635632966771",
              "380682102715313887272148668327801040777382881606702107850536514097939994003366555868449428"
            ],
            "b": [
              [
                "(�\u001e�,���|�GU���$\u0019Xk{�\u001e�\u000b9%���*R�9\u0018\u00154\u0002\u0000\u0000",
                "(�X\r��^����\u0004��͉����\u0013��F���Voa5�؄�;`\u0017\u0001\u0000\u0000",
                "(U[�xN\u000f��=�\u0002�˭A��۝wΨ2i7�N���D#~�|�=\u0002\u0000\u0000"
              ],
              [
                "(\\W0�\f��\u001fjz��\u0014����8�{���w5�\u000b�h3F�5\u0010�\u0001\u0000\u0000",
                "(����Ht�7٠�m���GlIi�(`,%��-��:�\n�\u0016Yz\u0000\u0000\u0000",
                "(V:���\u0004\u001a\u000b���2\u0011����D��G.@å�dLl7��Qn��\u0000\u0000\u0000"
              ]
            ],
            "c": [
              "46921767730452517241380736440344140218366571819629705546741901678881023956119023148769066",
              "66438303753229158831058237066274079775972966217532648092550361739810692093353264254774414"
            ],
            "delta_prime": [
              [
                "(�u�aY���F�\b\u001f��[~�������\\��������\u0012�H�\u0002\u0000\u0000",
                "(.Q�`1��\u0002�j��! \u0013\u001b��6K�����}�i<+�2\u0010b�\\�\u0000\u0000\u0000",
                "(;�\u001d\u001f(��2\u0001E_�%\nn\u000b\u001a\u0015\f�}J\u0015����}��^�N\u0005\u0003\u0000\u0000"
              ],
              [
                "(-�&?\u0017�j�X�H�W��J�\u0019�]���b�Q��x�\u001f�u6�3\u0000\u0000\u0000",
                "(Z0���a�iK�s��߃\u0003SrCUa\u0003p�\t����(LI�kZ9�\u0000\u0000\u0000",
                "(��A3C6�`�l���\u0006@#\u001ag���U\u001d���NR�����VM\u0002\u0000\u0000"
              ]
            ],
            "z": [
              "191402908466973854108312208145692350507334241942752894702102060224530842999348098901091196",
              "256420081481118310873264410474877417472425868441845571465060221762173707469720931553950712"
            ]
          }
        },
        {
          "protocolStateProof": {
            "a": [
              "361147348322508534178922229981124815550694634710568970777845228804322874214018635632966771",
              "380682102715313887272148668327801040777382881606702107850536514097939994003366555868449428"
            ],
            "b": [
              [
                "(�\u001e�,���|�GU���$\u0019Xk{�\u001e�\u000b9%���*R�9\u0018\u00154\u0002\u0000\u0000",
                "(�X\r��^����\u0004��͉����\u0013��F���Voa5�؄�;`\u0017\u0001\u0000\u0000",
                "(U[�xN\u000f��=�\u0002�˭A��۝wΨ2i7�N���D#~�|�=\u0002\u0000\u0000"
              ],
              [
                "(\\W0�\f��\u001fjz��\u0014����8�{���w5�\u000b�h3F�5\u0010�\u0001\u0000\u0000",
                "(����Ht�7٠�m���GlIi�(`,%��-��:�\n�\u0016Yz\u0000\u0000\u0000",
                "(V:���\u0004\u001a\u000b���2\u0011����D��G.@å�dLl7��Qn��\u0000\u0000\u0000"
              ]
            ],
            "c": [
              "46921767730452517241380736440344140218366571819629705546741901678881023956119023148769066",
              "66438303753229158831058237066274079775972966217532648092550361739810692093353264254774414"
            ],
            "delta_prime": [
              [
                "(�u�aY���F�\b\u001f��[~�������\\��������\u0012�H�\u0002\u0000\u0000",
                "(.Q�`1��\u0002�j��! \u0013\u001b��6K�����}�i<+�2\u0010b�\\�\u0000\u0000\u0000",
                "(;�\u001d\u001f(��2\u0001E_�%\nn\u000b\u001a\u0015\f�}J\u0015����}��^�N\u0005\u0003\u0000\u0000"
              ],
              [
                "(-�&?\u0017�j�X�H�W��J�\u0019�]���b�Q��x�\u001f�u6�3\u0000\u0000\u0000",
                "(Z0���a�iK�s��߃\u0003SrCUa\u0003p�\t����(LI�kZ9�\u0000\u0000\u0000",
                "(��A3C6�`�l���\u0006@#\u001ag���U\u001d���NR�����VM\u0002\u0000\u0000"
              ]
            ],
            "z": [
              "191402908466973854108312208145692350507334241942752894702102060224530842999348098901091196",
              "256420081481118310873264410474877417472425868441845571465060221762173707469720931553950712"
            ]
          }
        }
      ]
    }
  }
}
```


edit:

New output looks like the following:


```
{
  "data": {
    "blocks": {
      "nodes": [
        {
          "stateHash": "TWogr3GykfwAkjiqur9vNJsokVCurdeQGjNbrJNY5owZK1w1a3TRnzuxKpy5tSi2",
          "protocolStateProof": {
            "a": [
              "218659069152196389374111529990691173023664859457440667326700485601809050062039006656366448",
              "70886220239726735381157050385259244767473536827419312615561230137655941915903779944887857"
            ],
            "b": [
              [
                "234794458455109139771021028430373306648733249042844481679643770635195227346453494440140199",
                "310459695560964773513966763739173172449182746511934905624017695432103792528600669690831520",
                "287707961161242561272416368712477704905999404761858058654494123333291078409490993969841666"
              ],
              [
                "53000926026643226274315269714342040191885030637284293362177363710887191112902109058217423",
                "33367879529490530920402612096772926020222968203684790091504340518569067980334948331781466",
                "67250666468171348745653280035482192547991887323399715708184941898959275650427517469203957"
              ]
            ]
          }
        },
        {
          "stateHash": "TWogAexosj5k39YXMLYG5Dc12xAbGDDgzh2p7jmV4AmNdytfRAv3xG2wks24qJda",
          "protocolStateProof": {
            "a": [
              "218659069152196389374111529990691173023664859457440667326700485601809050062039006656366448",
              "70886220239726735381157050385259244767473536827419312615561230137655941915903779944887857"
            ],
            "b": [
              [
                "234794458455109139771021028430373306648733249042844481679643770635195227346453494440140199",
                "310459695560964773513966763739173172449182746511934905624017695432103792528600669690831520",
                "287707961161242561272416368712477704905999404761858058654494123333291078409490993969841666"
              ],
              [
                "53000926026643226274315269714342040191885030637284293362177363710887191112902109058217423",
                "33367879529490530920402612096772926020222968203684790091504340518569067980334948331781466",
                "67250666468171348745653280035482192547991887323399715708184941898959275650427517469203957"
              ]
            ]
          }
        }
      ]
    }
  }
}
```

Explain your changes here.

Explain how you tested your changes here.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
