### PR TITLE
URGENT/SIMPLE: PV Keys changed names - this tries harder to find them

### DIFF
--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -64,15 +64,23 @@ compile_keys=$(./default/app/cli/src/coda.exe internal snark-hashes)
 for key in $compile_keys
 do
     echo -n "Looking for keys matching: ${key} -- "
-    if [ -f "/var/lib/coda/${key}_proving" ]; then
-        echo " [OK] found key in stable key set"
-        cp /var/lib/coda/${key}* "${BUILDDIR}/var/lib/coda/."
-    elif [ -f "/tmp/coda_cache_dir/${key}_proving" ]; then
-        echo " [WARN] found key in compile-time set"
-        cp /tmp/coda_cache_dir/${key}* "${BUILDDIR}/var/lib/coda/."
-    else
-        echo "Key not found!"
-    fi
+
+    # Awkward, you can't do a filetest on a wildcard - use loops
+    for f in  /var/lib/coda/${key}*; do
+        if [ -e "$f" ]; then
+            echo " [OK] found key in stable key set"
+            cp /var/lib/coda/${key}* "${BUILDDIR}/var/lib/coda/."
+            break
+        fi
+    done
+
+    for f in  /tmp/coda_cache_dir/${key}*; do
+        if [ -e "$f" ]; then
+            echo " [WARN] found key in compile-time set"
+            cp /tmp/coda_cache_dir/${key}* "${BUILDDIR}/var/lib/coda/."
+            break
+        fi
+    done
 done
 
 # Bash autocompletion


### PR DESCRIPTION
The PV keys now seem to be of this format:

/var/lib/coda/4e6d9a9afabfcf88877b1c7a490f92cd_step_verification

instead of just HASH_proving and HASH_verifying

This change should find them and install them in debs