### PR TITLE
Graphql: add experimental verification key

### DIFF
--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -25,6 +25,23 @@ let result_field_no_inputs ~resolve =
   Schema.io_field ~resolve:(fun resolve_info src ->
       Deferred.return @@ resolve resolve_info src )
 
+let verification_key =
+  lazy
+    (let open Async in
+    let%map vk = Snark_keys.blockchain_verification () in
+    let open Crypto_params.Tock_backend.Verification_key in
+    let open Lite_compat_algebra in
+    let key =
+      { Lite_base.Crypto_params.Tock.Bowe_gabizon.Verification_key.alpha_beta=
+          alpha_beta vk.wrap |> target_field
+      ; delta= delta vk.wrap |> g2
+      ; query= query vk.wrap |> g1_vector }
+    in
+    sprintf
+      !"%{sexp:\n\
+       \    Lite_base.Crypto_params.Tock.Bowe_gabizon.Verification_key.t}\n"
+      key)
+
 module Doc = struct
   let date =
     sprintf
@@ -1811,6 +1828,14 @@ module Queries = struct
       ~doc:"The version of the node (git commit hash)"
       ~resolve:(fun _ _ -> Some Coda_version.commit_id)
 
+  let blockchain_verification_key =
+    io_field "blockchainVerificationKey" ~typ:(non_null string)
+      ~args:Arg.[]
+      ~doc:"Experimental: Verification key for blockchain snark"
+      ~resolve:(fun _ _ ->
+        let%map key = Lazy.force verification_key in
+        Ok key )
+
   let tracked_accounts_resolver {ctx= coda; _} () =
     let wallets = Coda_lib.wallets coda in
     let propose_public_keys = Coda_lib.propose_public_keys coda in
@@ -1945,6 +1970,7 @@ module Queries = struct
     ; trust_status
     ; trust_status_all
     ; snark_pool
+    ; blockchain_verification_key
     ; pending_snark_work ]
 end
 

--- a/src/lib/coda_graphql/dune
+++ b/src/lib/coda_graphql/dune
@@ -5,5 +5,5 @@
     ; opam deps
     async core cohttp graphql-async graphql-cohttp
     ; libs
-    auxiliary_database coda_base coda_commands coda_lib)
+    auxiliary_database coda_base coda_commands coda_lib lite_compat)
   (preprocess (pps ppx_coda ppx_jane)))


### PR DESCRIPTION
Very experimental, unlikely that we will keep this format, but this is necessary for verifying statehash in the browser.