### PR TITLE
Disallow include Stable.Vn

### DIFF
--- a/src/lib/ppx_coda/lint_version_syntax.ml
+++ b/src/lib/ppx_coda/lint_version_syntax.ml
@@ -2,7 +2,7 @@
 
    - "deriving bin_io" and "deriving version" never appear in types defined inside functor bodies
    - otherwise, "bin_io" may appear in a "deriving" attribute only if "version" also appears in that extension
-   - the construct "include Stable.Latest" is prohibited
+   - the constructs "include Stable.Latest" and "include Stable.Vn" are prohibited
 
 *)
 
@@ -85,9 +85,17 @@ let validate_version_if_bin_io =
     ~pred:(fun has_bin_io has_version -> has_bin_io && not has_version)
     "Must have deriving version if deriving bin_io"
 
-let is_stable_latest_inc_decl inc_decl =
+let is_version_module vn =
+  let len = String.length vn in
+  len >= 2
+  && Char.equal vn.[0] 'V'
+  && (not @@ Char.equal vn.[1] '0')
+  && String.for_all (String.sub vn ~pos:1 ~len:(len - 1)) ~f:Char.is_digit
+
+let is_versioned_module_inc_decl inc_decl =
   match inc_decl.pincl_mod.pmod_desc with
-  | Pmod_ident {txt= Ldot (Lident "Stable", "Latest"); _} ->
+  | Pmod_ident {txt= Ldot (Lident "Stable", name); _}
+    when String.equal name "Latest" || is_version_module name ->
       true
   | _ ->
       false
@@ -95,8 +103,8 @@ let is_stable_latest_inc_decl inc_decl =
 let versioned_in_functor_error loc =
   (loc, "Cannot use versioned extension within a functor body")
 
-let include_stable_latest_error loc =
-  (loc, "Cannot use \"include Stable.Latest\"")
+let include_versioned_module_error loc =
+  (loc, "Cannot include a stable versioned module")
 
 (* traverse AST, collect errors *)
 let check_deriving_usage =
@@ -129,8 +137,8 @@ let check_deriving_usage =
         when String.equal name.txt "test_module" ->
           (* don't check for errors in test code *)
           acc
-      | Pstr_include inc_decl when is_stable_latest_inc_decl inc_decl ->
-          (in_functor, errors @ [include_stable_latest_error str.pstr_loc])
+      | Pstr_include inc_decl when is_versioned_module_inc_decl inc_decl ->
+          (in_functor, errors @ [include_versioned_module_error str.pstr_loc])
       | _ ->
           super#structure_item str acc
   end

--- a/src/lib/secrets/secret_box.ml
+++ b/src/lib/secrets/secret_box.ml
@@ -36,6 +36,8 @@ module Stable = struct
       ; ciphertext: Bytes.t }
     [@@deriving sexp]
   end
+
+  module Latest = V1
 end
 
 module Json : sig
@@ -64,7 +66,14 @@ end = struct
     {Stable.V1.box_primitive; pw_primitive; nonce; pwsalt; pwdiff; ciphertext}
 end
 
-include Stable.V1
+type t = Stable.Latest.t =
+  { box_primitive: string
+  ; pw_primitive: string
+  ; nonce: Bytes.t
+  ; pwsalt: Bytes.t
+  ; pwdiff: Int64.t * int
+  ; ciphertext: Bytes.t }
+[@@deriving sexp]
 
 let to_yojson t : Yojson.Safe.json = Json.to_yojson (Json.of_stable t)
 


### PR DESCRIPTION
Just as we already prohibited `include Stable.Latest`, also disallow `include Stable.Vn`.

Fixed the one occurrence of that. It was benign, because the type was not `bin_io` or versioned, but better to not have that construct.
