### PR TITLE
Fix versioning of Lite_base.Nat

### DIFF
--- a/src/lib/lite_base/account.ml
+++ b/src/lib/lite_base/account.ml
@@ -1,56 +1,31 @@
 open Core_kernel
-open Module_version
 
 module Balance = struct
-  module V1_make_0 = Nat.Make64 ()
-
-  module V1_make = V1_make_0.Stable.V1
-
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      include V1_make.Stable.V1
-      include Registration.Make_latest_version (V1_make.Stable.V1)
+      type t = Nat.Inputs_64.Stable.V1.t Nat.T.Stable.V1.t
+      [@@deriving eq, sexp, to_yojson, compare]
+
+      let to_latest = Fn.id
     end
+  end]
 
-    module Latest = V1
-
-    module Module_decl = struct
-      let name = "balance_lite"
-
-      type latest = Latest.t
-    end
-
-    module Registrar = Registration.Make (Module_decl)
-    module Registered_V1 = Registrar.Register (V1)
-  end
-
-  include V1_make.Impl
+  include Nat.Make64 ()
 end
 
 module Nonce = struct
-  module V1_make_0 = Nat.Make32 ()
-
-  module V1_make = V1_make_0.Stable.V1
-
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      include V1_make.Stable.V1
-      include Registration.Make_latest_version (V1_make.Stable.V1)
+      type t = Nat.Inputs_32.Stable.V1.t Nat.T.Stable.V1.t
+      [@@deriving eq, sexp, to_yojson, compare]
+
+      let to_latest = Fn.id
     end
+  end]
 
-    module Latest = V1
-
-    module Module_decl = struct
-      let name = "nonce_lite"
-
-      type latest = Latest.t
-    end
-
-    module Registrar = Registration.Make (Module_decl)
-    module Registered_V1 = Registrar.Register (V1)
-  end
-
-  include V1_make.Impl
+  include Nat.Make32 ()
 end
 
 module Stable = struct

--- a/src/lib/lite_base/block_time.ml
+++ b/src/lib/lite_base/block_time.ml
@@ -1,25 +1,15 @@
-open Module_version
+(* block_time.ml *)
 
-module V1_make_0 = Nat.Make64 ()
+open Core_kernel
 
-module V1_make = V1_make_0.Stable.V1
-
+[%%versioned
 module Stable = struct
   module V1 = struct
-    include V1_make.Stable.V1
-    include Registration.Make_latest_version (V1_make.Stable.V1)
+    type t = Nat.Inputs_64.Stable.V1.t Nat.T.Stable.V1.t
+    [@@deriving eq, sexp, to_yojson, compare]
+
+    let to_latest = Fn.id
   end
+end]
 
-  module Latest = V1
-
-  module Module_decl = struct
-    let name = "block_time_lite"
-
-    type latest = Latest.t
-  end
-
-  module Registrar = Registration.Make (Module_decl)
-  module Registered_V1 = Registrar.Register (V1)
-end
-
-include V1_make.Impl
+include Nat.Make64 ()

--- a/src/lib/lite_base/length.ml
+++ b/src/lib/lite_base/length.ml
@@ -1,25 +1,15 @@
-open Module_version
+(* length.ml *)
 
-module V1_make_0 = Nat.Make32 ()
+open Core_kernel
 
-module V1_make = V1_make_0.Stable.V1
-
+[%%versioned
 module Stable = struct
   module V1 = struct
-    include V1_make.Stable.V1
-    include Registration.Make_latest_version (V1_make.Stable.V1)
+    type t = Nat.Inputs_32.Stable.V1.t Nat.T.Stable.V1.t
+    [@@deriving eq, sexp, to_yojson, compare]
+
+    let to_latest = Fn.id
   end
+end]
 
-  module Latest = V1
-
-  module Module_decl = struct
-    let name = "length_lite"
-
-    type latest = Latest.t
-  end
-
-  module Registrar = Registration.Make (Module_decl)
-  module Registered_V1 = Registrar.Register (V1)
-end
-
-include V1_make.Impl
+include Nat.Make32 ()


### PR DESCRIPTION
Lift the `bin_io` type in `Lite_base.Nat` out of `Nat.Make`. Use `%%versioned` where `Nat.Make{32,64}` was used elsewhere in `Lite_base`. The code is much simpler now.

There was a mixture of `Int32` and `Int64` from the OCaml standard library and `Core_kernel`. Opening `Core_kernel` at the top assures we're using just the Jane St ones.

