### PR TITLE
Fix/hack bump max connect to 40

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -487,7 +487,7 @@ let daemon logger =
            if
              or_from_config YJ.Util.to_bool_option "max-concurrent-connections"
                ~default:true limit_connections
-           then Some 10
+           then Some 32
            else None
          in
          let work_selection_method =

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -487,7 +487,7 @@ let daemon logger =
            if
              or_from_config YJ.Util.to_bool_option "max-concurrent-connections"
                ~default:true limit_connections
-           then Some 32
+           then Some 40
            else None
          in
          let work_selection_method =


### PR DESCRIPTION
Seeing lots of connection limits at 10. Bumping to 40 until gossip uses libp2p.