### PR TITLE
Nat, no bin_io in Make body

### DIFF
--- a/src/lib/coda_numbers/dune
+++ b/src/lib/coda_numbers/dune
@@ -6,6 +6,6 @@
  (libraries fold_lib tuple_lib snark_bits snark_params unsigned_extended
    core snarky snarky_integer crypto_params module_version codable)
  (preprocess
-  (pps ppx_jane ppx_coda -lint-version-syntax-warnings ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
+  (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
     -conditional))
  (synopsis "Snark-friendly numbers used in Coda consensus"))

--- a/src/lib/coda_numbers/intf.ml
+++ b/src/lib/coda_numbers/intf.ml
@@ -11,15 +11,6 @@ module type S_unchecked = sig
 
   include Hashable.S with type t := t
 
-  module Stable : sig
-    module V1 : sig
-      type nonrec t = t
-      [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
-    end
-
-    module Latest = V1
-  end
-
   val length_in_bits : int
 
   val length_in_triples : int
@@ -112,7 +103,16 @@ module type S = sig
 end
 
 module type UInt32 = sig
-  include S with type t = Unsigned_extended.UInt32.t
+  module Stable : sig
+    module V1 : sig
+      type nonrec t = Unsigned_extended.UInt32.t
+      [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
+    end
+
+    module Latest = V1
+  end
+
+  include S with type t = Stable.Latest.t
 
   val to_uint32 : t -> uint32
 
@@ -120,7 +120,16 @@ module type UInt32 = sig
 end
 
 module type UInt64 = sig
-  include S with type t = Unsigned_extended.UInt64.t
+  module Stable : sig
+    module V1 : sig
+      type t = Unsigned_extended.UInt64.t
+      [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
+    end
+
+    module Latest = V1
+  end
+
+  include S with type t = Stable.Latest.t
 
   val to_uint64 : t -> uint64
 

--- a/src/lib/consensus/global_slot.mli
+++ b/src/lib/consensus/global_slot.mli
@@ -1,4 +1,12 @@
-include Coda_numbers.Nat.Intf.S_unchecked
+module Stable : sig
+  module V1 : sig
+    type t [@@deriving bin_io, sexp, eq, compare, hash, yojson, version]
+  end
+
+  module Latest = V1
+end
+
+include Coda_numbers.Nat.Intf.S_unchecked with type t = Stable.Latest.t
 
 val ( + ) : t -> int -> t
 


### PR DESCRIPTION
Remove `bin_io` from body of functor `Nat.Make`.

The functors `Make32` and `Make64`  now have the `Stable` modules with `bin_io` types in their bodies. Those are functors of no arguments, where such types are allowed.

The errors-as-warnings flag to `ppx_coda` in the dune file is removed.

There's some tweaking of the interface in `global_slot.mli` to accommodate the change.