### PR TITLE
Always rebuild coda_version.ml

### DIFF
--- a/src/lib/coda_version/dune
+++ b/src/lib/coda_version/dune
@@ -5,5 +5,5 @@
 
 (rule
  (targets coda_version.ml)
- (deps (:< gen.sh))
+ (deps (:< gen.sh) (universe))
  (action (run %{<} %{targets})))


### PR DESCRIPTION
Without this, partial rebuilds won't update the reported git hash and the
version message will be wrong.

Tested by running `dune b` with and without the change and looking at the modification time of the relevant file.