### PR TITLE
Versioned ppx in Trust_system.Record

### DIFF
--- a/src/lib/trust_system/dune
+++ b/src/lib/trust_system/dune
@@ -4,5 +4,5 @@
   (library_flags (-linkall))
   (libraries core async envelope key_value_database logger pipe_lib rocksdb coda_metrics module_version)
   (inline_tests)
-  (preprocess (pps ppx_base ppx_coda -lint-version-syntax-warnings ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx -conditional))
+  (preprocess (pps ppx_base ppx_coda ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx -conditional))
   (synopsis "Track how much we trust peers"))

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -387,6 +387,7 @@ module Make (Action : Action_intf) = Make0 (struct
   end
 
   module Config = String
-  module Db = Rocksdb.Serializable.Make (Unix.Inet_addr.Blocking_sexp) (Record)
+  module Db =
+    Rocksdb.Serializable.Make (Unix.Inet_addr.Blocking_sexp) (Record.Stable.V1)
   module Action = Action
 end)

--- a/src/lib/trust_system/record.ml
+++ b/src/lib/trust_system/record.ml
@@ -1,8 +1,20 @@
 open Core
 
-type t =
+[%%versioned
+module Stable = struct
+  module V1 = struct
+    type t =
+      { trust: float
+      ; trust_last_updated: Core.Time.Stable.V1.t
+      ; banned_until_opt: Core.Time.Stable.V1.t Core_kernel.Option.Stable.V1.t
+      }
+
+    let to_latest = Fn.id
+  end
+end]
+
+type t = Stable.Latest.t =
   {trust: float; trust_last_updated: Time.t; banned_until_opt: Time.t Option.t}
-[@@deriving bin_io]
 
 module type S = sig
   val init : unit -> t

--- a/src/lib/trust_system/record.mli
+++ b/src/lib/trust_system/record.mli
@@ -1,6 +1,14 @@
 open Core
 
-type t [@@deriving bin_io]
+module Stable : sig
+  module V1 : sig
+    type t [@@deriving bin_io, version]
+  end
+
+  module Latest = V1
+end
+
+type t = Stable.Latest.t
 
 module type S = sig
   val init : unit -> t


### PR DESCRIPTION
Use `%%versioned` for the serialized type in `Trust_system.Record`.

The versioned module is passed to `Rocksdb.Serialized.Make`. We'll see if we can change that in a subsequent PR.