### PR TITLE
fix for "bad statement"

### DIFF
--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -198,7 +198,9 @@ let create_expected_statement
   let pending_coinbase_after =
     match transaction with
     | Coinbase c ->
-        Pending_coinbase.Stack.push pending_coinbase_before c
+        if Coda_compile_config.pending_coinbase_hack then
+          Pending_coinbase.Stack.empty
+        else Pending_coinbase.Stack.push pending_coinbase_before c
     | _ ->
         pending_coinbase_before
   in

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -198,9 +198,7 @@ let create_expected_statement
   let pending_coinbase_after =
     match transaction with
     | Coinbase c ->
-        if Coda_compile_config.pending_coinbase_hack then
-          Pending_coinbase.Stack.empty
-        else Pending_coinbase.Stack.push pending_coinbase_before c
+        Pending_coinbase.Stack.push pending_coinbase_before c
     | _ ->
         pending_coinbase_before
   in


### PR DESCRIPTION
Since we are passing empty stacks (as part of the pending coinbase hack), when validating the scan state the target stack should be empty