### PR TITLE
Preserve exit status of integration tests in CI

### DIFF
--- a/scripts/test.py
+++ b/scripts/test.py
@@ -237,7 +237,7 @@ def run(args):
                 coda_exe, test)
             cmd += '| tee \'%s\' | %s -f \'%s\' ' % (log, logproc_exe,
                                                      logproc_filter)
-            cmd += '; ./scripts/link-subprocess-logs.sh \'%s\' ' % profile_dir
+            cmd += '&& ./scripts/link-subprocess-logs.sh \'%s\' ' % profile_dir
             print('Running: %s' % (cmd))
             run_cmd(cmd, lambda: fail('Test "%s:%s" failed' % (profile, test)))
 


### PR DESCRIPTION
This change makes it so the exit status of integration tests is the exit status of `test.py`. Before it'd always appear to succeed because we were using `;` in the bash script, which swallows the exit status of the previous command.