### PR TITLE
Permute response items to get a new RPC version

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -278,7 +278,7 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
     in
     let%bind staged_ledger_aux_result =
       let open Deferred.Or_error.Let_syntax in
-      let%bind scan_state, expected_merkle_root, pending_coinbases =
+      let%bind scan_state, pending_coinbases, expected_merkle_root =
         Coda_networking.get_staged_ledger_aux_and_pending_coinbases_at_hash
           t.network sender hash
       in

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -674,7 +674,7 @@ let create (config : Config.t) =
                     let%bind frontier =
                       Broadcast_pipe.Reader.peek frontier_broadcast_pipe_r
                     in
-                    let%map scan_state, expected_merkle_root, pending_coinbases
+                    let%map scan_state, pending_coinbases, expected_merkle_root
                         =
                       Sync_handler
                       .get_staged_ledger_aux_and_pending_coinbases_at_hash
@@ -683,7 +683,7 @@ let create (config : Config.t) =
                     let staged_ledger_hash =
                       Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
                         (Staged_ledger.Scan_state.hash scan_state)
-                        expected_merkle_root pending_coinbases
+                        pending_coinbases expected_merkle_root
                     in
                     Logger.debug config.logger ~module_:__MODULE__
                       ~location:__LOC__

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -15,8 +15,8 @@ module Rpcs : sig
 
     type response =
       ( Staged_ledger.Scan_state.Stable.V1.t
-      * Ledger_hash.Stable.V1.t
-      * Pending_coinbase.Stable.V1.t )
+      * Pending_coinbase.Stable.V1.t
+      * Ledger_hash.Stable.V1.t )
       option
   end
 
@@ -162,7 +162,7 @@ val get_staged_ledger_aux_and_pending_coinbases_at_hash :
      t
   -> Unix.Inet_addr.t
   -> State_hash.t
-  -> (Staged_ledger.Scan_state.t * Ledger_hash.t * Pending_coinbase.t)
+  -> (Staged_ledger.Scan_state.t * Pending_coinbase.t * Ledger_hash.t)
      Deferred.Or_error.t
 
 val ban_notify : t -> Network_peer.Peer.t -> Time.t -> unit Deferred.Or_error.t
@@ -211,9 +211,9 @@ val create :
                                                           -> ( Staged_ledger
                                                                .Scan_state
                                                                .t
-                                                             * Ledger_hash.t
                                                              * Pending_coinbase
-                                                               .t )
+                                                               .t
+                                                             * Ledger_hash.t )
                                                              Deferred.Option.t)
   -> answer_sync_ledger_query:(   (Ledger_hash.t * Sync_ledger.Query.t)
                                   Envelope.Incoming.t

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -73,7 +73,7 @@ let setup (type n) ?(logger = Logger.null ())
                   let input = Envelope.Incoming.data query_env in
                   Deferred.return
                     (let open Option.Let_syntax in
-                    let%map scan_state, expected_merkle_root, pending_coinbases
+                    let%map scan_state, pending_coinbases, expected_merkle_root
                         =
                       Sync_handler
                       .get_staged_ledger_aux_and_pending_coinbases_at_hash
@@ -82,7 +82,7 @@ let setup (type n) ?(logger = Logger.null ())
                     let staged_ledger_hash =
                       Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
                         (Staged_ledger.Scan_state.hash scan_state)
-                        expected_merkle_root pending_coinbases
+                        pending_coinbases expected_merkle_root
                     in
                     Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
                       ~metadata:


### PR DESCRIPTION
Create a `V2` for the the RPC `Get_staged_ledger_aux_and_pending_coinbases_at_hash` by permuting the tuple items in the `response` type.

Change the RPC's "Master" type to track that change, and modify the coercions in `V1`.

This change is to validate that we can update an RPC type. 

It would be useful to run a network with nodes running both `V1` and `V2` to know that they interoperate.
