### PR TITLE
Bump snarky for JSON printing

### DIFF
--- a/src/lib/snark_params/snark_params.ml
+++ b/src/lib/snark_params/snark_params.ml
@@ -325,7 +325,7 @@ module Tock = struct
       {Proof.a= a p; b= conv_g2 (b p); c= c p}
 
     let vk_of_backend_vk vk =
-      let open Tick_backend.Full.Groth16_verification_key_accessors in
+      let open Tick_backend.Full.Groth16.Verification_key in
       let open Inner_curve.Vector in
       let q = query vk in
       { Verification_key.query_base= get q 0


### PR DESCRIPTION
This PR updates snarky to
* fix libsnark JSON printing
* stop libsnark printing from closing stdout.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: