### PR TITLE
Fix nits requested by psteckler in #3845

### DIFF
--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -237,8 +237,9 @@ module Make (T : Transaction_snark.Verification.S) = struct
              (Step_base.main (Logger.null ())))
 
     let cached () =
+      let open Cached.Deferred_with_track_generated.Let_syntax in
       let paths = Fn.compose Cache_dir.possible_paths Filename.basename in
-      let%bind (step_vk, step_pk), dirty1 = Cached.run step_cached in
+      let%bind step_vk, step_pk = Cached.run step_cached in
       let module Wrap = Wrap_base (struct
         let verification_key = step_vk.value
       end) in
@@ -265,7 +266,7 @@ module Make (T : Transaction_snark.Verification.S) = struct
           ~input:(lazy (Tock.constraint_system ~exposing:Wrap.input Wrap.main))
           ~create_env:(fun x -> Tock.Keypair.generate (Lazy.force x))
       in
-      let%map (wrap_vk, wrap_pk), dirty2 = Cached.run wrap_cached in
+      let%map wrap_vk, wrap_pk = Cached.run wrap_cached in
       let location : Location.t =
         { proving= {step= paths step_pk.path; wrap= paths wrap_pk.path}
         ; verification= {step= paths step_vk.path; wrap= paths wrap_vk.path} }
@@ -278,7 +279,7 @@ module Make (T : Transaction_snark.Verification.S) = struct
         }
       in
       let t : Verification.t = {step= step_vk.value; wrap= wrap_vk.value} in
-      ((location, t, checksum), Cached.Track_generated.(dirty1 + dirty2))
+      (location, t, checksum)
   end
 end
 

--- a/src/lib/cached/cached.mli
+++ b/src/lib/cached/cached.mli
@@ -40,13 +40,22 @@ module Spec : sig
     -> 'a t
 end
 
-(** A Semigroup for tracking the "dirty bit" of whether or not we've generated
+(** A monoid for tracking the "dirty bit" of whether or not we've generated
  * something or only received cache hits *)
 module Track_generated : sig
   type t = [`Generated_something | `Cache_hit]
 
-  (** Generated_something overrides caches hits *)
+  val empty : t
+
   val ( + ) : t -> t -> t
+  (** Generated_something overrides caches hits *)
 end
 
-val run : 'a Spec.t -> ('a * Track_generated.t) Deferred.t
+module With_track_generated : sig
+  type 'a t = {data: 'a; dirty: Track_generated.t}
+end
+
+module Deferred_with_track_generated :
+  Monad.S with type 'a t = 'a With_track_generated.t Deferred.t
+
+val run : 'a Spec.t -> 'a Deferred_with_track_generated.t

--- a/src/lib/cached/cached.mli
+++ b/src/lib/cached/cached.mli
@@ -47,8 +47,8 @@ module Track_generated : sig
 
   val empty : t
 
-  val ( + ) : t -> t -> t
   (** Generated_something overrides caches hits *)
+  val ( + ) : t -> t -> t
 end
 
 module With_track_generated : sig

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -185,7 +185,7 @@ let gen_keys () =
                                                    (struct
       let keys = tx_keys
     end)) in
-    let%bind bc_keys_location, _bc_keys, bc_keys_checksum = M.Keys.cached () in
+    let%map bc_keys_location, _bc_keys, bc_keys_checksum = M.Keys.cached () in
     ( Blockchain_snark_keys.Proving.load_expr ~loc bc_keys_location.proving
         bc_keys_checksum.proving
     , Blockchain_snark_keys.Proving.key_location ~loc bc_keys_location.proving

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -173,7 +173,7 @@ let location_expr key_location =
 
 let gen_keys () =
   let open Async_kernel in
-  let%bind {With_track_generated.data= acc; dirty} =
+  let%bind {Cached.With_track_generated.data= acc; dirty} =
     let open Cached.Deferred_with_track_generated.Let_syntax in
     let%bind tx_keys_location, tx_keys, tx_keys_checksum =
       Transaction_snark.Keys.cached ()

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -201,7 +201,7 @@ let gen_keys () =
     , Transaction_snark_keys.Verification.key_location ~loc
         tx_keys_location.verification )
   in
-  match Cached.Track_generated.(dirty1 + dirty2) with
+  match dirty with
   | `Generated_something -> (
     (* TODO: Check if circleci and die *)
     match (Sys.getenv "CI", Sys.getenv "DUNE_PROFILE") with

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -172,20 +172,20 @@ let location_expr key_location =
                 key_location)])]
 
 let gen_keys () =
-  let%bind (tx_keys_location, tx_keys, tx_keys_checksum), dirty1 =
-    Transaction_snark.Keys.cached ()
-  in
-  let module M =
-  (* TODO make toplevel library to encapsulate consensus params *)
-  Blockchain_snark.Blockchain_transition.Make (Transaction_snark.Verification
-                                               .Make
-                                                 (struct
-    let keys = tx_keys
-  end)) in
-  let%bind (bc_keys_location, _bc_keys, bc_keys_checksum), dirty2 =
-    M.Keys.cached ()
-  in
-  let acc =
+  let open Async_kernel in
+  let%bind {With_track_generated.data= acc; dirty} =
+    let open Cached.Deferred_with_track_generated.Let_syntax in
+    let%bind tx_keys_location, tx_keys, tx_keys_checksum =
+      Transaction_snark.Keys.cached ()
+    in
+    let module M =
+    (* TODO make toplevel library to encapsulate consensus params *)
+    Blockchain_snark.Blockchain_transition.Make (Transaction_snark.Verification
+                                                 .Make
+                                                   (struct
+      let keys = tx_keys
+    end)) in
+    let%bind bc_keys_location, _bc_keys, bc_keys_checksum = M.Keys.cached () in
     ( Blockchain_snark_keys.Proving.load_expr ~loc bc_keys_location.proving
         bc_keys_checksum.proving
     , Blockchain_snark_keys.Proving.key_location ~loc bc_keys_location.proving

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1470,10 +1470,10 @@ module Keys = struct
 
   let cached () =
     let paths path = Cache_dir.possible_paths (Filename.basename path) in
-    let open Async in
-    let%bind (base_vk, base_pk), dirty1 = Cached.run Base.cached in
-    let%bind (merge_vk, merge_pk), dirty2 = Cached.run Merge.cached in
-    let%map (wrap_vk, wrap_pk), dirty3 =
+    let open Cached.Deferred_with_track_generated.Let_syntax in
+    let%bind base_vk, base_pk = Cached.run Base.cached in
+    let%bind merge_vk, merge_pk = Cached.run Merge.cached in
+    let%map wrap_vk, wrap_pk =
       let module Wrap = Wrap (struct
         let base = base_vk.value
 
@@ -1502,7 +1502,7 @@ module Keys = struct
           Verification.checksum ~base:base_vk.checksum ~merge:merge_vk.checksum
             ~wrap:wrap_vk.checksum }
     in
-    ((location, t, checksum), Cached.Track_generated.(dirty1 + dirty2 + dirty3))
+    (location, t, checksum)
 end
 
 let%test_module "transaction_snark" =

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -145,8 +145,8 @@ module Keys : sig
 
   val cached :
        unit
-    -> ((Location.t * Verification.t * Checksum.t) * Cached.Track_generated.t)
-       Async.Deferred.t
+    -> (Location.t * Verification.t * Checksum.t)
+       Cached.Deferred_with_track_generated.t
 end
 
 module Verification : sig


### PR DESCRIPTION
With the record the code looked really messy, so I wrapped it up into
what is essentially a `('a, Track_generated.t) Deferred.Writer.t` and
it's a lot cleaner (no more manual tracking the dirty bits nor messing
with the records)

Tested by running it in CI last time (also the compiler)