### PR TITLE
Fixes: staking button refetch, and adds new well

### DIFF
--- a/frontend/wallet/src/render/views/settings/AccountSettings.re
+++ b/frontend/wallet/src/render/views/settings/AccountSettings.re
@@ -337,7 +337,7 @@ module BlockRewards = {
                                     onMouseLeave={_ =>
                                       setStakingHovered(_ => false)
                                     }
-                                    onClick={_ => Task.liftPromise(mutate) |> Task.perform(~f=_ => {Bindings.setTimeout(1000) |> ignore response.refetch(Some(accountInfoVariables))} |> ignore) }
+                                    onClick={_ => Task.liftPromise(mutate) |> Task.perform(~f=_ => {Bindings.setTimeout(100) |> ignore response.refetch(Some(accountInfoVariables))} |> ignore) }
                                   />
                               )
                             </DisableStakingMutation>


### PR DESCRIPTION
Adds new warning when a node is synced, but the account has not received funds yet (so is not included in the ledger) 

<img width="704" alt="Screen Shot 2019-11-14 at 11 29 34 AM" src="https://user-images.githubusercontent.com/12700801/68897242-f1a8c800-06e1-11ea-83c7-f6b260e65ce1.png">

Also fixes staking button refresh after disabling staking
