### PR TITLE
Make the public key copy button

### DIFF
--- a/frontend/wallet/src/render/components/Icon.re
+++ b/frontend/wallet/src/render/components/Icon.re
@@ -12,7 +12,8 @@ type kind =
   | BackArrow
   | Locked
   | Unlocked
-  | Cross;
+  | Cross
+  | Copy;
 
 [@react.component]
 let make = (~kind) =>
@@ -97,6 +98,12 @@ let make = (~kind) =>
          fillRule="evenodd"
          clipRule="evenodd"
          d="M6.55558 5L5.00002 6.55546L10.4449 12L5 17.4446L6.55556 19.0001L12.0005 13.5555L17.4445 18.9992L19 17.4437L13.556 12L19 6.55636L17.4444 5.00089L12.0005 10.4446L6.55558 5Z"
+       />
+     | Copy =>
+       <path
+         fillRule="evenodd"
+         clipRule="evenodd"
+         d="M4.13793 3.42857V4.02685V16.5907H8.7516V15.3941H5.29323V4.62513H13.7654V6.21275H14.9207V3.42857H4.13793ZM9.90689 7.4093V8.00758V20.5714H20.6897V7.4093H9.90689ZM19.5344 8.60586H11.0622V19.3749H19.5344V8.60586Z"
        />
      }}
   </svg>;

--- a/frontend/wallet/src/render/views/onboarding/CompletionStep.re
+++ b/frontend/wallet/src/render/views/onboarding/CompletionStep.re
@@ -144,7 +144,7 @@ let make = (~closeOnboarding, ~prevStep) => {
         <FadeIn duration=500 delay=150>
           <p className=Styles.heroBody>
             {React.string(
-               "You've successfully set up Coda Wallet. Head over to the Faucet to request funds to start sending transactions on the Coda network.",
+               "You’ve completed your intial account set up. You may now request funds and make transactions. Please use our Discord faucet channel to request funds. You may skip this step for now.",
              )}
           </p>
         </FadeIn>

--- a/frontend/wallet/src/render/views/onboarding/CompletionStep.re
+++ b/frontend/wallet/src/render/views/onboarding/CompletionStep.re
@@ -32,12 +32,107 @@ module Styles = {
       style([maxWidth(`rem(21.5)), color(Theme.Colors.midnightBlue)]),
     ]);
   };
+
+  let line = {
+    style([
+      height(`rem(17.7)),
+      marginTop(`rem(5.5)),
+      marginLeft(`rem(5.)),
+      borderLeft(`px(4), `solid, Theme.Colors.slateAlpha(0.05)),
+    ]);
+  };
   let buttonRow = {
     style([display(`flex), flexDirection(`row)]);
   };
 };
 
 [@bs.scope "window"] [@bs.val] external openExternal: string => unit = "";
+
+module Accounts = [%graphql
+  {|
+    query getAccounts {
+      trackedAccounts {
+        publicKey @bsDecoder(fn: "Apollo.Decoders.publicKey")
+      }
+    }
+  |}
+];
+
+module AccountQuery = ReasonApollo.CreateQuery(Accounts);
+
+module CopyKeyButton = {
+  module Styles = {
+    open Css;
+
+    let container =
+      style([
+        display(`flex),
+        justifyContent(`center),
+        alignItems(`center),
+        marginLeft(`rem(5.)),
+        marginTop(`rem(-8.)),
+      ]);
+    let publicKey =
+      style([
+        maxWidth(`rem(10.6)),
+        height(`rem(3.43)),
+        color(Theme.Colors.marineAlpha(1.)),
+        backgroundColor(Theme.Colors.slateAlpha(0.05)),
+        borderRadius(`rem(0.25)),
+      ]);
+    let heading =
+      merge([
+        Theme.Text.Body.semiBold,
+        style([
+          marginTop(`rem(0.5)),
+          marginBottom(`zero),
+          marginLeft(`rem(1.0)),
+        ]),
+      ]);
+    let publicKeyString =
+      merge([
+        Theme.Text.Body.smallCaps,
+        style([
+          marginLeft(`rem(1.0)),
+          marginTop(`zero),
+          overflow(`hidden),
+          textOverflow(`ellipsis),
+        ]),
+      ]);
+    let button =
+      style([
+        display(`flex),
+        justifyContent(`center),
+        alignItems(`center),
+        color(Theme.Colors.marineAlpha(1.)),
+        backgroundColor(Theme.Colors.slateAlpha(0.05)),
+        height(`rem(3.43)),
+        width(`rem(6.0)),
+        border(`px(0), `solid, white),
+        borderRadius(`rem(0.25)),
+        hover([backgroundColor(Theme.Colors.marine), color(white)]),
+        focus([backgroundColor(Theme.Colors.marine), color(white)]),
+        active([backgroundColor(Theme.Colors.marine), color(white)]),
+      ]);
+  };
+  [@react.component]
+  let make = (~publicKey, ~onClick) => {
+    <div className=Styles.container>
+      <div className=Styles.publicKey>
+        <p className=Styles.heading> {React.string("Public Key")} </p>
+        <p className=Styles.publicKeyString> {React.string(publicKey)} </p>
+      </div>
+      <Spacer width=0.1 />
+      <div>
+        <button onClick={_ => onClick()} className=Styles.button>
+          <Icon kind=Icon.Copy />
+          <Spacer width=0.3 />
+          <p className=Theme.Text.Body.semiBold> {React.string("copy")} </p>
+        </button>
+      </div>
+    </div>;
+  };
+};
 
 [@react.component]
 let make = (~closeOnboarding, ~prevStep) => {
@@ -72,9 +167,21 @@ let make = (~closeOnboarding, ~prevStep) => {
           <Button label="Continue" onClick={_ => closeOnboarding()} />
         </div>
       </div>
-      <div
-        // Graphic goes here
-      />
+      <div className=Styles.line />
+      <div />
+      <AccountQuery>
+        {response =>
+           switch (response.result) {
+           | Loading => <Loader />
+           | Error(err) => React.string(err##message)
+           | Data(data) =>
+             let publicKey =
+               PublicKey.toString(data##trackedAccounts[0]##publicKey);
+             let handleClipboard = () =>
+               ignore(Bindings.Navigator.Clipboard.writeText(publicKey));
+             <CopyKeyButton publicKey onClick=handleClipboard />;
+           }}
+      </AccountQuery>
     </div>
   </div>;
 };


### PR DESCRIPTION
<img width="963" alt="Screen Shot 2019-11-14 at 5 03 57 PM" src="https://user-images.githubusercontent.com/12700801/68908637-c4b7dd80-0700-11ea-9574-5340457ee1f7.png">

First pass at the public key copier for the last step in onboarding. The current design is sort of confusing because it assumes we would be able to copy into the Discord channel in the next button, then this public key copier is pointless. 

<img width="726" alt="Screen Shot 2019-11-14 at 5 05 21 PM" src="https://user-images.githubusercontent.com/12700801/68908714-f5981280-0700-11ea-8268-6fd49d39bc62.png">


