### PR TITLE
To add the import command to the coda advance CLI menu

### DIFF
--- a/frontend/website/docs/cli-reference.md
+++ b/frontend/website/docs/cli-reference.md
@@ -46,6 +46,8 @@ The CLI is installed as part of the Coda bundle, and can be accessed from a shel
       stop-tracing               Stop async tracing
       visualization              Visualize data structures special to Coda
       wrap-key                   Wrap a private key into a private key file
+      import                     Set an pre-owned private key (-privkey-path) as the active 
+                                    key in a coda daemon
       help                       explain a given subcommand (perhaps recursively)
 
 `daemon` - Daemon commands to configure settings related to how node interacts with network


### PR DESCRIPTION
Lines 49 and 50
      import                     Set an pre-owned private key (-privkey-path) as the active 
                                    key in a coda daemon

Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

Explain your changes here.

Explain how you tested your changes here.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
