### PR TITLE
Feature/wallet 0.1.1

### DIFF
--- a/frontend/wallet/package.json
+++ b/frontend/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coda-wallet",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "./lib/js/src/main/App.js",
   "dependencies": {
@@ -69,7 +69,7 @@
       "bundle/**/*",
       "public/**/*"
     ],
-    "productName": "CodaWallet",
+    "productName": "Coda Wallet",
     "compression": "store",
     "dmg": {
       "contents": [

--- a/frontend/wallet/src/main/DaemonProcess.re
+++ b/frontend/wallet/src/main/DaemonProcess.re
@@ -138,16 +138,16 @@ module CodaProcess = {
   let port = 0xc0d;
 
   let defaultPeers = [
-    "/ip4/52.39.56.50/tcp/8303/ipfs/12D3KooWHMmfuS9DmmK9eH4GC31arDhbtHEBQzX6PwPtQftxzwJs",
-    "/ip4/18.212.230.102/tcp/8303/ipfs/12D3KooWAux9MAW1yAdD8gsDbYHmgVjRvdfYkpkfX7AnyGvQaRPF",
-    "/ip4/52.13.17.206/tcp/8303/ipfs/12D3KooWCZA4pPWmDAkQf6riDQ3XMRN5k99tCsiRhBAPZCkA8re7",
+    "/dns4/peer1-rising-phoenix.o1test.net/tcp/8303/ipfs/12D3KooWHMmfuS9DmmK9eH4GC31arDhbtHEBQzX6PwPtQftxzwJs",
+    "/dns4/peer2-rising-phoenix.o1test.net/tcp/8303/ipfs/12D3KooWAux9MAW1yAdD8gsDbYHmgVjRvdfYkpkfX7AnyGvQaRPF",
+    "/dns4/peer3-rising-phoenix.o1test.net/tcp/8303/ipfs/12D3KooWCZA4pPWmDAkQf6riDQ3XMRN5k99tCsiRhBAPZCkA8re7",
   ];
 
   let defaultArgs =
     List.foldr(
       ~f=(peer, acc) => List.concat([["-peer", peer], acc]),
       defaultPeers,
-      ~init=[],
+      ~init=["-discovery-port", "8303"],
     );
 
   let start: list(string) => t =


### PR DESCRIPTION
Bump version number to `0.1.1`.
Update the peers for the new network.
Fix the wallet name.