### PR TITLE
disable build-archive until its working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,36 +59,7 @@ jobs:
                   name: Build bot
                   command: cd frontend/bot && yarn run build-ci
 
-    build-archive:
-        docker:
-            - image: codaprotocol/coda:toolchain-54430467ba429af285ea937d1c1da7d4b4cbde3e
-              environment:
-                CODA_DOCKER: true
-                HASURA_PORT: 8080
-            - image: postgres:12
-              environment:
-                POSTGRES_PASSWORD: codarules
-                POSTGRES_USER: admin
-                POSTGRES_DB: archiver
-            - image: hasura/graphql-engine:v1.0.0-beta.6
-              environment:
-                HASURA_GRAPHQL_DATABASE_URL: postgres://admin:codarules@localhost:5432/archiver
-                HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
-                HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
-        steps:
-            - checkout
-            - run:
-                  name: Update Submodules
-                  command: git submodule sync && git submodule update --init --recursive
-            - run:
-                  name: Update OPAM
-                  command: ./scripts/update-opam-in-docker.sh
-            - run:
-                  name: Build Archive Process
-                  command:  bash -c 'eval `opam config env` && make build_archive'
-            - run:
-                  name: Configure Hasura
-                  command: ls && ./scripts/archive/make_hasura_configurations.sh
+    
     lint:
         docker:
             - image: codaprotocol/coda:toolchain-54430467ba429af285ea937d1c1da7d4b4cbde3e
@@ -702,7 +673,7 @@ workflows:
                     only: develop
             - tracetool
             - build-wallet
-            - build-archive
+            
             - build-macos
             - build-artifacts--testnet_postake_medium_curves
             - test-unit--test_postake_snarkless_unittest

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -59,6 +59,7 @@ jobs:
                   name: Build bot
                   command: cd frontend/bot && yarn run build-ci
 
+    {# # Disabled until working
     build-archive:
         docker:
             - image: codaprotocol/coda:toolchain-54430467ba429af285ea937d1c1da7d4b4cbde3e
@@ -88,7 +89,7 @@ jobs:
                   command:  bash -c 'eval `opam config env` && make build_archive'
             - run:
                   name: Configure Hasura
-                  command: ls && ./scripts/archive/make_hasura_configurations.sh
+                  command: ls && ./scripts/archive/make_hasura_configurations.sh #}
     lint:
         docker:
             - image: codaprotocol/coda:toolchain-54430467ba429af285ea937d1c1da7d4b4cbde3e
@@ -458,7 +459,7 @@ workflows:
                     only: develop
             - tracetool
             - build-wallet
-            - build-archive
+            {# - build-archive #}
             - build-macos
             {%- for profile in build_artifact_profiles %}
             - build-artifacts--{{profile}}


### PR DESCRIPTION
build-archive has been running in CircleCI for over a month, but has never passed.

approximately 7m of compute time @ ~10x a day for ~30 days adds up.

This PR comments out build-archive so it's easy to re-add once it's working.
