### PR TITLE
Update docs to have Github link

### DIFF
--- a/frontend/website/docs/developers/index.md
+++ b/frontend/website/docs/developers/index.md
@@ -2,6 +2,8 @@
 
 Welcome to the Coda developer docs - please quickly familiarize yourself with the below links to get a lay of the land.
 
+Explore the codebase on [Github](https://github.com/CodaProtocol/coda). 
+
 See the [Contributing Guide](/docs/contributing/) to start contributing code to Coda. The [protocol](https://github.com/CodaProtocol/coda/tree/master/src) and [CLI](https://github.com/CodaProtocol/coda/tree/master/src/app/cli) are written in OCaml, and the [website](https://github.com/CodaProtocol/coda/tree/master/frontend/website) and [Coda Wallet](https://github.com/CodaProtocol/coda/tree/master/frontend/wallet) are written in [ReasonReact](https://reasonml.github.io/reason-react/). Any level of experience in any or all of these tools is welcome.
 
 Other documents relevant to contributing code include:


### PR DESCRIPTION
Concurrent PR with Developer Portal page 
