### PR TITLE
simplify artifact builds

### DIFF
--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -264,11 +264,7 @@ jobs:
 
     {%- for profile in build_artifact_profiles %}
     build-artifacts--{{profile}}:
-        {%- if profile in medium_curve_profiles %}
         resource_class: xlarge
-        {%- else %}
-        resource_class: large
-        {%- endif %}
         docker:
             - image: codaprotocol/coda:toolchain-54430467ba429af285ea937d1c1da7d4b4cbde3e
         steps:
@@ -291,9 +287,7 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log'
                   environment:
                     DUNE_PROFILE: {{profile}}
-                  {%- if profile in medium_curve_profiles %}
                   no_output_timeout: 20m
-                  {%- endif %}
             - run:
                   name: Upload generated PV keys
                   command: ./scripts/skip_if_only_frontend.sh scripts/publish-pvkeys.sh
@@ -302,17 +296,13 @@ jobs:
                   command: ./scripts/skip_if_only_frontend.sh bash -c 'eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml2.log'
                   environment:
                     DUNE_PROFILE: {{profile}}
-                  {%- if profile in medium_curve_profiles %}
                   no_output_timeout: 20m
-                  {%- endif %}
             - run:
                   name: Build deb package with PV keys and PV key tar
                   command: ./scripts/skip_if_only_frontend.sh make deb
                   environment:
                     DUNE_PROFILE: {{profile}}
-                  {%- if profile in medium_curve_profiles %}
                   no_output_timeout: 20m
-                  {%- endif %}
             - run:
                   name: Store genesis public/private keypairs
                   command: ./scripts/skip_if_only_frontend.sh make genesiskeys
@@ -323,6 +313,7 @@ jobs:
             - run:
                   name: Copy artifacts to cloud
                   command: ./scripts/skip_if_only_frontend.sh scripts/artifacts.sh
+            {%- if profile in medium_curve_profiles %}
             - setup_remote_docker
             - run:
                   name: Build and Upload Docker
@@ -339,7 +330,6 @@ jobs:
                         -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                         --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
                     fi
-            {%- if profile in medium_curve_profiles %}
             - store_artifacts:
                   path: /tmp/artifacts
             {%- endif %}


### PR DESCRIPTION
* Remove complexity in jinja (skip a few ifs, only use xl)
* Only run docker for primary builds
* doesn't change rendered copy on develop
