### PR TITLE
Better comment re network master types

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -25,6 +25,9 @@ module Rpcs = struct
 
      https://ocaml.janestreet.com/ocaml-core/latest/doc/async_rpc_kernel/Async_rpc_kernel/Versioned_rpc/
 
+     The "master" types are the ones used internally in the code base. Each
+     version has coercions between their query and response types and the master
+     types.
    *)
 
   module Get_staged_ledger_aux_and_pending_coinbases_at_hash = struct


### PR DESCRIPTION
Add comment about the "master" types in `Coda_networking`.

Wanted to make it clear that these are the types internal to the code base.