### PR TITLE
Attempt to fix tuple pipe equality

### DIFF
--- a/src/lib/coda_lib/coda_subscriptions.ml
+++ b/src/lib/coda_lib/coda_subscriptions.ml
@@ -185,7 +185,9 @@ let add_block_subscriber t public_key =
          match
            List.filter pipes ~f:(fun rw_pair' ->
                (* Intentionally using pointer equality *)
-               not @@ phys_equal rw_pair rw_pair' )
+               not
+               @@ Tuple2.equal ~eq1:Pipe.equal ~eq2:Pipe.equal rw_pair rw_pair'
+           )
          with
          | [] ->
              None


### PR DESCRIPTION
Fixed a bug that @michellewong793 and @Schmavery. Hopefully this quick fix works :).

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
