### PR TITLE
Bot: Always unlock before sending

### DIFF
--- a/frontend/bot/src/App.re
+++ b/frontend/bot/src/App.re
@@ -1,23 +1,15 @@
 open Discord;
 
 let client = Client.createClient();
-
-{
-  // Unlock all the keys
-
-  open Constants;
-  Coda.unlock(~publicKey=faucetKey, ~password=faucetPassword);
-  Coda.unlockOpt(~publicKey=echoKey, ~password=echoPassword);
-  Coda.unlockOpt(~publicKey=echoKey2, ~password=echoPassword2);
-  Coda.unlockOpt(~publicKey=repeaterKey, ~password=repeaterPassword);
-};
+let log = (w, fmt) => Logger.log("App", w, fmt);
 
 let handleMessageHelper = msg =>
   switch (Array.to_list(Js.String.split(" ", Message.content(msg)))) {
   | ["$tiny"] => Message.reply(msg, Messages.greeting)
   | ["$help"] => Message.reply(msg, Messages.help)
   | ["$status"] => Status.handleMessage(msg)
-  | ["$request", pk] => Faucet.handleMessage(msg, pk)
+  | ["$request", pk] =>
+    Faucet.handleMessage(msg, pk, Constants.faucetPassword)
   | ["$request", ..._] => Message.reply(msg, Messages.requestError)
   | _ => ()
   };
@@ -32,30 +24,49 @@ let handleMessage = msg =>
     }
   };
 
-// Start echo service(s)
-switch (Constants.echoKey) {
-| Some(echoKey) => Echo.start(echoKey, Constants.feeAmount)
-| None => ()
-};
-switch (Constants.echoKey2) {
-| Some(echoKey2) => Echo.start(echoKey2, Constants.feeAmount)
-| None => ()
+let iterKey = (~key, ~password, ~name, ~f) => {
+  switch (key, password) {
+  | (Some(key), Some(password)) => f(key, password)
+  | (Some(_), None) => log(`Error, "No value for %s", name)
+  | _ => ()
+  };
 };
 
+// Start echo service(s)
+iterKey(
+  ~key=Constants.echoKey,
+  ~password=Constants.echoPassword,
+  ~name="ECHO_PASSWORD",
+  ~f=(key, password) =>
+  Echo.start(key, Constants.feeAmount, password)
+);
+
+iterKey(
+  ~key=Constants.echoKey2,
+  ~password=Constants.echoPassword2,
+  ~name="ECHO_PASSWORD2",
+  ~f=(key, password) =>
+  Echo.start(key, Constants.feeAmount, password)
+);
+
 // Start up optional repeater service
-switch (Constants.repeaterKey) {
-| Some(repeaterKey) =>
-  let _intervalID =
-    Repeater.start(
-      ~fromKey=repeaterKey,
-      ~toKey=Constants.faucetKey,
-      ~amount=Int64.of_int(0),
-      ~fee=Constants.repeaterFeeAmount,
-      ~timeout=Constants.repeatTimeMs,
-    );
-  ();
-| None => ()
-};
+iterKey(
+  ~key=Constants.repeaterKey,
+  ~password=Constants.repeaterPassword,
+  ~name="REPEATER_PASSWORD",
+  ~f=(key, password) => {
+    let _intervalID =
+      Repeater.start(
+        ~fromKey=key,
+        ~toKey=Constants.faucetKey,
+        ~amount=Int64.of_int(0),
+        ~fee=Constants.repeaterFeeAmount,
+        ~timeout=Constants.repeatTimeMs,
+        ~password,
+      );
+    ();
+  },
+);
 
 Client.onReady(client, _ => Logger.log("App", `Info, "Bot is ready"));
 

--- a/frontend/bot/src/Repeater.re
+++ b/frontend/bot/src/Repeater.re
@@ -1,6 +1,6 @@
 let log = (w, fmt) => Logger.log("Repeater", w, fmt);
 
-let start = (~fromKey, ~toKey, ~amount, ~fee, ~timeout) => {
+let start = (~fromKey, ~toKey, ~amount, ~fee, ~timeout, ~password) => {
   log(
     `Info,
     "Starting -- amount: %s, fee: %s, timeout: %d, from pubkey: %s to pubkey: %s",
@@ -12,7 +12,7 @@ let start = (~fromKey, ~toKey, ~amount, ~fee, ~timeout) => {
   );
   Js.Global.setInterval(
     () =>
-      Coda.sendPayment(~from=fromKey, ~to_=toKey, ~amount, ~fee)
+      Coda.sendPayment(~from=fromKey, ~to_=toKey, ~amount, ~fee, ~password)
       |> Wonka.forEach((. {ReasonUrql.Client.ClientTypes.response}) =>
            switch (response) {
            | Data(data) =>


### PR DESCRIPTION
Since the daemon container can restart independently of the bot, we need to make sure the accounts are unlocked before sending transactions.