### PR TITLE
Mention libp2p, not kademlia build

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -126,7 +126,7 @@ You should probably use `USEDOCKER=TRUE` unless you've done the [building withou
 
 These are the most important `make` targets:
 
-* `kademlia`: build the kademlia helper
+* `libp2p_helper`: build the libp2p helper
 * `build`: build everything
 * `docker`: build the container
 * `container`: restart the development container (or start it if it's not yet)


### PR DESCRIPTION
In `README-dev`, mention `libp2p_helper` make target instead of `kademlia`.