### PR TITLE
Use pinned ppx_optcomp in lint-opt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
             - checkout
             - run:
                   name: Create config.mlh
-                  command: cd ./src/config/ && dune build
+                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && cd ./src/config/ && dune build'
             - run:
                   name: Compare versioned types in PR
                   command: ./scripts/compare_pr_diff_types.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,9 @@ jobs:
         steps:
             - checkout
             - run:
+                  name: Create config.mlh
+                  command: cd ./src/config/ && dune build
+            - run:
                   name: Compare versioned types in PR
                   command: ./scripts/compare_pr_diff_types.sh
     update-branch-protection:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,11 @@ jobs:
         steps:
             - checkout
             - run:
-                  name: Create config.mlh
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && cd ./src/config/ && dune build'
+                  name: Update Submodules
+                  command: git submodule sync && git submodule update --init --recursive
+            - run:
+                  name: Update OPAM
+                  command: ./scripts/update-opam-in-docker.sh
             - run:
                   name: Compare versioned types in PR
                   command: ./scripts/compare_pr_diff_types.sh

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -122,6 +122,9 @@ jobs:
         steps:
             - checkout
             - run:
+                  name: Create config.mlh
+                  command: cd ./src/config/ && dune build
+            - run:
                   name: Compare versioned types in PR
                   command: ./scripts/compare_pr_diff_types.sh
     update-branch-protection:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -122,8 +122,11 @@ jobs:
         steps:
             - checkout
             - run:
-                  name: Create config.mlh
-                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && cd ./src/config/ && dune build'
+                  name: Update Submodules
+                  command: git submodule sync && git submodule update --init --recursive
+            - run:
+                  name: Update OPAM
+                  command: ./scripts/update-opam-in-docker.sh
             - run:
                   name: Compare versioned types in PR
                   command: ./scripts/compare_pr_diff_types.sh

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -123,7 +123,7 @@ jobs:
             - checkout
             - run:
                   name: Create config.mlh
-                  command: cd ./src/config/ && dune build
+                  command: ./scripts/skip_if_only_frontend.sh bash -c 'source ~/.profile && cd ./src/config/ && dune build'
             - run:
                   name: Compare versioned types in PR
                   command: ./scripts/compare_pr_diff_types.sh


### PR DESCRIPTION
The new `ppx_optcomp` has been breaking the `lint-opt` task in CI.

It looks like `config.mlh` is not found. Let's see if building that file explicitly fixes the problem.

Update: we weren't actually using the pinned `ppx_optcomp`. Latest commit fixes that.