### PR TITLE
Add new subscriptions when we track new accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,13 +260,6 @@ jobs:
                     . ~/.nix-profile/etc/profile.d/nix.sh
                     nix-env -iA cachix -f https://cachix.org/api/v1/install
             - run:
-                name: Build kademlia using cachix
-                command: |
-                    . ~/.nix-profile/etc/profile.d/nix.sh
-                    cachix use codaprotocol
-                    cd src/app/kademlia-haskell
-                    nix-build release2.nix
-            - run:
                 name: Build libp2p_helper using cachix
                 command: |
                     . ~/.nix-profile/etc/profile.d/nix.sh
@@ -288,9 +281,6 @@ jobs:
             - run:
                 name: Collect and rewrite aux binaries (kademlia + libp2p_helper + logproc)
                 command: |
-                    cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
-                    chmod +w package/kademlia
-                    ./scripts/librewrite-macos.sh package/kademlia
                     cp src/app/libp2p_helper/result/bin/libp2p_helper package/coda-libp2p_helper
                     chmod +w package/coda-libp2p_helper
                     ./scripts/librewrite-macos.sh package/coda-libp2p_helper

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -260,13 +260,6 @@ jobs:
                     . ~/.nix-profile/etc/profile.d/nix.sh
                     nix-env -iA cachix -f https://cachix.org/api/v1/install
             - run:
-                name: Build kademlia using cachix
-                command: |
-                    . ~/.nix-profile/etc/profile.d/nix.sh
-                    cachix use codaprotocol
-                    cd src/app/kademlia-haskell
-                    nix-build release2.nix
-            - run:
                 name: Build libp2p_helper using cachix
                 command: |
                     . ~/.nix-profile/etc/profile.d/nix.sh
@@ -288,9 +281,6 @@ jobs:
             - run:
                 name: Collect and rewrite aux binaries (kademlia + libp2p_helper + logproc)
                 command: |
-                    cp src/app/kademlia-haskell/result/bin/kademlia package/kademlia
-                    chmod +w package/kademlia
-                    ./scripts/librewrite-macos.sh package/kademlia
                     cp src/app/libp2p_helper/result/bin/libp2p_helper package/coda-libp2p_helper
                     chmod +w package/coda-libp2p_helper
                     ./scripts/librewrite-macos.sh package/coda-libp2p_helper

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1428,6 +1428,7 @@ module Mutations = struct
     let%map pk =
       Coda_lib.wallets t |> Secrets.Wallets.generate_new ~password
     in
+    Coda_lib.subscriptions t |> Coda_lib.Subscriptions.add_new_subscription ~pk ;
     Result.return pk
 
   let add_wallet =

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -107,6 +107,8 @@ val receipt_chain_database : t -> Receipt_chain_database.t
 
 val wallets : t -> Secrets.Wallets.t
 
+val subscriptions : t -> Coda_subscriptions.t
+
 val most_recent_valid_transition :
   t -> External_transition.t Broadcast_pipe.Reader.t
 


### PR DESCRIPTION
After the mutation creates a new keypair, make sure we add a new coda_subscription for this pk in both the block and transaction streams.