### PR TITLE
Add type constraint for Arg

### DIFF
--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -42,9 +42,14 @@ module Compressed = struct
       type t = (Snark_params.Tick.Field.t, bool) Poly.Stable.V1.t
       [@@deriving eq, compare, hash]
 
+      (* dummy type for inserting constraint
+         adding constraint to t produces "unused rec" error
+       *)
+      type unused = unit constraint t = Arg.Stable.V1.t
+
       let to_latest = Fn.id
 
-      module Base58 = Codable.Make_base58_check (Arg.Stable.Latest)
+      module Base58 = Codable.Make_base58_check (Arg.Stable.V1)
       include Base58
 
       (* sexp representation is a Base58Check string, like the yojson representation *)


### PR DESCRIPTION
In `Non_zero_curve_point`, we had no assurance that the `Arg` module contained the same type as the main `Stable` module. I had earlier tried adding a type constraint to the type `t`, but got an error.

The solution is to add the constraint to a dummy type.