### PR TITLE
Skip Scan State Validation on Persistent Loads

### DIFF
--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -4,40 +4,42 @@ type t = char
 
 (* each of the following values should be distinct *)
 
-let user_command : t = '\x17'
-
-let web_pipe : t = '\x41'
-
 let data_hash : t = '\x37'
 
-let proof : t = '\x70'
+let fee_transfer_single : t = '\x9F'
 
-let signature : t = '\x9A'
+let frontier_hash : t = '\xAC'
+
+let ledger_hash : t = '\x63'
+
+let lite_precomputed : t = '\xBC'
 
 let non_zero_curve_point : t = '\xCE'
 
 let non_zero_curve_point_compressed : t = '\xCB'
 
+let private_key : t = '\x5A'
+
+let proof : t = '\x70'
+
 let random_oracle_base : t = '\x03'
 
-let private_key : t = '\x5A'
+let receipt_chain_hash : t = '\x9D'
+
+let secret_box_byteswr : t = '\x02'
+
+let signature : t = '\x9A'
 
 let staged_ledger_hash_aux_hash : t = '\x0B'
 
 let staged_ledger_hash_pending_coinbase_aux : t = '\x81'
 
-let user_command_memo : t = '\xA2'
-
-let lite_precomputed : t = '\xBC'
-
-let receipt_chain_hash : t = '\x9D'
-
 let transaction_hash : t = '\x9E'
 
-let fee_transfer_single : t = '\x9F'
+let user_command : t = '\x17'
+
+let user_command_memo : t = '\xA2'
 
 let vrf_truncated_output : t = '\xA3'
 
-let secret_box_byteswr : t = '\x02'
-
-let ledger_hash : t = '\x63'
+let web_pipe : t = '\x41'

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -201,6 +201,19 @@ module T = struct
     in
     return t
 
+  let of_scan_state_and_ledger_unchecked ~snarked_ledger_hash ~ledger
+      ~scan_state ~pending_coinbase_collection =
+    let open Deferred.Or_error.Let_syntax in
+    let t = {ledger; scan_state; pending_coinbase_collection} in
+    let%bind () =
+      Statement_scanner.check_invariants scan_state ~verifier:()
+        ~error_prefix:"Staged_ledger.of_scan_state_and_ledger"
+        ~ledger_hash_end:
+          (Frozen_ledger_hash.of_ledger_hash (Ledger.merkle_root ledger))
+        ~ledger_hash_begin:(Some snarked_ledger_hash)
+    in
+    return t
+
   let of_scan_state_pending_coinbases_and_snarked_ledger ~logger ~verifier
       ~scan_state ~snarked_ledger ~expected_merkle_root ~pending_coinbases =
     let open Deferred.Or_error.Let_syntax in

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -82,6 +82,13 @@ val of_scan_state_and_ledger :
   -> pending_coinbase_collection:Pending_coinbase.t
   -> t Or_error.t Deferred.t
 
+val of_scan_state_and_ledger_unchecked :
+     snarked_ledger_hash:Frozen_ledger_hash.t
+  -> ledger:Ledger.t
+  -> scan_state:Scan_state.t
+  -> pending_coinbase_collection:Pending_coinbase.t
+  -> t Or_error.t Deferred.t
+
 val replace_ledger_exn : t -> Ledger.t -> t
 
 val proof_txns : t -> Transaction.t Non_empty_list.t option

--- a/src/lib/transition_frontier/frontier_base/dune
+++ b/src/lib/transition_frontier/frontier_base/dune
@@ -1,5 +1,5 @@
 (library
   (name frontier_base)
   (public_name transition_frontier_base)
-  (libraries core_kernel coda_base coda_state coda_transition staged_ledger)
+  (libraries core_kernel coda_base coda_state coda_transition staged_ledger base58_check)
   (preprocess (pps ppx_jane ppx_coda -lint-version-syntax-warnings ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -6,8 +6,7 @@ open Coda_transition
 open Frontier_base
 module Database = Database
 
-let construct_staged_ledger_at_root ~logger ~verifier ~root_ledger
-    ~root_transition ~root =
+let construct_staged_ledger_at_root ~root_ledger ~root_transition ~root =
   let open Deferred.Or_error.Let_syntax in
   let open Root_data.Minimal.Stable.Latest in
   let snarked_ledger_hash =
@@ -27,7 +26,7 @@ let construct_staged_ledger_at_root ~logger ~verifier ~root_ledger
            let%map _ = Ledger.apply_transaction mask txn in
            () ))
   in
-  Staged_ledger.of_scan_state_and_ledger ~logger ~verifier ~snarked_ledger_hash
+  Staged_ledger.of_scan_state_and_ledger_unchecked ~snarked_ledger_hash
     ~ledger:mask ~scan_state:root.scan_state
     ~pending_coinbase_collection:root.pending_coinbase
 
@@ -177,8 +176,7 @@ module Instance = struct
     let%bind root_staged_ledger =
       let open Deferred.Let_syntax in
       match%map
-        construct_staged_ledger_at_root ~logger:t.factory.logger
-          ~verifier:t.factory.verifier ~root_ledger ~root_transition ~root
+        construct_staged_ledger_at_root ~root_ledger ~root_transition ~root
       with
       | Error err ->
           Error (`Failure (Error.to_string_hum err))


### PR DESCRIPTION
We don't need to validate the scan state when deserializing from disk since we are assumed to have already validated prior to recording it on disk. This PR changes the persistent frontier loading to construct the staged ledger without verifying the SNARKs in the scan state.

Also included in this PR is proper base58 encoding of frontier hashes so that their JSON representation does not contain binary garbage strings. Additionally, I alphabetically ordered `version_bytes.ml` in the base58_check library, at @psteckler's request.