### PR TITLE
Graphql: sort blocks in descending order

### DIFF
--- a/src/lib/auxiliary_database/external_transition_database.ml
+++ b/src/lib/auxiliary_database/external_transition_database.ml
@@ -26,7 +26,12 @@ module Pagination =
     (struct
       type t = (Filtered_external_transition.t, State_hash.t) With_hash.t
     end)
-    (Block_time.Stable.V1)
+    (struct
+      include Block_time.Stable.V1
+
+      (* sort blocks in descending order *)
+      let compare a b = -compare a b
+    end)
 
 let fee_transfer_participants (pk, _) = [pk]
 


### PR DESCRIPTION
It seems that actually the blocks were already sorted in order of block_time? But in ascending order. Descending seems to make more sense but lmk if you disagree.

Not sure if there's a better way to do this and it's a bit hard to test but it seemed like a small change.