### PR TITLE
[DON'T MERGE] sanity check for RocksDB tests

### DIFF
--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -78,6 +78,8 @@ let to_alist t : (Bigstring.t * Bigstring.t) list =
 let logger = Logger.create ()
 
 let%test_unit "to_alist (of_alist l) = l" =
+  Async.Thread_safe.block_on_async_exn
+  @@ fun () ->
   Async.Quickcheck.async_test
     Quickcheck.Generator.(
       tuple2 String.quickcheck_generator String.quickcheck_generator |> list)
@@ -97,4 +99,3 @@ let%test_unit "to_alist (of_alist l) = l" =
           [%test_result: Bool.t] ~expect:true false ;
           [%test_result: (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
           Async.Deferred.unit ) )
-  |> Async.don't_wait_for

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -80,17 +80,17 @@ let logger = Logger.create ()
 let to_bigstring = Bigstring.of_string
 
 let%test_unit "to_alist (of_alist l) = l" =
-  let open Async in
-  Thread_safe.block_on_async_exn
-  @@ fun () ->
-  Quickcheck.async_test
+  Quickcheck.test ~trials:1000
     Quickcheck.Generator.(
       list @@ tuple2 String.quickcheck_generator String.quickcheck_generator)
     ~f:(fun kvs ->
       match Hashtbl.of_alist (module String) kvs with
       | `Duplicate_key _ ->
-          Deferred.unit
+          ()
       | `Ok db_hashtbl ->
+          let open Async in
+          Thread_safe.block_on_async_exn
+          @@ fun () ->
           let db_dir = Filename.temp_dir "db" "" in
           let db = create db_dir in
           Hashtbl.iteri db_hashtbl ~f:(fun ~key ~data ->

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -78,12 +78,11 @@ let to_alist t : (Bigstring.t * Bigstring.t) list =
 let logger = Logger.create ()
 
 let%test_unit "to_alist (of_alist l) = l" =
-  Quickcheck.test
+  Async.Quickcheck.async_test
     Quickcheck.Generator.(
       tuple2 String.quickcheck_generator String.quickcheck_generator |> list)
     ~f:(fun kvs ->
       File_system.with_temp_dir "/tmp/coda-test" ~f:(fun directory ->
-          Logger.debug logger ~module_:__MODULE__ ~location:__LOC__ "foo" ;
           let s = Bigstring.of_string in
           let sorted =
             List.sort kvs ~compare:[%compare: string * string]
@@ -95,7 +94,6 @@ let%test_unit "to_alist (of_alist l) = l" =
             List.sort (to_alist db)
               ~compare:[%compare: Bigstring.t * Bigstring.t]
           in
-          [%test_result: Bool.t] ~expect:true false ;
           [%test_result: (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
-          Async.Deferred.unit )
-      |> Async.don't_wait_for )
+          Async.Deferred.unit ) )
+  |> Async.don't_wait_for

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -96,6 +96,5 @@ let%test_unit "to_alist (of_alist l) = l" =
             List.sort (to_alist db)
               ~compare:[%compare: Bigstring.t * Bigstring.t]
           in
-          [%test_result: Bool.t] ~expect:true false ;
           [%test_result: (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
           Async.Deferred.unit ) )

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -95,6 +95,7 @@ let%test_unit "to_alist (of_alist l) = l" =
             List.sort (to_alist db)
               ~compare:[%compare: Bigstring.t * Bigstring.t]
           in
+          [%test_result: Bool.t] ~expect:true false ;
           [%test_result: (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
           Async.Deferred.unit )
       |> Async.don't_wait_for )

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -75,12 +75,15 @@ let to_alist t : (Bigstring.t * Bigstring.t) list =
   in
   loop []
 
+let logger = Logger.create ()
+
 let%test_unit "to_alist (of_alist l) = l" =
   Quickcheck.test
     Quickcheck.Generator.(
       tuple2 String.quickcheck_generator String.quickcheck_generator |> list)
     ~f:(fun kvs ->
       File_system.with_temp_dir "/tmp/coda-test" ~f:(fun directory ->
+          Logger.debug logger ~module_:__MODULE__ ~location:__LOC__ "foo" ;
           let s = Bigstring.of_string in
           let sorted =
             List.sort kvs ~compare:[%compare: string * string]

--- a/src/lib/rocksdb/database.ml
+++ b/src/lib/rocksdb/database.ml
@@ -94,6 +94,7 @@ let%test_unit "to_alist (of_alist l) = l" =
             List.sort (to_alist db)
               ~compare:[%compare: Bigstring.t * Bigstring.t]
           in
+          [%test_result: Bool.t] ~expect:true false ;
           [%test_result: (Bigstring.t * Bigstring.t) list] ~expect:sorted alist ;
           Async.Deferred.unit ) )
   |> Async.don't_wait_for

--- a/src/lib/rocksdb/dune
+++ b/src/lib/rocksdb/dune
@@ -3,7 +3,7 @@
  (public_name rocksdb)
  (library_flags -linkall)
  (inline_tests)
- (libraries core rocks key_value_database file_system)
+ (libraries core rocks key_value_database file_system logger)
  (preprocess
   (pps ppx_coda ppx_jane))
  (synopsis "RocksDB Database module"))


### PR DESCRIPTION
Sanity check for the rocksdb tests.

I have high confidence that the assertion in the test is totally ignored. So the test is not running anything useful at all.

UPDATE 1/6/2020:
Once we turn on `block_on_async`, then the test would be actually exercised by CI.