### PR TITLE
No versioned types in Coinbase.t defn

### DIFF
--- a/src/lib/coda_base/coinbase.ml
+++ b/src/lib/coda_base/coinbase.ml
@@ -59,10 +59,10 @@ end
 
 (* DO NOT add bin_io to the deriving list *)
 type t = Stable.Latest.t =
-  { proposer: Public_key.Compressed.Stable.V1.t
-  ; amount: Currency.Amount.Stable.V1.t
-  ; fee_transfer: Fee_transfer.Single.Stable.V1.t option
-  ; state_body_hash: State_body_hash.Stable.V1.t }
+  { proposer: Public_key.Compressed.t
+  ; amount: Currency.Amount.t
+  ; fee_transfer: Fee_transfer.Single.t option
+  ; state_body_hash: State_body_hash.t }
 [@@deriving sexp, compare, eq, hash, yojson]
 
 let is_valid = Stable.Latest.is_valid


### PR DESCRIPTION
Don't use versioned types for definition of `Coinbase.t`.

The definition of the `Stable` types should use `%%versioned`. The reason it's not is the use of `Binable.Of_binable`. That should probably go away, see #1767. The check for validity should go elsewhere, IMHO.