### PR TITLE
Attempt to fix CI mac build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,6 +305,7 @@ jobs:
                 command: |
                     mkdir -p package/keys
                     echo 'keys'
+                    mkdir -p /tmp/s3_cache_dir
                     cp /tmp/s3_cache_dir/* package/keys/.
                     echo 'coda'
                     cp _build/default/src/app/cli/src/coda.exe package/coda

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -305,6 +305,7 @@ jobs:
                 command: |
                     mkdir -p package/keys
                     echo 'keys'
+                    mkdir -p /tmp/s3_cache_dir
                     cp /tmp/s3_cache_dir/* package/keys/.
                     echo 'coda'
                     cp _build/default/src/app/cli/src/coda.exe package/coda


### PR DESCRIPTION
Looks like the build fails because sometimes there is no s3_cache_dir