### PR TITLE
TRIVIAL: use fakeroot when building deb

### DIFF
--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -119,7 +119,7 @@ find "${BUILDDIR}"
 
 # Build the package
 echo "------------------------------------------------------------"
-dpkg-deb --build "${BUILDDIR}" ${PROJECT}_${VERSION}.deb
+fakeroot dpkg-deb --build "${BUILDDIR}" ${PROJECT}_${VERSION}.deb
 ls -lh coda*.deb
 
 # Tar up keys for an artifact
@@ -158,5 +158,5 @@ EOF
 rm -f "${BUILDDIR}"/var/lib/coda/*_proving
 
 # build another deb
-dpkg-deb --build "${BUILDDIR}" ${PROJECT}-noprovingkeys_${VERSION}.deb
+fakeroot dpkg-deb --build "${BUILDDIR}" ${PROJECT}-noprovingkeys_${VERSION}.deb
 ls -lh coda*.deb


### PR DESCRIPTION
Currently our CI deb file generate debs the deposit coda binaries and /var/lib/coda content with uid 1001.  While this works for our testnets, most debs install software with uid root.

fakeroot is the common way to build a deb which will install with uid 0 ownership.