### PR TITLE
TRIVIAL: reduce fake accounts to 256

### DIFF
--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,5 +1,5 @@
 [%%define ledger_depth 14]
-[%%define fake_accounts_target 9000]
+[%%define fake_accounts_target 256]
 [%%import "/src/config/curve/medium.mlh"]
 [%%import "/src/config/coinbase/standard.mlh"]
 [%%import "/src/config/scan_state/point2tps.mlh"]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,5 +1,5 @@
 [%%define ledger_depth 14]
-[%%define fake_accounts_target 256]
+[%%define fake_accounts_target 50]
 [%%import "/src/config/curve/medium.mlh"]
 [%%import "/src/config/coinbase/standard.mlh"]
 [%%import "/src/config/scan_state/point2tps.mlh"]


### PR DESCRIPTION
9000 accounts was exhibiting the /slow/ responsiveness in the client.
'coda version' taking > 1m
bumping back down to 256
