### PR TITLE
Website2: Add page metadata to head

### DIFF
--- a/frontend/website2/src/components/Page.re
+++ b/frontend/website2/src/components/Page.re
@@ -113,15 +113,59 @@ module Footer = {
   };
 };
 
+let siteDescription = "Coda is the first cryptocurrency with a succinct blockchain. Our lightweight blockchain means anyone can use Coda directly from any device, in less data than a few tweets.";
+
+// TODO: Make title required so that it doesn't get forgotten.
+// Need to be able to pass title from MDX docs
 [@react.component]
-let make = (~children, ~footerColor=Theme.Colors.white) => {
+let make =
+    (
+      ~title=?,
+      ~description=siteDescription,
+      ~route=?,
+      ~children,
+      ~footerColor=Theme.Colors.white,
+    ) => {
+  let router = Next.Router.useRouter();
+  let route = Option.value(route, ~default=router.route);
+
   <>
     <Next.Head>
+      {ReactUtils.fromOpt(title, ~f=title =>
+         <>
+           <title> {React.string(title)} </title>
+           <meta property="og:title" content=title />
+         </>
+       )}
+      <meta property="og:image" content="/static/img/coda_facebook_OG.jpg" />
+      <meta property="og:type" content="website" />
+      <meta property="og:description" content=description />
+      <meta name="description" content=description />
+      <meta property="og:url" content={"https://codaprotocol.com" ++ route} />
+      <link rel="canonical" href={"https://codaprotocol.com" ++ route} />
+      <link
+        rel="icon"
+        type_="image/png"
+        href="/static/favicon-32x32.png"
+        sizes="32x32"
+      />
+      <link
+        rel="icon"
+        type_="image/png"
+        href="/static/favicon-16x16.png"
+        sizes="16x16"
+      />
       <link
         href="https://cdn.jsdelivr.net/npm/@ibm/plex@4.0.2/css/ibm-plex.min.css"
         rel="stylesheet"
       />
       <link href="https://use.typekit.net/mta7mwm.css" rel="stylesheet" />
+      // On recent versions of firefox, the browser will do a "flash of
+      // unstyled content" for images by displaying the alt text(!) before the
+      // image loads. Of course, we must disable this.
+      <style>
+        {React.string("img:-moz-loading { visibility: hidden; }")}
+      </style>
     </Next.Head>
     <Nav />
     <div> children </div>

--- a/frontend/website2/src/pages/Blog.re
+++ b/frontend/website2/src/pages/Blog.re
@@ -47,7 +47,7 @@ module Style = {
 
 [@react.component]
 let make = (~posts) => {
-  <Page>
+  <Page title="Coda Protocol Blog">
     <Wrapped>
       <Next.Head> Markdown.katexStylesheet </Next.Head>
       <ul className=Style.postList>

--- a/frontend/website2/src/pages/BlogPost.re
+++ b/frontend/website2/src/pages/BlogPost.re
@@ -121,9 +121,12 @@ let make = (~post: option(ContentType.Post.t)) => {
       </Next.Link>
     </Page>
   | Some(
-      ({title, subtitle, author, date, text: content}: ContentType.Post.t),
+      (
+        {title, subtitle, author, date, text: content, snippet, slug}: ContentType.Post.t
+      ),
     ) =>
-    <Page>
+    // Manually set the canonical route to remove .html
+    <Page title description=snippet route={"/blog/" ++ slug}>
       <Next.Head> Markdown.katexStylesheet </Next.Head>
       <div className=Style.wrapper>
         <div className=Style.title id="title"> {React.string(title)} </div>

--- a/frontend/website2/src/pages/Careers.re
+++ b/frontend/website2/src/pages/Careers.re
@@ -338,7 +338,7 @@ module CareersSpacer = {
 
 [@react.component]
 let make = (~posts) => {
-  <Page>
+  <Page title="Work with us!">
     <div className=Style.page>
       <h1 className=Theme.H3.wings> {React.string("Work with us!")} </h1>
       <Spacer height=2.0 />

--- a/frontend/website2/src/pages/Developers.re
+++ b/frontend/website2/src/pages/Developers.re
@@ -118,9 +118,11 @@ module Styles = {
     ]);
 };
 
+let description = "Coda is 100% open-source, built for and by community members like yourself. Find resources on how to join the network as a node operator, begin contributing code, and stay up to date on developer tooling and grants.";
+
 [@react.component]
 let make = () => {
-  <Page>
+  <Page title="Coda Developer Portal" description>
     <Wrapped>
       <div className=Styles.page>
         <div className=Styles.heroRow>

--- a/frontend/website2/src/pages/Index.re
+++ b/frontend/website2/src/pages/Index.re
@@ -5,7 +5,7 @@ module Styles = {
 
 [@react.component]
 let make = (~links) => {
-  <Page footerColor=Theme.Colors.navyBlue>
+  <Page title="Coda Cryptocurrency Protocol" footerColor=Theme.Colors.navyBlue>
     <div className=Styles.page>
       <section
         className=Css.(

--- a/frontend/website2/src/pages/JobPost.re
+++ b/frontend/website2/src/pages/JobPost.re
@@ -80,8 +80,9 @@ let make = (~post: option(ContentType.JobPost.t)) => {
         <a> {React.string("Check out the rest of our jobs instead")} </a>
       </Next.Link>
     </Page>
-  | Some(({title, jobDescription: content}: ContentType.JobPost.t)) =>
-    <Page>
+  | Some(({title, jobDescription: content, slug}: ContentType.JobPost.t)) =>
+    // Manually set the canonical route to remove .html
+    <Page title route={"/jobs/" ++ slug}>
       <Next.Head> Markdown.katexStylesheet </Next.Head>
       <div className=Style.wrapper>
         <div className=Style.title> {React.string(title)} </div>

--- a/frontend/website2/src/pages/MarkdownPage.re
+++ b/frontend/website2/src/pages/MarkdownPage.re
@@ -31,8 +31,8 @@ module Style = {
 };
 
 [@react.component]
-let make = (~children) => {
-  <Page>
+let make = (~title, ~children) => {
+  <Page title>
     <div className=Style.page>
       <div className=Style.content>
         <Next.MDXProvider

--- a/frontend/website2/src/pages/Testnet.re
+++ b/frontend/website2/src/pages/Testnet.re
@@ -3,13 +3,7 @@ module Styles = {
 
   let markdownStyles =
     style([
-      selector(
-        "a",
-        [
-          cursor(`pointer),
-          ...Theme.Link.basicStyles,
-        ],
-      ),
+      selector("a", [cursor(`pointer), ...Theme.Link.basicStyles]),
       selector(
         "h4",
         Theme.H4.wideStyles
@@ -330,7 +324,7 @@ module Section = {
 
 [@react.component]
 let make = () => {
-  <Page>
+  <Page title="Coda Testnet">
     <Next.Head>
       <script src="https://apis.google.com/js/api.js" />
       <script src="/static/js/leaderboard.js" />


### PR DESCRIPTION
Copied over several things from the old site and attempted to improve a bit.

Added canonical links to every page (https://yoast.com/rel-canonical/ + [google's advice](http://www.thesempost.com/using-rel-canonical-on-all-pages-for-duplicate-content-protection/)). The way we're doing might not be perfect but gives us a bit of control without too much hassle.

Customized the page title per page -- followed some advice [here](https://www.creativebloq.com/how-to/build-an-seo-friendly-head-component-for-nextjsreact), [here](https://www.searchenginejournal.com/on-page-seo/title-tag-optimization/) pointing out the downsides of duplicate title tags and suggesting that they usually match the h1.

Also added favicon and other og meta tags.

