### PR TITLE
Website: Specify contentful host

### DIFF
--- a/frontend/website2/next.config.js
+++ b/frontend/website2/next.config.js
@@ -10,9 +10,10 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const SPACE = process.env.CONTENTFUL_SPACE || '37811siqosrn';
 const TOKEN = process.env.CONTENTFUL_TOKEN || 'gONaARVCc0G5FLIkoJ2m4qi9yTpT8oi7u-C6VYxQ6UQ';
 const IMAGE_TOKEN = process.env.CONTENTFUL_IMAGE_TOKEN || "3B4LS4VD0c4RCsUl1rxmmX/d8ba4bd5295e3b65569cbda1329e90a6";
+const CONTENTFUL_HOST = process.env.CONTENTFUL_HOST || "cdn.contentful.com";
 
 const blogType = 'test';
-const client = createClient({ accessToken: TOKEN, space: SPACE });
+const client = createClient({ accessToken: TOKEN, space: SPACE, host: CONTENTFUL_HOST });
 
 module.exports = withTM(withBundleAnalyzer(withMDX({
   async exportPathMap(pages) {
@@ -52,5 +53,6 @@ module.exports = withTM(withBundleAnalyzer(withMDX({
     CONTENTFUL_TOKEN: TOKEN,
     CONTENTFUL_IMAGE_TOKEN: IMAGE_TOKEN,
     CONTENTFUL_SPACE: SPACE,
+    CONTENTFUL_HOST: CONTENTFUL_HOST,
   }
 })))

--- a/frontend/website2/src/bindings/Contentful.re
+++ b/frontend/website2/src/bindings/Contentful.re
@@ -1,9 +1,11 @@
 let spaceID = Next.Config.contentful_space;
 let contentAPIToken = Next.Config.contentful_token;
+let host = Next.Config.contentful_host;
 
 type clientArgs = {
   space: string,
   accessToken: string,
+  host: string,
 };
 
 type client;
@@ -12,7 +14,7 @@ type client;
 external createClient: clientArgs => client = "createClient";
 
 let client =
-  lazy(createClient({space: spaceID, accessToken: contentAPIToken}));
+  lazy(createClient({space: spaceID, accessToken: contentAPIToken, host}));
 
 [@bs.send]
 external getEntries:

--- a/frontend/website2/src/bindings/Next.re
+++ b/frontend/website2/src/bindings/Next.re
@@ -37,6 +37,8 @@ module Config = {
   external contentful_image_token: string = "CONTENTFUL_IMAGE_TOKEN";
   [@bs.val] [@bs.scope "process.env"]
   external contentful_space: string = "CONTENTFUL_SPACE";
+  [@bs.val] [@bs.scope "process.env"]
+  external contentful_host: string = "CONTENTFUL_HOST";
 };
 
 module MDXProvider = {


### PR DESCRIPTION
Add the ability to specify the contentful host for use with the contentful preview api. Shouldn't affect the live site at all.