### PR TITLE
Change positioning of edit button on mobile

### DIFF
--- a/frontend/website2/src/pages/Docs.re
+++ b/frontend/website2/src/pages/Docs.re
@@ -6,7 +6,7 @@ module Style = {
   let content =
     style([
       maxWidth(`rem(43.)),
-      marginLeft(`rem(1.)),
+      media(Theme.MediaQuery.notMobile, [marginLeft(`rem(1.))]),
       selector(
         "p > code, li > code",
         [
@@ -31,8 +31,7 @@ module Style = {
 
   let editLink =
     style([
-      position(`relative),
-      float(`right),
+      media(Theme.MediaQuery.tablet, [position(`relative), float(`right)]),
       display(`flex),
       alignItems(`center),
       marginTop(`rem(3.25)),


### PR DESCRIPTION


Taking suggestions for other ideas! Just an attempt to make the edit button look a liiiittle better 
Before: <img width="296" alt="Screen Shot 2020-01-21 at 4 24 26 PM" src="https://user-images.githubusercontent.com/12700801/72854852-87c11780-3c6a-11ea-84d5-2cf2ef946260.png">
After: <img width="323" alt="Screen Shot 2020-01-21 at 4 22 27 PM" src="https://user-images.githubusercontent.com/12700801/72854819-67915880-3c6a-11ea-969e-9a37650a3753.png">