### PR TITLE
Fix processor_handler test

### DIFF
--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -327,7 +327,7 @@ let%test_module "Transition_handler.Processor tests" =
       Printexc.record_backtrace true ;
       Async.Scheduler.set_record_backtraces true
 
-    let logger = Logger.null ()
+    let logger = Logger.create ()
 
     let time_controller = Block_time.Controller.basic ~logger
 
@@ -387,7 +387,7 @@ let%test_module "Transition_handler.Processor tests" =
                     |> Strict_pipe.Writer.write valid_transition_writer ) ;
                 match%map
                   Block_time.Timeout.await
-                    ~timeout_duration:(Block_time.Span.of_ms 5000L)
+                    ~timeout_duration:(Block_time.Span.of_ms 30000L)
                     time_controller
                     (Strict_pipe.Reader.fold_until processed_transition_reader
                        ~init:branch
@@ -400,6 +400,16 @@ let%test_module "Transition_handler.Processor tests" =
                                     next_expected_breadcrumb)
                                  (External_transition.Validated.state_hash
                                     newly_added_transition) ;
+                               Logger.info logger ~module_:__MODULE__
+                                 ~location:__LOC__
+                                 ~metadata:
+                                   [ ( "height"
+                                     , `Int
+                                         ( External_transition.Validated
+                                           .blockchain_length
+                                             newly_added_transition
+                                         |> Unsigned.UInt32.to_int ) ) ]
+                                 "transition of $height passed processor" ;
                                if tail = [] then `Stop true else `Continue tail
                            | [] ->
                                `Stop false ) ))


### PR DESCRIPTION
This PR increases the waiting time in processor_handler test from 5s to 30s.

I doesn't see anything suspicious from log. Since we are using `Deferred.choose`, which would execute every deferred computation, so the test goes on even though the timeout expires. This give me the confidence to increase the waiting time because the log indicates the test ends successfully.