### PR TITLE
[Hotfix] bootstrap using existing transition

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.ml
+++ b/src/lib/bootstrap_controller/bootstrap_controller.ml
@@ -178,6 +178,7 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
       Transition_frontier.Persistent_root.Instance.snarked_ledger
         temp_persistent_root_instance
     in
+    let start_time = Core.Time.now () in
     let%bind hash, sender, expected_staged_ledger_hash =
       let root_sync_ledger =
         Sync_ledger.Db.create temp_snarked_ledger ~logger:t.logger
@@ -192,12 +193,27 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
       Sync_ledger.Db.destroy root_sync_ledger ;
       data
     in
+    Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
+      ~metadata:
+        [ ( "time_elapsed"
+          , `String
+              (Core.Time.Span.to_string @@ Time.diff (Time.now ()) start_time)
+          ) ]
+      "Bootstrap: sync snarked ledger took $time_elapsed" ;
+    let start_time = Core.Time.now () in
     let%bind staged_ledger_aux_result =
       let open Deferred.Or_error.Let_syntax in
       let%bind scan_state, expected_merkle_root, pending_coinbases =
         Coda_networking.get_staged_ledger_aux_and_pending_coinbases_at_hash
           t.network sender hash
       in
+      Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
+        ~metadata:
+          [ ( "time_elapsed"
+            , `String
+                (Core.Time.Span.to_string @@ Time.diff (Time.now ()) start_time)
+            ) ]
+        "Bootstrap: download scan state and pending coinbase took $time_elapsed" ;
       let received_staged_ledger_hash =
         Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
           (Staged_ledger.Scan_state.hash scan_state)
@@ -277,6 +293,7 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
           |> External_transition.Initial_validated.consensus_state
         in
         (* Synchronize consensus local state if necessary *)
+        let start_time = Core.Time.now () in
         match%bind
           match
             Consensus.Hooks.required_local_state_sync ~consensus_state
@@ -317,6 +334,13 @@ let run ~logger ~trust_system ~verifier ~network ~consensus_local_state
             Writer.close sync_ledger_writer ;
             loop ()
         | Ok () ->
+            Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
+              ~metadata:
+                [ ( "time_elapsed"
+                  , `String
+                      ( Core.Time.Span.to_string
+                      @@ Core.Time.diff (Core.Time.now ()) start_time ) ) ]
+              "Bootstrap: sync consensus local state took $time_elapsed" ;
             (* Close the old frontier and reload a new on from disk. *)
             let new_root_data =
               Transition_frontier.Root_data.Limited.Stable.V1.

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -54,7 +54,8 @@ let start_bootstrap_controller ~logger ~trust_system ~verifier ~network
     ~time_controller ~proposer_transition_reader ~verified_transition_writer
     ~clear_reader ~transition_reader_ref ~transition_writer_ref
     ~consensus_local_state ~frontier_w ~initial_root_transition
-    ~persistent_root ~persistent_frontier ~genesis_state_hash ~genesis_ledger =
+    ~persistent_root ~persistent_frontier ~genesis_state_hash ~genesis_ledger
+    ~best_seen_transition =
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__
     "Starting Bootstrap Controller phase" ;
   let bootstrap_controller_reader, bootstrap_controller_writer =
@@ -62,6 +63,9 @@ let start_bootstrap_controller ~logger ~trust_system ~verifier ~network
   in
   transition_reader_ref := bootstrap_controller_reader ;
   transition_writer_ref := bootstrap_controller_writer ;
+  Option.iter best_seen_transition ~f:(fun best_seen_transition ->
+      Strict_pipe.Writer.write bootstrap_controller_writer best_seen_transition
+  ) ;
   don't_wait_for (Broadcast_pipe.Writer.write frontier_w None) ;
   trace_recurring "bootstrap controller" (fun () ->
       upon
@@ -198,7 +202,7 @@ let initialize ~logger ~network ~verifier ~trust_system ~time_controller
       (load_frontier ~logger ~verifier ~persistent_frontier ~persistent_root
          ~consensus_local_state ~genesis_state_hash ~genesis_ledger ~base_proof)
   with
-  | _, None ->
+  | best_tip, None ->
       let%map initial_root_transition =
         Persistent_frontier.(
           with_instance_exn persistent_frontier ~f:Instance.get_root_transition)
@@ -209,7 +213,7 @@ let initialize ~logger ~network ~verifier ~trust_system ~time_controller
         ~verified_transition_writer ~clear_reader ~transition_reader_ref
         ~consensus_local_state ~transition_writer_ref ~frontier_w
         ~persistent_root ~persistent_frontier ~initial_root_transition
-        ~genesis_state_hash ~genesis_ledger
+        ~genesis_state_hash ~genesis_ledger ~best_seen_transition:best_tip
   | None, Some frontier ->
       return
       @@ start_transition_frontier_controller ~logger ~trust_system ~verifier
@@ -231,6 +235,7 @@ let initialize ~logger ~network ~verifier ~trust_system ~time_controller
           ~consensus_local_state ~transition_writer_ref ~frontier_w
           ~persistent_root ~persistent_frontier ~initial_root_transition
           ~genesis_state_hash ~genesis_ledger
+          ~best_seen_transition:(Some best_tip)
       else
         let root = Transition_frontier.root frontier in
         let%map () =
@@ -402,7 +407,8 @@ let run ~logger ~trust_system ~verifier ~network ~time_controller
                          ~transition_reader_ref ~transition_writer_ref
                          ~consensus_local_state ~frontier_w ~persistent_root
                          ~persistent_frontier ~initial_root_transition
-                         ~genesis_state_hash ~genesis_ledger )
+                         ~genesis_state_hash ~genesis_ledger
+                         ~best_seen_transition:(Some enveloped_transition) )
                      else Deferred.unit
                  | None ->
                      Deferred.unit ) ) ) ;


### PR DESCRIPTION
This Hotfix makes bootstrap controller uses existing transitions to initiate the bootstrap processes.
I tested it on my machine. It took approximately 6min to finish bootstrap.

I also added some logs for bootstrap controller to record the time to different steps in bootstrap.