### PR TITLE
Website: Handle points service failure

### DIFF
--- a/frontend/website/src/components/Challenges.re
+++ b/frontend/website/src/components/Challenges.re
@@ -31,7 +31,8 @@ let fetchArray = endpoint => {
        | Some(arr) => arr
        | None => [||]
        };
-     });
+     })
+  |> Js.Promise.catch(_ => Promise.return([||]));
 };
 
 let fetchTestnet = uri =>
@@ -80,7 +81,8 @@ let renderChallenges = (challenges: array(challenge)) => {
 };
 
 [@react.component]
-let make = (~challenges as (testnetName, ranking, continuous, threshold)) => {
+let make = (~challenges, ~testnetName) => {
+  let (ranking, continuous, threshold) = challenges;
   switch (testnetName) {
   | None =>
     <h2 className=Styles.weekHeader> {React.string("No active testnet")} </h2>

--- a/frontend/website/src/components/Leaderboard.re
+++ b/frontend/website/src/components/Leaderboard.re
@@ -31,7 +31,8 @@ let fetchLeaderboard = () => {
        | Some(resultsArr) => Array.map(parseEntry, resultsArr)
        | None => [||]
        };
-     });
+     })
+  |> Js.Promise.catch(_ => Promise.return([||]));
 };
 
 module Styles = {
@@ -82,7 +83,8 @@ module Styles = {
     ]);
 
   let cell = style([whiteSpace(`nowrap), overflow(`hidden)]);
-  let rank = merge([cell, style([justifySelf(`flexEnd)])]);
+  let flexEnd = style([justifySelf(`flexEnd)]);
+  let rank = merge([cell, flexEnd]);
   let username = merge([cell, style([textOverflow(`ellipsis)])]);
   let current = merge([cell, style([justifySelf(`flexEnd)])]);
   let total = merge([cell, style([opacity(0.5)])]);
@@ -122,9 +124,9 @@ let make = () => {
   <div className=Styles.leaderboardContainer>
     <div id="testnet-leaderboard" className=Styles.leaderboard>
       <div className=Styles.headerRow>
-        <span> {React.string("#")} </span>
+        <span className=Styles.flexEnd> {React.string("#")} </span>
         <span> {React.string("Username")} </span>
-        <span> {React.string("Current")} </span>
+        <span className=Styles.flexEnd> {React.string("Current")} </span>
         <span> {React.string("Total")} </span>
       </div>
       <hr />

--- a/frontend/website/src/pages/Testnet.re
+++ b/frontend/website/src/pages/Testnet.re
@@ -252,7 +252,7 @@ module Section = {
 };
 
 [@react.component]
-let make = (~challenges) => {
+let make = (~challenges, ~testnetName) => {
   let (expanded, setExpanded) = React.useState(() => false);
   <Page title="Coda Testnet">
     <Wrapped>
@@ -363,7 +363,7 @@ let make = (~challenges) => {
                    " is to recognize Coda community members who are actively involved in the network. There will be regular challenges to make it fun, interesting, and foster some friendly competition! Points can be won in several ways like being first to complete a challenge, contributing code to Coda, or being an excellent community member and helping others out.",
                  )}
               </p>
-              <Challenges challenges />
+              <Challenges challenges testnetName />
               <p id="disclaimer" className=Css.(style([fontStyle(`italic)]))>
                 {React.string(
                    "* Testnet Points are designed solely to track contributions to the Testnet and Testnet Points have no cash or other monetary value. Testnet Points and are not transferable and are not redeemable or exchangeable for any cryptocurrency or digital assets. We may at any time amend or eliminate Testnet Points.",
@@ -395,7 +395,12 @@ let make = (~challenges) => {
   </Page>;
 };
 
-Next.injectGetInitialProps(make, _ => {
+Next.injectGetInitialProps(make, _ =>
   Challenges.fetchAllChallenges()
-  |> Promise.map(challenges => {{"challenges": challenges}})
-});
+  |> Promise.map(((testnetName, ranking, continuous, threshold)) => {
+       {
+         "challenges": (ranking, continuous, threshold),
+         "testnetName": testnetName,
+       }
+     })
+);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2154522/73229572-0f0d0000-412f-11ea-9b3a-fa3fcb9f6203.png)

This is what the leaderboard will look like if the points service is down. If we have leaderboard info but no active testnet, we'll show what we have. If we have challenge info but no active testnet, we don't show the challenges.

Also discovered an interesting issue in Next.. which means we need to avoid passing option in a tuple/array (which is why I split testnetName into its own prop)