### PR TITLE
Remove redundant items from deriving list

### DIFF
--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -1667,7 +1667,7 @@ module Data = struct
             ; staking_epoch_data: 'staking_epoch_data
             ; next_epoch_data: 'next_epoch_data
             ; has_ancestor_in_same_checkpoint_window: 'bool }
-          [@@deriving sexp, bin_io, eq, compare, hash, to_yojson, version]
+          [@@deriving sexp, eq, compare, hash, to_yojson]
         end
       end]
 


### PR DESCRIPTION
`bin_io` and `version` are generated items in the `deriving` list when the `%%versioned` ppx is used, don't need to add them. 