### PR TITLE
Website: Make challenges pull from https endpoint

### DIFF
--- a/frontend/website/src/components/Challenges.re
+++ b/frontend/website/src/components/Challenges.re
@@ -14,7 +14,7 @@ external parseTestnet: Js.Json.t => testnet = "%identity";
 
 let fetchArray = endpoint => {
   ReFetch.fetch(
-    "http://points.o1test.net/api/v1/" ++ endpoint,
+    "https://points.o1test.net/api/v1/" ++ endpoint,
     ~method_=Get,
     ~headers={
       "Accept": "application/json",


### PR DESCRIPTION
Attempt to try and fix strange behaviour during refresh/navigation by the leaderboard challenges.

Edit: Actually it seems to be caused by cors still being wrong.