### PR TITLE
Implement gossip_messages_received, and peers metrics

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -758,6 +758,7 @@ let create (config : Config.t)
     Strict_pipe.Reader.partition_map3 received_gossips
       ~f:(fun (envelope, valid_cb) ->
         Ivar.fill_if_empty first_received_message_signal () ;
+        Coda_metrics.(Counter.inc_one Network.gossip_messages_received) ;
         match Envelope.Incoming.data envelope with
         | New_state state ->
             Perf_histograms.add_span ~name:"external_transition_latency"

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -136,7 +136,13 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                 ~on_new_peer:(fun _ ->
                   Ivar.fill_if_empty first_peer_ivar () ;
                   if !ctr < 4 then incr ctr
-                  else Ivar.fill_if_empty high_connectivity_ivar () )
+                  else Ivar.fill_if_empty high_connectivity_ivar () ;
+                  don't_wait_for
+                    (let open Deferred.Let_syntax in
+                    let%map peers = peers net2 in
+                    Coda_metrics.(
+                      Gauge.set Network.peers
+                        (List.length peers |> Int.to_float))) )
             in
             let implementation_list =
               List.bind rpc_handlers ~f:create_rpc_implementations


### PR DESCRIPTION
I believe all metrics are now implemented.

This implements max blocklength as the max _valid_ block. Should it instead be _any_ block, even invalid ones? This opens the metric up for potential abuse.

Closes #3725