### PR TITLE
patchelf the coda-libp2p_helper

### DIFF
--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -58,8 +58,11 @@ echo "------------------------------------------------------------"
 mkdir -p "${BUILDDIR}/usr/local/bin"
 cp ./default/src/app/cli/src/coda.exe "${BUILDDIR}/usr/local/bin/coda"
 ls -l ../src/app/libp2p_helper/result/bin
-cp ../src/app/libp2p_helper/result/bin/libp2p_helper "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+p2p_path="${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+cp ../src/app/libp2p_helper/result/bin/libp2p_helper $p2p_path
+chmod +w $p2p_path
 patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+chmod -w $p2p_path
 cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/coda-logproc"
 cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/coda-create-genesis"
 

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -58,6 +58,7 @@ echo "------------------------------------------------------------"
 mkdir -p "${BUILDDIR}/usr/local/bin"
 cp ./default/src/app/cli/src/coda.exe "${BUILDDIR}/usr/local/bin/coda"
 cp "${SCRIPTPATH}/../src/app/libp2p_helper/result/bin/libp2p_helper" "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
 cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/coda-logproc"
 cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/coda-create-genesis"
 

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -58,7 +58,7 @@ echo "------------------------------------------------------------"
 mkdir -p "${BUILDDIR}/usr/local/bin"
 cp ./default/src/app/cli/src/coda.exe "${BUILDDIR}/usr/local/bin/coda"
 ls -l ../src/app/libp2p_helper/result/bin
-cp $(readlink "../src/app/libp2p_helper/result/bin/libp2p_helper") "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+cp ../src/app/libp2p_helper/result/bin/libp2p_helper "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
 patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
 cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/coda-logproc"
 cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/coda-create-genesis"

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -57,8 +57,8 @@ echo "------------------------------------------------------------"
 # Binaries
 mkdir -p "${BUILDDIR}/usr/local/bin"
 cp ./default/src/app/cli/src/coda.exe "${BUILDDIR}/usr/local/bin/coda"
-cp "${SCRIPTPATH}/../src/app/libp2p_helper/result/bin/libp2p_helper" "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
-sudo patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2
+cp $(readlink "${SCRIPTPATH}/../src/app/libp2p_helper/result/bin/libp2p_helper") "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
 cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/coda-logproc"
 cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/coda-create-genesis"
 

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -58,7 +58,7 @@ echo "------------------------------------------------------------"
 mkdir -p "${BUILDDIR}/usr/local/bin"
 cp ./default/src/app/cli/src/coda.exe "${BUILDDIR}/usr/local/bin/coda"
 cp "${SCRIPTPATH}/../src/app/libp2p_helper/result/bin/libp2p_helper" "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
-patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+sudo patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2
 cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/coda-logproc"
 cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/coda-create-genesis"
 

--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -57,7 +57,8 @@ echo "------------------------------------------------------------"
 # Binaries
 mkdir -p "${BUILDDIR}/usr/local/bin"
 cp ./default/src/app/cli/src/coda.exe "${BUILDDIR}/usr/local/bin/coda"
-cp $(readlink "${SCRIPTPATH}/../src/app/libp2p_helper/result/bin/libp2p_helper") "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
+ls -l ../src/app/libp2p_helper/result/bin
+cp $(readlink "../src/app/libp2p_helper/result/bin/libp2p_helper") "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
 patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 "${BUILDDIR}/usr/local/bin/coda-libp2p_helper"
 cp ./default/src/app/logproc/logproc.exe "${BUILDDIR}/usr/local/bin/coda-logproc"
 cp ./default/src/app/runtime_genesis_ledger/runtime_genesis_ledger.exe "${BUILDDIR}/usr/local/bin/coda-create-genesis"


### PR DESCRIPTION
Without this, INTERP is set to a dangling path and you'll see `bash: /usr/local/bin/coda-libp2p_helper: No such file or directory` when trying to run the helper in a container.