### PR TITLE
Improve transition rebroadcasting logging

### DIFF
--- a/src/lib/coda_intf/transition_frontier_components_intf.ml
+++ b/src/lib/coda_intf/transition_frontier_components_intf.ml
@@ -111,7 +111,10 @@ module type Transition_handler_processor_intf = sig
                                   , Strict_pipe.crash Strict_pipe.buffered
                                   , unit )
                                   Strict_pipe.Writer.t
-    -> processed_transition_writer:( External_transition.Validated.t
+    -> processed_transition_writer:( [ `Transition of
+                                       External_transition.Validated.t ]
+                                     * [ `Source of
+                                         [`Gossip | `Catchup | `Internal] ]
                                    , Strict_pipe.crash Strict_pipe.buffered
                                    , unit )
                                    Strict_pipe.Writer.t
@@ -358,5 +361,8 @@ module type Transition_router_intf = sig
     -> genesis_state_hash:State_hash.t
     -> genesis_ledger:Ledger.t Lazy.t
     -> base_proof:Coda_base.Proof.t
-    -> External_transition.Validated.t Strict_pipe.Reader.t * unit Ivar.t
+    -> ( [`Transition of External_transition.Validated.t]
+       * [`Source of [`Gossip | `Catchup | `Internal]] )
+       Strict_pipe.Reader.t
+       * unit Ivar.t
 end

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -822,7 +822,14 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
           let ( valid_transitions_for_network
               , valid_transitions_for_api
               , new_blocks ) =
-            Strict_pipe.Reader.Fork.three valid_transitions
+            let network_pipe, downstream_pipe =
+              Strict_pipe.Reader.Fork.two valid_transitions
+            in
+            let api_pipe, new_blocks_pipe =
+              Strict_pipe.Reader.(
+                Fork.two (map downstream_pipe ~f:(fun (`Transition t, _) -> t)))
+            in
+            (network_pipe, api_pipe, new_blocks_pipe)
           in
           trace_task "transaction pool broadcast loop" (fun () ->
               Linear_pipe.iter
@@ -832,7 +839,8 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                   Deferred.unit ) ) ;
           trace_task "valid_transitions_for_network broadcast loop" (fun () ->
               Strict_pipe.Reader.iter_without_pushback
-                valid_transitions_for_network ~f:(fun transition ->
+                valid_transitions_for_network
+                ~f:(fun (`Transition transition, `Source source) ->
                   let hash =
                     External_transition.Validated.state_hash transition
                   in
@@ -858,7 +866,7 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                                 transition ) ]
                         "Rebroadcasting $state_hash" ;
                       External_transition.Validated.broadcast transition
-                  | Error reason ->
+                  | Error reason -> (
                       let timing_error_json =
                         match reason with
                         | `Too_early ->
@@ -866,17 +874,28 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                         | `Too_late slots ->
                             `String (sprintf "%Lu slots too late" slots)
                       in
+                      let metadata =
+                        [ ("state_hash", State_hash.to_yojson hash)
+                        ; ( "external_transition"
+                          , External_transition.Validated.to_yojson transition
+                          )
+                        ; ("timing", timing_error_json) ]
+                      in
                       External_transition.Validated.don't_broadcast transition ;
-                      Logger.warn config.logger ~module_:__MODULE__
-                        ~location:__LOC__
-                        ~metadata:
-                          [ ("state_hash", State_hash.to_yojson hash)
-                          ; ( "external_transition"
-                            , External_transition.Validated.to_yojson
-                                transition )
-                          ; ("timing", timing_error_json) ]
-                        "Not rebroadcasting block $state_hash because it was \
-                         received $timing" ) ) ;
+                      match source with
+                      | `Catchup ->
+                          ()
+                      | `Internal ->
+                          Logger.error config.logger ~module_:__MODULE__
+                            ~location:__LOC__ ~metadata
+                            "Internally generated block $state_hash cannot be \
+                             rebroadcast because it's not a valid time to do \
+                             so ($timing)"
+                      | `Gossip ->
+                          Logger.warn config.logger ~module_:__MODULE__
+                            ~location:__LOC__ ~metadata
+                            "Not rebroadcasting block $state_hash because it \
+                             was received $timing" ) ) ) ;
           don't_wait_for
             (Strict_pipe.transfer
                (Coda_networking.states net)

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -31,7 +31,7 @@ let cached_transform_deferred_result ~transform_cached ~transform_result cached
 
 (* add a breadcrumb and perform post processing *)
 let add_and_finalize ~logger ~frontier ~catchup_scheduler
-    ~processed_transition_writer ~only_if_present cached_breadcrumb =
+    ~processed_transition_writer ~only_if_present ~source cached_breadcrumb =
   let breadcrumb =
     if Cached.is_pure cached_breadcrumb then Cached.peek cached_breadcrumb
     else Cached.invalidate_with_success cached_breadcrumb
@@ -55,7 +55,8 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
           Deferred.unit )
     else Transition_frontier.add_breadcrumb_exn frontier breadcrumb
   in
-  Writer.write processed_transition_writer transition ;
+  Writer.write processed_transition_writer
+    (`Transition transition, `Source source) ;
   Catchup_scheduler.notify catchup_scheduler
     ~hash:(External_transition.Validated.state_hash transition)
 
@@ -183,7 +184,8 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
         Transition_frontier_controller.breadcrumbs_built_by_processor) ;
     Deferred.map ~f:Result.return
       (add_and_finalize ~logger ~frontier ~catchup_scheduler
-         ~processed_transition_writer ~only_if_present:false breadcrumb))
+         ~processed_transition_writer ~only_if_present:false ~source:`Gossip
+         breadcrumb))
 
 let run ~logger ~verifier ~trust_system ~time_controller ~frontier
     ~(primary_transition_reader :
@@ -259,8 +261,9 @@ let run ~logger ~verifier ~trust_system ~time_controller ~frontier
                            (* It could be the case that by the time we try and
                            * add the breadcrumb, it's no longer relevant when
                            * we're catching up *)
-                           ~f:(add_and_finalize ~logger ~only_if_present:true)
-                     )
+                           ~f:
+                             (add_and_finalize ~logger ~only_if_present:true
+                                ~source:`Catchup) )
                    with
                  | Ok () ->
                      ()
@@ -296,7 +299,8 @@ let run ~logger ~verifier ~trust_system ~time_controller ~frontier
                       transition_time) ;
                  let%map () =
                    match%map
-                     add_and_finalize ~logger ~only_if_present:false breadcrumb
+                     add_and_finalize ~logger ~only_if_present:false
+                       ~source:`Internal breadcrumb
                    with
                    | Ok () ->
                        ()
@@ -392,7 +396,9 @@ let%test_module "Transition_handler.Processor tests" =
                     time_controller
                     (Strict_pipe.Reader.fold_until processed_transition_reader
                        ~init:branch
-                       ~f:(fun remaining_breadcrumbs newly_added_transition ->
+                       ~f:(fun remaining_breadcrumbs
+                          (`Transition newly_added_transition, _)
+                          ->
                          Deferred.return
                            ( match remaining_breadcrumbs with
                            | next_expected_breadcrumb :: tail ->


### PR DESCRIPTION
This will hide logs that trigger when we refuse to rebroadcast blocks we receive during catchup. It also heightens the level of logs for when internally generated blocks are not rebroadcast (which is an indication of a serious performance issue or misconfiguration).