### PR TITLE
fix best_tip_diff extension

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -504,12 +504,14 @@ let root_diff t =
                 Extensions.(get_view_pipe (extensions frontier) Identity))
               ~f:
                 (Deferred.List.iter ~f:(function
-                  | Transition_frontier.Diff.Full.E.E (New_node _) ->
+                  | Transition_frontier.Diff.Full.With_mutant.E (New_node _, _)
+                    ->
                       Deferred.unit
-                  | Transition_frontier.Diff.Full.E.E (Best_tip_changed _) ->
+                  | Transition_frontier.Diff.Full.With_mutant.E
+                      (Best_tip_changed _, _) ->
                       Deferred.unit
-                  | Transition_frontier.Diff.Full.E.E
-                      (Root_transitioned {new_root; _}) ->
+                  | Transition_frontier.Diff.Full.With_mutant.E
+                      (Root_transitioned {new_root; _}, _) ->
                       let new_root_breadcrumb =
                         Transition_frontier.find_exn frontier new_root.hash
                       in

--- a/src/lib/transition_frontier/extensions/extensions.ml
+++ b/src/lib/transition_frontier/extensions/extensions.ml
@@ -68,10 +68,10 @@ let close t : unit =
     ~identity:(close_extension (module Identity.Broadcasted))
     ~new_breadcrumbs:(close_extension (module New_breadcrumbs.Broadcasted))
 
-let notify (t : t) ~frontier ~diffs =
+let notify (t : t) ~frontier ~diffs_with_mutants =
   let update (type t)
       (module B : Intf.Broadcasted_extension_intf with type t = t) field =
-    B.update (Field.get field t) frontier diffs
+    B.update (Field.get field t) frontier diffs_with_mutants
   in
   Deferred.List.all_unit
     (Fields.to_list

--- a/src/lib/transition_frontier/extensions/extensions.mli
+++ b/src/lib/transition_frontier/extensions/extensions.mli
@@ -27,7 +27,10 @@ val create : logger:Logger.t -> Full_frontier.t -> t Deferred.t
 val close : t -> unit
 
 val notify :
-  t -> frontier:Full_frontier.t -> diffs:Diff.Full.E.t list -> unit Deferred.t
+     t
+  -> frontier:Full_frontier.t
+  -> diffs_with_mutants:Diff.Full.With_mutant.t list
+  -> unit Deferred.t
 
 type ('ext, 'view) access =
   | Root_history : (Root_history.t, Root_history.view) access

--- a/src/lib/transition_frontier/extensions/identity.ml
+++ b/src/lib/transition_frontier/extensions/identity.ml
@@ -4,11 +4,12 @@ open Frontier_base
 module T = struct
   type t = unit
 
-  type view = Diff.Full.E.t list
+  type view = Diff.Full.With_mutant.t list
 
   let create ~logger:_ _ = ((), [])
 
-  let handle_diffs () _ diffs : view option = Some diffs
+  let handle_diffs () _ diffs_with_mutants : view option =
+    Some diffs_with_mutants
 end
 
 include T

--- a/src/lib/transition_frontier/extensions/identity.mli
+++ b/src/lib/transition_frontier/extensions/identity.mli
@@ -1,3 +1,3 @@
 open Frontier_base
 
-include Intf.Extension_intf with type view = Diff.Full.E.t list
+include Intf.Extension_intf with type view = Diff.Full.With_mutant.t list

--- a/src/lib/transition_frontier/extensions/intf.ml
+++ b/src/lib/transition_frontier/extensions/intf.ml
@@ -10,7 +10,8 @@ module type Extension_base_intf = sig
   val create : logger:Logger.t -> Full_frontier.t -> t * view
 
   (* It is of upmost importance to make this synchronous. To prevent data races via context switching *)
-  val handle_diffs : t -> Full_frontier.t -> Diff.Full.E.t list -> view option
+  val handle_diffs :
+    t -> Full_frontier.t -> Diff.Full.With_mutant.t list -> view option
 end
 
 module type Broadcasted_extension_intf = sig
@@ -30,7 +31,8 @@ module type Broadcasted_extension_intf = sig
 
   val reader : t -> view Broadcast_pipe.Reader.t
 
-  val update : t -> Full_frontier.t -> Diff.Full.E.t list -> unit Deferred.t
+  val update :
+    t -> Full_frontier.t -> Diff.Full.With_mutant.t list -> unit Deferred.t
 end
 
 module type Extension_intf = sig

--- a/src/lib/transition_frontier/extensions/ledger_table.ml
+++ b/src/lib/transition_frontier/extensions/ledger_table.ml
@@ -42,18 +42,18 @@ module T = struct
 
   let lookup t ledger_hash = Ledger_hash.Table.find t.ledgers ledger_hash
 
-  let handle_diffs t _frontier diffs =
-    let open Diff.Full.E in
-    List.iter diffs ~f:(function
-      | E (New_node (Full breadcrumb)) ->
+  let handle_diffs t _frontier diffs_with_mutants =
+    let open Diff.Full.With_mutant in
+    List.iter diffs_with_mutants ~f:(function
+      | E (New_node (Full breadcrumb), _) ->
           let ledger =
             Staged_ledger.ledger @@ Breadcrumb.staged_ledger breadcrumb
           in
           let ledger_hash = Ledger.merkle_root ledger in
           add_entry t ~ledger_hash ~ledger
-      | E (New_node (Lite _)) ->
+      | E (New_node (Lite _), _) ->
           failwith "ledger_table extension: unexpected new lite node"
-      | E (Root_transitioned transition) -> (
+      | E (Root_transitioned transition, _) -> (
         match transition.garbage with
         | Full nodes ->
             let open Coda_state in
@@ -76,7 +76,7 @@ module T = struct
         | Lite _ ->
             failwith
               "ledger_table extension: unexpected garbage with lite nodes" )
-      | E (Best_tip_changed _) ->
+      | E (Best_tip_changed _, _) ->
           () ) ;
     None
 end

--- a/src/lib/transition_frontier/extensions/new_breadcrumbs.ml
+++ b/src/lib/transition_frontier/extensions/new_breadcrumbs.ml
@@ -8,11 +8,11 @@ module T = struct
 
   let create ~logger:_ frontier = ((), [Full_frontier.root frontier])
 
-  let handle_diffs () _frontier diffs =
-    let open Diff in
+  let handle_diffs () _frontier diffs_with_mutants =
+    let open Diff.Full.With_mutant in
     let new_nodes =
-      List.filter_map diffs ~f:(function
-        | Full.E.E (New_node (Full breadcrumb)) ->
+      List.filter_map diffs_with_mutants ~f:(function
+        | E (New_node (Full breadcrumb), _) ->
             Some breadcrumb
         | _ ->
             None )

--- a/src/lib/transition_frontier/extensions/root_history.ml
+++ b/src/lib/transition_frontier/extensions/root_history.ml
@@ -31,17 +31,17 @@ module T = struct
           t.current_root ) ;
     t.current_root <- new_root
 
-  let handle_diffs root_history frontier diffs =
-    let open Diff in
+  let handle_diffs root_history frontier diffs_with_mutants =
+    let open Diff.Full.With_mutant in
     let should_produce_view =
-      List.exists diffs ~f:(function
+      List.exists diffs_with_mutants ~f:(function
         (* TODO: send full diffs to extensions to avoid extra lookups in frontier *)
-        | Full.E.E (Root_transitioned {new_root; _}) ->
+        | E (Root_transitioned {new_root; _}, _) ->
             let open Root_data.Minimal.Stable.Latest in
             Full_frontier.find_exn frontier new_root.hash
             |> Root_data.Historical.of_breadcrumb |> enqueue root_history ;
             true
-        | Full.E.E _ ->
+        | E _ ->
             false )
     in
     Option.some_if should_produce_view root_history

--- a/src/lib/transition_frontier/extensions/transition_registry.ml
+++ b/src/lib/transition_frontier/extensions/transition_registry.ml
@@ -26,9 +26,9 @@ module T = struct
           | None ->
               [ivar] ) )
 
-  let handle_diffs transition_registry _ diffs =
-    List.iter diffs ~f:(function
-      | Diff.Full.E.E (New_node (Full breadcrumb)) ->
+  let handle_diffs transition_registry _ diffs_with_mutants =
+    List.iter diffs_with_mutants ~f:(function
+      | Diff.Full.With_mutant.E (New_node (Full breadcrumb), _) ->
           notify transition_registry (Breadcrumb.state_hash breadcrumb)
       | _ ->
           () ) ;

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -220,4 +220,8 @@ module Full = struct
 
     let to_lite (E diff) = Lite.E.E (to_lite diff)
   end
+
+  module With_mutant = struct
+    type t = E : (full, 'mutant) diff * 'mutant -> t
+  end
 end

--- a/src/lib/transition_frontier/frontier_base/diff.mli
+++ b/src/lib/transition_frontier/frontier_base/diff.mli
@@ -144,4 +144,8 @@ module Full : sig
 
     val to_lite : t -> Lite.E.t
   end
+
+  module With_mutant : sig
+    type t = E : (full, 'mutant) diff * 'mutant -> t
+  end
 end

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -510,21 +510,23 @@ let apply_diffs t diffs ~ignore_consensus_local_state =
       ~local_state:t.consensus_local_state
     |> Option.is_none
   in
-  let new_root, _diffs_with_mutants =
+  let new_root, diffs_with_mutants =
     List.fold diffs ~init:(None, [])
-      ~f:(fun (prev_root, diffs_with_mutant) (Diff.Full.E.E diff) ->
+      ~f:(fun (prev_root, diffs_with_mutants) (Diff.Full.E.E diff) ->
         let mutant, new_root =
           apply_diff t diff ~ignore_consensus_local_state
         in
         t.hash <- Frontier_hash.merge_diff t.hash (Diff.to_lite diff) mutant ;
         update_metrics_with_diff t diff ;
-        match new_root with
-        | None ->
-            ( prev_root
-            , Diff.Full.With_mutant.E (diff, mutant) :: diffs_with_mutant )
-        | Some state_hash ->
-            ( Some {state_hash; frontier_hash= t.hash}
-            , Diff.Full.With_mutant.E (diff, mutant) :: diffs_with_mutant ) )
+        let new_root =
+          match new_root with
+          | None ->
+              prev_root
+          | Some state_hash ->
+              Some {state_hash; frontier_hash= t.hash}
+        in
+        (new_root, Diff.Full.With_mutant.E (diff, mutant) :: diffs_with_mutants)
+    )
   in
   Logger.trace t.logger ~module_:__MODULE__ ~location:__LOC__
     "Reached state %s after applying diffs to full frontier"
@@ -560,7 +562,7 @@ let apply_diffs t diffs ~ignore_consensus_local_state =
                 "local state desynced after applying diffs to full frontier" )
         | None ->
             () ) ;
-  `New_root new_root
+  `New_root_and_diffs_with_mutants (new_root, diffs_with_mutants)
 
 module For_tests = struct
   let equal t1 t2 =

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -37,7 +37,8 @@ val apply_diffs :
      t
   -> Diff.Full.E.t list
   -> ignore_consensus_local_state:bool
-  -> [`New_root of Root_identifier.t option]
+  -> [ `New_root_and_diffs_with_mutants of
+       Root_identifier.t option * Diff.Full.With_mutant.t list ]
 
 module For_tests : sig
   val equal : t -> t -> bool

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -210,10 +210,10 @@ module Instance = struct
         ~f:Result.return
     in
     let apply_diff diff =
-      let (`New_root _) =
+      let (`New_root_and_diffs_with_mutants (_, diffs_with_mutants)) =
         Full_frontier.apply_diffs frontier [diff] ~ignore_consensus_local_state
       in
-      Extensions.notify extensions ~frontier ~diffs:[diff]
+      Extensions.notify extensions ~frontier ~diffs_with_mutants
       |> Deferred.map ~f:Result.return
     in
     (* crawl through persistent frontier and load transitions into in memory frontier *)

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -275,7 +275,8 @@ let add_breadcrumb_exn t breadcrumb =
             (List.map diffs ~f:(fun (Diff.Full.E.E diff) -> Diff.to_yojson diff))
         ) ]
     "Applying diffs: $diffs" ;
-  let (`New_root new_root_identifier) =
+  let (`New_root_and_diffs_with_mutants
+        (new_root_identifier, diffs_with_mutants)) =
     Full_frontier.apply_diffs t.full_frontier diffs
       ~ignore_consensus_local_state:false
   in
@@ -308,7 +309,7 @@ let add_breadcrumb_exn t breadcrumb =
             running, which indicates that transition frontier initialization \
             has not been performed correctly" )
   |> Result.ok_exn ;
-  Extensions.notify t.extensions ~frontier:t.full_frontier ~diffs
+  Extensions.notify t.extensions ~frontier:t.full_frontier ~diffs_with_mutants
 
 (* proxy full frontier functions *)
 include struct


### PR DESCRIPTION
The `Best_tip_diff` extension was getting the old best tip from frontier after it was updated with the new best tip, resulting in transactions from the new chain not being added and transactions from the old chain not being removed from the transaction pool. This is another reason for #4298. 
A diff now will contain the mutant as well which in the case of `Best_tip_diff` is the old best tip

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
