### PR TITLE
Fix times for block latency metrics

### DIFF
--- a/src/lib/coda_metrics/coda_metrics.ml
+++ b/src/lib/coda_metrics/coda_metrics.ml
@@ -696,10 +696,10 @@ module Block_latency = struct
 
   module Latency_time_spec = struct
     let tick_interval =
-      Core.Time.Span.of_min (Int.to_float (block_window_duration / 2))
+      Core.Time.Span.of_ms (Int.to_float (block_window_duration / 2))
 
     let rolling_interval =
-      Core.Time.Span.of_min (Int.to_float (block_window_duration * 20))
+      Core.Time.Span.of_ms (Int.to_float (block_window_duration * 20))
   end
 
   module Gossip_slots =


### PR DESCRIPTION
Made a silly mistake when addressing some PR comments for my block latency metrics.