### PR TITLE
Website: Remove old testnet form

### DIFF
--- a/frontend/website/pages/docs/contributing.mdx
+++ b/frontend/website/pages/docs/contributing.mdx
@@ -13,7 +13,7 @@ For any general questions on how to get involved, feel free to reach out to the 
 
 The Coda public testnet beta is live. **Technical skill is not required**, and we encourage anyone with an interest in cryptocurrencies and blockchains to get involved. 
 
-Specifically, we need help in the form of reporting bugs, validating economic assumptions, testing out node infrastructure, and general participation in consensus and compressing the blockchain. Please join the [Discord server](https://bit.ly/CodaDiscord) and checkout the #testnet-general and #testnet-beta channel to get involved. You can also [sign up for the mailing list here](http://bit.ly/TestnetForm) and we'll keep you posted with updates!
+Specifically, we need help in the form of reporting bugs, validating economic assumptions, testing out node infrastructure, and general participation in consensus and compressing the blockchain. Please join the [Discord server](https://bit.ly/CodaDiscord) and checkout the #testnet-general and #testnet-beta channel to get involved. You can also [sign up for the Genesis program here](/genesis) and we'll keep you posted with updates!
 
 Head over to the [testnet landing page](/testnet.html) to see how to participate in weekly challenges and get on the testnet leaderboard.
 

--- a/frontend/website/src/components/StatusBadge.re
+++ b/frontend/website/src/components/StatusBadge.re
@@ -113,11 +113,7 @@ module Inner = {
         | DegradedPerformance => ("Degraded", amberAlpha(0.1), amber)
         | PartialOutage => ("Partial Outage", amberAlpha(0.1), amber)
         | MajorOutage => ("Major Outage", amberAlpha(0.1), amber)
-        | UnderMaintenance => (
-            "Under Maintenance",
-            amberAlpha(0.1),
-            amber,
-          )
+        | UnderMaintenance => ("Under Maintenance", amberAlpha(0.1), amber)
         }
       );
     };

--- a/frontend/website/src/components/StatusBadge.re
+++ b/frontend/website/src/components/StatusBadge.re
@@ -110,13 +110,13 @@ module Inner = {
         switch (status) {
         | Unknown => ("Unknown", greyishAlpha(0.1), grey)
         | Operational => ("Operational", kernelAlpha(0.1), kernel)
-        | DegradedPerformance => ("Degraded", rosebudAlpha(0.1), rosebud)
-        | PartialOutage => ("Partial Outage", rosebudAlpha(0.1), rosebud)
-        | MajorOutage => ("Major Outage", rosebudAlpha(0.1), rosebud)
+        | DegradedPerformance => ("Degraded", amberAlpha(0.1), amber)
+        | PartialOutage => ("Partial Outage", amberAlpha(0.1), amber)
+        | MajorOutage => ("Major Outage", amberAlpha(0.1), amber)
         | UnderMaintenance => (
             "Under Maintenance",
-            rosebudAlpha(0.1),
-            rosebud,
+            amberAlpha(0.1),
+            amber,
           )
         }
       );

--- a/frontend/website/src/pages/Testnet.re
+++ b/frontend/website/src/pages/Testnet.re
@@ -330,12 +330,12 @@ let make = (~challenges as _, ~testnetName as _) => {
               href="https://forums.codaprotocol.com/"
             />
             <ActionButton
-              icon={React.string({js| 📬 |js})}
-              heading={React.string({js| Newsletter |js})}
+              icon={React.string({js| 🌟 |js})}
+              heading={React.string({js| Token Grant |js})}
               text={React.string(
-                "Sign up for the Testnet newsletter to get weekly updates",
+                "Apply to be one of the early members to receive a Genesis token grant",
               )}
-              href="https://docs.google.com/forms/d/e/1FAIpQLScQRGW0-xGattPmr5oT-yRb9aCkPE6yIKXSfw1LRmNx1oh6AA/viewform"
+              href="/genesis"
             />
           </div>
         </div>


### PR DESCRIPTION
Changes links to the old Testnet form to point to the Genesis program per marketing's request. Also fixes the color in the status widget.