### PR TITLE
GraphQL/CLI: Indicate which keys failed to stake in setStaking

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -310,6 +310,54 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "lockedPublicKeys",
+              "description": "List of public keys that could not be used to stake because they were locked",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "PublicKey",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "currentStakingKeys",
+              "description": "Returns the public keys that are now staking their funds",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "PublicKey",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -1685,7 +1733,7 @@
             },
             {
               "name": "setStaking",
-              "description": "Set keys you wish to stake with - silently fails if you pass keys corresponding to accounts that are either locked or in trackedAccounts",
+              "description": "Set keys you wish to stake with",
               "args": [
                 {
                   "name": "input",
@@ -5191,7 +5239,7 @@
             },
             {
               "name": "bestChain",
-              "description": "Retrieve a list of blocks from transition frontier's root to the current best tip.",
+              "description": "Retrieve a list of blocks from transition frontier's root to the current best tip. Returns null if the system is bootstrapping.",
               "args": [],
               "type": {
                 "kind": "LIST",

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1061,7 +1061,9 @@ let set_staking_graphql =
              graphql_endpoint
          in
          print_message "Stopped staking with" (result#setStaking)#lastStaking ;
-         print_message "Failed to start staking with"
+         print_message
+           "❌ Failed to start staking with keys (try `coda accounts unlock` \
+            first)"
            (result#setStaking)#lockedPublicKeys ;
          print_message "Started staking with"
            (result#setStaking)#currentStakingKeys ))

--- a/src/app/cli/src/init/graphql_client.ml
+++ b/src/app/cli/src/init/graphql_client.ml
@@ -77,6 +77,8 @@ module Decoders = struct
     Yojson.Basic.Util.to_string json
     |> Public_key.Compressed.of_base58_check_exn
 
+  let public_key_array = Array.map ~f:public_key
+
   let optional_public_key = Option.map ~f:public_key
 
   let uint64 json =

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -97,7 +97,9 @@ module Set_staking =
 {|
 mutation ($public_key: PublicKey) {
   setStaking(input : {publicKeys: [$public_key]}) {
-    lastStaking
+    lastStaking @bsDecoder(fn: "Decoders.public_key_array")
+    lockedPublicKeys @bsDecoder(fn: "Decoders.public_key_array")
+    currentStakingKeys @bsDecoder(fn: "Decoders.public_key_array")
     }
   }
 |}]

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -166,19 +166,6 @@ let reset_trust_status t (ip_address : Unix.Inet_addr.Blocking_sexp.t) =
   let trust_system = config.trust_system in
   Trust_system.reset trust_system ip_address
 
-let replace_block_production_keys keys pks =
-  let kps =
-    List.filter_map pks ~f:(fun pk ->
-        let open Option.Let_syntax in
-        let%map kps =
-          Coda_lib.wallets keys |> Secrets.Wallets.find_unlocked ~needle:pk
-        in
-        (kps, pk) )
-  in
-  Coda_lib.replace_block_production_keypairs keys
-    (Keypair.And_compressed_pk.Set.of_list kps) ;
-  kps |> List.map ~f:snd
-
 let setup_user_command ~fee ~nonce ~valid_until ~memo ~sender_kp
     user_command_body =
   let payload =

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1021,7 +1021,14 @@ module Types = struct
               ~doc:"Returns the public keys that were staking funds previously"
               ~typ:(non_null (list (non_null public_key)))
               ~args:Arg.[]
-              ~resolve:(fun _ -> Fn.id) ] )
+              ~resolve:(fun _ (lastStaking, _) -> lastStaking)
+          ; field "lockedPublicKeys"
+              ~doc:
+                "List of public keys that could not be used to stake because \
+                 they were locked"
+              ~typ:(non_null (list (non_null public_key)))
+              ~args:Arg.[]
+              ~resolve:(fun _ (_, locked) -> locked) ] )
 
     let set_snark_work_fee =
       obj "SetSnarkWorkFeePayload" ~fields:(fun _ ->
@@ -1676,20 +1683,27 @@ module Mutations = struct
         Some payment )
 
   let set_staking =
-    field "setStaking"
-      ~doc:
-        "Set keys you wish to stake with - silently fails if you pass keys \
-         corresponding to accounts that are either locked or in \
-         trackedAccounts"
+    field "setStaking" ~doc:"Set keys you wish to stake with"
       ~args:Arg.[arg "input" ~typ:(non_null Types.Input.set_staking)]
       ~typ:(non_null Types.Payload.set_staking)
       ~resolve:(fun {ctx= coda; _} () pks ->
-        (* TODO: Handle errors like: duplicates, etc *)
         let old_block_production_keys =
           Coda_lib.block_production_pubkeys coda
         in
-        ignore @@ Coda_commands.replace_block_production_keys coda pks ;
-        Public_key.Compressed.Set.to_list old_block_production_keys )
+        let wallet = Coda_lib.wallets coda in
+        let unlocked, locked =
+          List.partition_map pks ~f:(fun pk ->
+              match Secrets.Wallets.find_unlocked ~needle:pk wallet with
+              | Some kp ->
+                  `Fst (kp, pk)
+              | None ->
+                  `Snd pk )
+        in
+        ignore
+        @@ Coda_lib.replace_block_production_keypairs coda
+             (Keypair.And_compressed_pk.Set.of_list unlocked) ;
+        (Public_key.Compressed.Set.to_list old_block_production_keys, locked)
+        )
 
   let set_snark_worker =
     io_field "setSnarkWorker"

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1021,14 +1021,19 @@ module Types = struct
               ~doc:"Returns the public keys that were staking funds previously"
               ~typ:(non_null (list (non_null public_key)))
               ~args:Arg.[]
-              ~resolve:(fun _ (lastStaking, _) -> lastStaking)
+              ~resolve:(fun _ (lastStaking, _, _) -> lastStaking)
           ; field "lockedPublicKeys"
               ~doc:
                 "List of public keys that could not be used to stake because \
                  they were locked"
               ~typ:(non_null (list (non_null public_key)))
               ~args:Arg.[]
-              ~resolve:(fun _ (_, locked) -> locked) ] )
+              ~resolve:(fun _ (_, locked, _) -> locked)
+          ; field "currentStakingKeys"
+              ~doc:"Returns the public keys that are now staking their funds"
+              ~typ:(non_null (list (non_null public_key)))
+              ~args:Arg.[]
+              ~resolve:(fun _ (_, _, currentStaking) -> currentStaking) ] )
 
     let set_snark_work_fee =
       obj "SetSnarkWorkFeePayload" ~fields:(fun _ ->
@@ -1702,8 +1707,9 @@ module Mutations = struct
         ignore
         @@ Coda_lib.replace_block_production_keypairs coda
              (Keypair.And_compressed_pk.Set.of_list unlocked) ;
-        (Public_key.Compressed.Set.to_list old_block_production_keys, locked)
-        )
+        ( Public_key.Compressed.Set.to_list old_block_production_keys
+        , locked
+        , List.map ~f:Tuple.T2.get2 unlocked ) )
 
   let set_snark_worker =
     io_field "setSnarkWorker"


### PR DESCRIPTION
setStaking was giving the impression that it didn't work because it silently failed to stake with keys that were locked. Now we return an indication to the user that those keys failed.