### PR TITLE
Add memory stats for prover, verifier

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -291,70 +291,7 @@ let daemon logger =
                ~metadata:[("config_directory", `String conf_dir)] ;
              make_version ~wipe_dir:false
        in
-       don't_wait_for
-         (let bytes_per_word = Sys.word_size / 8 in
-          (* Curve points are allocated in C++ and deallocated with finalizers.
-             The points on the C++ heap are much bigger than the OCaml heap
-             objects that point to them, which makes the GC underestimate how
-             much memory has been allocated since the last collection and not
-             run major GCs often enough, which means the finalizers don't run
-             and we use way too much memory. As a band-aid solution, we run a
-             major GC cycle every ten minutes.
-          *)
-          let gc_method =
-            Option.value ~default:"full" @@ Unix.getenv "CODA_GC_HACK_MODE"
-          in
-          (* Doing Gc.major is known to work, but takes quite a bit of time.
-             Running a single slice might be sufficient, but I haven't tested it
-             and the documentation isn't super clear. *)
-          let gc_fun =
-            match gc_method with
-            | "full" ->
-                Gc.major
-            | "slice" ->
-                fun () -> ignore (Gc.major_slice 0)
-            | other ->
-                failwithf
-                  "CODA_GC_HACK_MODE was %s, it should be full or slice. \
-                   Default is full."
-                  other
-          in
-          let interval =
-            Time.Span.of_sec
-            @@ Option.(
-                 value ~default:600.
-                   ( map ~f:Float.of_string
-                   @@ Unix.getenv "CODA_GC_HACK_INTERVAL" ))
-          in
-          let log_stats suffix =
-            let stat = Gc.stat () in
-            Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-              "OCaml memory statistics, %s" suffix
-              ~metadata:
-                [ ("heap_size", `Int (stat.heap_words * bytes_per_word))
-                ; ("heap_chunks", `Int stat.heap_chunks)
-                ; ("max_heap_size", `Int (stat.top_heap_words * bytes_per_word))
-                ; ("live_size", `Int (stat.live_words * bytes_per_word))
-                ; ("live_blocks", `Int stat.live_blocks) ] ;
-            let {Jemalloc.active; resident; allocated; mapped} =
-              Jemalloc.get_memory_stats ()
-            in
-            Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
-              "Jemalloc memory statistics (in bytes)"
-              ~metadata:
-                [ ("active", `Int active)
-                ; ("resident", `Int resident)
-                ; ("allocated", `Int allocated)
-                ; ("mapped", `Int mapped) ]
-          in
-          let rec loop () =
-            log_stats "before major gc" ;
-            gc_fun () ;
-            log_stats "after major gc" ;
-            let%bind () = after interval in
-            loop ()
-          in
-          loop ()) ;
+       Memory_stats.log_memory_stats logger ;
        Parallel.init_master () ;
        let monitor = Async.Monitor.create ~name:"coda" () in
        let module Coda_initialization = struct

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -5,7 +5,7 @@
   (name coda)
   (public_name coda)
   (modes native)
-  (libraries init tests child_processes node_addrs_and_ports jemalloc genesis_ledger_helper)
+  (libraries init tests child_processes memory_stats node_addrs_and_ports jemalloc genesis_ledger_helper)
   (preprocessor_deps ../../../config.mlh)
   (preprocess (pps ppx_coda ppx_let ppx_sexp_conv ppx_optcomp))
   (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/lib/memory_stats/dune
+++ b/src/lib/memory_stats/dune
@@ -1,7 +1,6 @@
 (library
  (name memory_stats)
  (public_name memory_stats)
- (inline_tests)
  (library_flags -linkall)
  (libraries
     async_kernel

--- a/src/lib/memory_stats/dune
+++ b/src/lib/memory_stats/dune
@@ -1,0 +1,14 @@
+(library
+ (name memory_stats)
+ (public_name memory_stats)
+ (inline_tests)
+ (library_flags -linkall)
+ (libraries
+    async_kernel
+    core
+    jemalloc
+    logger
+    )
+ (preprocess
+  (pps ppx_snarky ppx_coda ppx_let))
+ (synopsis "Memory statistics for OCaml and jemalloc"))

--- a/src/lib/memory_stats/memory_stats.ml
+++ b/src/lib/memory_stats/memory_stats.ml
@@ -1,0 +1,69 @@
+(* memory_stats.ml -- log OCaml, jemalloc memory data *)
+
+open Core_kernel
+open Async
+
+let log_memory_stats logger =
+  don't_wait_for
+    (let bytes_per_word = Sys.word_size / 8 in
+     (* Curve points are allocated in C++ and deallocated with finalizers.
+             The points on the C++ heap are much bigger than the OCaml heap
+             objects that point to them, which makes the GC underestimate how
+             much memory has been allocated since the last collection and not
+             run major GCs often enough, which means the finalizers don't run
+             and we use way too much memory. As a band-aid solution, we run a
+             major GC cycle every ten minutes.
+      *)
+     let gc_method =
+       Option.value ~default:"full" @@ Unix.getenv "CODA_GC_HACK_MODE"
+     in
+     (* Doing Gc.major is known to work, but takes quite a bit of time.
+             Running a single slice might be sufficient, but I haven't tested it
+             and the documentation isn't super clear. *)
+     let gc_fun =
+       match gc_method with
+       | "full" ->
+           Gc.major
+       | "slice" ->
+           fun () -> ignore (Gc.major_slice 0)
+       | other ->
+           failwithf
+             "CODA_GC_HACK_MODE was %s, it should be full or slice. Default \
+              is full."
+             other
+     in
+     let interval =
+       Time.Span.of_sec
+       @@ Option.(
+            value ~default:600.
+              (map ~f:Float.of_string @@ Unix.getenv "CODA_GC_HACK_INTERVAL"))
+     in
+     let log_stats suffix =
+       let stat = Gc.stat () in
+       Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
+         "OCaml memory statistics, %s" suffix
+         ~metadata:
+           [ ("heap_size", `Int (stat.heap_words * bytes_per_word))
+           ; ("heap_chunks", `Int stat.heap_chunks)
+           ; ("max_heap_size", `Int (stat.top_heap_words * bytes_per_word))
+           ; ("live_size", `Int (stat.live_words * bytes_per_word))
+           ; ("live_blocks", `Int stat.live_blocks) ] ;
+       let {Jemalloc.active; resident; allocated; mapped} =
+         Jemalloc.get_memory_stats ()
+       in
+       Logger.debug logger ~module_:__MODULE__ ~location:__LOC__
+         "Jemalloc memory statistics (in bytes)"
+         ~metadata:
+           [ ("active", `Int active)
+           ; ("resident", `Int resident)
+           ; ("allocated", `Int allocated)
+           ; ("mapped", `Int mapped) ]
+     in
+     let rec loop () =
+       log_stats "before major gc" ;
+       gc_fun () ;
+       log_stats "after major gc" ;
+       let%bind () = after interval in
+       loop ()
+     in
+     loop ())

--- a/src/lib/prover/dune
+++ b/src/lib/prover/dune
@@ -1,6 +1,6 @@
 (library
   (name prover)
   (public_name prover)
-  (libraries async core rpc_parallel coda_base coda_state coda_transition blockchain_snark keys_lib precomputed_values child_processes)
+  (libraries async core rpc_parallel coda_base coda_state coda_transition blockchain_snark keys_lib memory_stats precomputed_values child_processes)
   (preprocessor_deps "../../config.mlh")
   (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane)))

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -182,6 +182,7 @@ module Worker_state = struct
          | _ ->
              failwith "unknown proof_level set in compile config"
        in
+       Memory_stats.log_memory_stats logger ;
        m)
 
   let get = Fn.id

--- a/src/lib/verifier/dune
+++ b/src/lib/verifier/dune
@@ -1,6 +1,6 @@
 (library
   (name verifier)
   (public_name verifier)
-  (libraries core_kernel async_kernel rpc_parallel coda_base coda_state blockchain_snark snark_keys snark_params ledger_proof logger child_processes)
+  (libraries core_kernel async_kernel rpc_parallel coda_base coda_state blockchain_snark memory_stats snark_keys snark_params ledger_proof logger child_processes)
   (preprocessor_deps "../../config.mlh")
   (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_optcomp ppx_bin_prot ppx_let ppx_deriving.std ppx_deriving_yojson)))

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -32,6 +32,7 @@ module Worker_state = struct
   type t = (module S) Deferred.t
 
   let create {logger; _} : t Deferred.t =
+    Memory_stats.log_memory_stats logger ;
     Deferred.return
       (let%map bc_vk = Snark_keys.blockchain_verification ()
        and tx_vk = Snark_keys.transaction_verification () in

--- a/src/memory_stats.opam
+++ b/src/memory_stats.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
Take memory stats code that was in `coda.ml`, make it into a library.

Add call to that library in `coda.ml`, and in the prover and verifier process creation code.