### PR TITLE
Fix broken glossary link in docs

### DIFF
--- a/frontend/website/pages/docs/my-first-transaction.mdx
+++ b/frontend/website/pages/docs/my-first-transaction.mdx
@@ -24,7 +24,7 @@ Run the following command to start up a Coda node instance and connect to the ne
         -peer /dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH \
         -peer /dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA
 
-The host and port specified above refer to the seed peer address - this is the initial peer we will connect to on the network. Since Coda is a [peer-to-peer](../glossary/#peer-to-peer) protocol, there is no single centralized server we rely on. 
+The host and port specified above refer to the seed peer address - this is the initial peer we will connect to on the network. Since Coda is a [peer-to-peer](/docs/glossary/#peer-to-peer) protocol, there is no single centralized server we rely on. 
 
 If you forwarded custom ports (other than 8302 and 8303), you'll need to replace the default ports above with the ones you forwarded.
 


### PR DESCRIPTION
Fixes a broken link to the glossary found by @nat8552, thanks!

Closes #4484 

Co-authored-by: @nat8552 <nat8552@gmail.com>