### PR TITLE
Website: Simple Genesis FAQ link

### DIFF
--- a/frontend/website/pages/docs/gui-wallet.mdx
+++ b/frontend/website/pages/docs/gui-wallet.mdx
@@ -10,7 +10,7 @@ export default Page({title: "GUI Wallet"});
 </Alert>
 
 
-<img width="100%" src="https://cdn.codaprotocol.com/website/static/img/coda-wallet-84ca8e1441ef0ff0a2cd22cebdf5aa84704c43d729b3c48732f76db2971ef20d.png" alt="Screenshot of the Coda Wallet GUI." />
+<img width="100%" src="/static/img/coda-wallet.png" alt="Screenshot of the Coda Wallet GUI." />
 
 The GUI Wallet is the easiest way to connect to the Coda network and run a node. You can use the wallet to send transactions, check your funds, stake coda, and create zk-SNARKs to compress transactions.
 

--- a/frontend/website/src/pages/Genesis.re
+++ b/frontend/website/src/pages/Genesis.re
@@ -267,9 +267,11 @@ let make = () => {
               {React.string(
                  "To learn more about the selection criteria and requirements, see the ",
                )}
-              <a className=Theme.Link.basic href="/tcGenesis">
-                {React.string("Terms and Conditions.")}
-              </a>
+              <Next.Link href="/tcGenesis">
+                <a className=Theme.Link.basic>
+                  {React.string("Terms and Conditions.")}
+                </a>
+              </Next.Link>
             </li>
           </ul>
         </div>
@@ -292,9 +294,17 @@ let make = () => {
           />
         </div>
         <Spacer height=1.5 />
-        <a className=Theme.Link.basic href="/tcGenesis">
-          {React.string("Terms and Conditions ")}
+        <a
+          className=Theme.Link.basic
+          href="https://forums.codaprotocol.com/t/genesis-token-program-faq/270">
+          {React.string("FAQ")}
         </a>
+        <Spacer height=1. />
+        <Next.Link href="/tcGenesis">
+          <a className=Theme.Link.basic>
+            {React.string("Terms and Conditions ")}
+          </a>
+        </Next.Link>
         <Spacer height=5.65 />
         <h1 className=Styles.textBlockHeading>
           {React.string("About Coda Protocol")}


### PR DESCRIPTION
Adds a simple link to the discourse FAQ thread. Can be replaced by the pretty FAQ when that's done.

Also:
- Clean up an old cdn-ed image in the docs
- Convert some internal links to tcGenesis to Next.Link (loads faster)