### PR TITLE
libp2p: temporarily bypass topic validation

### DIFF
--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -135,7 +135,7 @@ func MakeHelper(ctx context.Context, listenOn []ma.Multiaddr, externalAddr ma.Mu
 
 	kad := <-kadch
 
-	pubsub, err := pubsub.NewFloodSub(ctx, host, pubsub.WithStrictSignatureVerification(true), pubsub.WithMessageSigning(true))
+	pubsub, err := pubsub.NewRandomSub(ctx, host, pubsub.WithStrictSignatureVerification(true), pubsub.WithMessageSigning(true))
 	if err != nil {
 		return nil, err
 	}

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -989,7 +989,7 @@ type successResult struct {
 func main() {
 	logwriter.Configure(logwriter.Output(os.Stderr), logwriter.LdJSONFormatter)
 	log.SetOutput(os.Stderr)
-	logging.SetAllLoggers(logging2.INFO)
+	logging.SetAllLoggers(logging2.DEBUG)
 	helperLog := logging.Logger("helper top-level JSON handling")
 
 	go func() {

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -336,6 +336,7 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 		return nil, needsDHT()
 	}
 	err := app.P2p.Pubsub.RegisterTopicValidator(s.Topic, func(ctx context.Context, id peer.ID, msg *pubsub.Message) bool {
+		return true
 		if id == app.P2p.Me {
 			// messages from ourself are valid.
 			app.P2p.Logger.Info("would have validated but it's from us!")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -42,17 +42,21 @@ type subscription struct {
 	Cancel context.CancelFunc
 }
 
+type validationStatus struct {
+	Completion chan bool
+	TimedOutAt *time.Time
+}
+
 type app struct {
 	P2p             *codanet.Helper
 	Ctx             context.Context
 	Subs            map[int]subscription
-	Validators      map[int]chan bool
+	Validators      map[int]*validationStatus
 	ValidatorMutex  *sync.Mutex
 	Streams         map[int]net.Stream
 	OutLock         sync.Mutex
 	Out             *bufio.Writer
 	UnsafeNoTrustIP bool
-	Extra           *os.File
 }
 
 var seqs = make(chan int)
@@ -83,6 +87,8 @@ const (
 	unbanIP
 )
 
+const validationTimeout = 5 * time.Minute
+
 type codaPeerInfo struct {
 	Libp2pPort int    `json:"libp2p_port"`
 	Host       string `json:"host"`
@@ -99,7 +105,6 @@ func (app *app) writeMsg(msg interface{}) {
 	app.OutLock.Lock()
 	defer app.OutLock.Unlock()
 	bytes, err := json.Marshal(msg)
-	app.Extra.Write(bytes)
 	if err == nil {
 		n, err := app.Out.Write(bytes)
 		if err != nil {
@@ -340,7 +345,8 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 		seqno := <-seqs
 		ch := make(chan bool, 1)
 		app.ValidatorMutex.Lock()
-		app.Validators[seqno] = ch
+		app.Validators[seqno] = new(validationStatus)
+		(*app.Validators[seqno]).Completion = ch
 		app.ValidatorMutex.Unlock()
 
 		app.P2p.Logger.Info("validating a new pubsub message ...")
@@ -371,8 +377,14 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 			// validationComplete will remove app.Validators[seqno] once the
 			// coda process gets around to it.
 			app.P2p.Logger.Error("validation timed out :(")
+
+			app.ValidatorMutex.Lock()
+
+			(*app.Validators[seqno]).TimedOutAt = new(time.Time)
+			*((*app.Validators[seqno]).TimedOutAt) = time.Now()
+
 			if app.UnsafeNoTrustIP {
-				app.P2p.Logger.Info("validated!")
+				app.P2p.Logger.Info("validated anyway!")
 				return true
 			}
 			app.P2p.Logger.Info("unvalidated :(")
@@ -385,7 +397,7 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 			}
 			return res
 		}
-	}, pubsub.WithValidatorTimeout(5*time.Minute))
+	}, pubsub.WithValidatorTimeout(validationTimeout))
 
 	if err != nil {
 		return nil, badp2p(err)
@@ -466,8 +478,11 @@ func (r *validationCompleteMsg) run(app *app) (interface{}, error) {
 	}
 	app.ValidatorMutex.Lock()
 	defer app.ValidatorMutex.Unlock()
-	if ch, ok := app.Validators[r.Seqno]; ok {
-		ch <- r.Valid
+	if st, ok := app.Validators[r.Seqno]; ok {
+		st.Completion <- r.Valid
+		if st.TimedOutAt != nil {
+			app.P2p.Logger.Errorf("validation for item %d took %d seconds", r.Seqno, time.Now().Add(validationTimeout).Sub(*st.TimedOutAt))
+		}
 		delete(app.Validators, r.Seqno)
 		return "validationComplete success", nil
 	}
@@ -816,7 +831,7 @@ func (ap *beginAdvertisingMsg) run(app *app) (interface{}, error) {
 	// report dht peers
 	go func() {
 		// wait a bit for our advertisement to go out and get some responses
-		time.Sleep(5 * time.Second)
+		time.Sleep(1 * time.Second)
 
 		for {
 			// default is to yield only 100 peers at a time. for now, always be
@@ -829,7 +844,7 @@ func (ap *beginAdvertisingMsg) run(app *app) (interface{}, error) {
 			for info := range dhtpeers {
 				foundPeer(info, "dht")
 			}
-			time.Sleep(5 * time.Minute)
+			time.Sleep(30 * time.Second)
 		}
 	}()
 
@@ -971,13 +986,8 @@ type successResult struct {
 }
 
 func main() {
-    logwriter.Configure(logwriter.Output(os.Stderr), logwriter.LdJSONFormatter)
-    os.Mkdir("/tmp/artifacts", os.ModePerm)
-	logfile, err := os.Create("/tmp/artifacts/helper.log")
-	if err != nil {
-		panic(err)
-	}
-	log.SetOutput(logfile)
+	logwriter.Configure(logwriter.Output(os.Stderr), logwriter.LdJSONFormatter)
+	log.SetOutput(os.Stderr)
 	logging.SetAllLoggers(logging2.INFO)
 	helperLog := logging.Logger("helper top-level JSON handling")
 
@@ -1000,9 +1010,8 @@ func main() {
 		Ctx:            context.Background(),
 		Subs:           make(map[int]subscription),
 		ValidatorMutex: &sync.Mutex{},
-		Validators:     make(map[int]chan bool),
+		Validators:     make(map[int]*validationStatus),
 		Streams:        make(map[int]net.Stream),
-		Extra:          logfile,
 		// OutLock doesn't need to be initialized
 		Out: out,
 	}

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -96,8 +96,8 @@ module Helper = struct
     ; decode: string -> 'a Or_error.t
     ; write_pipe:
         ( 'a Envelope.Incoming.t
-        , Strict_pipe.crash Strict_pipe.buffered
-        , unit )
+        , Strict_pipe.synchronous
+        , unit Deferred.t )
         Strict_pipe.Writer.t
     ; read_pipe: 'a Envelope.Incoming.t Strict_pipe.Reader.t }
 
@@ -941,8 +941,8 @@ module Pubsub = struct
       ; decode: string -> 'a Or_error.t
       ; write_pipe:
           ( 'a Envelope.Incoming.t
-          , Strict_pipe.crash Strict_pipe.buffered
-          , unit )
+          , Strict_pipe.synchronous
+          , unit Deferred.t )
           Strict_pipe.Writer.t
       ; read_pipe: 'a Envelope.Incoming.t Strict_pipe.Reader.t }
 
@@ -973,9 +973,8 @@ module Pubsub = struct
       ~encode ~decode ~on_decode_failure =
     let subscription_idx = Helper.genseq net in
     let read_pipe, write_pipe =
-      Strict_pipe.create
-        ~name:(sprintf "subscription to topic «%s»" topic)
-        Strict_pipe.(Buffered (`Capacity 64, `Overflow Crash))
+      Strict_pipe.(
+        create ~name:(sprintf "subscription to topic «%s»" topic) Synchronous)
     in
     let sub =
       { Subscription.net

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -229,6 +229,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                    Instead of refactoring it to have validation up-front and decoupled,
                    we pass along a validation callback with the message. This ends up
                    ignoring the actual subscription message pipe, so drain it separately. *)
+                (* HACK: validation is currently bypassed, this function will never be called *)
                 ~should_forward_message:(fun envelope ->
                   (* Messages from ourselves are valid. Don't try and reingest them. *)
                   match Envelope.Incoming.sender envelope with
@@ -264,10 +265,14 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                       () ))
             in
             (* #4097 fix: drain the published message pipe, which we don't care about. *)
+            (* HACK: we're bypassing validation, use these messages *)
             don't_wait_for
               (Strict_pipe.Reader.iter
                  (Coda_net2.Pubsub.Subscription.message_pipe subscription)
-                 ~f:(Fn.const Deferred.unit)) ;
+                 ~f:(fun envelope ->
+                   let valid_ivar = Ivar.create () in
+                   Strict_pipe.Writer.write message_writer
+                     (envelope, Ivar.fill valid_ivar) )) ;
             let%map _ =
               (* XXX: this ALWAYS needs to be AFTER handle_protocol/subscribe
                 or it is possible to miss connections! *)


### PR DESCRIPTION
This is going wrong for some reason, and it's blocking a lot of work. This should unblock that work while the root cause is still being debugged.

Impact: we'll gossip messages we otherwise wouldn't, including messages that cause bans (!!).

Additionally, I switched over from floodsub (tell all peers) to randomsub (tell 6 random peers). This should keep network activity lower, at the expense of not too much latency. I also decreased the libp2p log level, so we'll get debug logs.