### PR TITLE
decrease libp2p log level

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -989,7 +989,7 @@ type successResult struct {
 func main() {
 	logwriter.Configure(logwriter.Output(os.Stderr), logwriter.LdJSONFormatter)
 	log.SetOutput(os.Stderr)
-	logging.SetAllLoggers(logging2.DEBUG)
+	logging.SetAllLoggers(logging2.INFO)
 	helperLog := logging.Logger("helper top-level JSON handling")
 
 	go func() {


### PR DESCRIPTION
our logs are enormous because of all this spam. I'll decrease it locally when I want to debug, for the most part we don't need those logs.