### PR TITLE
make five_even_txns not required

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,6 @@ pull_request_rules:
           - "status-success=ci/circleci: test--test_postake"
           - "status-success=ci/circleci: test--test_postake_bootstrap"
           - "status-success=ci/circleci: test--test_postake_delegation"
-          - "status-success=ci/circleci: test--test_postake_five_even_txns"
           - "status-success=ci/circleci: test--test_postake_snarkless"
           - "status-success=ci/circleci: test--test_postake_split"
           - "status-success=ci/circleci: test--test_postake_split_snarkless"

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -77,7 +77,8 @@ ci_excludes = [
 # of all the generated CI jobs, allow these specific ones to fail (extra excludes on top of ci_excludes)
 required_excludes = [
     'test_postake_catchup:*',
-    'test_postake_three_producers:*'
+    'test_postake_three_producers:*',
+    'test_postake_five_even_txns:*',
 ]
 
 # these extra jobs are not filters, they are full status check names


### PR DESCRIPTION
I made test_postake_five_even_txns not required to unblock other people's PR.
