### PR TITLE
SDK: Allow use of numbers and fix stake delegation

### DIFF
--- a/frontend/client_sdk/.gitignore
+++ b/frontend/client_sdk/.gitignore
@@ -13,6 +13,7 @@ yarn-error.log
 *.ts
 *.js
 !/src/SDKWrapper.ts
+!/src/TSTypes.ts
 !/test/Test.ts
 
 # These are generated but helpful for documentation

--- a/frontend/client_sdk/README.md
+++ b/frontend/client_sdk/README.md
@@ -20,6 +20,14 @@ let signed = CodaSDK.signMessage("hello", keys);
 if (CodaSDK.verifyMessage(signed)) {
     console.log("Message was verified successfully")
 };
+
+let signedPayment = CodaSDK.signPayment({
+    to: keys.publicKey,
+    from: keys.publicKey,
+    amount: 1,
+    fee: 1,
+    nonce: 0
+  }, key);
 ```
 
 NodeJS:
@@ -31,6 +39,14 @@ let signed = CodaSDK.signMessage("hello", keys);
 if (CodaSDK.verifyMessage(signed)) {
     console.log("Message was verified successfully")
 };
+
+let signedPayment = CodaSDK.signPayment({
+    to: keys.publicKey,
+    from: keys.publicKey,
+    amount: 1,
+    fee: 1,
+    nonce: 0
+  }, key);
 ```
 
 ReasonML:
@@ -46,6 +62,14 @@ let signed = CodaSDK.signMessage(. "hello", keys);
 if (CodaSDK.verifyMessage(. signed)) {
   Js.log("Message was verified successfully");
 };
+
+let signedPayment = CodaSDK.signPayment({
+    to_: keys.publicKey,
+    from: keys.publicKey,
+    amount: "1",
+    fee: "1",
+    nonce: "0"
+  }, key);
 
 ```
 

--- a/frontend/client_sdk/package.json
+++ b/frontend/client_sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@o1labs/client-sdk",
   "description": "Node API for signing transactions for Coda Protocol",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "scripts": {
     "build": "bsb -make-world && tsc src/SDKWrapper.ts -d",
     "start": "bsb -make-world -w",
@@ -11,7 +11,7 @@
     "test": "tsc test/Test.ts && node test/Test.js"
   },
   "keywords": [
-    "BuckleScript"
+    "coda", "cryptocurrency"
   ],
   "author": "o1labs",
   "license": "MIT",

--- a/frontend/client_sdk/package.json
+++ b/frontend/client_sdk/package.json
@@ -7,7 +7,7 @@
     "start": "bsb -make-world -w",
     "clean": "bsb -clean-world",
     "make-jsoo": "make -C ../.. client_sdk && cp ../../_build/default/src/app/client_sdk/client_sdk.bc.js src",
-    "prepublishOnly": "yarn make-jsoo && yarn build",
+    "prepublishOnly": "yarn make-jsoo && yarn build && yarn test",
     "test": "tsc test/Test.ts && node test/Test.js"
   },
   "keywords": [

--- a/frontend/client_sdk/src/CodaSDK.d.ts
+++ b/frontend/client_sdk/src/CodaSDK.d.ts
@@ -1,7 +1,9 @@
+import { uint32 as $$uint32 } from './TSTypes';
+import { uint64 as $$uint64 } from './TSTypes';
 export declare type publicKey = string;
 export declare type privateKey = string;
-export declare type globalSlot = string;
-export declare type uint64 = string;
+export declare type uint64 = $$uint64;
+export declare type uint32 = $$uint32;
 export declare type keypair = {
     readonly privateKey: privateKey;
     readonly publicKey: publicKey;
@@ -19,18 +21,18 @@ export declare type stakeDelegation = {
     readonly to: publicKey;
     readonly from: publicKey;
     readonly fee: uint64;
-    readonly nonce: number;
+    readonly nonce: uint32;
     readonly memo?: string;
-    readonly validUntil?: globalSlot;
+    readonly validUntil?: uint32;
 };
 export declare type payment = {
     readonly to: publicKey;
     readonly from: publicKey;
     readonly fee: uint64;
     readonly amount: uint64;
-    readonly nonce: number;
+    readonly nonce: uint32;
     readonly memo?: string;
-    readonly validUntil?: globalSlot;
+    readonly validUntil?: uint32;
 };
 /**
   * Generates a public/private keypair

--- a/frontend/client_sdk/src/TSTypes.d.ts
+++ b/frontend/client_sdk/src/TSTypes.d.ts
@@ -1,0 +1,2 @@
+export declare type uint32 = number | bigint | string;
+export declare type uint64 = number | bigint | string;

--- a/frontend/client_sdk/src/TSTypes.ts
+++ b/frontend/client_sdk/src/TSTypes.ts
@@ -1,0 +1,2 @@
+export type uint32 = number | bigint | string;
+export type uint64 = number | bigint | string;

--- a/frontend/client_sdk/test/Test.ts
+++ b/frontend/client_sdk/test/Test.ts
@@ -1,11 +1,29 @@
 import * as CodaSDK from "../src/SDKWrapper";
+import { deepStrictEqual } from "assert";
 
 let key = CodaSDK.genKeys();
 let signed = CodaSDK.signMessage("hello", key);
 CodaSDK.verifyMessage(signed);
 
-let signedPayment = CodaSDK.unsafeSignAny(
-    {"to": key.publicKey, "from": key.publicKey, "amount": "1", "fee": "1", "nonce": 0},
+
+let payment1 = CodaSDK.unsafeSignAny(
+    {to: key.publicKey, from: key.publicKey, amount: "1", fee: "1", nonce: "0"},
     key);
 
-console.log(signedPayment);
+
+let payment2 = CodaSDK.signPayment(
+    {to: key.publicKey, from: key.publicKey, amount: 1, fee: 1, nonce: 0},
+    key);
+
+deepStrictEqual(payment1, payment2, "Payment signatures don't match (string vs numeric inputs)");
+
+let sd1 = CodaSDK.signStakeDelegation(
+    {to: key.publicKey, from: key.publicKey, fee: "1", nonce: "0"},
+    key);
+
+
+let sd2 = CodaSDK.signStakeDelegation(
+    {to: key.publicKey, from: key.publicKey, fee: 1, nonce: 0},
+    key);
+
+deepStrictEqual(sd1, sd2, "Stake delegation signatures don't match (string vs numeric inputs)");


### PR DESCRIPTION
- Added signPayment example to docs
- Added ability to pass numeric arguments as numbers, automatically normalize them to string on use
- Fix bug in stake delegation signing and add a test for it
- Increase the version number to 0.1.2 in preparation for publishing these fixes to npm