### PR TITLE
Pickles type lib, cleanup versioning

### DIFF
--- a/src/lib/pickles_types/abc.ml
+++ b/src/lib/pickles_types/abc.ml
@@ -1,3 +1,5 @@
+open Core_kernel
+
 [%%versioned
 module Stable = struct
   module V1 = struct

--- a/src/lib/pickles_types/abc.ml
+++ b/src/lib/pickles_types/abc.ml
@@ -1,13 +1,12 @@
+[%%versioned
 module Stable = struct
   module V1 = struct
-    type 'a t = {a: 'a; b: 'a; c: 'a}
-    [@@deriving version, fields, bin_io, sexp]
+    type 'a t = {a: 'a; b: 'a; c: 'a} [@@deriving fields, sexp]
   end
+end]
 
-  module Latest = V1
-end
+type 'a t = 'a Stable.Latest.t = {a: 'a; b: 'a; c: 'a}
 
-include Stable.Latest
 module H_list = Snarky.H_list
 
 let to_hlist {a; b; c} = H_list.[a; b; c]

--- a/src/lib/pickles_types/dlog_marlin_types.ml
+++ b/src/lib/pickles_types/dlog_marlin_types.ml
@@ -2,18 +2,18 @@ open Tuple_lib
 open Core_kernel
 
 module Triple = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      type 'a t = 'a * 'a * 'a [@@deriving version, bin_io]
+      type 'a t = 'a * 'a * 'a
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type 'a t = 'a Stable.Latest.t
 end
 
 module Evals = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type 'a t =
@@ -30,13 +30,25 @@ module Evals = struct
         ; g_1: 'a
         ; g_2: 'a
         ; g_3: 'a }
-      [@@deriving version, fields, bin_io]
+      [@@deriving fields]
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type 'a t = 'a Stable.Latest.t =
+    { w_hat: 'a
+    ; z_hat_a: 'a
+    ; z_hat_b: 'a
+    ; h_1: 'a
+    ; h_2: 'a
+    ; h_3: 'a
+    ; row: 'a Abc.t
+    ; col: 'a Abc.t
+    ; value: 'a Abc.t
+    ; rc: 'a Abc.t
+    ; g_1: 'a
+    ; g_2: 'a
+    ; g_3: 'a }
+  [@@deriving fields]
 
   let to_vectors
       { w_hat
@@ -118,17 +130,17 @@ end
 
 module Openings = struct
   module Bulletproof = struct
+    [%%versioned
     module Stable = struct
       module V1 = struct
         type ('fq, 'g) t =
           {lr: ('g * 'g) array; z_1: 'fq; z_2: 'fq; delta: 'g; sg: 'g}
-        [@@deriving version, bin_io]
       end
+    end]
 
-      module Latest = V1
-    end
+    type ('fq, 'g) t = ('fq, 'g) Stable.Latest.t =
+      {lr: ('g * 'g) array; z_1: 'fq; z_2: 'fq; delta: 'g; sg: 'g}
 
-    include Stable.Latest
     open Snarky.H_list
 
     let to_hlist {lr; z_1; z_2; delta; sg} = [lr; z_1; z_2; delta; sg]
@@ -146,17 +158,17 @@ module Openings = struct
 
   open Evals
 
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type ('fq, 'g) t =
-        {proof: ('fq, 'g) Bulletproof.t; evals: 'fq Evals.Stable.V1.t Triple.t}
-      [@@deriving version, bin_io]
+        { proof: ('fq, 'g) Bulletproof.Stable.V1.t
+        ; evals: 'fq Evals.Stable.V1.t Triple.Stable.V1.t }
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type ('fq, 'g) t = ('fq, 'g) Stable.Latest.t =
+    {proof: ('fq, 'g) Bulletproof.t; evals: 'fq Evals.t Triple.t}
 
   let to_hlist {proof; evals} = Snarky.H_list.[proof; evals]
 

--- a/src/lib/pickles_types/dlog_marlin_types.ml
+++ b/src/lib/pickles_types/dlog_marlin_types.ml
@@ -23,10 +23,10 @@ module Evals = struct
         ; h_1: 'a
         ; h_2: 'a
         ; h_3: 'a
-        ; row: 'a Abc.t
-        ; col: 'a Abc.t
-        ; value: 'a Abc.t
-        ; rc: 'a Abc.t
+        ; row: 'a Abc.Stable.V1.t
+        ; col: 'a Abc.Stable.V1.t
+        ; value: 'a Abc.Stable.V1.t
+        ; rc: 'a Abc.Stable.V1.t
         ; g_1: 'a
         ; g_2: 'a
         ; g_3: 'a }

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -6,4 +6,5 @@
   (preprocess (pps ppx_coda ppx_jane ppx_deriving.std))
   (libraries
     snarky
-    core_kernel))
+    core_kernel
+    module_version))

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -1,4 +1,3 @@
-
 (library
   (inline_tests)
   (name pickles_types)
@@ -7,4 +6,4 @@
   (preprocess (pps ppx_coda ppx_jane ppx_deriving.std))
   (libraries
     snarky
-    core ))
+    core_kernel))

--- a/src/lib/pickles_types/matrix_evals.ml
+++ b/src/lib/pickles_types/matrix_evals.ml
@@ -1,3 +1,4 @@
+open Core_kernel
 module H_list = Snarky.H_list
 
 [%%versioned

--- a/src/lib/pickles_types/matrix_evals.ml
+++ b/src/lib/pickles_types/matrix_evals.ml
@@ -1,15 +1,13 @@
 module H_list = Snarky.H_list
 
+[%%versioned
 module Stable = struct
   module V1 = struct
-    type 'a t = {row: 'a; col: 'a; value: 'a; rc: 'a}
-    [@@deriving version, bin_io, sexp]
+    type 'a t = {row: 'a; col: 'a; value: 'a; rc: 'a} [@@deriving sexp]
   end
+end]
 
-  module Latest = V1
-end
-
-include Stable.Latest
+type 'a t = 'a Stable.Latest.t = {row: 'a; col: 'a; value: 'a; rc: 'a}
 
 let to_hlist {row; col; value; rc} = H_list.[row; col; value; rc]
 

--- a/src/lib/pickles_types/pairing_marlin_types.ml
+++ b/src/lib/pickles_types/pairing_marlin_types.ml
@@ -329,8 +329,6 @@ module Accumulator = struct
         type 'g t = {r_f_minus_r_v_plus_rz_pi: 'g; r_pi: 'g}
         [@@deriving fields, sexp]
       end
-
-      module Latest = V1
     end]
 
     type 'g t = 'g Stable.Latest.t = {r_f_minus_r_v_plus_rz_pi: 'g; r_pi: 'g}

--- a/src/lib/pickles_types/pairing_marlin_types.ml
+++ b/src/lib/pickles_types/pairing_marlin_types.ml
@@ -234,7 +234,8 @@ module Accumulator = struct
       [%%versioned
       module Stable = struct
         module V1 = struct
-          type 'a t = 'a Core_kernel.Shift.Map.t [@@deriving sexp]
+          type 'a t = 'a Core_kernel.Int.Stable.V1.Map.t
+          [@@deriving version {asserted}, sexp, compare]
         end
       end]
 
@@ -362,8 +363,9 @@ module Accumulator = struct
   module Stable = struct
     module V1 = struct
       type ('g, 'unshifted) t =
-        { opening_check: 'g Opening_check.t
-        ; degree_bound_checks: ('g, 'unshifted) Degree_bound_checks.t }
+        { opening_check: 'g Opening_check.Stable.V1.t
+        ; degree_bound_checks: ('g, 'unshifted) Degree_bound_checks.Stable.V1.t
+        }
       [@@deriving fields, sexp]
     end
   end]
@@ -437,7 +439,7 @@ module Openings = struct
   module Stable = struct
     module V1 = struct
       type ('proof, 'fp) t =
-        {proofs: 'proof * 'proof * 'proof; evals: 'fp Evals.t}
+        {proofs: 'proof * 'proof * 'proof; evals: 'fp Evals.Stable.V1.t}
     end
   end]
 
@@ -512,7 +514,7 @@ module Proof = struct
   module Stable = struct
     module V1 = struct
       type ('pc, 'fp, 'openings) t =
-        {messages: ('pc, 'fp) Messages.t; openings: 'openings}
+        {messages: ('pc, 'fp) Messages.Stable.V1.t; openings: 'openings}
       [@@deriving fields]
     end
   end]

--- a/src/lib/pickles_types/pairing_marlin_types.ml
+++ b/src/lib/pickles_types/pairing_marlin_types.ml
@@ -5,6 +5,7 @@ module Typ = Snarky.Typ
 module Evals = struct
   open Vector
 
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type 'a t =
@@ -21,13 +22,24 @@ module Evals = struct
         ; col: 'a Abc.Stable.V1.t
         ; value: 'a Abc.Stable.V1.t
         ; rc: 'a Abc.Stable.V1.t }
-      [@@deriving version, fields, bin_io]
+      [@@deriving fields]
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type 'a t = 'a Stable.Latest.t =
+    { w_hat: 'a
+    ; z_hat_a: 'a
+    ; z_hat_b: 'a
+    ; g_1: 'a
+    ; h_1: 'a
+    ; g_2: 'a
+    ; h_2: 'a
+    ; g_3: 'a
+    ; h_3: 'a
+    ; row: 'a Abc.t
+    ; col: 'a Abc.t
+    ; value: 'a Abc.t
+    ; rc: 'a Abc.t }
 
   (* This is just the order used for iterating when absorbing the evaluations
      into the sponge. *)
@@ -219,29 +231,28 @@ module Accumulator = struct
     module Shift = Int
 
     module Unshifted_accumulators = struct
+      [%%versioned
       module Stable = struct
         module V1 = struct
-          type 'a t = 'a Shift.Map.t
-          [@@deriving version {asserted}, sexp, bin_io]
+          type 'a t = 'a Core_kernel.Shift.Map.t [@@deriving sexp]
         end
+      end]
 
-        module Latest = V1
-      end
-
-      include Stable.Latest
+      type 'a t = 'a Stable.Latest.t
     end
 
+    [%%versioned
     module Stable = struct
       module V1 = struct
         type ('g, 'unshifted) t =
           {shifted_accumulator: 'g; unshifted_accumulators: 'unshifted}
-        [@@deriving version, fields, bin_io, sexp]
+        [@@deriving fields, sexp]
       end
+    end]
 
-      module Latest = V1
-    end
-
-    include Stable.Latest
+    type ('g, 'unshifted) t = ('g, 'unshifted) Stable.Latest.t =
+      {shifted_accumulator: 'g; unshifted_accumulators: 'unshifted}
+    [@@deriving fields, sexp]
 
     let to_hlist {shifted_accumulator; unshifted_accumulators} =
       H_list.[shifted_accumulator; unshifted_accumulators]
@@ -312,16 +323,18 @@ module Accumulator = struct
 
        e(f - [v] + z pi, H) = e(pi, beta*H)
     *)
+    [%%versioned
     module Stable = struct
       module V1 = struct
         type 'g t = {r_f_minus_r_v_plus_rz_pi: 'g; r_pi: 'g}
-        [@@deriving version, fields, bin_io, sexp]
+        [@@deriving fields, sexp]
       end
 
       module Latest = V1
-    end
+    end]
 
-    include Stable.Latest
+    type 'g t = 'g Stable.Latest.t = {r_f_minus_r_v_plus_rz_pi: 'g; r_pi: 'g}
+    [@@deriving fields, sexp]
 
     let to_hlist {r_f_minus_r_v_plus_rz_pi; r_pi} =
       H_list.[r_f_minus_r_v_plus_rz_pi; r_pi]
@@ -347,18 +360,20 @@ module Accumulator = struct
       ; r_pi= f t1.r_pi t2.r_pi }
   end
 
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type ('g, 'unshifted) t =
         { opening_check: 'g Opening_check.t
         ; degree_bound_checks: ('g, 'unshifted) Degree_bound_checks.t }
-      [@@deriving version, fields, bin_io, sexp]
+      [@@deriving fields, sexp]
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type ('g, 'unshifted) t = ('g, 'unshifted) Stable.Latest.t =
+    { opening_check: 'g Opening_check.t
+    ; degree_bound_checks: ('g, 'unshifted) Degree_bound_checks.t }
+  [@@deriving fields, sexp]
 
   let to_hlist {opening_check; degree_bound_checks} =
     H_list.[opening_check; degree_bound_checks]
@@ -396,16 +411,17 @@ module Accumulator = struct
 end
 
 module Opening = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type ('proof, 'values) t = {proof: 'proof; values: 'values}
-      [@@deriving version, fields, bin_io]
+      [@@deriving fields]
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type ('proof, 'values) t = ('proof, 'values) Stable.Latest.t =
+    {proof: 'proof; values: 'values}
+  [@@deriving fields]
 
   let to_hlist {proof; values} = H_list.[proof; values]
 
@@ -419,17 +435,16 @@ end
 module Openings = struct
   open Evals
 
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type ('proof, 'fp) t =
         {proofs: 'proof * 'proof * 'proof; evals: 'fp Evals.t}
-      [@@deriving version, bin_io]
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type ('proof, 'fp) t = ('proof, 'fp) Stable.Latest.t =
+    {proofs: 'proof * 'proof * 'proof; evals: 'fp Evals.t}
 
   let to_hlist {proofs; evals} = H_list.[proofs; evals]
 
@@ -444,18 +459,18 @@ module Openings = struct
 end
 
 module Degree_bounded = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      type 'pc t = 'pc * 'pc [@@deriving version, bin_io]
+      type 'pc t = 'pc * 'pc
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type 'pc t = 'pc Stable.Latest.t
 end
 
 module Messages = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type ('pc, 'fp) t =
@@ -465,13 +480,17 @@ module Messages = struct
         ; gh_1: 'pc Degree_bounded.Stable.V1.t * 'pc
         ; sigma_gh_2: 'fp * ('pc Degree_bounded.Stable.V1.t * 'pc)
         ; sigma_gh_3: 'fp * ('pc Degree_bounded.Stable.V1.t * 'pc) }
-      [@@deriving version, fields, bin_io]
+      [@@deriving fields]
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type ('pc, 'fp) t = ('pc, 'fp) Stable.Latest.t =
+    { w_hat: 'pc
+    ; z_hat_a: 'pc
+    ; z_hat_b: 'pc
+    ; gh_1: 'pc Degree_bounded.t * 'pc
+    ; sigma_gh_2: 'fp * ('pc Degree_bounded.t * 'pc)
+    ; sigma_gh_3: 'fp * ('pc Degree_bounded.t * 'pc) }
 
   let to_hlist {w_hat; z_hat_a; z_hat_b; gh_1; sigma_gh_2; sigma_gh_3} =
     H_list.[w_hat; z_hat_a; z_hat_b; gh_1; sigma_gh_2; sigma_gh_3]
@@ -491,17 +510,18 @@ module Messages = struct
 end
 
 module Proof = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
       type ('pc, 'fp, 'openings) t =
         {messages: ('pc, 'fp) Messages.t; openings: 'openings}
-      [@@deriving version, fields, bin_io]
+      [@@deriving fields]
     end
+  end]
 
-    module Latest = V1
-  end
-
-  include Stable.Latest
+  type ('pc, 'fp, 'openings) t = ('pc, 'fp, 'openings) Stable.Latest.t =
+    {messages: ('pc, 'fp) Messages.t; openings: 'openings}
+  [@@deriving fields]
 
   let to_hlist {messages; openings} = H_list.[messages; openings]
 


### PR DESCRIPTION
Looked at the recently-merged `Pickles_type` library, noticed the `%%versioned` ppx wasn't being used. Added that in several places. 

(There's a problematic `Binable` functor, not addressed here.)