### PR TITLE
Double libp2p input buffer size

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1001,8 +1001,9 @@ func main() {
 	}()
 
 	lines := bufio.NewScanner(os.Stdin)
-	// 11MiB buffer size, larger than the 10.66MB minimum for 8MiB to be b64'd
-	bufsize := (1024 * 1024) * 11
+	// 22MiB buffer size, larger than the 21.33MB minimum for 16MiB to be b64'd
+	// 4 * (2^24/3) / 2^20 = 21.33
+	bufsize := (1024 * 1024) * 22
 	lines.Buffer(make([]byte, bufsize), bufsize)
 	out := bufio.NewWriter(os.Stdout)
 


### PR DESCRIPTION
Ran into an issue on the hangry-lobster testnet where the libp2p input buffer size would be exceeded when broadcasting messages from the daemon to the network. For now, I'm just doubling the size. I'm opened #4571 for a longer term solution that will prevent this from happening in the future.