### PR TITLE
Change copy in Genesis page 

### DIFF
--- a/frontend/website/src/pages/Genesis.re
+++ b/frontend/website/src/pages/Genesis.re
@@ -245,9 +245,7 @@ let make = (~profiles) => {
         <div className=Styles.textBlock>
           <p className=Styles.heroCopy>
             {React.string(
-               "Meet some of the 48 Genesis Founding Members.
-               These community members are learning how to operate the protocol, and strengthening the Coda network and community.
-               They are the backbone of the global Coda community.",
+               "Meet a few of the 40 members who are part of Genesis Cohort 1. These community members are crucial to strengthening the Coda network. They are the backbone of the global Coda community.",
              )}
           </p>
         </div>


### PR DESCRIPTION
This is an update to the page here: 

<img width="1306" alt="Screen Shot 2020-03-23 at 6 14 33 PM" src="https://user-images.githubusercontent.com/12700801/77378049-2a147e80-6d32-11ea-9b04-aa233fb77a95.png">
