### PR TITLE
Print hashes in check_serialization when they differ

### DIFF
--- a/src/lib/module_version/serialization.ml
+++ b/src/lib/module_version/serialization.ml
@@ -9,7 +9,7 @@ let print_hash hash =
 (** use this function to test Bin_prot serialization of types with asserted versioning *)
 
 let check_serialization (type t) (module M : Binable.S with type t = t) (t : t)
-    known_good_hash =
+    ?(show_hash = false) known_good_hash =
   let open Digestif.SHA256 in
   (* serialize value *)
   let sz = M.bin_size_t t in
@@ -22,5 +22,5 @@ let check_serialization (type t) (module M : Binable.S with type t = t) (t : t)
   let ctx0 = init () in
   let ctx1 = feed_string ctx0 s in
   let hash = get ctx1 |> to_raw_string in
-  (* print_hash hash ; *)
+  if show_hash then print_hash hash ;
   String.equal hash known_good_hash

--- a/src/lib/module_version/serialization.ml
+++ b/src/lib/module_version/serialization.ml
@@ -9,7 +9,7 @@ let print_hash hash =
 (** use this function to test Bin_prot serialization of types with asserted versioning *)
 
 let check_serialization (type t) (module M : Binable.S with type t = t) (t : t)
-    ?(show_hash = false) known_good_hash =
+    known_good_hash =
   let open Digestif.SHA256 in
   (* serialize value *)
   let sz = M.bin_size_t t in
@@ -22,5 +22,10 @@ let check_serialization (type t) (module M : Binable.S with type t = t) (t : t)
   let ctx0 = init () in
   let ctx1 = feed_string ctx0 s in
   let hash = get ctx1 |> to_raw_string in
-  if show_hash then print_hash hash ;
-  String.equal hash known_good_hash
+  let result = String.equal hash known_good_hash in
+  if not result then (
+    printf "Expected hash: " ;
+    print_hash known_good_hash ;
+    printf "Got hash:      " ;
+    print_hash hash ) ;
+  result


### PR DESCRIPTION
Version-asserted types require tests to show their serialization hasn't changed. There's a function `check_serialization` for that purpose.

Until now, in order to show the expected result, you had to uncomment a line to print out a hash. In this PR, the expected and actual hashes are printed if they differ.