### PR TITLE
Website: Add initial docs for archive node

### DIFF
--- a/frontend/website/pages/docs/developers/archive-node.mdx
+++ b/frontend/website/pages/docs/developers/archive-node.mdx
@@ -1,0 +1,44 @@
+import Page from '@reason/pages/Docs';
+export default Page({title: "Archive Node"});
+
+# Archive Node
+
+Coda nodes are succinct by default, meaning they don't need to maintain historical information about the network, block, or transactions. For some usecases, it is useful to maintain this historical data, which you can do by running an "archive node".
+
+An archive node is just a regular Coda daemon that is connected to a running archive process. The daemon will regularly send blockchain data to the archive process, which will store it in a postgres database.  Running an archive node therefore requires some knowledge of managing a postgres database instance.
+
+## Setup Instructions
+
+Below are some basic instructions on how to set up everything required to get an archive node running locally. These will be slightly different if you're connecting to a cloud instance of postgres, if your deployment uses docker, or if you want to run these processes on different machines.
+
+<Alert>
+
+Note: Some of these instructions may depend on how your operating system installs postgres (and assume that it is installed in the first place).
+
+</Alert>
+
+1. Start a local postgres server. This will just run it in the foreground for testing, you will likely want to run it in the background or use your OS's service manager (like systemd) to run it for you. Alternatively, you may use a postgres service hosted by a cloud provider.
+```
+postgres -p 5432 -D /usr/local/var/postgres
+```
+
+2. Create database (here called `archiver`) on server and load the schema into it. This will only need to be done the first time the archive node is set up.
+```
+createdb -h localhost -p 5432 -e archiver
+
+psql -h localhost -p 5432 -d archiver -f <(curl -Ls https://raw.githubusercontent.com/CodaProtocol/coda/master/src/app/archive/create_schema.sql)
+```
+
+3. Start archive process on port 3086, connecting to the postgres database we started on port 5432 in step 1.
+```
+coda-archive \
+  -postgres-uri postgres://localhost:5432/archiver \
+  -server-port 3086
+```
+
+4. Start the daemon, connecting it to the archive process that we just started on port 3086. If you want to connect to an archive process on another machine, you can specify a hostname as well, like `localhost:3086`.
+
+<DaemonCommandExample args={[
+  "-archive-address 3086"
+]} />
+

--- a/frontend/website/pages/docs/my-first-transaction.mdx
+++ b/frontend/website/pages/docs/my-first-transaction.mdx
@@ -18,11 +18,7 @@ In this section, we'll make our first transaction on the Coda network. After [in
 
 Run the following command to start up a Coda node instance and connect to the network:
 
-    coda daemon \
-        -external-port 8302 \
-        -discovery-port 8303 \
-        -peer /dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH \
-        -peer /dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA
+<DaemonCommandExample args={[]} />
 
 The host and port specified above refer to the seed peer address - this is the initial peer we will connect to on the network. Since Coda is a [peer-to-peer](/docs/glossary/#peer-to-peer) protocol, there is no single centralized server we rely on. 
 

--- a/frontend/website/pages/docs/node-operator.mdx
+++ b/frontend/website/pages/docs/node-operator.mdx
@@ -24,12 +24,9 @@ The Coda network is secured by [Proof-of-Stake consensus](/docs/glossary/#proof-
 Since we have some funds in our wallet from [the previous step](/docs/my-first-transaction), we can now start the daemon with the `-propose-key` flag to begin staking coda. 
 Let's stop our current daemon process, and restart it with the following command, passing in the file path for the associated private key (by default, keypairs live in `~/.coda-config/wallets/store`). Since we conveniently saved it as an environment variable in the previous step, we can run the following command:
 
-    coda daemon \
-        -external-port 8302 \
-        -discovery-port 8303 \
-        -peer /dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH \
-        -peer /dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA \
-        -propose-key $CODA_PRIVATE_KEY_FILE
+<DaemonCommandExample args={[
+  "-propose-key $CODA_PRIVATE_KEY_FILE"
+]} />
 
 <Alert>
 
@@ -122,13 +119,10 @@ However, this isn't data encoding or compression in the traditional sense - rath
 
 When you [start the daemon](/docs/my-first-transaction/#start-up-a-node), set these extra arguments to also start a snark-worker:
 
-    coda daemon \
-        -external-port 8302 \
-        -discovery-port 8303 \
-        -peer /dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH \
-        -peer /dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA \
-        -run-snark-worker $CODA_PUBLIC_KEY \
-        -snark-worker-fee <fee>
+<DaemonCommandExample args={[
+  "-run-snark-worker $CODA_PUBLIC_KEY",
+  "-snark-worker-fee <fee>"
+]} />
 
 As a snark worker, you get to share some of the block reward for each block your compressed transactions make it in to. The block producer is responsible for gathering compressed transactions before including them into a block, and will be incentivized by the protocol to reward snark-workers.
 

--- a/frontend/website/src/components/DocsComponents.re
+++ b/frontend/website/src/components/DocsComponents.re
@@ -40,6 +40,9 @@ module Wrap = (C: Component) => {
   let make = props => {
     ReasonReact.cloneElement(C.element, ~props, [||]);
   };
+
+  [@bs.obj]
+  external makeProps: (~children: 'a, unit) => {. "children": 'a} = "";
 };
 
 module WrapHeader = (C: Component) => {
@@ -138,15 +141,12 @@ module Strong =
 external writeText: string => Js.Promise.t(unit) = "writeText";
 
 module Pre = {
-  let make = props => {
+  [@react.component]
+  let make = (~children) => {
     let text =
       Js.String.trim(
         Js.String.make(
-          {
-            let props =
-              ReactExt.Children.only(props##children) |> ReactExt.props;
-            props##children;
-          },
+          (ReactExt.Children.only(children) |> ReactExt.props)##children,
         ),
       );
     <div className={style([position(`relative)])}>
@@ -182,7 +182,7 @@ module Pre = {
           overflow(`scroll),
           selector("code", [Theme.Typeface.pragmataPro]),
         ])}>
-        {props##children}
+        children
       </pre>
     </div>;
   };
@@ -214,8 +214,25 @@ module Img =
     let element = <img width="100%" />;
   });
 
+module DaemonCommandExample = {
+  let defaultArgs = [
+    "coda daemon",
+    "-external-port 8302",
+    "-discovery-port 8303",
+    "-peer /dns4/seed-one.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWP7fTKbyiUcYJGajQDpCFo2rDexgTHFJTxCH8jvcL1eAH",
+    "-peer /dns4/seed-two.genesis-redux.o1test.net/tcp/10002/ipfs/12D3KooWL9ywbiXNfMBqnUKHSB1Q1BaHFNUzppu6JLMVn9TTPFSA",
+  ];
+  [@react.component]
+  let make = (~args: array(string)) => {
+    let processed_args =
+      String.concat(" \\\n    ", defaultArgs @ Array.to_list(args));
+    <Pre> <Code> {React.string(processed_args)} </Code> </Pre>;
+  };
+};
+
 let allComponents = () => {
   "Alert": Alert.make,
+  "DaemonCommandExample": DaemonCommandExample.make,
   "h1": H1.make,
   "h2": H2.make,
   "h3": H3.make,

--- a/frontend/website/src/components/DocsSideNav.re
+++ b/frontend/website/src/components/DocsSideNav.re
@@ -167,6 +167,7 @@ let make = (~currentSlug) => {
           <Page title="Code Reviews" slug="code-reviews" />
           <Page title="Style Guide" slug="style-guide" />
           <Page title="GraphQL API" slug="graphql-api" />
+          <Page title="Archive Node" slug="archive-node" />
         </Folder>
         <Folder title="Coda Protocol Architecture" slug="architecture">
           <Page title="Coda Overview" slug="" />


### PR DESCRIPTION
Putting some initial docs up for review.

Also:
- an attempt to remove some of the duplication in the specification of `coda daemon` commands.  Just so we don't forget to update it somewhere.

TODO: Add information about installing the actual archive binary once we build a distributable