### PR TITLE
Add a fork_id to the archive test compile-time config

### DIFF
--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]
 [%%define fake_hash true]


### PR DESCRIPTION
This fixes the error in CI when compiling the `coda-archive-processor-test`

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: