### PR TITLE
Resurrect define_from_scope ppx

### DIFF
--- a/src/lib/ppx_coda/define_from_scope.ml
+++ b/src/lib/ppx_coda/define_from_scope.ml
@@ -1,0 +1,65 @@
+open Core_kernel
+open Ppxlib
+open Asttypes
+
+(* define_from_scope creates local definitions from those in scope
+
+   Example:
+
+     [%%define_from_scope x,y,z]
+
+   expands to
+
+     let x,y,z = x,y,z
+
+   Useful when importing definitions from an enclosing scope:
+
+     let x = ...
+     let y = ...
+
+     module T = struct
+       [%%define_from_scope x,y]
+     end
+ *)
+
+let name = "define_from_scope"
+
+let pat_of_id loc id =
+  {ppat_desc= Ppat_var {txt= id; loc}; ppat_loc= loc; ppat_attributes= []}
+
+let ident_of_id loc id =
+  { pexp_desc= Pexp_ident {txt= Lident id; loc}
+  ; pexp_loc= loc
+  ; pexp_attributes= [] }
+
+let expr_to_id loc expr =
+  match expr.pexp_desc with
+  | Pexp_ident {txt= Lident s; _} ->
+      s
+  | _ ->
+      Location.raise_errorf ~loc "Expected identifier"
+
+let expand ~loc ~path:_ (items : expression list) =
+  let ids = List.map items ~f:(expr_to_id loc) in
+  let pats = List.map ids ~f:(pat_of_id loc) in
+  let idents = List.map ids ~f:(ident_of_id loc) in
+  { pstr_desc=
+      Pstr_value
+        ( Nonrecursive
+        , [ { pvb_pat=
+                {ppat_desc= Ppat_tuple pats; ppat_loc= loc; ppat_attributes= []}
+            ; pvb_expr=
+                { pexp_desc= Pexp_tuple idents
+                ; pexp_loc= loc
+                ; pexp_attributes= [] }
+            ; pvb_attributes= []
+            ; pvb_loc= loc } ] )
+  ; pstr_loc= loc }
+
+let ext =
+  Extension.declare name Extension.Context.structure_item
+    Ast_pattern.(single_expr_payload (pexp_tuple __))
+    expand
+
+let () =
+  Driver.register_transformation name ~rules:[Context_free.Rule.extension ext]

--- a/src/lib/ppx_coda/tests/Makefile
+++ b/src/lib/ppx_coda/tests/Makefile
@@ -30,6 +30,10 @@ positive-tests : unexpired.ml
 	@ echo -n "Define locally, should succeed..."
 	@ dune build define_locally_good.cma ${REDIRECT}
 	@ echo "OK"
+# define existing
+	@ echo -n "Define from scope, should succeed..."
+	@ dune build define_from_scope_good.cma ${REDIRECT}
+	@ echo "OK"
 # module versioning
 	@ echo -n "Module versioning, should succeed..."
 	@ dune exec ./versioned_module_good.exe ${REDIRECT}
@@ -52,7 +56,7 @@ negative-tests :
 	@ echo -n "Invalid format, should fail..."
 	@ ! dune build expiry_invalid_format.cma ${REDIRECT}
 	@ echo "OK"
-# version syntax 
+# version syntax
 	@ echo -n "Missing deriving version, should fail..."
 	@ ! dune build bad_version_syntax_missing_version.cma ${REDIRECT}
 	@ echo "OK"

--- a/src/lib/ppx_coda/tests/define_from_scope_good.ml
+++ b/src/lib/ppx_coda/tests/define_from_scope_good.ml
@@ -1,0 +1,15 @@
+module Outer = struct
+  let x = 42
+
+  let y = "This is a string"
+
+  let z = (x, y)
+
+  let q = (x, y, z)
+
+  module Inner = struct
+    [%%define_from_scope x, y, z, q]
+  end
+end
+
+let x, y, z, q = Outer.Inner.(x, y, z, q)

--- a/src/lib/ppx_coda/tests/dune
+++ b/src/lib/ppx_coda/tests/dune
@@ -26,11 +26,16 @@
   (modules versioned_good))
 
 ;; define locally
-
 (library
   (name define_locally_good)
   (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
   (modules define_locally_good))
+
+;; define from scope
+(library
+  (name define_from_scope_good)
+  (preprocess (pps ppx_jane ppx_deriving_yojson ppx_coda))
+  (modules define_from_scope_good))
 
 ;; module versioning
 (executable


### PR DESCRIPTION
Resurrect `%%define_from_scope` ppx.

You can write:
```ocaml
let x = ...
let y = ...
module T = struct
  [%%define_from_scope (x,y)]
end
```
I originally wrote this so that a module `T` could be used as a functor argument. At the time, @bkase objected, arguing that it would be better to use `include`, and not complicate things.

But #4586 has a statement where some definitions are pulled into a module, not for the purpose of creating a functor argument. In that case, there are 9 items to be defined, so this ppx would help make the code more concise and prevent error.

Note: some the `ppx_coda` tests are failing because of recent changes in the linter; not fixed here. The test added for this ppx succeeds.