### PR TITLE
Website: Fix genesis member profile text for Safari 

### DIFF
--- a/frontend/website/src/components/MemberProfile.re
+++ b/frontend/website/src/components/MemberProfile.re
@@ -53,7 +53,7 @@ module Styles = {
       lineHeight(`rem(1.)),
       color(white),
       height(`rem(1.)),
-      width(`rem(11.9)),
+      width(`rem(12.0)),
       padding2(~h=`rem(0.5), ~v=`zero),
     ]);
   let quote =


### PR DESCRIPTION
Small change to fix, will follow up with another PR to align icon and text on Safari 
Has checked that this doesn't break on Chrome 