### PR TITLE
Add peer id for node to telemetry I

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -761,7 +761,14 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                    Public_key.compress public_key )
           in
           let get_telemetry_data _env =
-            let node = config.gossip_net_params.addrs_and_ports.external_ip in
+            let node_ip_addr =
+              config.gossip_net_params.addrs_and_ports.external_ip
+            in
+            let peer_opt = config.gossip_net_params.addrs_and_ports.peer in
+            let node_peer_id =
+              Option.value_map peer_opt ~default:"<UNKNOWN>" ~f:(fun peer ->
+                  peer.peer_id )
+            in
             match !net_ref with
             | None ->
                 (* essentially unreachable; without a network, we wouldn't receive this RPC call *)
@@ -772,9 +779,10 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                 @@ Error
                      (Error.of_string
                         (sprintf
-                           !"Node: %{sexp: Unix.Inet_addr.t}, network not \
-                             instantiated when telemetry data requested"
-                           node))
+                           !"Node with IP address=%{sexp: Unix.Inet_addr.t}, \
+                             peer ID=%s, network not instantiated when \
+                             telemetry data requested"
+                           node_ip_addr node_peer_id))
             | Some net -> (
               match Broadcast_pipe.Reader.peek frontier_broadcast_pipe_r with
               | None ->
@@ -782,9 +790,10 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                   @@ Error
                        (Error.of_string
                           (sprintf
-                             !"Node: %{sexp: Unix.Inet_addr.t}, could not get \
+                             !"Node with IP address=%{sexp: \
+                               Unix.Inet_addr.t}, peer ID=%s, could not get \
                                transition frontier for telemetry data"
-                             node))
+                             node_ip_addr node_peer_id))
               | Some frontier ->
                   let%map peers = Coda_networking.peers net in
                   let protocol_state_hash =
@@ -805,7 +814,8 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                   in
                   Ok
                     Coda_networking.Rpcs.Get_telemetry_data.Telemetry_data.
-                      { node
+                      { node_ip_addr
+                      ; node_peer_id
                       ; peers
                       ; block_producers
                       ; protocol_state_hash

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -433,7 +433,8 @@ module Rpcs = struct
       module Stable = struct
         module V1 = struct
           type t =
-            { node: Core.Unix.Inet_addr.Stable.V1.t
+            { node_ip_addr: Core.Unix.Inet_addr.Stable.V1.t
+            ; node_peer_id: Network_peer.Peer.Id.Stable.V1.t
             ; peers: Network_peer.Peer.Stable.V1.t list
             ; block_producers:
                 Signature_lib.Public_key.Compressed.Stable.V1.t list
@@ -449,7 +450,9 @@ module Rpcs = struct
            *)
           let to_yojson t =
             `Assoc
-              [ ("node", `String (Unix.Inet_addr.to_string t.node))
+              [ ( "node_ip_addr"
+                , `String (Unix.Inet_addr.to_string t.node_ip_addr) )
+              ; ("node_peer_id", `String t.node_peer_id)
               ; ( "peers"
                 , `List
                     (List.map t.peers ~f:Network_peer.Peer.Stable.V1.to_yojson)
@@ -473,7 +476,8 @@ module Rpcs = struct
       end]
 
       type t = Stable.Latest.t =
-        { node: Unix.Inet_addr.t
+        { node_ip_addr: Unix.Inet_addr.t
+        ; node_peer_id: Network_peer.Peer.Id.t
         ; peers: Network_peer.Peer.t list
         ; block_producers: Signature_lib.Public_key.Compressed.t list
         ; protocol_state_hash: State_hash.t

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -68,7 +68,8 @@ module Rpcs : sig
       module Stable : sig
         module V1 : sig
           type t =
-            { node: Core.Unix.Inet_addr.Stable.V1.t
+            { node_ip_addr: Core.Unix.Inet_addr.Stable.V1.t
+            ; node_peer_id: Peer.Id.Stable.V1.t
             ; peers: Network_peer.Peer.Stable.V1.t list
             ; block_producers:
                 Signature_lib.Public_key.Compressed.Stable.V1.t list
@@ -82,7 +83,8 @@ module Rpcs : sig
       end]
 
       type t = Stable.Latest.t =
-        { node: Unix.Inet_addr.t
+        { node_ip_addr: Unix.Inet_addr.t
+        ; node_peer_id: Peer.Id.t
         ; peers: Network_peer.Peer.t list
         ; block_producers: Signature_lib.Public_key.Compressed.t list
         ; protocol_state_hash: State_hash.t

--- a/src/lib/node_addrs_and_ports/node_addrs_and_ports.ml
+++ b/src/lib/node_addrs_and_ports/node_addrs_and_ports.ml
@@ -12,8 +12,6 @@ type t =
   ; client_port: int }
 [@@deriving fields, sexp]
 
-let _ = Option.map
-
 module Display = struct
   [%%versioned
   module Stable = struct

--- a/src/lib/node_addrs_and_ports/node_addrs_and_ports.ml
+++ b/src/lib/node_addrs_and_ports/node_addrs_and_ports.ml
@@ -12,6 +12,8 @@ type t =
   ; client_port: int }
 [@@deriving fields, sexp]
 
+let _ = Option.map
+
 module Display = struct
   [%%versioned
   module Stable = struct


### PR DESCRIPTION
Include the node's peer ID in the telemetry response.

That's useful for the forthcoming telemetry script, which will build a map from peer IDs to responses.
