### PR TITLE
Don't fail CI when we are generating keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,7 +370,7 @@ jobs:
             - run:
                   name: Pin external packages
                   command: ./scripts/pin-external-packages.sh
-            # Builds fail once if keys need to be uploaded
+            # Explicitly generate PV-keys and uploading before building
             # See https://bkase.dev/posts/ocaml-writer#fn-3 for rationale
             - run:
                   name: Generate PV keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,8 @@ jobs:
                   command: ./scripts/pin-external-packages.sh
             - run:
                   name: Build OCaml
-                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log'
+                  # `make build` below *should* fail, exactly when it hass generated the keys to upload.
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log || true'
                   environment:
                     DUNE_PROFILE: testnet_postake_medium_curves
                     EXTRA_NIX_ARGS: --option sandbox false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ jobs:
                   command: ./scripts/pin-external-packages.sh
             - run:
                   name: Build OCaml
-                  # `make build` below *should* fail, exactly when it hass generated the keys to upload.
+                  # `make build` below *should* fail, exactly when it has generated the keys to upload.
                   command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log || true'
                   environment:
                     DUNE_PROFILE: testnet_postake_medium_curves

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,9 +373,8 @@ jobs:
             # Builds fail once if keys need to be uploaded
             # See https://bkase.dev/posts/ocaml-writer#fn-3 for rationale
             - run:
-                  name: Build OCaml
-                  # `make build` below *should* fail, exactly when it has generated the keys to upload.
-                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log || true'
+                  name: Generate PV keys
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build_pv_keys 2>&1 | tee /tmp/artifacts/buildocaml.log'
                   environment:
                     DUNE_PROFILE: testnet_postake_medium_curves
                     EXTRA_NIX_ARGS: --option sandbox false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,6 +370,8 @@ jobs:
             - run:
                   name: Pin external packages
                   command: ./scripts/pin-external-packages.sh
+            # Builds fail once if keys need to be uploaded
+            # See https://bkase.dev/posts/ocaml-writer#fn-3 for rationale
             - run:
                   name: Build OCaml
                   # `make build` below *should* fail, exactly when it has generated the keys to upload.

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -372,7 +372,7 @@ jobs:
             - run:
                   name: Pin external packages
                   command: ./scripts/pin-external-packages.sh
-            # Builds fail once if keys need to be uploaded
+            # Explicitly generate PV-keys and uploading before building
             # See https://bkase.dev/posts/ocaml-writer#fn-3 for rationale
             - run:
                   name: Generate PV keys

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -374,7 +374,7 @@ jobs:
                   command: ./scripts/pin-external-packages.sh
             - run:
                   name: Build OCaml
-                  # `make build` below *should* fail, exactly when it hass generated the keys to upload.
+                  # `make build` below *should* fail, exactly when it has generated the keys to upload.
                   command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log || true'
                   environment:
                     DUNE_PROFILE: {{profile}}

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -375,9 +375,8 @@ jobs:
             # Builds fail once if keys need to be uploaded
             # See https://bkase.dev/posts/ocaml-writer#fn-3 for rationale
             - run:
-                  name: Build OCaml
-                  # `make build` below *should* fail, exactly when it has generated the keys to upload.
-                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log || true'
+                  name: Generate PV keys
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build_pv_keys 2>&1 | tee /tmp/artifacts/buildocaml.log'
                   environment:
                     DUNE_PROFILE: {{profile}}
                     EXTRA_NIX_ARGS: --option sandbox false

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -374,7 +374,8 @@ jobs:
                   command: ./scripts/pin-external-packages.sh
             - run:
                   name: Build OCaml
-                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log'
+                  # `make build` below *should* fail, exactly when it hass generated the keys to upload.
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'set -o pipefail; eval `opam config env` && make build 2>&1 | tee /tmp/artifacts/buildocaml.log || true'
                   environment:
                     DUNE_PROFILE: {{profile}}
                     EXTRA_NIX_ARGS: --option sandbox false

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -372,6 +372,8 @@ jobs:
             - run:
                   name: Pin external packages
                   command: ./scripts/pin-external-packages.sh
+            # Builds fail once if keys need to be uploaded
+            # See https://bkase.dev/posts/ocaml-writer#fn-3 for rationale
             - run:
                   name: Build OCaml
                   # `make build` below *should* fail, exactly when it has generated the keys to upload.

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,11 @@ deb:
 	@cp _build/coda*.deb /tmp/artifacts/.
 	@cp _build/coda_pvkeys_* /tmp/artifacts/.
 
+build_pv_keys:
+	$(info Building keys)
+	ulimit -s 65532 && (ulimit -n 10240 || true) && $(WRAPAPP) env CODA_COMMIT_SHA1=$(GITLONGHASH) dune exec --profile=$(DUNE_PROFILE) src/lib/snark_keys/gen_keys/gen_keys.exe -- --generate-keys-only
+	$(info Keys built)
+
 publish_deb:
 	@./scripts/publish-deb.sh
 

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -222,7 +222,13 @@ let gen_keys () =
     match (Sys.getenv "CI", Sys.getenv "DUNE_PROFILE") with
     | Some _, Some profile
       when String.is_substring ~substring:"testnet" profile ->
-        exit 0xc1 (* exit with code 0xc1, get it "CI" *)
+        (* We are intentionally aborting the build here with a special error code
+        * so that we can signal to our CI job that we'd like to temporarily stop
+        * for key uploading. On CI, we can shell out to an aws utility to upload
+        * keys. Afterwards, when we rebuild we'll hit the `Cache_hit branch.
+        *
+        * Exit code is 0xc1 for "CI" *)
+        exit 0xc1
     | Some _, Some _ | _, None | None, _ ->
         return acc )
   | `Cache_hit ->

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -203,7 +203,22 @@ let gen_keys () =
   in
   match dirty with
   | `Generated_something -> (
-    (* TODO: Check if circleci and die *)
+    (* If we generated any keys, then we need to make sure to upload these keys
+     * to some central store to keep our builds compatible with one-another.
+     *
+     * We used to have a process where we manually upload keys whenever we want
+     * to persist a new change. This is an attempt to make that process
+     * automatic.
+     *
+     * We don't want to force an upload on every change as during development
+     * you could churn on changes. Instead, we force uploads on CI jobs that
+     * build testnet artifacts (as these are the binaries we want to make sure
+     * we can retrieve keys for).
+     * Uploads occur out-of-process in CI.
+     *
+     * See the background section of https://bkase.dev/posts/ocaml-writer
+     * for more info on how this system works.
+     *)
     match (Sys.getenv "CI", Sys.getenv "DUNE_PROFILE") with
     | Some _, Some profile
       when String.is_substring ~substring:"testnet" profile ->

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -225,9 +225,7 @@ let gen_keys () =
     | Some _, Some profile
       when String.is_substring ~substring:"testnet" profile ->
         (* We are intentionally aborting the build here with a special error code
-        * so that we can signal to our CI job that we'd like to temporarily stop
-        * for key uploading. On CI, we can shell out to an aws utility to upload
-        * keys. Afterwards, when we rebuild we'll hit the `Cache_hit branch.
+        * because we do not want builds to succeed if keys are not uploaded.
         *
         * Exit code is 0xc1 for "CI" *)
         exit 0xc1

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -201,6 +201,8 @@ let gen_keys () =
     , Transaction_snark_keys.Verification.key_location ~loc
         tx_keys_location.verification )
   in
+  if Array.mem ~equal:String.equal Sys.argv "--generate-keys-only" then
+    Stdlib.exit 0 ;
   match dirty with
   | `Generated_something -> (
     (* If we generated any keys, then we need to make sure to upload these keys


### PR DESCRIPTION
*Edit: Old description removed, retconning this for the actual fix.*

This updates the CircleCI artifacts job to continue after key generation 'fails'. This failure is done deliberately at a strategic point so that we can upload the keys before resuming the build.