### PR TITLE
Constants for new qa net

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -144,7 +144,7 @@ let daemon logger =
            (sprintf
               "FEE Amount a worker wants to get compensated for generating a \
                snark proof (default: %d)"
-              (Currency.Fee.to_int Cli_lib.Default.snark_worker_fee))
+              (Currency.Fee.to_int Coda_compile_config.default_snark_worker_fee))
          (optional txn_fee)
      and work_reassignment_wait =
        flag "work-reassignment-wait" (optional int)
@@ -408,7 +408,8 @@ let daemon logger =
              YJ.Util.to_int_option json |> Option.map ~f:Currency.Fee.of_int
            in
            or_from_config json_to_currency_fee_option "snark-worker-fee"
-             ~default:Cli_lib.Default.snark_worker_fee snark_work_fee
+             ~default:Coda_compile_config.default_snark_worker_fee
+             snark_work_fee
          in
          (* FIXME #4095: pass this through to Gossip_net.Libp2p *)
          let _max_concurrent_connections =

--- a/src/config/account_creation_fee/realistic.mlh
+++ b/src/config/account_creation_fee/realistic.mlh
@@ -1,0 +1,1 @@
+[%%define account_creation_fee_int "0.001"]

--- a/src/config/amount_defaults/realistic.mlh
+++ b/src/config/amount_defaults/realistic.mlh
@@ -1,5 +1,3 @@
-(* A payment requires 2 SNARKS, so this should always >= 2x the snark fee.
- * It is wise to also account for account-creation-fee for testnets. *)
 [%%define default_transaction_fee "0.1"]
 [%%define default_snark_worker_fee "0.025"]
 

--- a/src/config/amount_defaults/realistic.mlh
+++ b/src/config/amount_defaults/realistic.mlh
@@ -1,0 +1,5 @@
+(* A payment requires 2 SNARKS, so this should always >= 2x the snark fee.
+ * It is wise to also account for account-creation-fee for testnets. *)
+[%%define default_transaction_fee "0.1"]
+[%%define default_snark_worker_fee "0.025"]
+

--- a/src/config/amount_defaults/standard.mlh
+++ b/src/config/amount_defaults/standard.mlh
@@ -1,0 +1,5 @@
+(* A payment requires 2 SNARKS, so this should always >= 2x the snark fee.
+ * It is wise to also account for account-creation-fee for testnets. *)
+[%%define default_transaction_fee "5"]
+[%%define default_snark_worker_fee "1"]
+

--- a/src/config/amount_defaults/standard.mlh
+++ b/src/config/amount_defaults/standard.mlh
@@ -1,5 +1,3 @@
-(* A payment requires 2 SNARKS, so this should always >= 2x the snark fee.
- * It is wise to also account for account-creation-fee for testnets. *)
 [%%define default_transaction_fee "5"]
 [%%define default_snark_worker_fee "1"]
 

--- a/src/config/coinbase/realistic.mlh
+++ b/src/config/coinbase/realistic.mlh
@@ -1,0 +1,1 @@
+[%%define coinbase "200"]

--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/high.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/dev_frontend.mlh
+++ b/src/config/dev_frontend.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/high.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/nonconsensus_medium_curves.mlh
+++ b/src/config/nonconsensus_medium_curves.mlh
@@ -6,6 +6,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_bootstrap.mlh
+++ b/src/config/test_postake_bootstrap.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_delegation.mlh
+++ b/src/config/test_postake_delegation.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_split_snarkless.mlh
+++ b/src/config/test_postake_split_snarkless.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/test_postake_txns.mlh
+++ b/src/config/test_postake_txns.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets true]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,28 +1,29 @@
 [%%define ledger_depth 14]
 [%%define fake_accounts_target 50]
 [%%import "/src/config/curve/medium.mlh"]
-[%%import "/src/config/coinbase/standard.mlh"]
+[%%import "/src/config/coinbase/realistic.mlh"]
 [%%import "/src/config/scan_state/point2tps.mlh"]
 [%%import "/src/config/debug_level/some.mlh"]
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
-[%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/account_creation_fee/realistic.mlh"]
+[%%import "/src/config/amount_defaults/realistic.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 (* custom consensus parameters for the testnet release *)
 [%%define consensus_mechanism "proof_of_stake"]
-[%%define k 10]
+[%%define k 20]
 [%%define c 8]
 [%%define delta 3]
 
 [%%define record_async_backtraces false]
-[%%define time_offsets true]
+[%%define time_offsets false]
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
 [%%define genesis_ledger "testnet_postake"]
 
-[%%define genesis_state_timestamp "2020-02-25 10:00:00-07:00"]
+[%%define genesis_state_timestamp "2020-04-01 10:00:00-07:00"]
 [%%define block_window_duration 180000]
 
 [%%define integration_tests false]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/check.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/none.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -7,6 +7,7 @@
 [%%import "/src/config/proof_level/full.mlh"]
 [%%import "/src/config/txpool_size.mlh"]
 [%%import "/src/config/account_creation_fee/standard.mlh"]
+[%%import "/src/config/amount_defaults/standard.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
 [%%define time_offsets false]

--- a/src/lib/cli_lib/default.ml
+++ b/src/lib/cli_lib/default.ml
@@ -1,10 +1,4 @@
 (* Default values for cli flags *)
-(* A payment requires 2 SNARKS, so this should always >= 2x the snark fee. *)
-let transaction_fee = Currency.Fee.of_int 5_000_000_000
-
-(*Fee for a snark bundle*)
-let snark_worker_fee = Currency.Fee.of_int 1_000_000_000
-
 let work_reassignment_wait = 420000
 
 let conf_dir_name = ".coda-config"

--- a/src/lib/cli_lib/flag.ml
+++ b/src/lib/cli_lib/flag.ml
@@ -289,7 +289,8 @@ let user_command_common : user_command_common Command.Param.t =
         (Printf.sprintf
            "FEE Amount you are willing to pay to process the transaction \
             (default: %s) (minimum: %s)"
-           (Currency.Fee.to_formatted_string Default.transaction_fee)
+           (Currency.Fee.to_formatted_string
+              Coda_compile_config.default_transaction_fee)
            (Currency.Fee.to_formatted_string Coda_base.User_command.minimum_fee))
       (optional txn_fee)
   and nonce =
@@ -304,7 +305,10 @@ let user_command_common : user_command_common Command.Param.t =
     flag "memo" ~doc:"STRING Memo accompanying the transaction"
       (optional string)
   in
-  {sender; fee= Option.value fee ~default:Default.transaction_fee; nonce; memo}
+  { sender
+  ; fee= Option.value fee ~default:Coda_compile_config.default_transaction_fee
+  ; nonce
+  ; memo }
 
 module User_command = struct
   open Arg_type
@@ -331,7 +335,8 @@ module User_command = struct
         (Printf.sprintf
            "FEE Amount you are willing to pay to process the transaction \
             (default: %s) (minimum: %s)"
-           (Currency.Fee.to_formatted_string Default.transaction_fee)
+           (Currency.Fee.to_formatted_string
+              Coda_compile_config.default_transaction_fee)
            (Currency.Fee.to_formatted_string Coda_base.User_command.minimum_fee))
       (optional txn_fee)
 

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -19,6 +19,12 @@
 [%%inject
 "account_creation_fee_string", account_creation_fee_int]
 
+[%%inject
+"default_transaction_fee_string", default_transaction_fee]
+
+[%%inject
+"default_snark_worker_fee", default_snark_worker_fee]
+
 let coinbase = Currency.Amount.of_formatted_string coinbase_string
 
 let account_creation_fee =

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -29,3 +29,9 @@ let coinbase = Currency.Amount.of_formatted_string coinbase_string
 
 let account_creation_fee =
   Currency.Fee.of_formatted_string account_creation_fee_string
+
+let default_transaction_fee =
+  Currency.Fee.of_formatted_string default_transaction_fee
+
+let default_snark_worker_fee =
+  Currency.Fee.of_formatted_string default_snark_worker_fee

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -31,7 +31,7 @@ let account_creation_fee =
   Currency.Fee.of_formatted_string account_creation_fee_string
 
 let default_transaction_fee =
-  Currency.Fee.of_formatted_string default_transaction_fee
+  Currency.Fee.of_formatted_string default_transaction_fee_string
 
 let default_snark_worker_fee =
-  Currency.Fee.of_formatted_string default_snark_worker_fee
+  Currency.Fee.of_formatted_string default_snark_worker_fee_string

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -23,7 +23,7 @@
 "default_transaction_fee_string", default_transaction_fee]
 
 [%%inject
-"default_snark_worker_fee", default_snark_worker_fee]
+"default_snark_worker_fee_string", default_snark_worker_fee]
 
 let coinbase = Currency.Amount.of_formatted_string coinbase_string
 


### PR DESCRIPTION
Setting constants for new qa net.

Spec:
1. Adjust snark work fees — 0.025
2. Adjust account creation fee — 0.001
3. Adjust coinbase — 200.0
4. Adjust default transaction fees — 0.1