### PR TITLE
Disable telemetry

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -211,6 +211,9 @@ let daemon logger =
               "HEX-STRING (%d characters) Current fork ID for this node, only \
                blocks with the same ID accepted"
               Fork_id.required_length)
+     and disable_telemetry =
+       flag "disable-telemetry" no_arg
+         ~doc:"Disable reporting telemetry to other nodes"
      in
      fun () ->
        let open Deferred.Let_syntax in
@@ -734,8 +737,8 @@ let daemon logger =
          let%map coda =
            Coda_lib.create
              (Coda_lib.Config.make ~logger ~pids ~trust_system ~conf_dir
-                ~is_seed ~demo_mode ~coinbase_receiver ~net_config
-                ~gossip_net_params ~initial_fork_id:current_fork_id
+                ~is_seed ~disable_telemetry ~demo_mode ~coinbase_receiver
+                ~net_config ~gossip_net_params ~initial_fork_id:current_fork_id
                 ~work_selection_method:
                   (Cli_lib.Arg_type.work_selection_method_to_module
                      work_selection_method)

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -546,8 +546,8 @@ module T = struct
           let coda_deferred () =
             Coda_lib.create
               (Coda_lib.Config.make ~logger ~pids ~trust_system ~conf_dir
-                 ~is_seed ~coinbase_receiver:`Producer ~net_config
-                 ~gossip_net_params ~initial_fork_id:Fork_id.empty
+                 ~is_seed ~disable_telemetry:true ~coinbase_receiver:`Producer
+                 ~net_config ~gossip_net_params ~initial_fork_id:Fork_id.empty
                  ~work_selection_method:
                    (Cli_lib.Arg_type.work_selection_method_to_module
                       work_selection_method)

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -186,7 +186,8 @@ let run_test () : unit Deferred.t =
         Coda_lib.create
           (Coda_lib.Config.make ~logger ~pids ~trust_system ~net_config
              ~coinbase_receiver:`Producer ~conf_dir:temp_conf_dir
-             ~gossip_net_params ~is_seed:true ~initial_fork_id:Fork_id.empty
+             ~gossip_net_params ~is_seed:true ~disable_telemetry:true
+             ~initial_fork_id:Fork_id.empty
              ~work_selection_method:
                (module Work_selector.Selection_methods.Sequence)
              ~initial_block_production_keypairs:(Keypair.Set.singleton keypair)

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -522,7 +522,7 @@ let initialization_finish_signal t = t.initialization_finish_signal
  *   - uses an abstraction leak to patch new functionality instead of making a new extension
  *   - every call to this function will create a new, unique pipe with it's own thread for transfering
  *     items from the identity extension with no route for termination
- *)
+*)
 let root_diff t =
   let root_diff_reader, root_diff_writer =
     Strict_pipe.create ~name:"root diff"
@@ -808,58 +808,67 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
               Option.value_map peer_opt ~default:"<UNKNOWN>" ~f:(fun peer ->
                   peer.peer_id )
             in
-            match !net_ref with
-            | None ->
-                (* essentially unreachable; without a network, we wouldn't receive this RPC call *)
-                Logger.info config.logger
-                  "Network not instantiated when telemetry data requested"
-                  ~module_:__MODULE__ ~location:__LOC__ ;
-                Deferred.return
-                @@ Error
-                     (Error.of_string
-                        (sprintf
-                           !"Node with IP address=%{sexp: Unix.Inet_addr.t}, \
-                             peer ID=%s, network not instantiated when \
-                             telemetry data requested"
-                           node_ip_addr node_peer_id))
-            | Some net -> (
-              match Broadcast_pipe.Reader.peek frontier_broadcast_pipe_r with
+            if config.disable_telemetry then
+              Deferred.return
+              @@ Error
+                   (Error.of_string
+                      (sprintf
+                         !"Node with IP address=%{sexp: Unix.Inet_addr.t}, \
+                           peer ID=%s, telemetry is disabled"
+                         node_ip_addr node_peer_id))
+            else
+              match !net_ref with
               | None ->
+                  (* essentially unreachable; without a network, we wouldn't receive this RPC call *)
+                  Logger.info config.logger
+                    "Network not instantiated when telemetry data requested"
+                    ~module_:__MODULE__ ~location:__LOC__ ;
                   Deferred.return
                   @@ Error
                        (Error.of_string
                           (sprintf
                              !"Node with IP address=%{sexp: \
-                               Unix.Inet_addr.t}, peer ID=%s, could not get \
-                               transition frontier for telemetry data"
+                               Unix.Inet_addr.t}, peer ID=%s, network not \
+                               instantiated when telemetry data requested"
                              node_ip_addr node_peer_id))
-              | Some frontier ->
-                  let%map peers = Coda_networking.peers net in
-                  let protocol_state_hash =
-                    let tip = Transition_frontier.best_tip frontier in
-                    let state =
-                      Transition_frontier.Breadcrumb.protocol_state tip
+              | Some net -> (
+                match Broadcast_pipe.Reader.peek frontier_broadcast_pipe_r with
+                | None ->
+                    Deferred.return
+                    @@ Error
+                         (Error.of_string
+                            (sprintf
+                               !"Node with IP address=%{sexp: \
+                                 Unix.Inet_addr.t}, peer ID=%s, could not get \
+                                 transition frontier for telemetry data"
+                               node_ip_addr node_peer_id))
+                | Some frontier ->
+                    let%map peers = Coda_networking.peers net in
+                    let protocol_state_hash =
+                      let tip = Transition_frontier.best_tip frontier in
+                      let state =
+                        Transition_frontier.Breadcrumb.protocol_state tip
+                      in
+                      Coda_state.Protocol_state.hash state
                     in
-                    Coda_state.Protocol_state.hash state
-                  in
-                  let ban_statuses =
-                    Trust_system.Peer_trust.peer_statuses config.trust_system
-                  in
-                  let k_block_hashes =
-                    List.map
-                      ( Transition_frontier.root frontier
-                      :: Transition_frontier.best_tip_path frontier )
-                      ~f:Transition_frontier.Breadcrumb.state_hash
-                  in
-                  Ok
-                    Coda_networking.Rpcs.Get_telemetry_data.Telemetry_data.
-                      { node_ip_addr
-                      ; node_peer_id
-                      ; peers
-                      ; block_producers
-                      ; protocol_state_hash
-                      ; ban_statuses
-                      ; k_block_hashes } )
+                    let ban_statuses =
+                      Trust_system.Peer_trust.peer_statuses config.trust_system
+                    in
+                    let k_block_hashes =
+                      List.map
+                        ( Transition_frontier.root frontier
+                        :: Transition_frontier.best_tip_path frontier )
+                        ~f:Transition_frontier.Breadcrumb.state_hash
+                    in
+                    Ok
+                      Coda_networking.Rpcs.Get_telemetry_data.Telemetry_data.
+                        { node_ip_addr
+                        ; node_peer_id
+                        ; peers
+                        ; block_producers
+                        ; protocol_state_hash
+                        ; ban_statuses
+                        ; k_block_hashes } )
           in
           let%bind net =
             Coda_networking.create config.net_config
@@ -1120,7 +1129,7 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                (Coda_networking.states net)
                external_transitions_writer ~f:ident) ;
           (* FIXME #4093: augment ban_notifications with a Peer.ID so we can implement ban_notify
-           trace_task "ban notification loop" (fun () ->
+             trace_task "ban notification loop" (fun () ->
               Linear_pipe.iter (Coda_networking.ban_notification_reader net)
                 ~f:(fun notification ->
                   let open Gossip_net in

--- a/src/lib/coda_lib/config.ml
+++ b/src/lib/coda_lib/config.ml
@@ -20,6 +20,7 @@ type t =
   ; trust_system: Trust_system.t
   ; monitor: Monitor.t option
   ; is_seed: bool
+  ; disable_telemetry: bool
   ; initial_block_production_keypairs: Keypair.Set.t
   ; coinbase_receiver: [`Producer | `Other of Public_key.Compressed.t]
   ; work_selection_method: (module Work_selector.Selection_method_intf)


### PR DESCRIPTION
Add CLI daemon flag `-disable-telemetry`. If set, the telemetry RPC returns an error indicating the disabling.

Note that this PR is against the `release/0.0.13-beta` branch.

Closes #4628.