### PR TITLE
Bot: format currency, trim env vars

### DIFF
--- a/frontend/bot/src/Constants.re
+++ b/frontend/bot/src/Constants.re
@@ -6,7 +6,8 @@ let getEnvOrFail = name =>
 
 let getEnv = (~default, name) =>
   Js.Dict.get(Node.Process.process##env, name)
-  ->Belt.Option.getWithDefault(default);
+  ->Belt.Option.getWithDefault(default)
+  ->Js.String2.trim;
 
 let getEnvOpt = name => Js.Dict.get(Node.Process.process##env, name);
 

--- a/frontend/bot/src/Messages.re
+++ b/frontend/bot/src/Messages.re
@@ -6,7 +6,7 @@ Woof! I can help you get some coda on the testnet.
 Just send me a message in the #faucet channel with the following contents:
 `$request <public-key>`
 Once a mod approves, `|}
-  ++ Int64.to_string(Constants.faucetAmount)
+  ++ CurrencyFormatter.toFormattedString(Constants.faucetAmount)
   ++ {| coda` will be sent to the requested address!|};
 
 let requestError = {|


### PR DESCRIPTION
Fixes two issues with the bot:
- For some reason an extra newline is getting into the publickey env var (gotta fix the configuration but this will help for now)
- We aren't formatting the currency amount. I removed the parse function from CurrencyFormatter because we don't need it and it depends on bs-platform 7.... not the time to upgrade right now.