### PR TITLE
More detailed hardware wallet instructions

### DIFF
--- a/frontend/website/pages/docs/hardware-wallet.mdx
+++ b/frontend/website/pages/docs/hardware-wallet.mdx
@@ -38,12 +38,6 @@ sudo apt install libusb-1.0-0-dev libudev1 libudev-dev
 - If the Ledger device is not listed, follow the suggestions
   [here](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).
 
-### Build/download the Coda Ledger application
-
-Either download the precompiled app binary from
-[here](https://github.com/CodaProtocol/ledger-coda-app/releases/tag/v0.1.0), or follow the instructions
-at the end of this document to [build the app from source](/docs/hardware-wallet#building-from-source).
-
 ### Install the python app loader
 
 The Ledger python loader exists [here](https://github.com/LedgerHQ/blue-loader-python)
@@ -62,6 +56,12 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000", MODE="0660
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
 ```
+
+### Build/download the Coda Ledger application
+
+Either download the precompiled app binary from
+[here](https://github.com/CodaProtocol/ledger-coda-app/releases/tag/v0.1.0), or follow the instructions
+at the end of this document to [build the app from source](/docs/hardware-wallet#building-from-source).
 
 To load the precompiled app onto the Ledger device, after downloading `ledger-precompile.zip`
 from the link above, navigate to the directory that `ledger-precompile.zip` is in, and run the following:
@@ -124,6 +124,7 @@ You can use the same commands to send payments found in
 [the docs](/docs/my-first-transaction/).
 
 There are 2 differences:
+
 1. You do not need to unlock your account before sending the transaction because
   your account is protected by your hardware wallet already.
 2. Your hardware wallet may ask you to confirm the operation while signing the
@@ -181,24 +182,7 @@ git clone git@github.com:LedgerHQ/nanos-secure-sdk.git
 ```
 and add `export BOLOS_SDK=<PATH-TO-SDK>` to your `~/.bashrc` or `~/.profile`.
 
-### Install the python app loader
-
-The Ledger python loader exists [here](https://github.com/LedgerHQ/blue-loader-python)
-and can be downloaded/installed with the following:
-```
-sudo apt install -y libudev-dev libusb
-pip3 install ledgerblue
-```
-After installing, make sure the following rules have been added to `/etc/udev/rules.d/`
-(e.g. with `sudo vim /etc/udev/rules.d/20-hw1.rules`), changing `<UNIX username>` to your unix username:
-
-```
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
-```
-
-### Download the Coda Ledger app
+### Build and Load the Coda Ledger app
 
 Running the following will install the Coda app on your Ledger device:
 ```

--- a/frontend/website/pages/docs/hardware-wallet.mdx
+++ b/frontend/website/pages/docs/hardware-wallet.mdx
@@ -1,7 +1,16 @@
-# Hardware wallets
+import Page from '@reason/pages/Docs';
+export default Page({title: "Hardware Wallet"});
+
+# Hardware Wallet
 
 Coda now supports the usage of hardware wallets such as Ledger to interact with
 the protocol, and sign transactions.
+
+<Alert kind="warning">
+
+Disclaimer: Ledger support is experimental. Don't use it on a Ledger device that is handling or has ever handled private keys associated with any accounts of value.
+
+</Alert>
 
 ## Requirements
 
@@ -9,7 +18,7 @@ the protocol, and sign transactions.
 
 Note: macOS and Windows are not officially supported at this time.
 
-**Hardware**: Currently only `Ledger Nano S` is supported
+**Hardware**: Currently only [Ledger Nano S](https://shop.ledger.com/products/ledger-nano-s) is supported
 
 ## Installation
 
@@ -32,7 +41,7 @@ sudo apt install libusb-1.0-0-dev libudev1 libudev-dev
 ### Build/download the Coda Ledger application
 
 Either download the precompiled app binary from [here](...), or follow the instructions
-at the end of this document to build the app from source.
+at the end of this document to [build the app from source](/docs/hardware-wallet#building-from-source).
 
 ### Install the python app loader
 
@@ -78,7 +87,7 @@ following command to automatically add the rules and reload udev:
 wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
 ```
 
-## Create a new account using the hardware wallet
+## Create a new account
 
 Run the following command which will create a public and private keypair in the hardware wallet:
 
@@ -107,17 +116,15 @@ properly by trying `echo $CODA_PUBLIC_KEY`.
 
 ## Make a payment
 
-Sending a payment with a hardware wallet is almost the same as send a payment
-from an ordinary account.
+You can use the same commands to send payments found in
+[the docs](/docs/my-first-transaction/).
 
-There are only 2 differences:
+There are 2 differences:
 1. You do not need to unlock your account before sending the transaction because
   your account is protected by your hardware wallet already.
 2. Your hardware wallet may ask you to confirm the operation while signing the
   transaction.
 
-You can simply use the same commands to send payments found in
-[the docs](/docs/my-first-transaction/).
 
 ## Troubleshooting
 

--- a/frontend/website/pages/docs/hardware-wallet.mdx
+++ b/frontend/website/pages/docs/hardware-wallet.mdx
@@ -40,7 +40,8 @@ sudo apt install libusb-1.0-0-dev libudev1 libudev-dev
 
 ### Build/download the Coda Ledger application
 
-Either download the precompiled app binary from [here](...), or follow the instructions
+Either download the precompiled app binary from
+[here](https://github.com/CodaProtocol/ledger-coda-app/releases/tag/v0.1.0), or follow the instructions
 at the end of this document to [build the app from source](/docs/hardware-wallet#building-from-source).
 
 ### Install the python app loader
@@ -62,8 +63,11 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001", MODE="0660
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
 ```
 
-To load the precompiled app onto the Ledger device, run the following:
+To load the precompiled app onto the Ledger device, after downloading `ledger-precompile.zip`
+from the link above, navigate to the directory that `ledger-precompile.zip` is in, and run the following:
 ```
+unzip ledger-precompile.zip
+cd ledger-precompile
 ./load.sh
 ```
 

--- a/frontend/website/pages/hardware-wallet.mdx
+++ b/frontend/website/pages/hardware-wallet.mdx
@@ -1,6 +1,7 @@
 # Hardware wallets
 
-Coda now supports the usage of hardware wallets such as Ledger to interact with the protocol, and sign transactions.
+Coda now supports the usage of hardware wallets such as Ledger to interact with
+the protocol, and sign transactions.
 
 ## Requirements
 
@@ -12,7 +13,9 @@ Note: macOS and Windows are not officially supported at this time.
 
 ## Installation
 
-**Disclaimer**: This is still highly experimental -- use cautiously, as these instructions may change. Once the hardware wallet app is available on [Ledger Live](https://www.ledger.com/ledger-live), the installation steps will be stabilized.
+**Disclaimer**: This is still highly experimental -- use cautiously, as these
+instructions may change. Once the hardware wallet app is available on
+[Ledger Live](https://www.ledger.com/ledger-live), the installation steps will be stabilized.
 
 The following debian packages are needed to use hardware wallets on linux:
 ```
@@ -23,28 +26,132 @@ sudo apt install libusb-1.0-0-dev libudev1 libudev-dev
 
 - Plug in the Ledger device, unlock it with your passcode, and go to the menu. Don't open any app,
 - Run `lsusb`, and see if the device is listed -- it will have ID `2c97:0001`
-- If the Ledger device is not listed, follow the suggestions [here](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).
+- If the Ledger device is not listed, follow the suggestions
+  [here](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).
 
 ### Build/download the Coda Ledger application
 
-Either download the precompiled app binary from [here](...).
+Either download the precompiled app binary from [here](...), or follow the instructions
+at the end of this document to build the app from source.
 
-#### System-wide installation
+### Install the python app loader
 
-Or install gcc and clang.
-This can be done in two ways. You can install them with
-` sudo apt install gcc clang`
+The Ledger python loader exists [here](https://github.com/LedgerHQ/blue-loader-python)
+and can be downloaded/installed with the following:
+```
+sudo apt install -y libudev-dev libusb
+pip3 install ledgerblue
+```
 
-##### Downloading precompiled gcc and clang
+After installing, when running on Linux, make sure the following rules have been
+added to `/etc/udev/rules.d/` (e.g. with `sudo vim /etc/udev/rules.d/20-hw1.rules`),
+changing `<UNIX username>` to your unix username:
 
-Or , following the instructions at [the Ledger Wiki](https://ledger.readthedocs.io/en/latest/userspace/getting_started.html):
+```
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
+```
+
+To load the precompiled app onto the Ledger device, run the following:
+```
+./load.sh
+```
+
+To delete the app, you can run
+```
+./delete.sh
+```
+
+# Using the hardware wallet
+
+The coda hardware wallet command line tool is a python package called `coda-ledger-cli`:
+```
+python3 -mpip install coda-ledger-cli==0.0.5
+```
+
+If you have connection issues with your hardware wallet, please take a look at
+[the troubleshooting help on the Ledger support page](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).
+Oftentimes, connectivity issues can be resolved by adding udev rules. Enter the
+following command to automatically add the rules and reload udev:
+```
+wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
+```
+
+## Create a new account using the hardware wallet
+
+Run the following command which will create a public and private keypair in the hardware wallet:
+
+    coda accounts create-hd HD-index
+
+HD-index is a number that works like a seed that you give to the hardware wallet
+to create your public and private keypair. If you use the same HD-index with the
+same hardware wallet twice, then public and private keypair that gets generated
+is the same. If you need to use the same account on another machine, then you
+just need to use this command with the same HD-index and the same hardware wallet.
+
+During account creation, your hardware wallet may ask you to confirm the operation.
+
+The response from this command will look like this:
+
+    Keypair generated
+    Public key:  4vsRCVbLm6LvUyzYWT95WaCzyi4D4UHxRpLBhMn7q2mRPgNCgRG3Jr3tDuhgQdmzbvCcBxhUwB3REpY2Dyf1NAxSSs8Q2vdJX93pT7eyqcyRU2S9UpDddDgovj46BSknNjzydKoopebp5Kva
+
+Since the public key is quite long and difficult to remember, let's save it as
+an environment variable:
+
+    export CODA_PUBLIC_KEY=<YOUR-PUBLIC-KEY>
+
+Now we can access this everywhere as `$CODA_PUBLIC_KEY` -- see if it saved
+properly by trying `echo $CODA_PUBLIC_KEY`.
+
+## Make a payment
+
+Sending a payment with a hardware wallet is almost the same as send a payment
+from an ordinary account.
+
+There are only 2 differences:
+1. You do not need to unlock your account before sending the transaction because
+  your account is protected by your hardware wallet already.
+2. Your hardware wallet may ask you to confirm the operation while signing the
+  transaction.
+
+You can simply use the same commands to send payments found in
+[the docs](/docs/my-first-transaction/).
+
+## Troubleshooting
+
+### What if I lose my hardware wallet?
+You can buy another `Ledger Nano S` and initialize it with the same 24-word
+seed to gain access to your existing account.
+
+### What if I forget the public key of my account?
+If you remember the HD-index which you use to generate your account, then you
+can use `coda accounts create-hd HD-index` with the same HD-index to regenerate
+the public_key.
+
+## Building from source
+
+Building the Ledger app from source requires installing versions of gcc and clang.
+This can be done in two ways: you can install them with `sudo apt install gcc clang`,
+or you can download precompiled versions of both clang and gcc and then add them
+to your `PATH`.
+
+### Downloading precompiled gcc and clang
+
+Following the instructions at [the Ledger Wiki](https://ledger.readthedocs.io/en/latest/userspace/getting_started.html):
 - Install standard gcc (for microcontroller firmware and secure device linking)
-(link from ledger link?), by downloading a precompiled binary from [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
-- Install a standard clang with ROPI support (for secure processor applications), following the instructions [here](https://clang.llvm.org/get_started.html) to build from source or download a precompiled binary.
+  (link from ledger link?), by downloading a precompiled binary from
+  [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+- Install a standard clang with ROPI support (for secure processor applications),
+  following the instructions [here](https://clang.llvm.org/get_started.html) to
+  build from source or download a precompiled binary.
 - Once you have downloaded the binaries, unzip and install them, for example with
-  `cd Downloads`
-  `tar -xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz`
-  `bzip2 -dk gcc-arm-none-eabi-5_3-2016q1tar.bz2`
+  ```
+  cd Downloads
+  tar -xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+  bzip2 -dk gcc-arm-none-eabi-5_3-2016q1tar.bz2
+  ```
   and then add them to your PATH with
   ```
   # GCC
@@ -53,8 +160,10 @@ Or , following the instructions at [the Ledger Wiki](https://ledger.readthedocs.
   PATH=~/bolos-devenv/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin:$PATH
   ```
 
-Next, use `sudo apt install gcc-multilib g++-multilib` or equivalent to install the cross compilation
-headers required.
+Next, to install the cross compilation headers required, use:
+```
+sudo apt install gcc-multilib g++-multilib
+```
 Then install the Nano S SDK with
 ```
 git clone git@github.com:LedgerHQ/nanos-secure-sdk.git
@@ -69,9 +178,8 @@ and can be downloaded/installed with the following:
 sudo apt install -y libudev-dev libusb
 pip3 install ledgerblue
 ```
-
-After installing, when running on Linux, make sure the following rules have been added to `/etc/udev/rules.d/`
-(eg with `sudo vim /etc/udev/rules.d/20-hw1.rules`), changing `<UNIX username>` to your unix username:
+After installing, make sure the following rules have been added to `/etc/udev/rules.d/`
+(e.g. with `sudo vim /etc/udev/rules.d/20-hw1.rules`), changing `<UNIX username>` to your unix username:
 
 ```
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
@@ -88,55 +196,3 @@ cd ledger-coda-app
 git checkout 4574d3c
 make load
 ```
-
-# Using the hardware wallet
-
-The coda hardware wallet command line tool is a python package called `coda-ledger-cli`:
-```
-python3 -mpip install coda-ledger-cli==0.0.5
-```
-
-If you have connection issues with your hardware wallet, please take a look at [the troubleshooting help on the Ledger support page](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).
-Oftentimes, connectivity issues can be resolved by adding udev rules. Enter the following command to automatically add the rules and reload udev:
-```
-wget -q -O - https://raw.githubusercontent.com/LedgerHQ/udev-rules/master/add_udev_rules.sh | sudo bash
-```
-
-## Create a new account using the hardware wallet
-
-Run the following command which will create a public and private keypair in the hardware wallet:
-
-    coda accounts create-hd HD-index
-
-HD-index is a number that works like a seed that you give to the hardware wallet to create your public and private keypair. If you use the same HD-index with the same hardware wallet twice, then public and private keypair that gets generated is the same. If you need to use the same account on another machine, then you just need to use this command with the same HD-index and the same hardware wallet.
-
-During account creation, your hardware wallet may ask you to confirm the operation.
-
-The response from this command will look like this:
-
-    Keypair generated
-    Public key:  4vsRCVbLm6LvUyzYWT95WaCzyi4D4UHxRpLBhMn7q2mRPgNCgRG3Jr3tDuhgQdmzbvCcBxhUwB3REpY2Dyf1NAxSSs8Q2vdJX93pT7eyqcyRU2S9UpDddDgovj46BSknNjzydKoopebp5Kva
-
-Since the public key is quite long and difficult to remember, let's save it as an environment variable:
-
-    export CODA_PUBLIC_KEY=<YOUR-PUBLIC-KEY>
-
-Now we can access this everywhere as `$CODA_PUBLIC_KEY` -- see if it saved properly by trying `echo $CODA_PUBLIC_KEY`.
-
-## Make a payment
-
-Sending a payment with a hardware wallet is almost the same as send a payment from an ordinary account.
-
-There are only 2 differences:
-1. You do not need to unlock your account before sending the transaction because your account is protected by your hardware wallet already.
-2. Your hardware wallet may ask you to confirm the operation while signing the transaction.
-
-You can simply use the same commands to send payments found in [the docs](/docs/my-first-transaction/).
-
-## Troubleshooting
-
-### What if I lose my hardware wallet?
-You can buy another `Ledger Nano S` and initialize it with the same 24-word seed to gain access to your existing account.
-
-### What if I forget the public key of my account?
-If you remember the HD-index which you use to generate your account, then you can use `coda accounts create-hd HD-index` with the same HD-index to regenerate the public_key.

--- a/frontend/website/pages/hardware-wallet.mdx
+++ b/frontend/website/pages/hardware-wallet.mdx
@@ -19,6 +19,74 @@ The following debian packages are needed to use hardware wallets on linux:
 sudo apt install libusb-1.0-0-dev libudev1 libudev-dev
 ```
 
+### Make sure your computer is recognising the Ledger device
+- Plug in the Ledger device, unlock, go to menu (not inside any app!)
+- Run `lsusb`, see if the device is listed. It will have ID `2c97:0001`
+  - If not, see if these instructions help https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues
+  - Get into the menu of the ledger by clicking both buttons — it shouldnt say ‘go to ledger live to install applications’ and should show the settings menu and two arrows
+
+### Build/download the Coda Ledger application
+
+Either download the precompiled app binary from [here](...).
+
+#### System-wide installation
+Or install gcc and clang. 
+This can be done in two ways. You can install them with 
+` sudo apt install gcc clang`
+
+#### Downloading precompiled gcc and clang
+Or , following the instructions at [the Ledger Wiki](https://ledger.readthedocs.io/en/latest/userspace/getting_started.html):
+- Install standard gcc (for microcontroller firmware and secure device linking)
+(link from ledger link?), by downloading a precompiled binary from [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
+- Install a standard clang with ROPI support (for secure processor applications), following the instructions [here](https://clang.llvm.org/get_started.html) to build from source or download a precompiled binary.
+- Once you have downloaded the binaries, unzip and install them, for example with 
+  `cd Downloads`
+  `tar -xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz`
+  `bzip2 -dk gcc-arm-none-eabi-5_3-2016q1tar.bz2`
+  and then add them to your PATH with
+  ```
+  # GCC
+  PATH=~/bolos-devenv/gcc-arm-none-eabi-5_3-2016q1/bin:$PATH
+  # Clang
+  PATH=~/bolos-devenv/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin:$PATH
+  ```
+
+
+Next, use `sudo apt install gcc-multilib g++-multilib` or equivalent to install the cross compilation 
+headers required. 
+Then install the Nano S SDK with 
+```
+git clone git@github.com:LedgerHQ/nanos-secure-sdk.git
+```
+and add `export BOLOS_SDK=<PATH-TO-SDK>` to your `~/.bashrc` or `~/.profile`.
+
+### Install the python app loader
+
+The Ledger python loader exists [here](https://github.com/LedgerHQ/blue-loader-python) 
+and can also be downloaded/installed with the following:
+```
+sudo apt install -y libudev-dev libusb
+pip install ledgerblue
+pip3 install ledgerblue
+```
+
+After installing, when running on Linux, make sure the following rules have been added to `/etc/udev/rules.d/`
+(eg with `sudo vim /etc/udev/rules.d/20-hw1.rules`), changing `<UNIX username>` to your unix username:
+
+```
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="<UNIX username>"
+```
+
+### Download the Coda Ledger app
+Running the following will install the Coda app on your Ledger device:
+```
+git clone git@github.com:CodaProtocol/ledger-coda-app.git
+cd ledger-coda-app
+make load
+```
+
 The coda hardware wallet command line tool is a python package called `coda-ledger-cli`:
 ```
 python3 -mpip install coda-ledger-cli 

--- a/frontend/website/pages/hardware-wallet.mdx
+++ b/frontend/website/pages/hardware-wallet.mdx
@@ -67,7 +67,6 @@ The Ledger python loader exists [here](https://github.com/LedgerHQ/blue-loader-p
 and can be downloaded/installed with the following:
 ```
 sudo apt install -y libudev-dev libusb
-pip install ledgerblue
 pip3 install ledgerblue
 ```
 
@@ -86,6 +85,7 @@ Running the following will install the Coda app on your Ledger device:
 ```
 git clone git@github.com:CodaProtocol/ledger-coda-app.git
 cd ledger-coda-app
+git checkout 4574d3c
 make load
 ```
 
@@ -93,7 +93,7 @@ make load
 
 The coda hardware wallet command line tool is a python package called `coda-ledger-cli`:
 ```
-python3 -mpip install coda-ledger-cli
+python3 -mpip install coda-ledger-cli==0.0.5
 ```
 
 If you have connection issues with your hardware wallet, please take a look at [the troubleshooting help on the Ledger support page](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).

--- a/frontend/website/pages/hardware-wallet.mdx
+++ b/frontend/website/pages/hardware-wallet.mdx
@@ -20,26 +20,28 @@ sudo apt install libusb-1.0-0-dev libudev1 libudev-dev
 ```
 
 ### Make sure your computer is recognising the Ledger device
-- Plug in the Ledger device, unlock, go to menu (not inside any app!)
-- Run `lsusb`, see if the device is listed. It will have ID `2c97:0001`
-  - If not, see if these instructions help https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues
-  - Get into the menu of the ledger by clicking both buttons — it shouldnt say ‘go to ledger live to install applications’ and should show the settings menu and two arrows
+
+- Plug in the Ledger device, unlock it with your passcode, and go to the menu. Don't open any app,
+- Run `lsusb`, and see if the device is listed -- it will have ID `2c97:0001`
+- If the Ledger device is not listed, follow the suggestions [here](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).
 
 ### Build/download the Coda Ledger application
 
 Either download the precompiled app binary from [here](...).
 
 #### System-wide installation
-Or install gcc and clang. 
-This can be done in two ways. You can install them with 
+
+Or install gcc and clang.
+This can be done in two ways. You can install them with
 ` sudo apt install gcc clang`
 
-#### Downloading precompiled gcc and clang
+##### Downloading precompiled gcc and clang
+
 Or , following the instructions at [the Ledger Wiki](https://ledger.readthedocs.io/en/latest/userspace/getting_started.html):
 - Install standard gcc (for microcontroller firmware and secure device linking)
 (link from ledger link?), by downloading a precompiled binary from [here](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 - Install a standard clang with ROPI support (for secure processor applications), following the instructions [here](https://clang.llvm.org/get_started.html) to build from source or download a precompiled binary.
-- Once you have downloaded the binaries, unzip and install them, for example with 
+- Once you have downloaded the binaries, unzip and install them, for example with
   `cd Downloads`
   `tar -xf clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz`
   `bzip2 -dk gcc-arm-none-eabi-5_3-2016q1tar.bz2`
@@ -51,10 +53,9 @@ Or , following the instructions at [the Ledger Wiki](https://ledger.readthedocs.
   PATH=~/bolos-devenv/clang+llvm-7.0.0-x86_64-linux-gnu-ubuntu-16.04/bin:$PATH
   ```
 
-
-Next, use `sudo apt install gcc-multilib g++-multilib` or equivalent to install the cross compilation 
-headers required. 
-Then install the Nano S SDK with 
+Next, use `sudo apt install gcc-multilib g++-multilib` or equivalent to install the cross compilation
+headers required.
+Then install the Nano S SDK with
 ```
 git clone git@github.com:LedgerHQ/nanos-secure-sdk.git
 ```
@@ -62,8 +63,8 @@ and add `export BOLOS_SDK=<PATH-TO-SDK>` to your `~/.bashrc` or `~/.profile`.
 
 ### Install the python app loader
 
-The Ledger python loader exists [here](https://github.com/LedgerHQ/blue-loader-python) 
-and can also be downloaded/installed with the following:
+The Ledger python loader exists [here](https://github.com/LedgerHQ/blue-loader-python)
+and can be downloaded/installed with the following:
 ```
 sudo apt install -y libudev-dev libusb
 pip install ledgerblue
@@ -80,6 +81,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0004", MODE="0660
 ```
 
 ### Download the Coda Ledger app
+
 Running the following will install the Coda app on your Ledger device:
 ```
 git clone git@github.com:CodaProtocol/ledger-coda-app.git
@@ -87,9 +89,11 @@ cd ledger-coda-app
 make load
 ```
 
+# Using the hardware wallet
+
 The coda hardware wallet command line tool is a python package called `coda-ledger-cli`:
 ```
-python3 -mpip install coda-ledger-cli 
+python3 -mpip install coda-ledger-cli
 ```
 
 If you have connection issues with your hardware wallet, please take a look at [the troubleshooting help on the Ledger support page](https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues).

--- a/frontend/website/src/components/DocsSideNav.re
+++ b/frontend/website/src/components/DocsSideNav.re
@@ -183,6 +183,7 @@ let make = (~currentSlug) => {
           <Page title="The snarky-universe library" slug="snarky-universe" />
         </Folder>
         <Page title="GUI Wallet" slug="gui-wallet" />
+        <Page title="Hardware Wallet" slug="hardware-wallet" />
         <Page title="CLI Reference" slug="cli-reference" />
         <Page title="Troubleshooting" slug="troubleshooting" />
         <Page title="FAQ" slug="faq" />


### PR DESCRIPTION
This PR adds more detailed instructions for getting the coda Ledger app up and running on the hardware wallet.