### PR TITLE
Update docker image for test-archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
     test-archive:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-ccd2abf0c78d6b78024ec6add601aee6fc01044d
+            - image: codaprotocol/coda:toolchain-133674cbc6003c087bc2add74d3e9d18f091768d
               environment:
                 CODA_DOCKER: true
             - image: postgres:12

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -52,7 +52,7 @@ jobs:
     test-archive:
         resource_class: xlarge
         docker:
-            - image: codaprotocol/coda:toolchain-ccd2abf0c78d6b78024ec6add601aee6fc01044d
+            - image: codaprotocol/coda:toolchain-133674cbc6003c087bc2add74d3e9d18f091768d
               environment:
                 CODA_DOCKER: true
             - image: postgres:12


### PR DESCRIPTION
This was omitted in #4552, `test-archive` has been broken ever since.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: