### PR TITLE
Fix log interpolation

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1299,7 +1299,9 @@ let glue_sync_ledger :
               Logger.info t.logger ~module_:__MODULE__ ~location:__LOC__
                 "Peer $peer didn't have enough information to answer \
                  ledger_hash query. See error for more details: $error"
-                ~metadata:[("error", `String (Error.to_string_hum e))] ;
+                ~metadata:
+                  [ ("error", `String (Error.to_string_hum e))
+                  ; ("peer", Peer.to_yojson peer) ] ;
               Hash_set.add peers_tried peer ;
               None
           | Connected {data= Error e; _} ->

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -191,7 +191,7 @@ let create ~logger ~pids ~conf_dir =
          return
          @@ Logger.error logger ~module_:__MODULE__ ~location:__LOC__
               "Verifier stderr: $stderr"
-              ~metadata:[("stdout", `String stderr)] ) ;
+              ~metadata:[("stderr", `String stderr)] ) ;
   connection
 
 let verify_blockchain_snark t chain =


### PR DESCRIPTION
Fixes these two interpolation errors:
```
logproc interpolation error in File "src/lib/coda_networking/coda_networking.ml", line 1299, characters 65-72: bad interpolation for peer
logproc interpolation error in File "src/lib/verifier/prod.ml", line 192, characters 62-69: bad interpolation for stderr
```

P.S. I was thinking we could add a compile-time setting to the logger to make interpolation errors crash the program when encountered during CI. Could be nice since they can be pretty obtrusive to users.