### PR TITLE
Re-enable validation

### DIFF
--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -337,7 +337,6 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 		return nil, needsDHT()
 	}
 	err := app.P2p.Pubsub.RegisterTopicValidator(s.Topic, func(ctx context.Context, id peer.ID, msg *pubsub.Message) bool {
-		return true
 		if id == app.P2p.Me {
 			// messages from ourself are valid.
 			app.P2p.Logger.Info("would have validated but it's from us!")

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -385,6 +385,8 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 			(*app.Validators[seqno]).TimedOutAt = new(time.Time)
 			*((*app.Validators[seqno]).TimedOutAt) = time.Now()
 
+			app.ValidatorMutex.Unlock()
+
 			if app.UnsafeNoTrustIP {
 				app.P2p.Logger.Info("validated anyway!")
 				return true

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -1036,12 +1036,13 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                          let et =
                            Transition_frontier.Breadcrumb.validated_transition
                              breadcrumb
-                           |> External_transition.Validation.forget_validation
                          in
-                         External_transition.poke_validation_callback et
-                           (fun v ->
-                             if v then Coda_networking.broadcast_state net et
-                         ) ;
+                         External_transition.Validated.poke_validation_callback
+                           et (fun v ->
+                             if v then
+                               Coda_networking.broadcast_state net
+                               @@ External_transition.Validation
+                                  .forget_validation et ) ;
                          breadcrumb ))
                   ~most_recent_valid_block
                   ~genesis_state_hash:config.genesis_state_hash ~genesis_ledger

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -772,6 +772,8 @@ module With_validation = struct
   let broadcast t = lift broadcast t
 
   let don't_broadcast t = lift don't_broadcast t
+
+  let poke_validation_callback t = lift poke_validation_callback t
 end
 
 module Initial_validated = struct
@@ -930,6 +932,7 @@ module Validated = struct
     , fork_id_status
     , broadcast
     , don't_broadcast
+    , poke_validation_callback
     , protocol_state_proof
     , blockchain_state
     , blockchain_length

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -47,6 +47,8 @@ module type External_transition_common_intf = sig
   val broadcast : t -> unit
 
   val don't_broadcast : t -> unit
+
+  val poke_validation_callback : t -> (bool -> unit) -> unit
 end
 
 module type External_transition_base_intf = sig
@@ -67,8 +69,6 @@ end
 
 module type S = sig
   include External_transition_base_intf
-
-  val poke_validation_callback : t -> (bool -> unit) -> unit
 
   type external_transition = t
 

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -236,7 +236,6 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                    Instead of refactoring it to have validation up-front and decoupled,
                    we pass along a validation callback with the message. This ends up
                    ignoring the actual subscription message pipe, so drain it separately. *)
-                (* HACK: validation is currently bypassed, this function will never be called *)
                 ~should_forward_message:(fun envelope ->
                   (* Messages from ourselves are valid. Don't try and reingest them. *)
                   match Envelope.Incoming.sender envelope with
@@ -272,14 +271,10 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                       () ))
             in
             (* #4097 fix: drain the published message pipe, which we don't care about. *)
-            (* HACK: we're bypassing validation, use these messages *)
             don't_wait_for
               (Strict_pipe.Reader.iter
                  (Coda_net2.Pubsub.Subscription.message_pipe subscription)
-                 ~f:(fun envelope ->
-                   let valid_ivar = Ivar.create () in
-                   Strict_pipe.Writer.write message_writer
-                     (envelope, Ivar.fill valid_ivar) )) ;
+                 ~f:(fun _envelope -> Deferred.unit)) ;
             let%map _ =
               (* XXX: this ALWAYS needs to be AFTER handle_protocol/subscribe
                 or it is possible to miss connections! *)


### PR DESCRIPTION
This incorporates @ghost-not-in-the-shell 's fix for the validation callback duplication and forgotten mutex unlock, and undoes the validation bypass.