### PR TITLE
make the -log-received-blocks log metadata match the rebroadcasting log

### DIFF
--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -998,7 +998,10 @@ let create (config : Config.t)
               Logger.debug config.logger ~module_:__MODULE__ ~location:__LOC__
                 "Received a block $block from $sender"
                 ~metadata:
-                  [ ("block", External_transition.to_yojson state)
+                  [ ("external_transition", External_transition.to_yojson state)
+                  ; ( "state_hash"
+                    , External_transition.state_hash state
+                      |> State_hash.to_yojson )
                   ; ( "sender"
                     , Envelope.(Sender.to_yojson (Incoming.sender envelope)) )
                   ] ;


### PR DESCRIPTION
previously was missing the block's state hash, and also the key for the block itself mismatched