### PR TITLE
data_hash: use b58 check for json

### DIFF
--- a/src/lib/base58_check/version_bytes.ml
+++ b/src/lib/base58_check/version_bytes.ml
@@ -38,6 +38,8 @@ let staged_ledger_hash_pending_coinbase_aux : t = '\x81'
 
 let state_hash : t = '\x20'
 
+let state_body_hash : t = '\x21'
+
 let transaction_hash : t = '\x9E'
 
 let user_command : t = '\x17'

--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -46,9 +46,11 @@ end
 
 module Base58_check = Codable.Make_base58_check (T)
 
-let to_string t = Base58_check.String_ops.to_string t
+[%%define_locally
+Base58_check.String_ops.(to_string, of_string)]
 
-let of_string s = Base58_check.String_ops.of_string s
+[%%define_locally
+Base58_check.(to_yojson,of_yojson)]
 
 let merge ~height (h1 : t) (h2 : t) =
   Random_oracle.hash

--- a/src/lib/coda_base/ledger_hash.ml
+++ b/src/lib/coda_base/ledger_hash.ml
@@ -50,7 +50,7 @@ module Base58_check = Codable.Make_base58_check (T)
 Base58_check.String_ops.(to_string, of_string)]
 
 [%%define_locally
-Base58_check.(to_yojson,of_yojson)]
+Base58_check.(to_yojson, of_yojson)]
 
 let merge ~height (h1 : t) (h2 : t) =
   Random_oracle.hash

--- a/src/lib/coda_base/receipt.ml
+++ b/src/lib/coda_base/receipt.ml
@@ -32,7 +32,7 @@ module Chain_hash = struct
   Base58_check.String_ops.(to_string, of_string)]
 
   [%%define_locally
-  Base58_check.(to_yojson,of_yojson)]
+  Base58_check.(to_yojson, of_yojson)]
 
   let empty = of_hash Random_oracle.(salt "CodaReceiptEmpty" |> digest)
 

--- a/src/lib/coda_base/receipt.ml
+++ b/src/lib/coda_base/receipt.ml
@@ -20,25 +20,19 @@ module Random_oracle = Random_oracle_nonconsensus.Random_oracle
 module Chain_hash = struct
   include Data_hash.Make_full_size ()
 
-  module Base58_check = Base58_check.Make (struct
+  module Base58_check = Codable.Make_base58_check (struct
+    include Stable.Latest
+
     let description = "Receipt chain hash"
 
     let version_byte = Base58_check.Version_bytes.receipt_chain_hash
   end)
 
-  let to_string t =
-    Binable.to_string (module Stable.Latest) t |> Base58_check.encode
+  [%%define_locally
+  Base58_check.String_ops.(to_string, of_string)]
 
-  let of_string s =
-    Base58_check.decode_exn s |> Binable.of_string (module Stable.Latest)
-
-  include Codable.Make_of_string (struct
-    type nonrec t = t
-
-    let to_string = to_string
-
-    let of_string = of_string
-  end)
+  [%%define_locally
+  Base58_check.(to_yojson,of_yojson)]
 
   let empty = of_hash Random_oracle.(salt "CodaReceiptEmpty" |> digest)
 
@@ -97,7 +91,7 @@ module Chain_hash = struct
 
   let%test_unit "json" =
     Quickcheck.test ~trials:20 gen ~sexp_of:sexp_of_t ~f:(fun t ->
-        assert (For_tests.check_encoding ~equal t) )
+        assert (Base58_check.For_tests.check_encoding ~equal t) )
 
   [%%endif]
 end

--- a/src/lib/coda_base/state_body_hash.ml
+++ b/src/lib/coda_base/state_body_hash.ml
@@ -1,14 +1,14 @@
 include Data_hash.Make_full_size ()
 
-module Base58_check = Codable.Make_base58_check(struct
-    include Stable.Latest
+module Base58_check = Codable.Make_base58_check (struct
+  include Stable.Latest
 
-    let description = "State body hash"
+  let description = "State body hash"
 
-    let version_byte = Base58_check.Version_bytes.state_body_hash
+  let version_byte = Base58_check.Version_bytes.state_body_hash
 end)
 
 [%%define_locally
-Base58_check.(to_yojson,of_yojson)]
+Base58_check.(to_yojson, of_yojson)]
 
 let dummy = of_hash Outside_pedersen_image.t

--- a/src/lib/coda_base/state_body_hash.ml
+++ b/src/lib/coda_base/state_body_hash.ml
@@ -1,3 +1,14 @@
 include Data_hash.Make_full_size ()
 
+module Base58_check = Codable.Make_base58_check(struct
+    include Stable.Latest
+
+    let description = "State body hash"
+
+    let version_byte = Base58_check.Version_bytes.state_body_hash
+end)
+
+[%%define_locally
+Base58_check.(to_yojson,of_yojson)]
+
 let dummy = of_hash Outside_pedersen_image.t

--- a/src/lib/coda_base/state_hash.ml
+++ b/src/lib/coda_base/state_hash.ml
@@ -29,7 +29,7 @@ Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 Base58_check.String_ops.(to_string, of_string)]
 
 [%%define_locally
-Base58_check.(to_yojson,of_yojson)]
+Base58_check.(to_yojson, of_yojson)]
 
 let dummy = of_hash Outside_pedersen_image.t
 

--- a/src/lib/coda_base/state_hash.ml
+++ b/src/lib/coda_base/state_hash.ml
@@ -28,6 +28,9 @@ Base58_check.(to_base58_check, of_base58_check, of_base58_check_exn)]
 [%%define_locally
 Base58_check.String_ops.(to_string, of_string)]
 
+[%%define_locally
+Base58_check.(to_yojson,of_yojson)]
+
 let dummy = of_hash Outside_pedersen_image.t
 
 [%%ifdef


### PR DESCRIPTION
The Data_hash functors export to/of_yojson functions that go through the decimal representation of the field element. Avoid those, instead using the base58_check functions. Additionally, use base58_check for the state body hash.