### PR TITLE
libp2p tweaks for 3.2 QA

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -198,6 +198,11 @@ let daemon logger =
             generate-libp2p-keypair`) to use with libp2p discovery (default: \
             generate per-run temporary keypair)"
      and is_seed = flag "seed" ~doc:"Start the node as a seed node" no_arg
+     and enable_flooding =
+       flag "enable-flooding"
+         ~doc:
+           "Enable pubsub flooding, gossiping every message to every peer \
+            (uses lots of bandwidth! default: false)" no_arg
      and libp2p_peers_raw =
        flag "peer"
          ~doc:
@@ -644,6 +649,7 @@ let daemon logger =
              ; initial_peers
              ; addrs_and_ports
              ; trust_system
+             ; flood= enable_flooding
              ; keypair= libp2p_keypair }
          in
          let net_config =

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -202,7 +202,8 @@ let daemon logger =
        flag "enable-flooding"
          ~doc:
            "Enable pubsub flooding, gossiping every message to every peer \
-            (uses lots of bandwidth! default: false)" no_arg
+            (uses lots of bandwidth! default: false)"
+         no_arg
      and libp2p_peers_raw =
        flag "peer"
          ~doc:

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -514,6 +514,7 @@ module T = struct
               ; chain_id
               ; logger
               ; unsafe_no_trust_ip= true
+              ; flood= false
               ; trust_system
               ; keypair= Some libp2p_keypair }
           in

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -144,6 +144,7 @@ let run_test () : unit Deferred.t =
           ; logger
           ; initial_peers= []
           ; unsafe_no_trust_ip= true
+          ; flood= false
           ; conf_dir= temp_conf_dir
           ; chain_id= "bogus chain id for testing"
           ; addrs_and_ports=

--- a/src/app/libp2p_helper/src/codanet.go
+++ b/src/app/libp2p_helper/src/codanet.go
@@ -135,18 +135,13 @@ func MakeHelper(ctx context.Context, listenOn []ma.Multiaddr, externalAddr ma.Mu
 
 	kad := <-kadch
 
-	pubsub, err := pubsub.NewRandomSub(ctx, host, pubsub.WithStrictSignatureVerification(true), pubsub.WithMessageSigning(true))
-	if err != nil {
-		return nil, err
-	}
-
 	// nil fields are initialized by beginAdvertising
 	return &Helper{
 		Host:            host,
 		Ctx:             ctx,
 		Mdns:            nil,
 		Dht:             kad,
-		Pubsub:          pubsub,
+		Pubsub:          nil,
 		Logger:          logger,
 		DiscoveredPeers: nil,
 		Rendezvous:      rendezvousString,

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -57,6 +57,7 @@ type app struct {
 	StreamsMutex    sync.Mutex
 	OutLock         sync.Mutex
 	Out             *bufio.Writer
+	OutChan         chan interface{}
 	UnsafeNoTrustIP bool
 }
 
@@ -103,25 +104,7 @@ type envelope struct {
 }
 
 func (app *app) writeMsg(msg interface{}) {
-	app.OutLock.Lock()
-	defer app.OutLock.Unlock()
-	bytes, err := json.Marshal(msg)
-	if err == nil {
-		n, err := app.Out.Write(bytes)
-		if err != nil {
-			panic(err)
-		}
-		if n != len(bytes) {
-			// TODO: handle this correctly.
-			panic("short write :(")
-		}
-		app.Out.WriteByte(0x0a)
-		if err := app.Out.Flush(); err != nil {
-			panic(err)
-		}
-	} else {
-		panic(err)
-	}
+	app.OutChan <- msg
 }
 
 type action interface {
@@ -421,17 +404,21 @@ func (s *subscribeMsg) run(app *app) (interface{}, error) {
 		for {
 			msg, err := sub.Next(ctx)
 			if err == nil {
-				sender, err := findPeerInfo(app, msg.ReceivedFrom)
+				//sender, err := findPeerInfo(app, msg.ReceivedFrom)
 				if err != nil && !app.UnsafeNoTrustIP {
 					app.P2p.Logger.Errorf("failed to connect to peer %s that just sent us an already-validated pubsub message, dropping it", peer.IDB58Encode(msg.ReceivedFrom))
 				} else {
-					data := codaEncode(msg.Data)
-					app.writeMsg(publishUpcall{
-						Upcall:       "publish",
-						Subscription: s.Subscription,
-						Data:         data,
-						Sender:       sender,
-					})
+					/* Don't bother informing the helper about this message; it ignores it
+					   and we don't want to block here or else we might lose messages
+					   due to 'subscriber too slow'?
+						data := codaEncode(msg.Data)
+						app.writeMsg(publishUpcall{
+							Upcall:       "publish",
+							Subscription: s.Subscription,
+							Data:         data,
+							Sender:       sender,
+						})
+					*/
 				}
 			} else {
 				if ctx.Err() != context.Canceled {
@@ -1026,9 +1013,35 @@ func main() {
 		ValidatorMutex: &sync.Mutex{},
 		Validators:     make(map[int]*validationStatus),
 		Streams:        make(map[int]net.Stream),
+		OutChan:        make(chan interface{}, 4096),
 		// OutLock doesn't need to be initialized
 		Out: out,
 	}
+
+	go func() {
+		for {
+			msg := <-app.OutChan
+			app.OutLock.Lock()
+			defer app.OutLock.Unlock()
+			bytes, err := json.Marshal(msg)
+			if err == nil {
+				n, err := app.Out.Write(bytes)
+				if err != nil {
+					panic(err)
+				}
+				if n != len(bytes) {
+					// TODO: handle this correctly.
+					panic("short write :(")
+				}
+				app.Out.WriteByte(0x0a)
+				if err := app.Out.Flush(); err != nil {
+					panic(err)
+				}
+			} else {
+				panic(err)
+			}
+		}
+	}()
 
 	for lines.Scan() {
 		line := lines.Text()

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -235,18 +235,18 @@ func (m *configureMsg) run(app *app) (interface{}, error) {
 		return nil, badHelper(err)
 	}
 
-	var pubsub *pubsub.Pubsub
+	var ps *pubsub.PubSub
 	if m.Flood {
-		pubsub, err = pubsub.NewFloodSub(app.Ctx, helper.Host, pubsub.WithStrictSignatureVerification(true), pubsub.WithMessageSigning(true))
+		ps, err = pubsub.NewFloodSub(app.Ctx, helper.Host, pubsub.WithStrictSignatureVerification(true), pubsub.WithMessageSigning(true))
 	} else {
-		pubsub, err = pubsub.NewRandomSub(app.Ctx, helper.Host, pubsub.WithStrictSignatureVerification(true), pubsub.WithMessageSigning(true))
+		ps, err = pubsub.NewRandomSub(app.Ctx, helper.Host, pubsub.WithStrictSignatureVerification(true), pubsub.WithMessageSigning(true))
 	}
 
 	if err != nil {
 		return nil, badHelper(err)
 	}
 
-	helper.Pubsub = pubsub
+	helper.Pubsub = ps
 	app.P2p = helper
 
 	return "configure success", nil

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -23,7 +23,7 @@
 
 [%%define genesis_ledger "testnet_postake"]
 
-[%%define genesis_state_timestamp "2020-04-13 15:00:00-07:00"]
+[%%define genesis_state_timestamp "2020-04-14 13:50:00-07:00"]
 [%%define block_window_duration 180000]
 
 [%%define integration_tests false]

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -201,8 +201,12 @@ let reader_to_strict_pipe_with_logging :
                      Some
                        (Logger.Source.create ~module_:__MODULE__
                           ~location:__LOC__)
-                 ; message= sprintf "Output from process %s: %s" name line
-                 ; metadata= Logger.metadata logger }
+                 ; message=
+                     "Output from process $child_name: $line"
+                 ; metadata=
+                     String.Map.set ~key:"child_name" ~data:(`String name)
+                       (String.Map.set ~key:"line" ~data:(`String line)
+                          (Logger.metadata logger)) }
              in
              match
                Option.try_with (fun () -> Yojson.Safe.from_string line)

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -201,8 +201,7 @@ let reader_to_strict_pipe_with_logging :
                      Some
                        (Logger.Source.create ~module_:__MODULE__
                           ~location:__LOC__)
-                 ; message=
-                     "Output from process $child_name: $line"
+                 ; message= "Output from process $child_name: $line"
                  ; metadata=
                      String.Map.set ~key:"child_name" ~data:(`String name)
                        (String.Map.set ~key:"line" ~data:(`String line)

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -231,7 +231,8 @@ module Helper = struct
         ; ifaces: string list
         ; external_maddr: string
         ; network_id: string
-        ; unsafe_no_trust_ip: bool }
+        ; unsafe_no_trust_ip: bool
+        ; flood: bool }
       [@@deriving yojson]
 
       type output = string [@@deriving yojson]
@@ -1062,7 +1063,7 @@ let list_peers net =
       []
 
 let configure net ~me ~external_maddr ~maddrs ~network_id ~on_new_peer
-    ~unsafe_no_trust_ip =
+    ~unsafe_no_trust_ip ~flood =
   match%map
     Helper.do_rpc net
       (module Helper.Rpcs.Configure)
@@ -1071,7 +1072,8 @@ let configure net ~me ~external_maddr ~maddrs ~network_id ~on_new_peer
       ; ifaces= List.map ~f:Multiaddr.to_string maddrs
       ; external_maddr= Multiaddr.to_string external_maddr
       ; network_id
-      ; unsafe_no_trust_ip }
+      ; unsafe_no_trust_ip
+      ; flood }
   with
   | Ok "configure success" ->
       Ivar.fill net.me_keypair me ;
@@ -1374,12 +1376,12 @@ let%test_module "coda network tests" =
       let%bind kp_b = Keypair.random a in
       let maddrs = ["/ip4/127.0.0.1/tcp/0"] in
       let%bind () =
-        configure a ~external_maddr:(List.hd_exn maddrs) ~me:kp_a ~maddrs
-          ~network_id ~on_new_peer:Fn.ignore ~unsafe_no_trust_ip:true
+        configure a ~flood:false ~external_maddr:(List.hd_exn maddrs) ~me:kp_a
+          ~maddrs ~network_id ~on_new_peer:Fn.ignore ~unsafe_no_trust_ip:true
         >>| Or_error.ok_exn
       and () =
-        configure b ~external_maddr:(List.hd_exn maddrs) ~me:kp_b ~maddrs
-          ~network_id ~on_new_peer:Fn.ignore ~unsafe_no_trust_ip:true
+        configure b ~flood:false ~external_maddr:(List.hd_exn maddrs) ~me:kp_b
+          ~maddrs ~network_id ~on_new_peer:Fn.ignore ~unsafe_no_trust_ip:true
         >>| Or_error.ok_exn
       in
       let%bind a_advert = begin_advertising a

--- a/src/lib/coda_net2/coda_net2.mli
+++ b/src/lib/coda_net2/coda_net2.mli
@@ -185,6 +185,8 @@ val create : logger:Logger.t -> conf_dir:string -> net Deferred.Or_error.t
   * will be called for each peer we discover. [unsafe_no_trust_ip], if true, will not attempt to
   * report trust actions for the IPs of observed connections.
   *
+  * If [flood] is true, all valid gossip will be forwarded to every node. This is expensive.
+  *
   * This fails if initializing libp2p fails for any reason.
 *)
 val configure :
@@ -195,6 +197,7 @@ val configure :
   -> network_id:string
   -> on_new_peer:(discovered_peer -> unit)
   -> unsafe_no_trust_ip:bool
+  -> flood:bool
   -> unit Deferred.Or_error.t
 
 (** The keypair the network was configured with.

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -28,6 +28,7 @@ module Config = struct
     ; logger: Logger.t
     ; unsafe_no_trust_ip: bool
     ; trust_system: Trust_system.t
+    ; flood: bool
     ; keypair: Coda_net2.Keypair.t option }
   [@@deriving make]
 end
@@ -126,7 +127,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
           let initializing_libp2p_result : _ Deferred.Or_error.t =
             let open Deferred.Or_error.Let_syntax in
             let%bind () =
-              configure net2 ~me ~maddrs:[]
+              configure net2 ~me ~maddrs:[] ~flood:config.flood
                 ~external_maddr:
                   (Multiaddr.of_string
                      (sprintf "/ip4/%s/tcp/%d"

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -140,16 +140,17 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                   Ivar.fill_if_empty first_peer_ivar () ;
                   if !ctr < 4 then incr ctr
                   else Ivar.fill_if_empty high_connectivity_ivar () ;
-                  don't_wait_for
-                    (Throttle.enqueue throttle (fun () ->
-                         let open Deferred.Let_syntax in
-                         let%bind peers = peers net2 in
-                         Coda_metrics.(
-                           Gauge.set Network.peers
-                             (List.length peers |> Int.to_float)) ;
-                         after (Time.Span.of_sec 2.)
-                         (* don't spam the helper with peer fetches, only try update it every 2 seconds *)
-                     )) )
+                  if Throttle.num_jobs_waiting_to_start throttle <> 0 then
+                    don't_wait_for
+                      (Throttle.enqueue throttle (fun () ->
+                           let open Deferred.Let_syntax in
+                           let%bind peers = peers net2 in
+                           Coda_metrics.(
+                             Gauge.set Network.peers
+                               (List.length peers |> Int.to_float)) ;
+                           after (Time.Span.of_sec 2.)
+                           (* don't spam the helper with peer fetches, only try update it every 2 seconds *)
+                       )) )
             in
             let implementation_list =
               List.bind rpc_handlers ~f:create_rpc_implementations

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -140,7 +140,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
                   Ivar.fill_if_empty first_peer_ivar () ;
                   if !ctr < 4 then incr ctr
                   else Ivar.fill_if_empty high_connectivity_ivar () ;
-                  if Throttle.num_jobs_waiting_to_start throttle <> 0 then
+                  if Throttle.num_jobs_waiting_to_start throttle = 0 then
                     don't_wait_for
                       (Throttle.enqueue throttle (fun () ->
                            let open Deferred.Let_syntax in


### PR DESCRIPTION
This includes a few tweaks, most importantly the ability for some nodes to flood (should prevent any randomsub-related forks), and an attempt at avoiding the "subscriber too slow" problem we see by not blocking on acquiring the stdout lock.