### PR TITLE
Add inline_tests to dune

### DIFF
--- a/src/lib/snarky_field_extensions/dune
+++ b/src/lib/snarky_field_extensions/dune
@@ -1,8 +1,9 @@
 (library
-  (name snarky_field_extensions)
-  (public_name snarky_field_extensions)
-  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
-  (libraries
-    snarky
-    snarkette
-    core_kernel ))
+ (name snarky_field_extensions)
+ (public_name snarky_field_extensions)
+ (inline_tests)
+ (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson))
+ (libraries
+   snarky
+   snarkette
+   core_kernel ))

--- a/src/lib/sync_handler/dune
+++ b/src/lib/sync_handler/dune
@@ -1,5 +1,6 @@
 (library
-  (name sync_handler)
-  (public_name sync_handler)
-  (preprocess (pps ppx_coda ppx_jane))
-  (libraries async_kernel core_kernel coda_intf coda_base transition_frontier syncable_ledger merkle_address consensus best_tip_prover))
+ (name sync_handler)
+ (public_name sync_handler)
+ (inline_tests)
+ (preprocess (pps ppx_coda ppx_jane))
+ (libraries async_kernel core_kernel coda_intf coda_base transition_frontier syncable_ledger merkle_address consensus best_tip_prover))


### PR DESCRIPTION
I ran an audit of the library and nonconsensus dune files to make sure the `inline_tests` clause was present if there were, in fact, inline tests.

I found missing clauses in `Snarky_field_extensions` and `Sync_handler`. For the latter library, the tests are commented out, but it's probably good to have the clause when the tests are re-enabled.

The missing clause for `Coda_lib_nonconsensus` is already fixed in #4691.