### PR TITLE
Adds utcDate field to graphql

### DIFF
--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -9,7 +9,7 @@
 [%%import "/src/config/account_creation_fee/high.mlh"]
 [%%import "/src/config/fork_id/current.mlh"]
 
-[%%define time_offsets false]
+[%%define time_offsets true]
 [%%define fake_hash false]
 
 [%%define genesis_ledger "test"]

--- a/src/lib/block_time/block_time.ml
+++ b/src/lib/block_time/block_time.ml
@@ -168,6 +168,22 @@ module Time = struct
 
   let to_string = Fn.compose Int64.to_string to_int64
 
+  [%%if
+  time_offsets]
+
+  let to_string_system_time (offset : Controller.t) (t : t) : string =
+    let t2 : t =
+      of_span_since_epoch
+        Span.(to_span_since_epoch t + of_time_span (Lazy.force offset))
+    in
+    Int64.to_string (to_int64 t2)
+
+  [%%else]
+
+  let to_string_system_time _ = Fn.compose Int64.to_string to_int64
+
+  [%%endif]
+
   let of_string_exn string =
     Int64.of_string string |> Span.of_ms |> of_span_since_epoch
 

--- a/src/lib/block_time/block_time.mli
+++ b/src/lib/block_time/block_time.mli
@@ -117,6 +117,9 @@ module Time : sig
 
   val to_string : t -> string
 
+  (** Strip time offset *)
+  val to_string_system_time : Controller.t -> t -> string
+
   val of_string_exn : string -> t
 
   val gen_incl : t -> t -> t Quickcheck.Generator.t

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -42,10 +42,11 @@ let verification_key =
       key)
 
 module Doc = struct
-  let date =
+  let date ?(extra = "") s =
     sprintf
       !"%s (stringified Unix time - number of milliseconds since January 1, \
-        1970)"
+        1970)%s"
+      s extra
 
   let bin_prot =
     sprintf !"%s (base58-encoded janestreet/bin_prot serialization)"
@@ -393,6 +394,20 @@ module Types = struct
             ~args:Arg.[]
             ~resolve:(fun _ {Coda_state.Blockchain_state.Poly.timestamp; _} ->
               Block_time.to_string timestamp )
+        ; field "utcDate" ~typ:(non_null string)
+            ~doc:
+              (Doc.date
+                 ~extra:
+                   ". Time offsets are adjusted to reflect true wall-clock \
+                    time instead of genesis time."
+                 "utcDate")
+            ~args:Arg.[]
+            ~resolve:
+              (fun {ctx= coda; _}
+                   {Coda_state.Blockchain_state.Poly.timestamp; _} ->
+              Block_time.to_string_system_time
+                (Coda_lib.time_controller coda)
+                timestamp )
         ; field "snarkedLedgerHash" ~typ:(non_null string)
             ~doc:"Base58Check-encoded hash of the snarked ledger"
             ~args:Arg.[]

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -89,6 +89,8 @@ type t =
   ; sync_status: Sync_status.t Coda_incremental.Status.Observer.t }
 [@@deriving fields]
 
+let time_controller t = t.config.time_controller
+
 let subscription t = t.subscriptions
 
 let peek_frontier frontier_broadcast_pipe =

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -14,6 +14,8 @@ exception Snark_worker_error of int
 
 exception Snark_worker_signal_interrupt of Signal.t
 
+val time_controller : t -> Block_time.Controller.t
+
 val subscription : t -> Coda_subscriptions.t
 
 (** Derived from local state (aka they may not reflect the latest public keys to which you've attempted to change *)


### PR DESCRIPTION
Adds utcDate field to blockchain state in graphql. This field adds back the CODA_TIME_OFFSET that gets subtracted from timestamps. This is required to get an accurate picture of the true system time of events in the network.

Also turning time-offsets on dev (as this is we'll need this on for our releases, so we should be dev-ing with it on too)