### PR TITLE
Fix typo in Sandbox Node Docs

### DIFF
--- a/frontend/website/pages/docs/developers/sandbox-node.mdx
+++ b/frontend/website/pages/docs/developers/sandbox-node.mdx
@@ -57,4 +57,4 @@ There are a few things you can do with your sandbox now that you have it running
 
 - Install the [GUI Wallet](/docs/gui-wallet) app to use a graphical interface to your node. Enter '127.0.0.1' as the host of your node during setup.
 
-- Head over to https://localhost:3085/graphql to play with the GraphQL API directly.
+- Head over to http://localhost:3085/graphql to play with the GraphQL API directly.


### PR DESCRIPTION
I found a typo in new Docs.
Just fix typo.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
