### PR TITLE
Website: More Sandbox Instructions

### DIFF
--- a/frontend/website/pages/docs/developers/sandbox-node.mdx
+++ b/frontend/website/pages/docs/developers/sandbox-node.mdx
@@ -45,8 +45,6 @@ You can use the Coda CLI to interact with the sandbox node. The following comman
 docker exec -it coda bash
 ```
 
-Now you can execute coda commands like normal.
-
 ### Account details
 
 The container has one account with this public key:

--- a/frontend/website/pages/docs/developers/sandbox-node.mdx
+++ b/frontend/website/pages/docs/developers/sandbox-node.mdx
@@ -39,6 +39,14 @@ And stop coda by running.
 docker stop coda
 ```
 
+If you want to execute commands, use the following command to start a shell inside the docker container. 
+
+```
+docker exec -it coda bash
+```
+
+Now you can execute coda commands like normal.
+
 ### Account details
 
 The container has one account with this public key:

--- a/frontend/website/pages/docs/developers/sandbox-node.mdx
+++ b/frontend/website/pages/docs/developers/sandbox-node.mdx
@@ -39,7 +39,7 @@ And stop coda by running.
 docker stop coda
 ```
 
-If you want to execute commands, use the following command to start a shell inside the docker container. 
+You can use the Coda CLI to interact with the sandbox node. The following command opens a shell inside the docker container from where you can issue any of the available [coda commands](/docs/cli-reference).
 
 ```
 docker exec -it coda bash


### PR DESCRIPTION
Adds instructions on getting a bash instance inside of the docker container. Seen this question asked quite a few times in discord and @garethtdavies has been providing this so I propose adding to the website.