### PR TITLE
Pass ledger and genesis_constants down through to External_transition

### DIFF
--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -945,11 +945,9 @@ module For_tests = struct
     create ~protocol_state ~protocol_state_proof ~staged_ledger_diff
       ~delta_transition_chain_proof ~validation_callback ?next_fork_id_opt ()
 
-  let genesis () =
+  let genesis ~genesis_ledger ~base_proof ~genesis_constants () =
     Fork_id.(set_current empty) ;
-    genesis ~genesis_ledger:Test_genesis_ledger.t
-      ~base_proof:Precomputed_values.base_proof
-      ~genesis_constants:Genesis_constants.compiled
+    genesis ~genesis_ledger ~base_proof ~genesis_constants
 end
 
 module Transition_frontier_validation (Transition_frontier : sig

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -289,7 +289,12 @@ module type S = sig
       -> unit
       -> t
 
-    val genesis : unit -> Validated.t
+    val genesis :
+         genesis_ledger:Ledger.t Lazy.t
+      -> base_proof:Proof.t
+      -> genesis_constants:Genesis_constants.t
+      -> unit
+      -> Validated.t
   end
 
   val timestamp : t -> Block_time.t

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -26,14 +26,22 @@ val setup :
 module Generator : sig
   open Quickcheck
 
-  type peer_config = max_frontier_length:int -> peer_state Generator.t
+  type peer_config =
+       genesis_ledger:Genesis_ledger.Packed.t
+    -> base_proof:Coda_base.Proof.t
+    -> genesis_constants:Genesis_constants.t
+    -> max_frontier_length:int
+    -> peer_state Generator.t
 
   val fresh_peer : peer_config
 
   val peer_with_branch : frontier_branch_size:int -> peer_config
 
   val gen :
-       max_frontier_length:int
+       genesis_ledger:Genesis_ledger.Packed.t
+    -> base_proof:Coda_base.Proof.t
+    -> genesis_constants:Genesis_constants.t
+    -> max_frontier_length:int
     -> (peer_config, 'n num_peers) Vect.t
     -> 'n num_peers t Generator.t
 end

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -410,6 +410,12 @@ let%test_module "Ledger_catchup tests" =
 
     let trust_system = Trust_system.null ()
 
+    let genesis_ledger = Genesis_ledger.for_unit_tests
+
+    let base_proof = Precomputed_values.base_proof
+
+    let genesis_constants = Genesis_constants.compiled
+
     let time_controller = Block_time.Controller.basic ~logger
 
     let downcast_transition transition =
@@ -527,7 +533,8 @@ let%test_module "Ledger_catchup tests" =
           let%bind peer_branch_size =
             Int.gen_incl (max_frontier_length / 2) (max_frontier_length - 1)
           in
-          gen ~max_frontier_length
+          gen ~max_frontier_length ~genesis_ledger ~base_proof
+            ~genesis_constants
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:peer_branch_size ])
         ~f:(fun network ->
@@ -546,7 +553,8 @@ let%test_module "Ledger_catchup tests" =
                    in the frontier" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          gen ~max_frontier_length
+          gen ~max_frontier_length ~genesis_ledger ~base_proof
+            ~genesis_constants
             [fresh_peer; peer_with_branch ~frontier_branch_size:1])
         ~f:(fun network ->
           let open Fake_network in
@@ -560,7 +568,8 @@ let%test_module "Ledger_catchup tests" =
     let%test_unit "catchup fails if one of the parent transitions fail" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          gen ~max_frontier_length
+          gen ~max_frontier_length ~genesis_ledger ~base_proof
+            ~genesis_constants
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:(max_frontier_length * 2)
             ])

--- a/src/lib/transaction_status/transaction_status.ml
+++ b/src/lib/transaction_status/transaction_status.ml
@@ -75,6 +75,12 @@ let%test_module "transaction_status" =
 
     let pool_max_size = Genesis_constants.compiled.txpool_max_size
 
+    let genesis_ledger = Genesis_ledger.for_unit_tests
+
+    let base_proof = Precomputed_values.base_proof
+
+    let genesis_constants = Genesis_constants.compiled
+
     let key_gen =
       let open Quickcheck.Generator in
       let open Quickcheck.Generator.Let_syntax in
@@ -87,8 +93,8 @@ let%test_module "transaction_status" =
           (Option.value_exn random_key_opt) )
 
     let gen_frontier =
-      Transition_frontier.For_tests.gen ~logger ~trust_system ~max_length
-        ~size:frontier_size ()
+      Transition_frontier.For_tests.gen ~logger ~genesis_ledger ~base_proof
+        ~genesis_constants ~trust_system ~max_length ~size:frontier_size ()
 
     let gen_user_command =
       User_command.Gen.payment ~sign_type:`Real ~max_amount:100 ~max_fee:10

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -82,6 +82,9 @@ module For_tests : sig
   val gen_genesis_breadcrumb :
        ?logger:Logger.t
     -> ?verifier:Verifier.t
+    -> genesis_ledger:Ledger.t Lazy.t
+    -> base_proof:Proof.t
+    -> genesis_constants:Genesis_constants.t
     -> unit
     -> Breadcrumb.t Quickcheck.Generator.t
 
@@ -94,6 +97,9 @@ module For_tests : sig
   val gen :
        ?logger:Logger.t
     -> ?verifier:Verifier.t
+    -> genesis_ledger:Genesis_ledger.Packed.t
+    -> base_proof:Proof.t
+    -> genesis_constants:Genesis_constants.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> ?root_ledger_and_accounts:Ledger.t
@@ -107,6 +113,9 @@ module For_tests : sig
   val gen_with_branch :
        ?logger:Logger.t
     -> ?verifier:Verifier.t
+    -> genesis_ledger:Genesis_ledger.Packed.t
+    -> base_proof:Proof.t
+    -> genesis_constants:Genesis_constants.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
     -> ?root_ledger_and_accounts:Ledger.t

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -279,6 +279,12 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
 
     let trust_system = Trust_system.null ()
 
+    let genesis_ledger = Genesis_ledger.for_unit_tests
+
+    let base_proof = Precomputed_values.base_proof
+
+    let genesis_constants = Genesis_constants.compiled
+
     let pids = Child_processes.Termination.create_pid_table ()
 
     let time_controller = Block_time.Controller.basic ~logger
@@ -305,7 +311,8 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
             Verifier.create ~logger ~conf_dir:None ~pids )
       in
       Quickcheck.test ~trials:3
-        (Transition_frontier.For_tests.gen_with_branch ~verifier ~max_length
+        (Transition_frontier.For_tests.gen_with_branch ~verifier
+           ~genesis_ledger ~base_proof ~genesis_constants ~max_length
            ~frontier_size:1 ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
           let catchup_job_reader, catchup_job_writer =
             Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
@@ -358,7 +365,8 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
             Verifier.create ~logger ~conf_dir:None ~pids )
       in
       Quickcheck.test ~trials:3
-        (Transition_frontier.For_tests.gen_with_branch ~verifier ~max_length
+        (Transition_frontier.For_tests.gen_with_branch ~verifier
+           ~genesis_ledger ~base_proof ~genesis_constants ~max_length
            ~frontier_size:1 ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
           let cache = Unprocessed_transition_cache.create ~logger in
           let register_breadcrumb breadcrumb =
@@ -442,7 +450,8 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
             Verifier.create ~logger ~conf_dir:None ~pids )
       in
       Quickcheck.test ~trials:3
-        (Transition_frontier.For_tests.gen_with_branch ~verifier ~max_length
+        (Transition_frontier.For_tests.gen_with_branch ~verifier
+           ~genesis_ledger ~base_proof ~genesis_constants ~max_length
            ~frontier_size:1 ~branch_size:5 ()) ~f:(fun (frontier, branch) ->
           let catchup_job_reader, catchup_job_writer =
             Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -363,6 +363,12 @@ let%test_module "Transition_handler.Processor tests" =
 
     let trust_system = Trust_system.null ()
 
+    let genesis_ledger = Genesis_ledger.for_unit_tests
+
+    let base_proof = Precomputed_values.base_proof
+
+    let genesis_constants = Genesis_constants.compiled
+
     let downcast_breadcrumb breadcrumb =
       let transition =
         Transition_frontier.Breadcrumb.validated_transition breadcrumb
@@ -377,8 +383,9 @@ let%test_module "Transition_handler.Processor tests" =
       let branch_size = 10 in
       let max_length = frontier_size + branch_size in
       Quickcheck.test ~trials:4
-        (Transition_frontier.For_tests.gen_with_branch ~max_length
-           ~frontier_size ~branch_size ()) ~f:(fun (frontier, branch) ->
+        (Transition_frontier.For_tests.gen_with_branch ~genesis_ledger
+           ~base_proof ~genesis_constants ~max_length ~frontier_size
+           ~branch_size ()) ~f:(fun (frontier, branch) ->
           assert (
             Thread_safe.block_on_async_exn (fun () ->
                 let pids = Child_processes.Termination.create_pid_table () in


### PR DESCRIPTION
This PR passes the genesis ledger, base proof and genesis constants down through the generators for tests. This removes dependencies on `Test_genesis_ledger`, and allows us to set the archive test configuration separately at runtime.

This breaks out part of #4769.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: