### PR TITLE
Allow build-archive and build-macos to succeed for external contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,7 @@ jobs:
                 command: cd frontend/wallet && bundle exec fastlane ci && cd ../..
             - run:
                 name: Build portable binary
+                context: org-global
                 command: |
                     LIBP2P_NIXLESS=1 make macos-portable
                     cp _build/coda-daemon-macos.zip package/.

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -331,6 +331,7 @@ jobs:
                 command: cd frontend/wallet && bundle exec fastlane ci && cd ../..
             - run:
                 name: Build portable binary
+                context: org-global
                 command: |
                     LIBP2P_NIXLESS=1 make macos-portable
                     cp _build/coda-daemon-macos.zip package/.

--- a/scripts/archive/build-release-archives.sh
+++ b/scripts/archive/build-release-archives.sh
@@ -12,7 +12,7 @@
 ###
 
 if [ -z $AWS_ACCESS_KEY_ID ]; then
-    HAS_AWS_ACCESS_KEY_ID=""
+    AWS_ACCESS_KEY_ID=""
 fi
 
 set -euo pipefail

--- a/scripts/archive/build-release-archives.sh
+++ b/scripts/archive/build-release-archives.sh
@@ -3,6 +3,18 @@
 # This script makes a .deb archive for the Coda Archive process
 # and releases it to the AWS .deb repository packages.o1test.net
 
+###
+# Set missing variables
+#
+# We do this here because setting the -u flag will cause an error for undefined
+# variables later in the script, and external contributors will not have these
+# variables available.
+###
+
+if [ -z $AWS_ACCESS_KEY_ID ]; then
+    HAS_AWS_ACCESS_KEY_ID=""
+fi
+
 set -euo pipefail
 
 # Set up variables for build


### PR DESCRIPTION
Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: