### PR TITLE
Allow CI to generate snark keys for external contributors

### DIFF
--- a/src/lib/cached/cached.ml
+++ b/src/lib/cached/cached.ml
@@ -157,7 +157,7 @@ module Spec = struct
 end
 
 module Track_generated = struct
-  type t = [`Generated_something | `Cache_hit]
+  type t = [`Generated_something | `Locally_generated | `Cache_hit]
 
   let empty = `Cache_hit
 
@@ -165,6 +165,8 @@ module Track_generated = struct
     match (x, y) with
     | `Generated_something, _ | _, `Generated_something ->
         `Generated_something
+    | `Locally_generated, _ | _, `Locally_generated ->
+        `Locally_generated
     | `Cache_hit, `Cache_hit ->
         `Cache_hit
 end
@@ -282,8 +284,8 @@ let run
                 !"Loaded %s from autogen path %{sexp: string list}\n"
                 name (full_paths autogen_path) ;
               (* We consider this a "cache miss" for the purposes of tracking
-             * that we need to push to s3 *)
-              return {With_track_generated.data; dirty= `Generated_something}
+               * that we need to push to s3 *)
+              return {With_track_generated.data; dirty= `Locally_generated}
           | Error _e ->
               Core_kernel.printf
                 !"Could not load %s from autogen path %{sexp: string list}. \

--- a/src/lib/cached/cached.mli
+++ b/src/lib/cached/cached.mli
@@ -43,7 +43,7 @@ end
 (** A monoid for tracking the "dirty bit" of whether or not we've generated
  * something or only received cache hits *)
 module Track_generated : sig
-  type t = [`Generated_something | `Cache_hit]
+  type t = [`Generated_something | `Locally_generated | `Cache_hit]
 
   val empty : t
 

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -204,7 +204,7 @@ let gen_keys () =
   if Array.mem ~equal:String.equal Sys.argv "--generate-keys-only" then
     Stdlib.exit 0 ;
   match dirty with
-  | `Generated_something -> (
+  | `Generated_something | `Locally_generated -> (
     (* If we generated any keys, then we need to make sure to upload these keys
      * to some central store to keep our builds compatible with one-another.
      *

--- a/src/lib/snark_keys/gen_keys/gen_keys.ml
+++ b/src/lib/snark_keys/gen_keys/gen_keys.ml
@@ -220,8 +220,32 @@ let gen_keys () =
      *
      * See the background section of https://bkase.dev/posts/ocaml-writer
      * for more info on how this system works.
+     *
+     * NOTE: This behaviour is overriden or external contributors, because they
+     * cannot upload new keys if they have modified the snark. See branch
+     * referencing "CIRCLE_PR_USERNAME" below.
      *)
     match (Sys.getenv "CI", Sys.getenv "DUNE_PROFILE") with
+    | Some _, Some profile
+      when Option.is_some (Sys.get_env "CIRCLE_PR_USERNAME") ->
+        (* External contributors cannot upload new keys to AWS, but we would
+           still like to run CI for their pull requests if they have modified the
+           snark.
+        *)
+        ( match dirty with
+        | `Generated_something ->
+            Format.eprintf
+              "No keys were found in the cache, but this pull-request is from \
+               an external contributor.@ Generated fresh keys for this \
+               build.@."
+        | `Locally_generated ->
+            Format.eprintf
+              "Only locally-generated keys were found in the cache, but this \
+               pull-request is from an external contributor.@ Using the local \
+               keys@."
+        | `Cache_hit ->
+            (* Excluded above. *) assert false ) ;
+        return acc
     | Some _, Some profile
       when String.is_substring ~substring:"testnet" profile ->
         (* We are intentionally aborting the build here with a special error code


### PR DESCRIPTION
This PR allows CI to run on external pull requests which change the snark, by overriding the cached keys check in the `snark_keys` for those pull requests. For example, #4783 fails CI because of this check.

Behaviour for internal PRs should be unchanged.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them