### PR TITLE
Combine genesis_state/ledger/hash/proof into Precomputed_values.t

### DIFF
--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -4,154 +4,172 @@ open Coda_base
 open Pipe_lib
 open Signature_lib
 
-let logger = Logger.create ()
+let%test_module "Archive node unit tests" =
+  ( module struct
+    let logger = Logger.create ()
 
-let conn_lazy =
-  lazy
-    ( Thread_safe.block_on_async_exn
-    @@ fun () ->
-    match%map
-      Caqti_async.connect
-        (Uri.of_string "postgres://admin:codarules@localhost:5432/archiver")
-    with
-    | Ok conn ->
-        conn
-    | Error e ->
-        failwith @@ Caqti_error.show e )
+    let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
-let keys = Array.init 5 ~f:(fun _ -> Keypair.create ())
+    let conn_lazy =
+      lazy
+        ( Thread_safe.block_on_async_exn
+        @@ fun () ->
+        match%map
+          Caqti_async.connect
+            (Uri.of_string "postgres://admin:codarules@localhost:5432/archiver")
+        with
+        | Ok conn ->
+            conn
+        | Error e ->
+            failwith @@ Caqti_error.show e )
 
-let user_command_gen =
-  User_command.Gen.payment_with_random_participants ~keys ~max_amount:1000
-    ~max_fee:10 ()
+    let keys = Array.init 5 ~f:(fun _ -> Keypair.create ())
 
-let fee_transfer_gen =
-  Fee_transfer.Single.Gen.with_random_receivers ~keys ~max_fee:10
+    let user_command_gen =
+      User_command.Gen.payment_with_random_participants ~keys ~max_amount:1000
+        ~max_fee:10 ()
 
-let coinbase_gen =
-  Coinbase.Gen.with_random_receivers ~keys ~min_amount:20 ~max_amount:100
-    ~fee_transfer:
-      (Coinbase.Fee_transfer.Gen.with_random_receivers ~keys
-         ~max_fee:(Currency.Fee.of_int 10))
+    let fee_transfer_gen =
+      Fee_transfer.Single.Gen.with_random_receivers ~keys ~max_fee:10
 
-let%test_unit "User_command: read and write" =
-  let conn = Lazy.force conn_lazy in
-  Thread_safe.block_on_async_exn
-  @@ fun () ->
-  Async.Quickcheck.async_test ~sexp_of:[%sexp_of: User_command.t]
-    user_command_gen ~f:(fun user_command ->
-      let transaction_hash = Transaction_hash.hash_user_command user_command in
-      match%map
-        let open Deferred.Result.Let_syntax in
-        let%bind user_command_id =
-          Processor.User_command.add_if_doesn't_exist conn user_command
-        in
-        let%map result = Processor.User_command.find conn ~transaction_hash in
-        [%test_result: int] ~expect:user_command_id (Option.value_exn result)
-      with
-      | Ok () ->
-          ()
-      | Error e ->
-          failwith @@ Caqti_error.show e )
+    let coinbase_gen =
+      Coinbase.Gen.with_random_receivers ~keys ~min_amount:20 ~max_amount:100
+        ~fee_transfer:
+          (Coinbase.Fee_transfer.Gen.with_random_receivers ~keys
+             ~max_fee:(Currency.Fee.of_int 10))
 
-let%test_unit "Fee_transfer: read and write" =
-  let conn = Lazy.force conn_lazy in
-  Thread_safe.block_on_async_exn
-  @@ fun () ->
-  Async.Quickcheck.async_test ~sexp_of:[%sexp_of: Fee_transfer.Single.t]
-    fee_transfer_gen ~f:(fun fee_transfer ->
-      let transaction_hash = Transaction_hash.hash_fee_transfer fee_transfer in
-      match%map
-        let open Deferred.Result.Let_syntax in
-        let%bind fee_transfer_id =
-          Processor.Fee_transfer.add_if_doesn't_exist conn fee_transfer
-        in
-        let%map result =
-          Processor.Internal_command.find conn ~transaction_hash
-        in
-        [%test_result: int] ~expect:fee_transfer_id (Option.value_exn result)
-      with
-      | Ok () ->
-          ()
-      | Error e ->
-          failwith @@ Caqti_error.show e )
-
-let%test_unit "Coinbase: read and write" =
-  let conn = Lazy.force conn_lazy in
-  Thread_safe.block_on_async_exn
-  @@ fun () ->
-  Async.Quickcheck.async_test ~sexp_of:[%sexp_of: Coinbase.t] coinbase_gen
-    ~f:(fun coinbase ->
-      let transaction_hash = Transaction_hash.hash_coinbase coinbase in
-      match%map
-        let open Deferred.Result.Let_syntax in
-        let%bind coinbase_id =
-          Processor.Coinbase.add_if_doesn't_exist conn coinbase
-        in
-        let%map result =
-          Processor.Internal_command.find conn ~transaction_hash
-        in
-        [%test_result: int] ~expect:coinbase_id (Option.value_exn result)
-      with
-      | Ok () ->
-          ()
-      | Error e ->
-          failwith @@ Caqti_error.show e )
-
-let%test_unit "Block: read and write" =
-  let conn = Lazy.force conn_lazy in
-  Quickcheck.test ~trials:20
-    ( Quickcheck.Generator.with_size ~size:10
-    @@ Quickcheck_lib.gen_imperative_list
-         (Transition_frontier.For_tests.gen_genesis_breadcrumb ())
-         (Transition_frontier.Breadcrumb.For_tests.gen_non_deferred
-            ?logger:None ?verifier:None ?trust_system:None
-            ~accounts_with_secret_keys:
-              (Lazy.force Test_genesis_ledger.accounts)) )
-    ~f:(fun breadcrumbs ->
+    let%test_unit "User_command: read and write" =
+      let conn = Lazy.force conn_lazy in
       Thread_safe.block_on_async_exn
       @@ fun () ->
-      let reader, writer =
-        Strict_pipe.create ~name:"archive"
-          (Buffered (`Capacity 100, `Overflow Crash))
-      in
-      let processor_deferred_computation = Processor.run conn reader ~logger in
-      let diffs =
-        List.map
-          ~f:(fun breadcrumb ->
-            Diff.Transition_frontier (Diff.Builder.breadcrumb_added breadcrumb)
-            )
-          breadcrumbs
-      in
-      List.iter diffs ~f:(Strict_pipe.Writer.write writer) ;
-      Strict_pipe.Writer.close writer ;
-      let%bind () = processor_deferred_computation in
-      match%map
-        Processor.deferred_result_list_fold breadcrumbs ~init:()
-          ~f:(fun () breadcrumb ->
+      Async.Quickcheck.async_test ~sexp_of:[%sexp_of: User_command.t]
+        user_command_gen ~f:(fun user_command ->
+          let transaction_hash =
+            Transaction_hash.hash_user_command user_command
+          in
+          match%map
             let open Deferred.Result.Let_syntax in
-            match%bind
-              Processor.Block.find conn
-                ~state_hash:
-                  (Transition_frontier.Breadcrumb.state_hash breadcrumb)
-            with
-            | Some id ->
-                let%bind Processor.Block.{parent_id; _} =
-                  Processor.Block.load conn ~id
-                in
-                if
-                  Transition_frontier.Breadcrumb.blockchain_length breadcrumb
-                  > Unsigned.UInt32.of_int 1
-                then
-                  Processor.For_test.assert_parent_exist ~parent_id
-                    ~parent_hash:
-                      (Transition_frontier.Breadcrumb.parent_hash breadcrumb)
-                    conn
-                else Deferred.Result.return ()
-            | None ->
-                failwith "Failed to find saved block in database" )
-      with
-      | Ok () ->
-          ()
-      | Error e ->
-          failwith @@ Caqti_error.show e )
+            let%bind user_command_id =
+              Processor.User_command.add_if_doesn't_exist conn user_command
+            in
+            let%map result =
+              Processor.User_command.find conn ~transaction_hash
+            in
+            [%test_result: int] ~expect:user_command_id
+              (Option.value_exn result)
+          with
+          | Ok () ->
+              ()
+          | Error e ->
+              failwith @@ Caqti_error.show e )
+
+    let%test_unit "Fee_transfer: read and write" =
+      let conn = Lazy.force conn_lazy in
+      Thread_safe.block_on_async_exn
+      @@ fun () ->
+      Async.Quickcheck.async_test ~sexp_of:[%sexp_of: Fee_transfer.Single.t]
+        fee_transfer_gen ~f:(fun fee_transfer ->
+          let transaction_hash =
+            Transaction_hash.hash_fee_transfer fee_transfer
+          in
+          match%map
+            let open Deferred.Result.Let_syntax in
+            let%bind fee_transfer_id =
+              Processor.Fee_transfer.add_if_doesn't_exist conn fee_transfer
+            in
+            let%map result =
+              Processor.Internal_command.find conn ~transaction_hash
+            in
+            [%test_result: int] ~expect:fee_transfer_id
+              (Option.value_exn result)
+          with
+          | Ok () ->
+              ()
+          | Error e ->
+              failwith @@ Caqti_error.show e )
+
+    let%test_unit "Coinbase: read and write" =
+      let conn = Lazy.force conn_lazy in
+      Thread_safe.block_on_async_exn
+      @@ fun () ->
+      Async.Quickcheck.async_test ~sexp_of:[%sexp_of: Coinbase.t] coinbase_gen
+        ~f:(fun coinbase ->
+          let transaction_hash = Transaction_hash.hash_coinbase coinbase in
+          match%map
+            let open Deferred.Result.Let_syntax in
+            let%bind coinbase_id =
+              Processor.Coinbase.add_if_doesn't_exist conn coinbase
+            in
+            let%map result =
+              Processor.Internal_command.find conn ~transaction_hash
+            in
+            [%test_result: int] ~expect:coinbase_id (Option.value_exn result)
+          with
+          | Ok () ->
+              ()
+          | Error e ->
+              failwith @@ Caqti_error.show e )
+
+    let%test_unit "Block: read and write" =
+      let conn = Lazy.force conn_lazy in
+      Quickcheck.test ~trials:20
+        ( Quickcheck.Generator.with_size ~size:10
+        @@ Quickcheck_lib.gen_imperative_list
+             (Transition_frontier.For_tests.gen_genesis_breadcrumb
+                ~precomputed_values ())
+             (Transition_frontier.Breadcrumb.For_tests.gen_non_deferred
+                ?logger:None ?verifier:None ?trust_system:None
+                ~accounts_with_secret_keys:
+                  (Lazy.force Test_genesis_ledger.accounts)) )
+        ~f:(fun breadcrumbs ->
+          Thread_safe.block_on_async_exn
+          @@ fun () ->
+          let reader, writer =
+            Strict_pipe.create ~name:"archive"
+              (Buffered (`Capacity 100, `Overflow Crash))
+          in
+          let processor_deferred_computation =
+            Processor.run conn reader ~logger
+          in
+          let diffs =
+            List.map
+              ~f:(fun breadcrumb ->
+                Diff.Transition_frontier
+                  (Diff.Builder.breadcrumb_added breadcrumb) )
+              breadcrumbs
+          in
+          List.iter diffs ~f:(Strict_pipe.Writer.write writer) ;
+          Strict_pipe.Writer.close writer ;
+          let%bind () = processor_deferred_computation in
+          match%map
+            Processor.deferred_result_list_fold breadcrumbs ~init:()
+              ~f:(fun () breadcrumb ->
+                let open Deferred.Result.Let_syntax in
+                match%bind
+                  Processor.Block.find conn
+                    ~state_hash:
+                      (Transition_frontier.Breadcrumb.state_hash breadcrumb)
+                with
+                | Some id ->
+                    let%bind Processor.Block.{parent_id; _} =
+                      Processor.Block.load conn ~id
+                    in
+                    if
+                      Transition_frontier.Breadcrumb.blockchain_length
+                        breadcrumb
+                      > Unsigned.UInt32.of_int 1
+                    then
+                      Processor.For_test.assert_parent_exist ~parent_id
+                        ~parent_hash:
+                          (Transition_frontier.Breadcrumb.parent_hash
+                             breadcrumb)
+                        conn
+                    else Deferred.Result.return ()
+                | None ->
+                    failwith "Failed to find saved block in database" )
+          with
+          | Ok () ->
+              ()
+          | Error e ->
+              failwith @@ Caqti_error.show e )
+  end )

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -431,6 +431,8 @@ module T = struct
             ; ("port", `Int addrs_and_ports.libp2p_port) ]
           ()
       in
+      let precomputed_values = Lazy.force Precomputed_values.for_unit_tests in
+      let (module Genesis_ledger) = precomputed_values.genesis_ledger in
       let pids = Child_processes.Termination.create_pid_table () in
       let%bind () =
         Option.value_map trace_dir
@@ -479,8 +481,8 @@ module T = struct
           in
           let block_production_keypair =
             Option.map block_production_key ~f:(fun i ->
-                List.nth_exn (Lazy.force Test_genesis_ledger.accounts) i
-                |> Test_genesis_ledger.keypair_of_account_record_exn )
+                List.nth_exn (Lazy.force Genesis_ledger.accounts) i
+                |> Genesis_ledger.keypair_of_account_record_exn )
           in
           let initial_block_production_keypairs =
             Keypair.Set.of_list (block_production_keypair |> Option.to_list)
@@ -494,7 +496,7 @@ module T = struct
           in
           let consensus_local_state =
             Consensus.Data.Local_state.create initial_block_production_keys
-              ~genesis_ledger:Test_genesis_ledger.t
+              ~genesis_ledger:Genesis_ledger.t
           in
           let gossip_net_params =
             Gossip_net.Libp2p.Config.
@@ -517,7 +519,7 @@ module T = struct
             ; consensus_local_state
             ; is_seed= List.is_empty peers
             ; genesis_ledger_hash=
-                Ledger.merkle_root (Lazy.force Test_genesis_ledger.t)
+                Ledger.merkle_root (Lazy.force Genesis_ledger.t)
             ; log_gossip_heard=
                 { snark_pool_diff= true
                 ; transaction_pool_diff= true
@@ -530,12 +532,6 @@ module T = struct
           let monitor = Async.Monitor.create ~name:"coda" () in
           let with_monitor f input =
             Async.Scheduler.within' ~monitor (fun () -> f input)
-          in
-          let genesis_state_hash =
-            Coda_state.Genesis_protocol_state.t
-              ~genesis_ledger:Test_genesis_ledger.t
-              ~genesis_constants:Genesis_constants.compiled
-            |> With_hash.hash
           in
           let coda_deferred () =
             Coda_lib.create
@@ -561,16 +557,14 @@ module T = struct
                  ~initial_block_production_keypairs ~monitor
                  ~consensus_local_state ~transaction_database
                  ~external_transition_database ~is_archive_rocksdb
-                 ~work_reassignment_wait:420000 ~genesis_state_hash
-                 ~genesis_constants:Genesis_constants.compiled
+                 ~work_reassignment_wait:420000 ~precomputed_values
                  ~archive_process_location:
                    (Option.map archive_process_location
                       ~f:(fun host_and_port ->
                         Cli_lib.Flag.Types.
                           {name= "dummy"; value= host_and_port} ))
                  ())
-              ~genesis_ledger:Test_genesis_ledger.t
-              ~base_proof:Precomputed_values.base_proof
+              ~precomputed_values
           in
           let coda_ref : Coda_lib.t option ref = ref None in
           Coda_run.handle_shutdown ~monitor ~time_controller ~conf_dir

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -431,7 +431,7 @@ module T = struct
             ; ("port", `Int addrs_and_ports.libp2p_port) ]
           ()
       in
-      let precomputed_values = Lazy.force Precomputed_values.for_unit_tests in
+      let precomputed_values = Lazy.force Precomputed_values.compiled in
       let (module Genesis_ledger) = precomputed_values.genesis_ledger in
       let pids = Child_processes.Termination.create_pid_table () in
       let%bind () =

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -84,6 +84,8 @@ let print_heartbeat logger =
 
 let run_test () : unit Deferred.t =
   let logger = Logger.create () in
+  let precomputed_values = Lazy.force Precomputed_values.for_unit_tests in
+  let (module Genesis_ledger) = precomputed_values.genesis_ledger in
   let pids = Child_processes.Termination.create_pid_table () in
   let consensus_constants =
     Consensus.Constants.create
@@ -94,7 +96,7 @@ let run_test () : unit Deferred.t =
   Parallel.init_master () ;
   File_system.with_temp_dir (Filename.temp_dir_name ^/ "full_test_config")
     ~f:(fun temp_conf_dir ->
-      let keypair = Test_genesis_ledger.largest_account_keypair_exn () in
+      let keypair = Genesis_ledger.largest_account_keypair_exn () in
       let%bind () =
         match Unix.getenv "CODA_TRACING" with
         | Some trace_dir ->
@@ -138,7 +140,7 @@ let run_test () : unit Deferred.t =
       in
       let time_controller = Block_time.Controller.(create @@ basic ~logger) in
       let consensus_local_state =
-        Consensus.Data.Local_state.create ~genesis_ledger:Test_genesis_ledger.t
+        Consensus.Data.Local_state.create ~genesis_ledger:Genesis_ledger.t
           (Public_key.Compressed.Set.singleton
              (Public_key.compress keypair.public_key))
       in
@@ -170,7 +172,7 @@ let run_test () : unit Deferred.t =
           ; consensus_local_state
           ; is_seed= true
           ; genesis_ledger_hash=
-              Ledger.merkle_root (Lazy.force Test_genesis_ledger.t)
+              Ledger.merkle_root (Lazy.force Genesis_ledger.t)
           ; log_gossip_heard=
               { snark_pool_diff= false
               ; transaction_pool_diff= false
@@ -183,7 +185,7 @@ let run_test () : unit Deferred.t =
       Core.Backtrace.elide := false ;
       Async.Scheduler.set_record_backtraces true ;
       let largest_account_keypair =
-        Test_genesis_ledger.largest_account_keypair_exn ()
+        Genesis_ledger.largest_account_keypair_exn ()
       in
       let fee = Currency.Fee.of_int in
       let snark_work_fee, transaction_fee =
@@ -213,12 +215,8 @@ let run_test () : unit Deferred.t =
              ~time_controller ~receipt_chain_database ~snark_work_fee
              ~consensus_local_state ~transaction_database
              ~external_transition_database ~work_reassignment_wait:420000
-             ~genesis_state_hash:
-               (Coda_state.Genesis_protocol_state.For_tests.genesis_state_hash
-                  ())
-             ~genesis_constants:Genesis_constants.compiled ())
-          ~genesis_ledger:Test_genesis_ledger.t
-          ~base_proof:Precomputed_values.base_proof
+             ~precomputed_values ())
+          ~precomputed_values
       in
       don't_wait_for
         (Strict_pipe.Reader.iter_without_pushback
@@ -421,20 +419,20 @@ let run_test () : unit Deferred.t =
         sending multiple payments*)
       let receiver_keypair =
         let receiver =
-          Test_genesis_ledger.find_new_account_record_exn
+          Genesis_ledger.find_new_account_record_exn
             [largest_account_keypair.public_key]
         in
-        Test_genesis_ledger.keypair_of_account_record_exn receiver
+        Genesis_ledger.keypair_of_account_record_exn receiver
       in
       let sender_keypair =
         let sender =
-          Test_genesis_ledger.find_new_account_record_exn
+          Genesis_ledger.find_new_account_record_exn
             [largest_account_keypair.public_key; receiver_keypair.public_key]
         in
-        Test_genesis_ledger.keypair_of_account_record_exn sender
+        Genesis_ledger.keypair_of_account_record_exn sender
       in
       let other_accounts =
-        List.filter (Lazy.force Test_genesis_ledger.accounts)
+        List.filter (Lazy.force Genesis_ledger.accounts)
           ~f:(fun (_, account) ->
             let reserved_public_keys =
               [ largest_account_keypair.public_key
@@ -447,7 +445,7 @@ let run_test () : unit Deferred.t =
                      (Public_key.decompress_exn @@ Account.public_key account)
                )) )
         |> List.map ~f:(fun (sk, account) ->
-               ( Test_genesis_ledger.keypair_of_account_record_exn (sk, account)
+               ( Genesis_ledger.keypair_of_account_record_exn (sk, account)
                , account ) )
       in
       let timeout_mins =

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -84,7 +84,7 @@ let print_heartbeat logger =
 
 let run_test () : unit Deferred.t =
   let logger = Logger.create () in
-  let precomputed_values = Lazy.force Precomputed_values.for_unit_tests in
+  let precomputed_values = Lazy.force Precomputed_values.compiled in
   let (module Genesis_ledger) = precomputed_values.genesis_ledger in
   let pids = Child_processes.Termination.create_pid_table () in
   let consensus_constants =

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -25,11 +25,17 @@ let generate_base_proof ~ledger ~(genesis_constants : Genesis_constants.t) =
     Coda_state.Genesis_protocol_state.t ~genesis_ledger ~genesis_constants
   in
   let base_hash = Keys.Step.instance_hash protocol_state_with_hash.data in
-  let base_proof =
-    Genesis_proof.create ~keys ~genesis_ledger ~protocol_state_with_hash
-      ~base_hash ~protocol_constants:genesis_constants.protocol ()
+  let computed_values =
+    Genesis_proof.create_values ~keys
+      { genesis_ledger=
+          ( module Genesis_ledger.Of_ledger (struct
+            let t = genesis_ledger
+          end) )
+      ; protocol_state_with_hash
+      ; base_hash
+      ; genesis_constants }
   in
-  (base_hash, base_proof)
+  (base_hash, computed_values.genesis_proof)
 
 let compiled_accounts_json () : Account_config.t =
   List.map (Lazy.force Test_genesis_ledger.accounts) ~f:(fun (sk_opt, acc) ->

--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -15,9 +15,7 @@ val run :
   -> persistent_root:Transition_frontier.Persistent_root.t
   -> persistent_frontier:Transition_frontier.Persistent_frontier.t
   -> initial_root_transition:External_transition.Validated.t
-  -> genesis_state_hash:Coda_base.State_hash.t
-  -> genesis_ledger:Coda_base.Ledger.t Lazy.t
-  -> genesis_constants:Genesis_constants.t
+  -> precomputed_values:Precomputed_values.t
   -> ( Transition_frontier.t
      * External_transition.Initial_validated.t Envelope.Incoming.t list )
      Deferred.t

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -214,7 +214,9 @@ type active_state_fields =
 let get_status ~flag t =
   let open Coda_lib.Config in
   let config = Coda_lib.config t in
-  let protocol_constants = config.genesis_constants.protocol in
+  let protocol_constants =
+    config.precomputed_values.genesis_constants.protocol
+  in
   let consensus_constants = Consensus.Constants.create ~protocol_constants in
   let uptime_secs =
     Time_ns.diff (Time_ns.now ()) start_time

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -8,7 +8,12 @@ module Currency = Currency_nonconsensus.Currency
 
 [%%endif]
 
-(*This file consists of compile time constants that are not in Genesis_constants.t or  i.e., all the constants that are defined at compile-time for both tests and production*)
+(** This file consists of compile-time constants that are not in
+    Genesis_constants.
+    This file includes all of the constants defined at compile-time for both
+    tests and production.
+*)
+
 [%%inject
 "proof_level", proof_level]
 
@@ -47,19 +52,21 @@ let default_transaction_fee =
 let default_snark_worker_fee =
   Currency.Fee.of_formatted_string default_snark_worker_fee_string
 
-(*transaction_capacity_log_2: Log of the capacity of transactions per
-transition. 1 will only work if we don't have prover fees. 2 will work with
-prover fees, but not if we want a transaction included in every block. At least
-3 ensures a transaction per block and the staged-ledger unit tests pass.
-work_delay: All the proofs before the last <work_delay> blocks are required to
-be completed to add transactions. <work_delay> is the minimum number of blocks
-and will increase if the throughput is less. If delay = 0, then all the work
-that was added to the scan state in the previous block is expected to be
-completed and included in the current block if any transactions/coinbase are to
-be included. Having a delay >= 1 means there's at least two block times for
-completing the proofs *)
+(** All the proofs before the last [work_delay] blocks must be completed to add
+    transactions. [work_delay] is the minimum number of blocks and will
+    increase if the throughput is less.
+    - If [work_delay = 0], all the work that was added to the scan state in the
+      previous block is expected to be completed and included in the current
+      block if any transactions/coinbase are to be included.
+    - [work_delay >= 1] means that there's at least two block times for
+      completing the proofs.
+*)
+
 [%%inject
 "work_delay", scan_state_work_delay]
+
+[%%inject
+"block_window_duration_ms", block_window_duration]
 
 [%%if
 scan_state_with_tps_goal]
@@ -67,17 +74,21 @@ scan_state_with_tps_goal]
 [%%inject
 "tps_goal_x10", scan_state_tps_goal_x10]
 
-[%%inject
-"block_window_duration_ms", block_window_duration]
-
 let max_coinbases = 2
 
 (* block_window_duration is in milliseconds, so divide by 1000
-       divide by 10 again because we have tps * 10
-     *)
+   divide by 10 again because we have tps * 10
+*)
 let max_user_commands_per_block =
   tps_goal_x10 * block_window_duration_ms / (1000 * 10)
 
+(** Log of the capacity of transactions per transition.
+    - 1 will only work if we don't have prover fees.
+    - 2 will work with prover fees, but not if we want a transaction included
+      in every block.
+    - At least 3 ensures a transaction per block and the staged-ledger unit
+      tests pass.
+*)
 let transaction_capacity_log_2 =
   1 + Core_kernel.Int.ceil_log2 (max_user_commands_per_block + max_coinbases)
 
@@ -95,14 +106,12 @@ let pending_coinbase_depth =
 [%%ifdef
 consensus_mechanism]
 
-(*Consensus constants*)
+(** Consensus constants *)
+
 [%%inject
 "c", c]
 
 [%%endif]
-
-[%%inject
-"block_window_duration_ms", block_window_duration]
 
 (* This is a bit of a hack, see #3232. *)
 let inactivity_ms = block_window_duration_ms * 8

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -155,7 +155,8 @@ module Types = struct
               let constants =
                 Consensus.Constants.create
                   ~protocol_constants:
-                    (Coda_lib.config coda).genesis_constants.protocol
+                    (Coda_lib.config coda).precomputed_values.genesis_constants
+                      .protocol
               in
               Block_time.to_string @@ C.start_time ~constants global_slot )
         ; field "endTime" ~typ:(non_null string)
@@ -164,7 +165,8 @@ module Types = struct
               let constants =
                 Consensus.Constants.create
                   ~protocol_constants:
-                    (Coda_lib.config coda).genesis_constants.protocol
+                    (Coda_lib.config coda).precomputed_values.genesis_constants
+                      .protocol
               in
               Block_time.to_string @@ C.end_time ~constants global_slot ) ] )
 
@@ -185,7 +187,8 @@ module Types = struct
               let consensus_constants =
                 Consensus.Constants.create
                   ~protocol_constants:
-                    (Coda_lib.config coda).genesis_constants.protocol
+                    (Coda_lib.config coda).precomputed_values.genesis_constants
+                      .protocol
               in
               function
               | `Check_again _time ->

--- a/src/lib/coda_intf/transition_frontier_components_intf.ml
+++ b/src/lib/coda_intf/transition_frontier_components_intf.ml
@@ -363,10 +363,7 @@ module type Transition_router_intf = sig
                                Broadcast_pipe.Reader.t
                                * External_transition.Initial_validated.t
                                  Broadcast_pipe.Writer.t
-    -> genesis_state_hash:State_hash.t
-    -> genesis_ledger:Ledger.t Lazy.t
-    -> base_proof:Coda_base.Proof.t
-    -> genesis_constants:Genesis_constants.t
+    -> precomputed_values:Precomputed_values.t
     -> ( [`Transition of External_transition.Validated.t]
        * [`Source of [`Gossip | `Catchup | `Internal]] )
        Strict_pipe.Reader.t

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -667,7 +667,8 @@ let staking_ledger t =
   let open Option.Let_syntax in
   let consensus_constants =
     Consensus.Constants.create
-      ~protocol_constants:t.config.genesis_constants.protocol
+      ~protocol_constants:
+        (Precomputed_values.protocol_constants t.config.precomputed_values)
   in
   let%map transition_frontier =
     Broadcast_pipe.Reader.peek t.components.transition_frontier
@@ -723,13 +724,15 @@ let start t =
     ~frontier_reader:t.components.transition_frontier
     ~transition_writer:t.pipes.producer_transition_writer
     ~log_block_creation:t.config.log_block_creation
-    ~genesis_constants:t.config.genesis_constants ;
+    ~genesis_constants:
+      (Precomputed_values.genesis_constants t.config.precomputed_values) ;
   Snark_worker.start t
 
-let create (config : Config.t) ~genesis_ledger ~base_proof =
+let create (config : Config.t) ~precomputed_values =
   let consensus_constants =
     Consensus.Constants.create
-      ~protocol_constants:config.genesis_constants.protocol
+      ~protocol_constants:
+        (Precomputed_values.protocol_constants precomputed_values)
   in
   let monitor = Option.value ~default:(Monitor.create ()) config.monitor in
   Async.Scheduler.within' ~monitor (fun () ->
@@ -965,7 +968,8 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
           let txn_pool_config =
             Network_pool.Transaction_pool.Resource_pool.make_config
               ~trust_system:config.trust_system
-              ~pool_max_size:config.genesis_constants.txpool_max_size
+              ~pool_max_size:
+                config.precomputed_values.genesis_constants.txpool_max_size
           in
           let transaction_pool =
             Network_pool.Transaction_pool.create ~config:txn_pool_config
@@ -1001,8 +1005,7 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
           let ((most_recent_valid_block_reader, _) as most_recent_valid_block)
               =
             Broadcast_pipe.create
-              ( External_transition.genesis ~genesis_ledger ~base_proof
-                  ~genesis_constants:config.genesis_constants
+              ( External_transition.genesis ~precomputed_values
               |> External_transition.Validated.to_initial_validated )
           in
           let valid_transitions, initialization_finish_signal =
@@ -1061,9 +1064,7 @@ let create (config : Config.t) ~genesis_ledger ~base_proof =
                                @@ External_transition.Validation
                                   .forget_validation et ) ;
                          breadcrumb ))
-                  ~most_recent_valid_block
-                  ~genesis_state_hash:config.genesis_state_hash ~genesis_ledger
-                  ~base_proof ~genesis_constants:config.genesis_constants )
+                  ~most_recent_valid_block ~precomputed_values )
           in
           let ( valid_transitions_for_network
               , valid_transitions_for_api

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -129,10 +129,7 @@ val start : t -> unit Deferred.t
 val stop_snark_worker : ?should_wait_kill:bool -> t -> unit Deferred.t
 
 val create :
-     Config.t
-  -> genesis_ledger:Ledger.t Lazy.t
-  -> base_proof:Proof.t
-  -> t Deferred.t
+  Config.t -> precomputed_values:Precomputed_values.t -> t Deferred.t
 
 val staged_ledger_ledger_proof : t -> Ledger_proof.t option
 

--- a/src/lib/coda_lib/config.ml
+++ b/src/lib/coda_lib/config.ml
@@ -1,6 +1,5 @@
 open Core_kernel
 open Async_kernel
-open Coda_base
 open Auxiliary_database
 open Signature_lib
 
@@ -48,7 +47,6 @@ type t =
       Core.Host_and_port.t Cli_lib.Flag.Types.with_name option
         [@default None]
   ; demo_mode: bool [@default false]
-  ; genesis_state_hash: State_hash.t
   ; log_block_creation: bool [@default false]
-  ; genesis_constants: Genesis_constants.t }
+  ; precomputed_values: Precomputed_values.t }
 [@@deriving make]

--- a/src/lib/coda_state/genesis_protocol_state.ml
+++ b/src/lib/coda_state/genesis_protocol_state.ml
@@ -53,11 +53,12 @@ let t ~genesis_ledger ~(genesis_constants : Genesis_constants.t) =
   in
   With_hash.of_data ~hash_data:Protocol_state.hash state
 
-let compile_time_genesis () =
-  t ~genesis_ledger:Test_genesis_ledger.t
-    ~genesis_constants:Genesis_constants.compiled
+let compile_time_genesis =
+  lazy
+    (t ~genesis_ledger:Test_genesis_ledger.t
+       ~genesis_constants:Genesis_constants.compiled)
 
 module For_tests = struct
   (*Use test_ledger generated at compile time*)
-  let genesis_state_hash () = compile_time_genesis () |> With_hash.hash
+  let genesis_state_hash = Lazy.map ~f:With_hash.hash compile_time_genesis
 end

--- a/src/lib/coda_state/genesis_protocol_state.mli
+++ b/src/lib/coda_state/genesis_protocol_state.mli
@@ -12,8 +12,8 @@ val t :
   -> (Protocol_state.Value.t, State_hash.t) With_hash.t
 
 val compile_time_genesis :
-  unit -> (Protocol_state.Value.t, State_hash.t) With_hash.t
+  (Protocol_state.Value.t, State_hash.t) With_hash.t Lazy.t
 
 module For_tests : sig
-  val genesis_state_hash : unit -> State_hash.t
+  val genesis_state_hash : State_hash.t Lazy.t
 end

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -954,9 +954,9 @@ module For_tests = struct
       ~delta_transition_chain_proof ~validation_callback
       ?proposed_protocol_version_opt ()
 
-  let unit_test_genesis () =
+  let genesis ~precomputed_values =
     Protocol_version.(set_current zero) ;
-    genesis ~precomputed_values:(Lazy.force Precomputed_values.for_unit_tests)
+    genesis ~precomputed_values
 end
 
 module Transition_frontier_validation (Transition_frontier : sig

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -285,7 +285,7 @@ module type S = sig
       -> unit
       -> t
 
-    val unit_test_genesis : unit -> Validated.t
+    val genesis : precomputed_values:Precomputed_values.t -> Validated.t
   end
 
   val timestamp : t -> Block_time.t

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -272,11 +272,7 @@ module type S = sig
     -> unit
     -> t
 
-  val genesis :
-       genesis_ledger:Ledger.t Lazy.t
-    -> base_proof:Proof.t
-    -> genesis_constants:Genesis_constants.t
-    -> Validated.t
+  val genesis : precomputed_values:Precomputed_values.t -> Validated.t
 
   module For_tests : sig
     val create :
@@ -289,7 +285,7 @@ module type S = sig
       -> unit
       -> t
 
-    val genesis : unit -> Validated.t
+    val unit_test_genesis : unit -> Validated.t
   end
 
   val timestamp : t -> Block_time.t

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -26,14 +26,18 @@ val setup :
 module Generator : sig
   open Quickcheck
 
-  type peer_config = max_frontier_length:int -> peer_state Generator.t
+  type peer_config =
+       precomputed_values:Precomputed_values.t
+    -> max_frontier_length:int
+    -> peer_state Generator.t
 
   val fresh_peer : peer_config
 
   val peer_with_branch : frontier_branch_size:int -> peer_config
 
   val gen :
-       max_frontier_length:int
+       precomputed_values:Precomputed_values.t
+    -> max_frontier_length:int
     -> (peer_config, 'n num_peers) Vect.t
     -> 'n num_peers t Generator.t
 end

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -169,7 +169,7 @@ end) : Intf.S = struct
             Balance.compare a.Account.Poly.balance b.Account.Poly.balance )
         |> Option.value_exn ?here:None ?error:None ~message:error_msg )
 
-  let largest_account_keypair_exn =
+  let largest_account_keypair_exn () =
     failwith "cannot access genesis ledger account private key"
 end
 

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -136,6 +136,43 @@ module Packed = struct
     L.keypair_of_account_record_exn
 end
 
+module Of_ledger (T : sig
+  val t : Ledger.t Lazy.t
+end) : Intf.S = struct
+  include T
+
+  let accounts =
+    Lazy.map t
+      ~f:(Ledger.foldi ~init:[] ~f:(fun _loc accs acc -> (None, acc) :: accs))
+
+  let find_account_record_exn ~f =
+    List.find_exn (Lazy.force accounts) ~f:(fun (_, account) -> f account)
+
+  let find_new_account_record_exn old_account_pks =
+    find_account_record_exn ~f:(fun new_account ->
+        not
+          (List.exists old_account_pks ~f:(fun old_account_pk ->
+               Public_key.equal
+                 (Public_key.decompress_exn (Account.public_key new_account))
+                 old_account_pk )) )
+
+  let keypair_of_account_record_exn _ =
+    failwith "cannot access genesis ledger account private key"
+
+  let largest_account_exn =
+    let error_msg =
+      "cannot calculate largest account in genesis ledger: "
+      ^ "genesis ledger has no accounts"
+    in
+    Memo.unit (fun () ->
+        List.max_elt (Lazy.force accounts) ~compare:(fun (_, a) (_, b) ->
+            Balance.compare a.Account.Poly.balance b.Account.Poly.balance )
+        |> Option.value_exn ?here:None ?error:None ~message:error_msg )
+
+  let largest_account_keypair_exn =
+    failwith "cannot access genesis ledger account private key"
+end
+
 let fetch_ledger, register_ledger =
   let ledgers = ref String.Map.empty in
   let register_ledger ((module Ledger : Intf.Named_accounts_intf) as l) =

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -1,6 +1,58 @@
 open Coda_base
 open Coda_state
 
+module Inputs = struct
+  type t =
+    { genesis_constants: Genesis_constants.t
+    ; genesis_ledger: Genesis_ledger.Packed.t
+    ; protocol_state_with_hash:
+        (Protocol_state.value, State_hash.t) With_hash.t
+    ; base_hash: State_hash.t }
+end
+
+module T = struct
+  type t =
+    { genesis_constants: Genesis_constants.t
+    ; genesis_ledger: Genesis_ledger.Packed.t
+    ; protocol_state_with_hash:
+        (Protocol_state.value, State_hash.t) With_hash.t
+    ; base_hash: State_hash.t
+    ; genesis_proof: Proof.t }
+
+  let genesis_constants {genesis_constants; _} = genesis_constants
+
+  let protocol_constants t = (genesis_constants t).protocol
+
+  let genesis_ledger {genesis_ledger; _} =
+    Genesis_ledger.Packed.t genesis_ledger
+
+  let accounts {genesis_ledger; _} =
+    Genesis_ledger.Packed.accounts genesis_ledger
+
+  let find_new_account_record_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.find_new_account_record_exn genesis_ledger
+
+  let largest_account_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.largest_account_exn genesis_ledger
+
+  let largest_account_keypair_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.largest_account_keypair_exn genesis_ledger
+
+  let keypair_of_account_record_exn {genesis_ledger; _} =
+    Genesis_ledger.Packed.keypair_of_account_record_exn genesis_ledger
+
+  let genesis_state_with_hash {protocol_state_with_hash; _} =
+    protocol_state_with_hash
+
+  let genesis_state t = (genesis_state_with_hash t).data
+
+  let genesis_state_hash t = (genesis_state_with_hash t).hash
+
+  let genesis_proof {genesis_proof; _} = genesis_proof
+end
+
+include T
+
 let wrap ~keys:(module Keys : Keys_lib.Keys.S) hash proof =
   let open Snark_params in
   let module Wrap = Keys.Wrap in
@@ -14,17 +66,16 @@ let wrap ~keys:(module Keys : Keys_lib.Keys.S) hash proof =
   proof
 
 let base_proof ?(logger = Logger.create ())
-    ~keys:((module Keys : Keys_lib.Keys.S) as keys) ~genesis_ledger
-    ~protocol_constants
-    ~(protocol_state_with_hash :
-       (Protocol_state.value, State_hash.t) With_hash.t) ~base_hash () =
+    ~keys:((module Keys : Keys_lib.Keys.S) as keys) (t : Inputs.t) =
+  let genesis_ledger = Genesis_ledger.Packed.t t.genesis_ledger in
+  let protocol_constants = t.genesis_constants.protocol in
   let open Snark_params in
   let prover_state =
     { Keys.Step.Prover_state.prev_proof= Tock.Proof.dummy
     ; wrap_vk= Tock.Keypair.vk Keys.Wrap.keys
     ; prev_state=
         Protocol_state.negative_one ~genesis_ledger ~protocol_constants
-    ; genesis_state_hash= protocol_state_with_hash.hash
+    ; genesis_state_hash= t.protocol_state_with_hash.hash
     ; expected_next_state= None
     ; update= Snark_transition.genesis ~genesis_ledger }
   in
@@ -35,12 +86,17 @@ let base_proof ?(logger = Logger.create ())
   let tick =
     Tick.prove
       (Tick.Keypair.pk Keys.Step.keys)
-      (Keys.Step.input ()) prover_state main base_hash
+      (Keys.Step.input ()) prover_state main t.base_hash
   in
   assert (
     Tick.verify tick
       (Tick.Keypair.vk Keys.Step.keys)
-      (Keys.Step.input ()) base_hash ) ;
-  wrap ~keys base_hash tick
+      (Keys.Step.input ()) t.base_hash ) ;
+  wrap ~keys t.base_hash tick
 
-let create = base_proof
+let create_values ?logger ~keys (t : Inputs.t) =
+  { genesis_constants= t.genesis_constants
+  ; genesis_ledger= t.genesis_ledger
+  ; protocol_state_with_hash= t.protocol_state_with_hash
+  ; base_hash= t.base_hash
+  ; genesis_proof= base_proof ?logger ~keys t }

--- a/src/lib/keys_lib/keys.ml
+++ b/src/lib/keys_lib/keys.ml
@@ -58,6 +58,13 @@ let bc_pk = lazy (Snark_keys.blockchain_proving ())
 
 let bc_vk = lazy (Snark_keys.blockchain_verification ())
 
+let step_instance_hash protocol_state =
+  let open Async in
+  let%map bc_vk = Lazy.force bc_vk in
+  unstage
+    (Blockchain_snark.Blockchain_transition.instance_hash bc_vk.wrap)
+    protocol_state
+
 let keys = Set_once.create ()
 
 let create () : (module S) Async.Deferred.t =

--- a/src/lib/keys_lib/keys.mli
+++ b/src/lib/keys_lib/keys.mli
@@ -51,4 +51,6 @@ module type S = sig
   end
 end
 
+val step_instance_hash : Protocol_state.value -> Tick.Field.t Async.Deferred.t
+
 val create : unit -> (module S) Async.Deferred.t

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -408,6 +408,8 @@ let%test_module "Ledger_catchup tests" =
 
     let logger = Logger.null ()
 
+    let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
+
     let trust_system = Trust_system.null ()
 
     let time_controller = Block_time.Controller.basic ~logger
@@ -527,7 +529,7 @@ let%test_module "Ledger_catchup tests" =
           let%bind peer_branch_size =
             Int.gen_incl (max_frontier_length / 2) (max_frontier_length - 1)
           in
-          gen ~max_frontier_length
+          gen ~precomputed_values ~max_frontier_length
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:peer_branch_size ])
         ~f:(fun network ->
@@ -546,7 +548,7 @@ let%test_module "Ledger_catchup tests" =
                    in the frontier" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          gen ~max_frontier_length
+          gen ~precomputed_values ~max_frontier_length
             [fresh_peer; peer_with_branch ~frontier_branch_size:1])
         ~f:(fun network ->
           let open Fake_network in
@@ -560,7 +562,7 @@ let%test_module "Ledger_catchup tests" =
     let%test_unit "catchup fails if one of the parent transitions fail" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          gen ~max_frontier_length
+          gen ~precomputed_values ~max_frontier_length
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:(max_frontier_length * 2)
             ])

--- a/src/lib/precomputed_values/dune
+++ b/src/lib/precomputed_values/dune
@@ -1,7 +1,13 @@
 (library
  (name precomputed_values)
  (public_name precomputed_values)
- (libraries crypto_params dummy_values snarky snark_keys coda_base)
+ (libraries
+   coda_base
+   crypto_params
+   dummy_values
+   genesis_proof
+   snark_keys
+   snarky)
  (ppx_runtime_libraries base)
  (preprocess
   (pps ppx_coda ppx_jane ppxlib.metaquot)))

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -37,9 +37,18 @@ end
 module Make_real (Keys : Keys_lib.Keys.S) = struct
   let loc = Ppxlib.Location.none
 
-  let protocol_state_with_hash = Genesis_protocol_state.compile_time_genesis ()
+  let protocol_state_with_hash =
+    Lazy.force Genesis_protocol_state.compile_time_genesis
 
   let base_hash = Keys.Step.instance_hash protocol_state_with_hash.data
+
+  let values_for_unit_tests =
+    Genesis_proof.create_values
+      ~keys:(module Keys : Keys_lib.Keys.S)
+      { genesis_constants= Genesis_constants.for_unit_tests
+      ; genesis_ledger= Genesis_ledger.for_unit_tests
+      ; protocol_state_with_hash
+      ; base_hash }
 
   let base_hash_expr =
     [%expr
@@ -49,18 +58,12 @@ module Make_real (Keys : Keys_lib.Keys.S) = struct
             (Snark_params.Tick.Field.sexp_of_t base_hash)]]
 
   let base_proof_expr =
-    let proof =
-      Genesis_proof.create
-        ~keys:(module Keys : Keys_lib.Keys.S)
-        ~genesis_ledger:Test_genesis_ledger.t
-        ~protocol_constants:Genesis_constants.compiled.protocol
-        ~protocol_state_with_hash ~base_hash ()
-    in
     [%expr
       Coda_base.Proof.Stable.V1.t_of_sexp
         [%e
           Ppx_util.expr_of_sexp ~loc
-            (Coda_base.Proof.Stable.V1.sexp_of_t proof)]]
+            (Coda_base.Proof.Stable.V1.sexp_of_t
+               values_for_unit_tests.genesis_proof)]]
 end
 
 open Async
@@ -77,9 +80,23 @@ let main () =
   in
   let structure =
     [%str
-      let base_hash = [%e M.base_hash_expr]
+      module T = Genesis_proof.T
+      include T
 
-      let base_proof = [%e M.base_proof_expr]]
+      let unit_test_base_hash = [%e M.base_hash_expr]
+
+      let unit_test_base_proof = [%e M.base_proof_expr]
+
+      let for_unit_tests =
+        lazy
+          (let protocol_state_with_hash =
+             Lazy.force Coda_state.Genesis_protocol_state.compile_time_genesis
+           in
+           { genesis_constants= Genesis_constants.for_unit_tests
+           ; genesis_ledger= Genesis_ledger.for_unit_tests
+           ; protocol_state_with_hash
+           ; base_hash= unit_test_base_hash
+           ; genesis_proof= unit_test_base_proof })]
   in
   Pprintast.top_phrase fmt (Ptop_def structure) ;
   exit 0

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -156,7 +156,7 @@ module Worker_state = struct
                         prover_state)
                      ~f:(fun () ->
                        { Blockchain.state= next_state
-                       ; proof= Precomputed_values.base_proof } )
+                       ; proof= Dummy_values.Tock.Bowe_gabizon18.proof } )
                  in
                  Or_error.iter_error res ~f:(fun e ->
                      Logger.error logger ~module_:__MODULE__ ~location:__LOC__
@@ -174,7 +174,7 @@ module Worker_state = struct
                let extend_blockchain _chain next_state _block
                    _state_for_handler _pending_coinbase =
                  Ok
-                   { Blockchain.proof= Precomputed_values.base_proof
+                   { Blockchain.proof= Dummy_values.Tock.Bowe_gabizon18.proof
                    ; state= next_state }
 
                let verify _ _ = true

--- a/src/lib/transaction_status/transaction_status.ml
+++ b/src/lib/transaction_status/transaction_status.ml
@@ -71,6 +71,8 @@ let%test_module "transaction_status" =
 
     let logger = Logger.null ()
 
+    let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
+
     let trust_system = Trust_system.null ()
 
     let pool_max_size = Genesis_constants.compiled.txpool_max_size
@@ -87,8 +89,8 @@ let%test_module "transaction_status" =
           (Option.value_exn random_key_opt) )
 
     let gen_frontier =
-      Transition_frontier.For_tests.gen ~logger ~trust_system ~max_length
-        ~size:frontier_size ()
+      Transition_frontier.For_tests.gen ~logger ~precomputed_values
+        ~trust_system ~max_length ~size:frontier_size ()
 
     let gen_user_command =
       User_command.Gen.payment ~sign_type:`Real ~max_amount:100 ~max_fee:10

--- a/src/lib/transition_frontier/persistent_root/persistent_root.ml
+++ b/src/lib/transition_frontier/persistent_root/persistent_root.ml
@@ -124,14 +124,17 @@ let with_instance_exn t ~f =
   let x = f instance in
   Instance.destroy instance ; x
 
-let reset_to_genesis_exn t ~genesis_ledger ~genesis_state_hash =
+let reset_to_genesis_exn t ~precomputed_values =
   let open Deferred.Let_syntax in
   assert (t.instance = None) ;
   let%map () = File_system.remove_dir t.directory in
   with_instance_exn t ~f:(fun instance ->
       ignore
         (Ledger_transfer.transfer_accounts
-           ~src:(Lazy.force genesis_ledger)
+           ~src:
+             (Lazy.force (Precomputed_values.genesis_ledger precomputed_values))
            ~dest:(Instance.snarked_ledger instance)) ;
       Instance.set_root_identifier instance
-        (genesis_root_identifier ~genesis_state_hash) )
+        (genesis_root_identifier
+           ~genesis_state_hash:
+             (Precomputed_values.genesis_state_hash precomputed_values)) )

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -50,7 +50,10 @@ let%test_module "Full_frontier tests" =
       in
       let root_data =
         let open Root_data in
-        { transition= External_transition.For_tests.genesis ()
+        { transition=
+            External_transition.For_tests.genesis
+              ~precomputed_values:
+                (Lazy.force Precomputed_values.for_unit_tests)
         ; staged_ledger= Staged_ledger.create_exn ~ledger:root_ledger }
       in
       Full_frontier.create ~logger ~root_data

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -425,7 +425,7 @@ module For_tests = struct
     in
     Quickcheck.Generator.create (fun ~size:_ ~random:_ ->
         let genesis_transition =
-          External_transition.genesis ~precomputed_values
+          External_transition.For_tests.genesis ~precomputed_values
         in
         let genesis_ledger =
           Lazy.force (Precomputed_values.genesis_ledger precomputed_values)

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -29,19 +29,17 @@ type t =
   ; extensions: Extensions.t
   ; genesis_state_hash: State_hash.t }
 
-let genesis_root_data ~genesis_ledger ~base_proof ~genesis_constants =
+let genesis_root_data ~precomputed_values =
   let open Root_data.Limited.Stable.Latest in
-  let transition =
-    External_transition.genesis ~genesis_ledger ~base_proof ~genesis_constants
-  in
+  let transition = External_transition.genesis ~precomputed_values in
   let scan_state = Staged_ledger.Scan_state.empty () in
   let pending_coinbase = Or_error.ok_exn (Pending_coinbase.create ()) in
   {transition; scan_state; pending_coinbase}
 
 let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
     ~max_length ~persistent_root ~persistent_root_instance ~persistent_frontier
-    ~persistent_frontier_instance ~genesis_state_hash
-    ignore_consensus_local_state ~genesis_constants =
+    ~persistent_frontier_instance ~precomputed_values
+    ignore_consensus_local_state =
   let open Deferred.Result.Let_syntax in
   let root_identifier =
     match
@@ -89,7 +87,8 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
          ~root_ledger:
            (Persistent_root.Instance.snarked_ledger persistent_root_instance)
          ~consensus_local_state ~ignore_consensus_local_state
-         ~genesis_constants)
+         ~genesis_constants:
+           (Precomputed_values.genesis_constants precomputed_values))
       ~f:
         (Result.map_error ~f:(function
           | `Sync_cannot_be_running ->
@@ -117,7 +116,8 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
   ; persistent_frontier
   ; persistent_frontier_instance
   ; extensions
-  ; genesis_state_hash }
+  ; genesis_state_hash=
+      Precomputed_values.genesis_state_hash precomputed_values }
 
 let rec load_with_max_length :
        max_length:int
@@ -127,10 +127,7 @@ let rec load_with_max_length :
     -> consensus_local_state:Consensus.Data.Local_state.t
     -> persistent_root:Persistent_root.t
     -> persistent_frontier:Persistent_frontier.t
-    -> genesis_state_hash:State_hash.t
-    -> genesis_ledger:Ledger.t Lazy.t
-    -> ?base_proof:Proof.t
-    -> genesis_constants:Genesis_constants.t
+    -> precomputed_values:Precomputed_values.t
     -> unit
     -> ( t
        , [> `Bootstrap_required
@@ -139,8 +136,7 @@ let rec load_with_max_length :
        Deferred.Result.t =
  fun ~max_length ?(retry_with_fresh_db = true) ~logger ~verifier
      ~consensus_local_state ~persistent_root ~persistent_frontier
-     ~genesis_state_hash ~genesis_ledger
-     ?(base_proof = Precomputed_values.base_proof) ~genesis_constants () ->
+     ~precomputed_values () ->
   let open Deferred.Let_syntax in
   (* TODO: #3053 *)
   let continue persistent_frontier_instance ~ignore_consensus_local_state =
@@ -150,8 +146,8 @@ let rec load_with_max_length :
     match%bind
       load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
         ~max_length ~persistent_root ~persistent_root_instance
-        ~persistent_frontier ~persistent_frontier_instance ~genesis_state_hash
-        ~genesis_constants ignore_consensus_local_state
+        ~persistent_frontier ~persistent_frontier_instance ~precomputed_values
+        ignore_consensus_local_state
     with
     | Ok _ as result ->
         return result
@@ -171,12 +167,10 @@ let rec load_with_max_length :
     in
     let%bind () =
       Persistent_frontier.reset_database_exn persistent_frontier
-        ~root_data:
-          (genesis_root_data ~genesis_ledger ~base_proof ~genesis_constants)
+        ~root_data:(genesis_root_data ~precomputed_values)
     in
     let%bind () =
-      Persistent_root.reset_to_genesis_exn persistent_root ~genesis_ledger
-        ~genesis_state_hash
+      Persistent_root.reset_to_genesis_exn persistent_root ~precomputed_values
     in
     continue
       (Persistent_frontier.create_instance_exn persistent_frontier)
@@ -212,8 +206,7 @@ let rec load_with_max_length :
         in
         load_with_max_length ~max_length ~logger ~verifier
           ~consensus_local_state ~persistent_root ~persistent_frontier
-          ~retry_with_fresh_db:false () ~genesis_state_hash ~genesis_ledger
-          ~base_proof ~genesis_constants
+          ~retry_with_fresh_db:false () ~precomputed_values
         >>| Result.map_error ~f:(function
               | `Persistent_frontier_malformed ->
                   `Failure
@@ -226,12 +219,13 @@ let rec load_with_max_length :
       continue persistent_frontier_instance ~ignore_consensus_local_state:true
 
 let load ?(retry_with_fresh_db = true) ~logger ~verifier ~consensus_local_state
-    ~persistent_root ~persistent_frontier ~genesis_state_hash ~genesis_ledger
-    ?(base_proof = Precomputed_values.base_proof) ~genesis_constants () =
-  let max_length = global_max_length genesis_constants in
+    ~persistent_root ~persistent_frontier ~precomputed_values () =
+  let max_length =
+    global_max_length (Precomputed_values.genesis_constants precomputed_values)
+  in
   load_with_max_length ~max_length ~retry_with_fresh_db ~logger ~verifier
     ~consensus_local_state ~persistent_root ~persistent_frontier
-    ~genesis_state_hash ~genesis_ledger ~base_proof ~genesis_constants ()
+    ~precomputed_values ()
 
 (* The persistent root and persistent frontier as safe to ignore here
  * because their lifecycle is longer than the transition frontier's *)
@@ -418,7 +412,8 @@ module For_tests = struct
   *)
 
   (* a helper quickcheck generator which always returns the genesis breadcrumb *)
-  let gen_genesis_breadcrumb ?(logger = Logger.null ()) ?verifier () =
+  let gen_genesis_breadcrumb ?(logger = Logger.null ()) ?verifier
+      ~precomputed_values () =
     let verifier =
       match verifier with
       | Some x ->
@@ -429,8 +424,12 @@ module For_tests = struct
                 ~pids:(Child_processes.Termination.create_pid_table ()) )
     in
     Quickcheck.Generator.create (fun ~size:_ ~random:_ ->
-        let genesis_transition = External_transition.For_tests.genesis () in
-        let genesis_ledger = Lazy.force Test_genesis_ledger.t in
+        let genesis_transition =
+          External_transition.genesis ~precomputed_values
+        in
+        let genesis_ledger =
+          Lazy.force (Precomputed_values.genesis_ledger precomputed_values)
+        in
         let genesis_staged_ledger =
           Or_error.ok_exn
             (Async.Thread_safe.block_on_async_exn (fun () ->
@@ -498,17 +497,16 @@ module For_tests = struct
         (persistent_root, persistent_frontier) )
 
   let gen ?(logger = Logger.null ()) ?verifier ?trust_system
-      ?consensus_local_state
+      ?consensus_local_state ~precomputed_values
       ?(root_ledger_and_accounts =
-        ( Lazy.force Test_genesis_ledger.t
-        , Lazy.force Test_genesis_ledger.accounts ))
-      ?(gen_root_breadcrumb = gen_genesis_breadcrumb ~logger ?verifier ())
+        ( Lazy.force (Precomputed_values.genesis_ledger precomputed_values)
+        , Lazy.force (Precomputed_values.accounts precomputed_values) ))
+      ?(gen_root_breadcrumb =
+        gen_genesis_breadcrumb ~logger ?verifier ~precomputed_values ())
       ~max_length ~size () =
     let open Quickcheck.Generator.Let_syntax in
     let genesis_state_hash =
-      Coda_state.Genesis_protocol_state.t ~genesis_ledger:Test_genesis_ledger.t
-        ~genesis_constants:Genesis_constants.compiled
-      |> With_hash.hash
+      Precomputed_values.genesis_state_hash precomputed_values
     in
     let verifier =
       match verifier with
@@ -526,7 +524,8 @@ module For_tests = struct
       Option.value consensus_local_state
         ~default:
           (Consensus.Data.Local_state.create
-             ~genesis_ledger:Test_genesis_ledger.t
+             ~genesis_ledger:
+               (Precomputed_values.genesis_ledger precomputed_values)
              Public_key.Compressed.Set.empty)
     in
     let root_snarked_ledger, root_ledger_accounts = root_ledger_and_accounts in
@@ -562,9 +561,7 @@ module For_tests = struct
       Async.Thread_safe.block_on_async_exn (fun () ->
           load_with_max_length ~max_length ~retry_with_fresh_db:false ~logger
             ~verifier ~consensus_local_state ~persistent_root
-            ~persistent_frontier ~genesis_state_hash
-            ~genesis_ledger:(lazy root_snarked_ledger)
-            ~genesis_constants:Genesis_constants.compiled () )
+            ~persistent_frontier ~precomputed_values () )
     in
     let frontier =
       let fail msg = failwith ("failed to load transition frontier: " ^ msg) in
@@ -584,15 +581,17 @@ module For_tests = struct
     frontier
 
   let gen_with_branch ?logger ?verifier ?trust_system ?consensus_local_state
+      ~precomputed_values
       ?(root_ledger_and_accounts =
-        ( Lazy.force Test_genesis_ledger.t
-        , Lazy.force Test_genesis_ledger.accounts )) ?gen_root_breadcrumb
-      ?(get_branch_root = root) ~max_length ~frontier_size ~branch_size () =
+        ( Lazy.force (Precomputed_values.genesis_ledger precomputed_values)
+        , Lazy.force (Precomputed_values.accounts precomputed_values) ))
+      ?gen_root_breadcrumb ?(get_branch_root = root) ~max_length ~frontier_size
+      ~branch_size () =
     let open Quickcheck.Generator.Let_syntax in
     let%bind frontier =
       gen ?logger ?verifier ?trust_system ?consensus_local_state
-        ?gen_root_breadcrumb ~root_ledger_and_accounts ~max_length
-        ~size:frontier_size ()
+        ~precomputed_values ?gen_root_breadcrumb ~root_ledger_and_accounts
+        ~max_length ~size:frontier_size ()
     in
     let%map make_branch =
       Breadcrumb.For_tests.gen_seq ?logger ?verifier ?trust_system

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -30,10 +30,7 @@ val load :
   -> consensus_local_state:Consensus.Data.Local_state.t
   -> persistent_root:Persistent_root.t
   -> persistent_frontier:Persistent_frontier.t
-  -> genesis_state_hash:State_hash.t
-  -> genesis_ledger:Ledger.t Lazy.t
-  -> ?base_proof:Coda_base.Proof.t
-  -> genesis_constants:Genesis_constants.t
+  -> precomputed_values:Precomputed_values.t
   -> unit
   -> ( t
      , [> `Failure of string
@@ -68,10 +65,7 @@ module For_tests : sig
     -> consensus_local_state:Consensus.Data.Local_state.t
     -> persistent_root:Persistent_root.t
     -> persistent_frontier:Persistent_frontier.t
-    -> genesis_state_hash:State_hash.t
-    -> genesis_ledger:Ledger.t Lazy.t
-    -> ?base_proof:Coda_base.Proof.t
-    -> genesis_constants:Genesis_constants.t
+    -> precomputed_values:Precomputed_values.t
     -> unit
     -> ( t
        , [> `Failure of string
@@ -82,6 +76,7 @@ module For_tests : sig
   val gen_genesis_breadcrumb :
        ?logger:Logger.t
     -> ?verifier:Verifier.t
+    -> precomputed_values:Precomputed_values.t
     -> unit
     -> Breadcrumb.t Quickcheck.Generator.t
 
@@ -96,6 +91,7 @@ module For_tests : sig
     -> ?verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
+    -> precomputed_values:Precomputed_values.t
     -> ?root_ledger_and_accounts:Ledger.t
                                  * (Private_key.t option * Account.t) list
     -> ?gen_root_breadcrumb:Breadcrumb.t Quickcheck.Generator.t
@@ -109,6 +105,7 @@ module For_tests : sig
     -> ?verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
+    -> precomputed_values:Precomputed_values.t
     -> ?root_ledger_and_accounts:Ledger.t
                                  * (Private_key.t option * Account.t) list
     -> ?gen_root_breadcrumb:Breadcrumb.t Quickcheck.Generator.t

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -277,6 +277,8 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
 
     let logger = Logger.null ()
 
+    let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
+
     let trust_system = Trust_system.null ()
 
     let pids = Child_processes.Termination.create_pid_table ()
@@ -305,8 +307,9 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
             Verifier.create ~logger ~conf_dir:None ~pids )
       in
       Quickcheck.test ~trials:3
-        (Transition_frontier.For_tests.gen_with_branch ~verifier ~max_length
-           ~frontier_size:1 ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
+        (Transition_frontier.For_tests.gen_with_branch ~verifier
+           ~precomputed_values ~max_length ~frontier_size:1 ~branch_size:2 ())
+        ~f:(fun (frontier, branch) ->
           let catchup_job_reader, catchup_job_writer =
             Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
               (Buffered (`Capacity 10, `Overflow Crash))
@@ -358,8 +361,9 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
             Verifier.create ~logger ~conf_dir:None ~pids )
       in
       Quickcheck.test ~trials:3
-        (Transition_frontier.For_tests.gen_with_branch ~verifier ~max_length
-           ~frontier_size:1 ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
+        (Transition_frontier.For_tests.gen_with_branch ~verifier
+           ~precomputed_values ~max_length ~frontier_size:1 ~branch_size:2 ())
+        ~f:(fun (frontier, branch) ->
           let cache = Unprocessed_transition_cache.create ~logger in
           let register_breadcrumb breadcrumb =
             Unprocessed_transition_cache.register_exn cache
@@ -442,8 +446,9 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
             Verifier.create ~logger ~conf_dir:None ~pids )
       in
       Quickcheck.test ~trials:3
-        (Transition_frontier.For_tests.gen_with_branch ~verifier ~max_length
-           ~frontier_size:1 ~branch_size:5 ()) ~f:(fun (frontier, branch) ->
+        (Transition_frontier.For_tests.gen_with_branch ~verifier
+           ~precomputed_values ~max_length ~frontier_size:1 ~branch_size:5 ())
+        ~f:(fun (frontier, branch) ->
           let catchup_job_reader, catchup_job_writer =
             Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
               (Buffered (`Capacity 10, `Overflow Crash))

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -359,6 +359,8 @@ let%test_module "Transition_handler.Processor tests" =
 
     let logger = Logger.create ()
 
+    let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
+
     let time_controller = Block_time.Controller.basic ~logger
 
     let trust_system = Trust_system.null ()
@@ -377,8 +379,9 @@ let%test_module "Transition_handler.Processor tests" =
       let branch_size = 10 in
       let max_length = frontier_size + branch_size in
       Quickcheck.test ~trials:4
-        (Transition_frontier.For_tests.gen_with_branch ~max_length
-           ~frontier_size ~branch_size ()) ~f:(fun (frontier, branch) ->
+        (Transition_frontier.For_tests.gen_with_branch ~precomputed_values
+           ~max_length ~frontier_size ~branch_size ())
+        ~f:(fun (frontier, branch) ->
           assert (
             Thread_safe.block_on_async_exn (fun () ->
                 let pids = Child_processes.Termination.create_pid_table () in

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -142,8 +142,14 @@ module Duplicate_block_detector = struct
 end
 
 let run ~logger ~trust_system ~verifier ~transition_reader
-    ~valid_transition_writer ~initialization_finish_signal ~genesis_state_hash
-    ~genesis_constants =
+    ~valid_transition_writer ~initialization_finish_signal ~precomputed_values
+    =
+  let genesis_state_hash =
+    Precomputed_values.genesis_state_hash precomputed_values
+  in
+  let genesis_constants =
+    Precomputed_values.genesis_constants precomputed_values
+  in
   let open Deferred.Let_syntax in
   let duplicate_checker = Duplicate_block_detector.create () in
   don't_wait_for


### PR DESCRIPTION
This PR
* adds `Precomputed_values.t` (` = Genesis_proof.t`) to carry all of the precomputed values
* replaces uses of multiple precomputed values with a single `Precomputed_values.t`

This breaks out some work from #4769.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: