### PR TITLE
Lift versioned type out of snark pool, diff functors

### DIFF
--- a/src/lib/gossip_net/message.ml
+++ b/src/lib/gossip_net/message.ml
@@ -25,7 +25,7 @@ module V1 = struct
   module T = struct
     type msg = Master.T.msg =
       | New_state of External_transition.Stable.V1.t
-      | Snark_pool_diff of Snark_pool.Resource_pool.Diff.Stable.V1.t
+      | Snark_pool_diff of Snark_pool.Diff_versioned.Stable.V1.t
       | Transaction_pool_diff of
           Transaction_pool.Resource_pool.Diff.Stable.V1.t
     [@@deriving bin_io, sexp, version {rpc}]

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -150,6 +150,7 @@ module type Snark_resource_pool_intf = sig
   val make_config :
     trust_system:Trust_system.t -> verifier:Verifier.t -> Config.t
 
+  (* TODO: we don't seem to be using the bin_io here, can this type be removed? *)
   type serializable [@@deriving bin_io]
 
   val of_serializable : serializable -> config:Config.t -> logger:Logger.t -> t
@@ -186,20 +187,11 @@ end
 module type Snark_pool_diff_intf = sig
   type resource_pool
 
-  module Stable : sig
-    module V1 : sig
-      type t =
-        | Add_solved_work of
-            Transaction_snark_work.Statement.Stable.V1.t
-            * Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
-              Priced_proof.Stable.V1.t
-      [@@deriving bin_io, compare, sexp, to_yojson, version]
-    end
-
-    module Latest = V1
-  end
-
-  type t = Stable.Latest.t [@@deriving compare, sexp]
+  type t =
+    | Add_solved_work of
+        Transaction_snark_work.Statement.t
+        * Ledger_proof.t One_or_two.t Priced_proof.t
+  [@@deriving compare, sexp]
 
   include
     Resource_pool_diff_intf with type t := t and type pool := resource_pool

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -2,6 +2,42 @@ open Core_kernel
 open Async
 open Pipe_lib
 open Network_peer
+module Statement_table = Transaction_snark_work.Statement.Table
+
+module Snark_tables = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        { all:
+            Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
+            Priced_proof.Stable.V1.t
+            Transaction_snark_work.Statement.Stable.V1.Table.t
+              (** Every SNARK in the pool *)
+        ; rebroadcastable:
+            ( Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
+              Priced_proof.Stable.V1.t
+            * Core.Time.Stable.With_utc_sexp.V2.t )
+            Transaction_snark_work.Statement.Stable.V1.Table.t
+              (** Rebroadcastable SNARKs generated on this machine, along with
+                  when they were first added. *)
+        }
+      [@@deriving sexp]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  type t = Stable.Latest.t =
+    { all:
+        Ledger_proof.t One_or_two.t Priced_proof.t
+        Transaction_snark_work.Statement.Table.t
+    ; rebroadcastable:
+        ( Ledger_proof.t One_or_two.t Priced_proof.t
+        * Time.Stable.With_utc_sexp.V2.t )
+        Transaction_snark_work.Statement.Table.t }
+  [@@deriving sexp]
+end
 
 module type S = sig
   type transition_frontier
@@ -10,6 +46,7 @@ module type S = sig
     include
       Intf.Snark_resource_pool_intf
       with type transition_frontier := transition_frontier
+       and type serializable := Snark_tables.t
 
     val remove_solved_work : t -> Transaction_snark_work.Statement.t -> unit
 
@@ -66,27 +103,8 @@ end
 
 module Make (Transition_frontier : Transition_frontier_intf) :
   S with type transition_frontier := Transition_frontier.t = struct
-  module Statement_table = Transaction_snark_work.Statement.Stable.V1.Table
-
   module Resource_pool = struct
     module T = struct
-      (* TODO : Version this type *)
-      type serializable =
-        { all:
-            Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
-            Priced_proof.Stable.V1.t
-            Statement_table.t
-              (** Every SNARK in the pool *)
-        ; rebroadcastable:
-            ( Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
-              Priced_proof.Stable.V1.t
-            * Time.Stable.With_utc_sexp.V2.t )
-            Statement_table.t
-              (** Rebroadcastable SNARKs generated on this machine, along with
-                  when they were first added. *)
-        }
-      [@@deriving sexp, bin_io]
-
       module Config = struct
         type t =
           { trust_system: Trust_system.t sexp_opaque
@@ -98,7 +116,7 @@ module Make (Transition_frontier : Transition_frontier_intf) :
         int * int Transaction_snark_work.Statement.Table.t
 
       type t =
-        { snark_tables: serializable
+        { snark_tables: Snark_tables.t
         ; mutable ref_table: int Statement_table.t option
         ; config: Config.t
         ; logger: Logger.t sexp_opaque
@@ -106,6 +124,9 @@ module Make (Transition_frontier : Transition_frontier_intf) :
               (*A counter for transition frontier breadcrumbs removed. When this reaches a certain value, unreferenced snark work is removed from ref_table*)
         }
       [@@deriving sexp]
+
+      type serializable = Snark_tables.Stable.Latest.t
+      [@@deriving bin_io_unversioned]
 
       let make_config = Config.make
 
@@ -334,7 +355,7 @@ module Make (Transition_frontier : Transition_frontier_intf) :
               true ) ;
       Hashtbl.to_alist t.snark_tables.rebroadcastable
       |> List.map ~f:(fun (stmt, (snark, _time)) ->
-             Diff.Stable.Latest.Add_solved_work (stmt, snark) )
+             Diff.Add_solved_work (stmt, snark) )
 
     let remove_solved_work t work =
       Statement_table.remove t.snark_tables.all work ;
@@ -362,7 +383,7 @@ module Make (Transition_frontier : Transition_frontier_intf) :
     in
     match%map
       Async.Reader.load_bin_prot disk_location
-        Resource_pool.bin_reader_serializable
+        Snark_tables.Stable.Latest.bin_reader_t
     with
     | Ok snark_table ->
         let pool = Resource_pool.of_serializable snark_table ~config ~logger in
@@ -386,6 +407,28 @@ include Make (struct
     Extensions.(get_view_pipe (extensions t) Snark_pool_refcount)
 end)
 
+module Diff_versioned = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = Resource_pool.Diff.t =
+        | Add_solved_work of
+            Transaction_snark_work.Statement.Stable.V1.t
+            * Ledger_proof.Stable.V1.t One_or_two.Stable.V1.t
+              Priced_proof.Stable.V1.t
+      [@@deriving compare, sexp, to_yojson]
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  type t = Stable.Latest.t =
+    | Add_solved_work of
+        Transaction_snark_work.Statement.t
+        * Ledger_proof.t One_or_two.t Priced_proof.t
+  [@@deriving compare, sexp, to_yojson]
+end
+
 let%test_module "random set test" =
   ( module struct
     open Coda_base
@@ -401,7 +444,7 @@ let%test_module "random set test" =
         ?(proof = One_or_two.map ~f:mk_dummy_proof)
         ?(sender = Envelope.Sender.Local) fee =
       let diff =
-        Mock_snark_pool.Resource_pool.Diff.Stable.Latest.Add_solved_work
+        Mock_snark_pool.Resource_pool.Diff.Add_solved_work
           (work, {Priced_proof.Stable.Latest.proof= proof work; fee})
       in
       Mock_snark_pool.Resource_pool.Diff.unsafe_apply resource_pool
@@ -605,7 +648,7 @@ let%test_module "random set test" =
                 ; prover= Signature_lib.Public_key.Compressed.empty } }
           in
           let command =
-            Mock_snark_pool.Resource_pool.Diff.Stable.V1.Add_solved_work
+            Mock_snark_pool.Resource_pool.Diff.Add_solved_work
               (fake_work, priced_proof)
           in
           don't_wait_for
@@ -637,7 +680,7 @@ let%test_module "random set test" =
           in
           let per_reader = work_count / 2 in
           let create_work work =
-            Mock_snark_pool.Resource_pool.Diff.Stable.V1.Add_solved_work
+            Mock_snark_pool.Resource_pool.Diff.Add_solved_work
               ( work
               , Priced_proof.
                   { proof= One_or_two.map ~f:mk_dummy_proof work
@@ -686,8 +729,8 @@ let%test_module "random set test" =
                  ~f:(fun work_command ->
                    let work =
                      match work_command with
-                     | Mock_snark_pool.Resource_pool.Diff.Stable.V1
-                       .Add_solved_work (work, _) ->
+                     | Mock_snark_pool.Resource_pool.Diff.Add_solved_work
+                         (work, _) ->
                          work
                    in
                    assert (List.mem works work ~equal:( = )) ;

--- a/src/lib/network_pool/snark_pool.mli
+++ b/src/lib/network_pool/snark_pool.mli
@@ -111,5 +111,8 @@ module Diff_versioned : sig
     end
   end]
 
-  type t = Stable.Latest.t
+  type t = Stable.Latest.t =
+    | Add_solved_work of
+        Transaction_snark_work.Statement.t
+        * Ledger_proof.t One_or_two.t Priced_proof.t
 end

--- a/src/lib/network_pool/test.ml
+++ b/src/lib/network_pool/test.ml
@@ -48,7 +48,7 @@ let%test_module "network pool test" =
               ~frontier_broadcast_pipe:frontier_broadcast_pipe_r
           in
           let command =
-            Mock_snark_pool.Resource_pool.Diff.Stable.V1.Add_solved_work
+            Mock_snark_pool.Resource_pool.Diff.Add_solved_work
               (work, priced_proof)
           in
           don't_wait_for
@@ -76,7 +76,7 @@ let%test_module "network pool test" =
       in
       let per_reader = work_count / 2 in
       let create_work work =
-        Mock_snark_pool.Resource_pool.Diff.Stable.V1.Add_solved_work
+        Mock_snark_pool.Resource_pool.Diff.Add_solved_work
           ( work
           , Priced_proof.
               { proof=
@@ -121,8 +121,8 @@ let%test_module "network pool test" =
              ~f:(fun work_command ->
                let work =
                  match work_command with
-                 | Mock_snark_pool.Resource_pool.Diff.Stable.V1.Add_solved_work
-                     (work, _) ->
+                 | Mock_snark_pool.Resource_pool.Diff.Add_solved_work (work, _)
+                   ->
                      work
                in
                assert (List.mem works work ~equal:( = )) ;

--- a/src/lib/ppx_coda/versioned_type.ml
+++ b/src/lib/ppx_coda/versioned_type.ml
@@ -272,25 +272,26 @@ let ocaml_builtin_type_constructors = ["list"; "array"; "option"; "ref"]
 
 let jane_street_type_constructors = ["sexp_opaque"]
 
+let is_version_module vn =
+  let len = String.length vn in
+  len > 1
+  && Char.equal vn.[0] 'V'
+  &&
+  let numeric_part = String.sub vn ~pos:1 ~len:(len - 1) in
+  String.for_all numeric_part ~f:Char.is_digit
+  && not (Int.equal (Char.get_digit_exn numeric_part.[0]) 0)
+
 (* true iff module_path is of form M. ... .Stable.Vn, where M is Core or Core_kernel, and n is integer *)
 let is_jane_street_stable_module module_path =
   let hd_elt = List.hd_exn module_path in
-  let is_version_module vn =
-    let len = String.length vn in
-    len > 1
-    && Char.equal vn.[0] 'V'
-    &&
-    let numeric_part = String.sub vn ~pos:1 ~len:(len - 1) in
-    String.for_all numeric_part ~f:Char.is_digit
-    && not (Int.equal (Char.get_digit_exn numeric_part.[0]) 0)
-  in
   List.mem jane_street_modules hd_elt ~equal:String.equal
   &&
   match List.rev module_path with
   | vn :: "Stable" :: _ ->
       is_version_module vn
-  | vn :: "Span" :: "Stable" :: "Time" :: _ ->
-      (* special case, maybe improper module structure *)
+  | vn :: label :: "Stable" :: "Time" :: _
+    when List.mem ["Span"; "With_utc_sexp"] label ~equal:String.equal ->
+      (* special cases, maybe improper module structure *)
       is_version_module vn
   | _ ->
       false
@@ -372,8 +373,24 @@ let rec generate_core_type_version_decls type_name core_type =
         else
           let loc = core_type.ptyp_loc in
           let pexp_loc = loc in
+          let new_prefix =
+            (* allow types within stable-versioned modules generated
+               by Hashable.Make_binable, like M.Stable.Vn.Table.t;
+               generate "let _ = M.Stable.Vn.__versioned__"
+            *)
+            match prefix with
+            | Ldot ((Ldot (_, vn) as longident), label)
+              when is_version_module vn
+                   && List.mem
+                        ["Table"; "Hash_set"; "Hash_queue"]
+                        label ~equal:String.equal ->
+                longident
+            | _ ->
+                prefix
+          in
           let versioned_ident =
-            { pexp_desc= Pexp_ident {txt= Ldot (prefix, "__versioned__"); loc}
+            { pexp_desc=
+                Pexp_ident {txt= Ldot (new_prefix, "__versioned__"); loc}
             ; pexp_loc
             ; pexp_attributes= [] }
           in

--- a/src/lib/transaction_snark_work/transaction_snark_work.ml
+++ b/src/lib/transaction_snark_work/transaction_snark_work.ml
@@ -1,34 +1,34 @@
 open Core_kernel
-open Module_version
 open Currency
 open Signature_lib
 
 module Statement = struct
-  module Stable = struct
-    module V1 = struct
-      module T = struct
+  module Arg = struct
+    [%%versioned
+    module Stable = struct
+      module V1 = struct
         type t = Transaction_snark.Statement.Stable.V1.t One_or_two.Stable.V1.t
-        [@@deriving eq, bin_io, compare, hash, sexp, version, yojson]
+        [@@deriving hash, sexp, compare]
+
+        let to_latest = Fn.id
       end
-
-      include T
-      include Registration.Make_latest_version (T)
-      include Hashable.Make_binable (T)
-    end
-
-    module Latest = V1
-
-    module Module_decl = struct
-      let name = "transaction_snark_work_statement"
-
-      type latest = Latest.t
-    end
-
-    module Registrar = Registration.Make (Module_decl)
-    module Registered_V1 = Registrar.Register (V1)
+    end]
   end
 
-  (* bin_io omitted *)
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = Transaction_snark.Statement.Stable.V1.t One_or_two.Stable.V1.t
+      [@@deriving eq, compare, hash, sexp, yojson]
+
+      let to_latest = Fn.id
+
+      type _unused = unit constraint t = Arg.Stable.V1.t
+
+      include Hashable.Make_binable (Arg.Stable.V1)
+    end
+  end]
+
   type t = Stable.Latest.t [@@deriving sexp, hash, compare, yojson, eq]
 
   include Hashable.Make (Stable.Latest)


### PR DESCRIPTION
Lift versioned types out of `Snark_pool.Make` and `Snark_pool_diff.Make`.

Substituted `%%versioned` for the registration functor in `Transaction_snark_work`.

Change: `ppx_coda` considers `Foo.Stable.V1.{Table,Hash_set,Hash_queue}.t` to be versioned types. Such types are created by `Hashable.Make_binable`. Essentially, this is more whitelisting of Jane St types, though we don't have absolute guarantees they won't change.

