### PR TITLE
Client side validation for invalid delegation transaction fee 

### DIFF
--- a/frontend/wallet/src/render/views/settings/DelegationSettings.re
+++ b/frontend/wallet/src/render/views/settings/DelegationSettings.re
@@ -90,22 +90,11 @@ let make = (~publicKey) => {
 
   let renderError = () => {
     switch (state.error) {
-    | Some(EmptyDelegateKey) =>
-      <>
-        <Alert kind=`Danger defaultMessage="Please enter a public key" />
-        <Spacer height=2. />
-      </>
+    | Some(EmptyDelegateKey) => Some("Please enter a public key")
     | Some(InvalidTransactionFee) =>
-      <>
-        <Alert
-          kind=`Danger
-          defaultMessage={"The minimum transaction fee is " ++ minimumFee}
-        />
-        <Spacer height=2. />
-      </>
-    | Some(InvalidGraphQLResponse(error)) =>
-      <> <Alert kind=`Danger defaultMessage=error /> <Spacer height=2. /> </>
-    | None => React.null
+      Some("The minimum transaction fee is " ++ minimumFee)
+    | Some(InvalidGraphQLResponse(error)) => Some(error)
+    | None => None
     };
   };
 
@@ -155,7 +144,14 @@ let make = (~publicKey) => {
            <Spacer width=0.2 />
            <AccountName pubkey=publicKey className=Styles.breadcrumbText />
          </div>
-         {renderError()}
+         {switch (renderError()) {
+          | Some(errorMessage) =>
+            <>
+              <Alert kind=`Danger defaultMessage=errorMessage />
+              <Spacer height=2. />
+            </>
+          | None => React.null
+          }}
          <div className=Theme.Text.Header.h3>
            {React.string("Delegate Participation To")}
          </div>


### PR DESCRIPTION
Added client-side validation for the delegate transaction fee. Currently, the delegation goes through if the transaction fee is invalid. Added validation for checking if the transaction fee is empty or below the minimum fee (0.00001). 

Tested by manual testing. Attempted the following:
- Empty transaction fee -> User Error
- Transaction fee that is below the minimum -> User Error
- Malformed transaction fee ->User Error
- Correct transaction fee but invalid delegate key -> User Error
- Correct delegate key and valid transaction fee -> Delegation goes through

Screenshots:
**Zero Transaction Fee**
![image](https://user-images.githubusercontent.com/9512405/80827422-c84cfd00-8b98-11ea-87e4-a34f8a5239b8.png)

**Transaction fee below minimum**
![image](https://user-images.githubusercontent.com/9512405/80827448-d6028280-8b98-11ea-8483-157528b8e54c.png)

**Empty transaction fee**
![image](https://user-images.githubusercontent.com/9512405/80827715-13671000-8b99-11ea-8dbe-02f10190b8bc.png)


Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)