### PR TITLE
BuildKite jobs in Docker

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -1,5 +1,5 @@
 # Builds all dhall entrypoints
 check:
-	dhall --file "./src/Prepare.dhall"
-	dhall --file "./src/Monorepo.dhall"
-	bash -c 'for f in ./src/Jobs/**/Pipeline.dhall; do dhall --file $$f; done'
+	dhall --file './src/Prepare.dhall'
+	dhall --file './src/Monorepo.dhall'
+	for f in ./src/Jobs/**/Pipeline.dhall; do dhall --file $$f; done

--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -1,5 +1,5 @@
 # Builds all dhall entrypoints
 check:
-	dhall <<< './src/Prepare.dhall'
-	dhall <<< './src/Monorepo.dhall'
-	for f in ./src/Jobs/**/Pipeline.dhall; do dhall --file $$f; done
+	dhall --file "./src/Prepare.dhall"
+	dhall --file "./src/Monorepo.dhall"
+	bash -c 'for f in ./src/Jobs/**/Pipeline.dhall; do dhall --file $$f; done'

--- a/.buildkite/agent.nix
+++ b/.buildkite/agent.nix
@@ -1,19 +1,80 @@
-# Minimal nix shell config for running local agents for testing purposes
+# Minimal nix config for describing agent deps
 #
-# Usage:
+# To generate a local environment to test your scripts or to run an agent (for
+# example):
 #
-# nix-shell agent.nix
-# buildkite-agent start --tags size=small --token <TOKEN> --build-path ~/buildkite
+#   nix-shell shell.nix # optionally add --pure to _only_ use these packages
+#   buildkite-agent start --tags size=small --token <TOKEN> --build-path ~/buildkite
 #
 # Replace `tags` with anything relevant and token with the buildkite token for O(1) Labs
+#
+#
+# To generate a docker image:
+#
+# Make sure you're in a linux environment with nix installed (not macOS), and pointing to the nixpkgs-unstable channel:
+# For example:
+#
+#   docker run -v $PWD:/workdir -it nixos/nix
+#   nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+#   nix-channel --update
+#   cd /workdir
+#
+# Then build the docker image:
+#
+#   nix-build docker.nix
+#
+# Finally, copy the built image to your host OS (if necessary) and load it:
+#
+#   docker cp <CONTAINER ID>:<PATH TO BUILT IMAGE> image.tar.gz
+#   docker load < image.tar.gz
+#
+# You will now see:
+#
+#   docker images
+#   # codaprotocol/ci-toolchain-base, latest, ...
+#
+# If you'd like you can push it up:
+#
+#   docker push codaprotocol/ci-toolchain-base:latest
+#
 
 { pkgs ? import <nixpkgs> {} }:
-  pkgs.mkShell {
-    buildInputs = [ pkgs.buildkite-agent pkgs.dhall pkgs.dhall-json ];
-    shellHook = ''
-      mkdir -p ~/buildkite
-      export GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
-      export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-    '';
-}
+
+# Stick deps in here
+let deps = with pkgs; [
+  # buildkite
+  buildkite-agent
+
+  # dhall
+  dhall
+  dhall-json
+
+  # shell stuff
+  bash
+  git
+  coreutils
+  gnused
+  gnugrep
+  findutils
+  diffutils
+  gnumake
+  ];
+in
+{
+  shell =
+    pkgs.mkShell {
+      buildInputs = deps;
+      shellHook = ''
+        mkdir -p ~/buildkite
+        export GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt
+        export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+      '';
+    };
+  docker =
+    pkgs.dockerTools.buildLayeredImage {
+      name = "codaprotocol/ci-toolchain-base";
+      tag = "latest";
+      contents = deps;
+    };
+  }
 

--- a/.buildkite/agent.nix
+++ b/.buildkite/agent.nix
@@ -80,6 +80,7 @@ let
       mkdir -p $out/.cache
       export XDG_CACHE_HOME=$out/.cache
       make check
+      chmod -R 766 $out/.cache
     '';
     installPhase = "echo 'skip'";
   };

--- a/.buildkite/agent.nix
+++ b/.buildkite/agent.nix
@@ -77,10 +77,10 @@ let
     src = ./.;
     buildInputs = [ pkgs.dhall ];
     buildPhase = ''
-      mkdir -p $out/.cache
-      export XDG_CACHE_HOME=$out/.cache
+      #!${pkgs.runtimeShell}
+      mkdir -p $out/cache
+      export XDG_CACHE_HOME=$out/cache
       make check
-      chmod -R 766 $out/.cache
     '';
     installPhase = "echo 'skip'";
   };

--- a/.buildkite/agent.nix
+++ b/.buildkite/agent.nix
@@ -78,8 +78,8 @@ let
     buildInputs = [ pkgs.dhall ];
     buildPhase = ''
       #!${pkgs.runtimeShell}
-      mkdir -p $out/cache
-      export XDG_CACHE_HOME=$out/cache
+      mkdir -p $out/.cache
+      export XDG_CACHE_HOME=$out/.cache
       make check
     '';
     installPhase = "echo 'skip'";

--- a/.buildkite/agent.nix
+++ b/.buildkite/agent.nix
@@ -68,6 +68,22 @@ let
     gnumake
   ];
 in
+  # little nix derivation that caches dhall
+  # Note: `make check` runs in the buildPhase to make sure to fully
+  #      populate the dhall cache
+let
+  dhallCache = pkgs.stdenv.mkDerivation {
+    name = "dhall-ci-cache-0.0.1";
+    src = ./.;
+    buildInputs = [ pkgs.dhall ];
+    buildPhase = ''
+      mkdir -p $out/.cache
+      export XDG_CACHE_HOME=$out/.cache
+      make check
+    '';
+    installPhase = "echo 'skip'";
+  };
+in
 {
   shell =
     pkgs.mkShell {
@@ -82,6 +98,6 @@ in
     pkgs.dockerTools.buildLayeredImage {
       name = "codaprotocol/ci-toolchain-base";
       tag = "latest";
-      contents = deps;
+      contents = deps ++ [ dhallCache ];
     };
 }

--- a/.buildkite/agent.nix
+++ b/.buildkite/agent.nix
@@ -23,9 +23,13 @@
 #
 #   nix-build docker.nix
 #
+# Note: The first built has to download things, but subsequent builds will cache
+# hit no matter the order of the packages in the below array.
+#
 # Finally, copy the built image to your host OS (if necessary) and load it:
 #
-#   docker cp <CONTAINER ID>:<PATH TO BUILT IMAGE> image.tar.gz
+#   export CONTAINER_ID=$(docker ps | grep nixos | awk '{ print $1 }')
+#   docker cp ${CONTAINER_ID}:<PATH TO BUILT IMAGE> image.tar.gz
 #   docker load < image.tar.gz
 #
 # You will now see:
@@ -41,23 +45,27 @@
 { pkgs ? import <nixpkgs> {} }:
 
 # Stick deps in here
-let deps = with pkgs; [
-  # buildkite
-  buildkite-agent
+let
+  deps = with pkgs; [
+    # buildkite
+    buildkite-agent
 
-  # dhall
-  dhall
-  dhall-json
+    # ssl
+    cacert
 
-  # shell stuff
-  bash
-  git
-  coreutils
-  gnused
-  gnugrep
-  findutils
-  diffutils
-  gnumake
+    # dhall
+    dhall
+    dhall-json
+
+    # shell stuff
+    bash
+    git
+    coreutils
+    gnused
+    gnugrep
+    findutils
+    diffutils
+    gnumake
   ];
 in
 {
@@ -76,5 +84,4 @@ in
       tag = "latest";
       contents = deps;
     };
-  }
-
+}

--- a/.buildkite/docker.nix
+++ b/.buildkite/docker.nix
@@ -1,0 +1,1 @@
+(import ./agent.nix {}).docker

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,0 +1,1 @@
+git fetch origin

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,3 +1,13 @@
+# Freshen the remote so that our diff is accurate
 git fetch origin
 ./.buildkite/scripts/generate-diff.sh > $computed_diff.txt
+
+#
+# TODO: Remove this when we figure out where to stick this cache long term
+#
+# Docker volumes by default are created if they do not exist, but there is not
+# an easy way to set the uid/guid or permissions on the volume. Since we intend
+# on running our agent containers without root, we need to fix the volume first.
+#
+docker run -v dhall-cache:/.cache -it nixos/nix sh -c 'chmod 777 .cache'
 

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -2,12 +2,3 @@
 git fetch origin
 ./.buildkite/scripts/generate-diff.sh > $computed_diff.txt
 
-#
-# TODO: Remove this when we figure out where to stick this cache long term
-#
-# Docker volumes by default are created if they do not exist, but there is not
-# an easy way to set the uid/guid or permissions on the volume. Since we intend
-# on running our agent containers without root, we need to fix the volume first.
-#
-docker run -v dhall-cache:/.cache -it nixos/nix sh -c 'chmod 777 .cache'
-

--- a/.buildkite/hooks/post-checkout
+++ b/.buildkite/hooks/post-checkout
@@ -1,1 +1,3 @@
 git fetch origin
+./.buildkite/scripts/generate-diff.sh > $computed_diff.txt
+

--- a/.buildkite/shell.nix
+++ b/.buildkite/shell.nix
@@ -1,0 +1,1 @@
+(import ./agent.nix {}).shell

--- a/.buildkite/src/Constants/ContainerImages.dhall
+++ b/.buildkite/src/Constants/ContainerImages.dhall
@@ -1,0 +1,5 @@
+-- TODO: Automatically push, tag, and update images #4862
+
+{
+  toolchainBase = "codaprotocol/ci-toolchain-base:v1"
+}

--- a/.buildkite/src/Lib/Command.dhall
+++ b/.buildkite/src/Lib/Command.dhall
@@ -62,15 +62,8 @@ let targetToAgent = \(target : Size) ->
         }
         target
 
--- /cache is read-only for the uid/gid we run our steps in. We fix the
--- permissions by copying it to our work directory, fixing perms, and redirects
--- all cache accesses here instead.
--- This command adds no observable overhead to build steps.
-let fixCacheCommand = "cp -r /cache .cache && chmod -R 766 .cache && export XDG_CACHE_HOME=\$PWD/.cache"
-
 let build : Config.Type -> Result.Type = \(c : Config.Type) ->
   Config.upcast c // {
-    command = [ fixCacheCommand ] # c.command,
     depends_on = if Prelude.List.null Text c.depends_on then None (List Text) else Some c.depends_on,
     agents =
       let agents = targetToAgent c.target in

--- a/.buildkite/src/Lib/Command.dhall
+++ b/.buildkite/src/Lib/Command.dhall
@@ -57,8 +57,8 @@ let Result =
 in
 
 let targetToAgent = \(target : Size) ->
-  merge { Large = [ { mapKey = "size", mapValue = "large" } ],
-          Small = [ { mapKey = "size", mapValue = "small" } ]
+  merge { Large = toMap { size = "large" },
+          Small = toMap { size = "size" }
         }
         target
 
@@ -69,9 +69,7 @@ let build : Config.Type -> Result.Type = \(c : Config.Type) ->
       let agents = targetToAgent c.target in
       if Prelude.List.null (Map.Entry Text Text) agents then None (Map.Type Text Text) else Some agents,
     plugins =
-      [ { mapKey = "docker#v3.5.0"
-      , mapValue = Docker.build c.docker
-      } ]
+      toMap { `docker#v3.5.0` = Docker.build c.docker }
   }
 
 in {Config = Config, build = build} /\ Result

--- a/.buildkite/src/Lib/Command.dhall
+++ b/.buildkite/src/Lib/Command.dhall
@@ -58,7 +58,7 @@ in
 
 let targetToAgent = \(target : Size) ->
   merge { Large = toMap { size = "large" },
-          Small = toMap { size = "size" }
+          Small = toMap { size = "small" }
         }
         target
 

--- a/.buildkite/src/Lib/Command.dhall
+++ b/.buildkite/src/Lib/Command.dhall
@@ -3,6 +3,7 @@
 let Prelude = ../External/Prelude.dhall
 let Map = Prelude.Map
 
+let Docker = ./Docker.dhall
 let Size = ./Size.dhall
 
 let Shared =
@@ -25,6 +26,7 @@ let Config =
     let Typ = Shared.Type //\\
         { target : Size
         , depends_on : List Text
+        , docker : Docker.Config.Type
         }
     let upcast : Typ -> Shared.Type =
       \(c : Typ) -> Shared::{
@@ -46,6 +48,7 @@ let Result =
   { Type = Shared.Type //\\
     { agents : Optional (Map.Type Text Text)
     , depends_on : Optional (List Text)
+    , plugins : Map.Type Text Docker.Type
     }
   , default = Shared.default /\ {
       depends_on = None (List Text)
@@ -64,7 +67,11 @@ let build : Config.Type -> Result.Type = \(c : Config.Type) ->
     depends_on = if Prelude.List.null Text c.depends_on then None (List Text) else Some c.depends_on,
     agents =
       let agents = targetToAgent c.target in
-      if Prelude.List.null (Map.Entry Text Text) agents then None (Map.Type Text Text) else Some agents
+      if Prelude.List.null (Map.Entry Text Text) agents then None (Map.Type Text Text) else Some agents,
+    plugins =
+      [ { mapKey = "docker#v3.5.0"
+      , mapValue = Docker.build c.docker
+      } ]
   }
 
 in {Config = Config, build = build} /\ Result

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -25,7 +25,7 @@ let Result = {
     `propagate-uid-gid` = True,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
     volumes = [
-      "dhall-cache:/.cache",
+      "dhall-cache:/.cache"
     ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -17,16 +17,12 @@ let Result = {
      image: Text,
      `propagate-environment`: Bool,
      `propagate-uid-gid`: Bool,
-     environment: List Text,
-     volumes: List Text
+     environment: List Text
   },
   default = {
     `propagate-environment` = True,
     `propagate-uid-gid` = True,
-    environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
-    volumes = [
-      "dhall-cache:/.cache:rw"
-    ]
+    environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ]
   }
 }
 

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -2,6 +2,8 @@
 --
 -- See https://github.com/buildkite-plugins/docker-buildkite-plugin for options
 -- if you'd like to extend this definition for example
+--
+-- TODO: Move volume to something in the cloud or artifacts from gcloud storage
 
 let Config = {
   Type = {
@@ -23,8 +25,7 @@ let Result = {
     `propagate-uid-gid` = True,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
     volumes = [
-      "/Users/bkase/.cache/dhall:/.cache/dhall",
-      "/Users/bkase/.cache/dhall-haskell:/.cache/dhall-haskell"
+      "dhall-cache:/.cache",
     ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -17,11 +17,13 @@ let Result = {
      image: Text,
      `propagate-environment`: Bool,
      `propagate-uid-gid`: Bool,
+     `mount-buildkite-agent`: Bool,
      environment: List Text
   },
   default = {
     `propagate-environment` = True,
     `propagate-uid-gid` = True,
+    `mount-buildkite-agent` = True,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -16,13 +16,11 @@ let Result = {
   Type = {
      image: Text,
      `propagate-environment`: Bool,
-     `propagate-uid-gid`: Bool,
      `mount-buildkite-agent`: Bool,
      environment: List Text
   },
   default = {
     `propagate-environment` = True,
-    `propagate-uid-gid` = True,
     `mount-buildkite-agent` = False,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ]
   }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -23,8 +23,8 @@ let Result = {
     `propagate-uid-gid` = True,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
     volumes = [
-      (env:HOME as Text) ++ "/.cache/dhall:/.cache/dhall",
-      (env:HOME as Text) ++ "/.cache/dhall-haskell:/.cache/dhall-haskell"
+      "/Users/bkase/.cache/dhall:/.cache/dhall",
+      "/Users/bkase/.cache/dhall-haskell:/.cache/dhall-haskell"
     ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -23,8 +23,8 @@ let Result = {
     `propagate-uid-gid` = True,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
     volumes = [
-      "~/.cache/dhall:~/.cache/dhall",
-      "~/.cache/dhall-haskell:~/.cache/dhall-haskell"
+      "~/.cache/dhall:/.cache/dhall",
+      "~/.cache/dhall-haskell:/.cache/dhall-haskell"
     ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -1,0 +1,31 @@
+-- Docker plugin specific settings for commands
+--
+-- See https://github.com/buildkite-plugins/docker-buildkite-plugin for options
+-- if you'd like to extend this definition for example
+
+let Config = {
+  Type = {
+    image: Text
+  },
+  default = {=}
+}
+
+let Result = {
+  Type = {
+     image: Text,
+     `propagate-environment`: Bool,
+     `propagate-uid-gid`: Bool
+  },
+  default = {
+    `propagate-environment` = True,
+    `propagate-uid-gid` = True
+  }
+}
+
+let build : Config.Type -> Result.Type = \(c: Config.Type) ->
+  Result::{ image = c.image }
+
+in
+
+{Config = Config, build = build } /\ Result
+

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -23,8 +23,8 @@ let Result = {
     `propagate-uid-gid` = True,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
     volumes = [
-      "~/.cache/dhall:/.cache/dhall",
-      "~/.cache/dhall-haskell:/.cache/dhall-haskell"
+      (env:HOME as Text) ++ "/.cache/dhall:/.cache/dhall",
+      (env:HOME as Text) ++ "/.cache/dhall-haskell:/.cache/dhall-haskell"
     ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -15,12 +15,17 @@ let Result = {
      image: Text,
      `propagate-environment`: Bool,
      `propagate-uid-gid`: Bool,
-     environment: List Text
+     environment: List Text,
+     volumes: List Text
   },
   default = {
     `propagate-environment` = True,
     `propagate-uid-gid` = True,
-    environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ]
+    environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
+    volumes = [
+      "~/.cache/dhall:~/.cache/dhall",
+      "~/.cache/dhall-haskell:~/.cache/dhall-haskell"
+    ]
   }
 }
 

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -25,7 +25,7 @@ let Result = {
     `propagate-uid-gid` = True,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ],
     volumes = [
-      "dhall-cache:/.cache"
+      "dhall-cache:/.cache:rw"
     ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -23,7 +23,7 @@ let Result = {
   default = {
     `propagate-environment` = True,
     `propagate-uid-gid` = True,
-    `mount-buildkite-agent` = True,
+    `mount-buildkite-agent` = False,
     environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ]
   }
 }

--- a/.buildkite/src/Lib/Docker.dhall
+++ b/.buildkite/src/Lib/Docker.dhall
@@ -14,11 +14,13 @@ let Result = {
   Type = {
      image: Text,
      `propagate-environment`: Bool,
-     `propagate-uid-gid`: Bool
+     `propagate-uid-gid`: Bool,
+     environment: List Text
   },
   default = {
     `propagate-environment` = True,
-    `propagate-uid-gid` = True
+    `propagate-uid-gid` = True,
+    environment = [ "BUILDKITE_AGENT_ACCESS_TOKEN" ]
   }
 }
 

--- a/.buildkite/src/Monorepo.dhall
+++ b/.buildkite/src/Monorepo.dhall
@@ -37,7 +37,7 @@ in Pipeline.build Pipeline.Config::{
       label = "Monorepo triage",
       key = "cmds",
       target = Size.Small,
-      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json/gnugrep" }
+      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json/gnugrep/gnused/diffutils" }
     }
   ]
 }

--- a/.buildkite/src/Monorepo.dhall
+++ b/.buildkite/src/Monorepo.dhall
@@ -34,7 +34,7 @@ in Pipeline.build Pipeline.Config::{
       label = "Monorepo triage",
       key = "cmds",
       target = Size.Small,
-      docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
+      docker = Docker.Config::{ image = (./Constants/ContainerImages.dhall).toolchainBase }
     }
   ]
 }

--- a/.buildkite/src/Monorepo.dhall
+++ b/.buildkite/src/Monorepo.dhall
@@ -9,16 +9,13 @@ let triggerCommand = ./Lib/TriggerCommand.dhall
 
 let jobs : List JobSpec.Type = ./gen/Jobs.dhall
 
--- precompute the diffed files as this command takes a few seconds to run
-let prepareCommand = "./.buildkite/scripts/generate-diff.sh > computed_diff.txt"
-
 -- Run a job if we touched a dirty path
 let makeCommand = \(job : JobSpec.Type) ->
   let trigger = triggerCommand "src/jobs/${job.name}/Pipeline.dhall"
   in ''
-    if cat computed_diff.txt | egrep -q '${job.dirtyWhen}'; then
+    if cat $computed_diff.txt | egrep -q '${job.dirtyWhen}'; then
         echo "Triggering ${job.name} for reason:"
-        cat computed_diff.txt | egrep '${job.dirtyWhen}'
+        cat $computed_diff.txt | egrep '${job.dirtyWhen}'
         ${trigger}
     fi
   ''
@@ -33,7 +30,7 @@ in Pipeline.build Pipeline.Config::{
   },
   steps = [
     Command.Config::{
-      command = [ prepareCommand ] # commands,
+      command = commands,
       label = "Monorepo triage",
       key = "cmds",
       target = Size.Small,

--- a/.buildkite/src/Monorepo.dhall
+++ b/.buildkite/src/Monorepo.dhall
@@ -10,7 +10,7 @@ let triggerCommand = ./Lib/TriggerCommand.dhall
 let jobs : List JobSpec.Type = ./gen/Jobs.dhall
 
 -- precompute the diffed files as this command takes a few seconds to run
-let prepareCommand = "git fetch origin && ./.buildkite/scripts/generate-diff.sh > computed_diff.txt"
+let prepareCommand = "./.buildkite/scripts/generate-diff.sh > computed_diff.txt"
 
 -- Run a job if we touched a dirty path
 let makeCommand = \(job : JobSpec.Type) ->

--- a/.buildkite/src/Monorepo.dhall
+++ b/.buildkite/src/Monorepo.dhall
@@ -1,6 +1,7 @@
 let Prelude = ./External/Prelude.dhall
 
 let Command = ./Lib/Command.dhall
+let Docker = ./Lib/Docker.dhall
 let JobSpec = ./Lib/JobSpec.dhall
 let Pipeline = ./Lib/Pipeline.dhall
 let Size = ./Lib/Size.dhall
@@ -35,7 +36,8 @@ in Pipeline.build Pipeline.Config::{
       command = [ prepareCommand ] # commands,
       label = "Monorepo triage",
       key = "cmds",
-      target = Size.Small
+      target = Size.Small,
+      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json" }
     }
   ]
 }

--- a/.buildkite/src/Monorepo.dhall
+++ b/.buildkite/src/Monorepo.dhall
@@ -37,7 +37,7 @@ in Pipeline.build Pipeline.Config::{
       label = "Monorepo triage",
       key = "cmds",
       target = Size.Small,
-      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json" }
+      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json/gnugrep" }
     }
   ]
 }

--- a/.buildkite/src/Monorepo.dhall
+++ b/.buildkite/src/Monorepo.dhall
@@ -34,7 +34,7 @@ in Pipeline.build Pipeline.Config::{
       label = "Monorepo triage",
       key = "cmds",
       target = Size.Small,
-      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json/gnugrep/gnused/diffutils" }
+      docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
     }
   ]
 }

--- a/.buildkite/src/Prepare.dhall
+++ b/.buildkite/src/Prepare.dhall
@@ -23,7 +23,7 @@ let config : Pipeline.Config.Type = Pipeline.Config::{
       label = "Prepare monorepo triage",
       key = "monorepo",
       target = Size.Small,
-      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json" }
+      docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
     }
   ]
 }

--- a/.buildkite/src/Prepare.dhall
+++ b/.buildkite/src/Prepare.dhall
@@ -23,7 +23,7 @@ let config : Pipeline.Config.Type = Pipeline.Config::{
       label = "Prepare monorepo triage",
       key = "monorepo",
       target = Size.Small,
-      docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
+      docker = Docker.Config::{ image = (./Constants/ContainerImages.dhall).toolchainBase }
     }
   ]
 }

--- a/.buildkite/src/Prepare.dhall
+++ b/.buildkite/src/Prepare.dhall
@@ -2,6 +2,7 @@
 -- Keep these rules lean! They have to run unconditionally.
 
 let Command = ./Lib/Command.dhall
+let Docker = ./Lib/Docker.dhall
 let JobSpec = ./Lib/JobSpec.dhall
 let Pipeline = ./Lib/Pipeline.dhall
 let Size = ./Lib/Size.dhall
@@ -21,7 +22,8 @@ let config : Pipeline.Config.Type = Pipeline.Config::{
       ],
       label = "Prepare monorepo triage",
       key = "monorepo",
-      target = Size.Small
+      target = Size.Small,
+      docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent/dhall/dhall-json" }
     }
   ]
 }

--- a/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
+++ b/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
@@ -10,7 +10,7 @@ Pipeline.build
     spec = ./Spec.dhall,
     steps = [
       Command.Config::{ command = [ "cd .buildkite && make check" ], label = "Check all CI Dhall entrypoints", key = "check", target = Size.Small,
-      docker = Docker.Config::{ image = "localhost:8080/bash/git/buildkite-agent/coreutils/dhall/gnumake" }
+      docker = Docker.Config::{ image = "localhost:8080/bash/git/buildkite-agent/coreutils/dhall/gnumake/findutils" }
       }
     ]
   }

--- a/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
+++ b/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
@@ -9,8 +9,12 @@ Pipeline.build
   Pipeline.Config::{
     spec = ./Spec.dhall,
     steps = [
-      Command.Config::{ command = [ "cd .buildkite && make check" ], label = "Check all CI Dhall entrypoints", key = "check", target = Size.Small,
-      docker = Docker.Config::{ image = "localhost:8080/bash/git/buildkite-agent/coreutils/dhall/gnumake/findutils" }
+      Command.Config::{
+        command = [ "cd .buildkite && make check" ],
+        label = "Check all CI Dhall entrypoints",
+        key = "check",
+        target = Size.Small,
+        docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
       }
     ]
   }

--- a/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
+++ b/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
@@ -10,7 +10,7 @@ Pipeline.build
     spec = ./Spec.dhall,
     steps = [
       Command.Config::{ command = [ "cd .buildkite && make check" ], label = "Check all CI Dhall entrypoints", key = "check", target = Size.Small,
-      docker = Docker.Config::{ image = "localhost:8080/bash/git/buildkite-agent/coreutils/dhall" }
+      docker = Docker.Config::{ image = "localhost:8080/bash/git/buildkite-agent/coreutils/dhall/gnumake" }
       }
     ]
   }

--- a/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
+++ b/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
@@ -14,7 +14,7 @@ Pipeline.build
         label = "Check all CI Dhall entrypoints",
         key = "check",
         target = Size.Small,
-        docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
+        docker = Docker.Config::{ image = (../../Constants/ContainerImages.dhall).toolchainBase }
       }
     ]
   }

--- a/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
+++ b/.buildkite/src/jobs/CheckDhall/Pipeline.dhall
@@ -1,5 +1,6 @@
 let Pipeline = ../../Lib/Pipeline.dhall
 let Command = ../../Lib/Command.dhall
+let Docker = ../../Lib/Docker.dhall
 let Size = ../../Lib/Size.dhall
 
 in
@@ -8,6 +9,8 @@ Pipeline.build
   Pipeline.Config::{
     spec = ./Spec.dhall,
     steps = [
-      Command.Config::{ command = [ "cd .buildkite && make check" ], label = "Check all CI Dhall entrypoints", key = "check", target = Size.Small }
+      Command.Config::{ command = [ "cd .buildkite && make check" ], label = "Check all CI Dhall entrypoints", key = "check", target = Size.Small,
+      docker = Docker.Config::{ image = "localhost:8080/bash/git/buildkite-agent/coreutils/dhall" }
+      }
     ]
   }

--- a/.buildkite/src/jobs/Sample/Pipeline.dhall
+++ b/.buildkite/src/jobs/Sample/Pipeline.dhall
@@ -1,5 +1,6 @@
 let Pipeline = ../../Lib/Pipeline.dhall
 let Command = ../../Lib/Command.dhall
+let Docker = ../../Lib/Docker.dhall
 let Size = ../../Lib/Size.dhall
 
 in
@@ -8,6 +9,11 @@ Pipeline.build
   Pipeline.Config::{
     spec = ./Spec.dhall,
     steps = [
-      Command.Config::{ command = [ "echo \"hello\"" ], label = "Test Echo", key = "hello", target = Size.Small }
+      Command.Config::{
+        command = [ "echo \"hello\"" ],
+        label = "Test Echo", key = "hello",
+        target = Size.Small,
+        docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent" }
+      }
     ]
   }

--- a/.buildkite/src/jobs/Sample/Pipeline.dhall
+++ b/.buildkite/src/jobs/Sample/Pipeline.dhall
@@ -13,7 +13,7 @@ Pipeline.build
         command = [ "echo \"hello\"" ],
         label = "Test Echo", key = "hello",
         target = Size.Small,
-        docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent" }
+        docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
       }
     ]
   }

--- a/.buildkite/src/jobs/Sample/Pipeline.dhall
+++ b/.buildkite/src/jobs/Sample/Pipeline.dhall
@@ -13,7 +13,7 @@ Pipeline.build
         command = [ "echo \"hello\"" ],
         label = "Test Echo", key = "hello",
         target = Size.Small,
-        docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
+        docker = Docker.Config::{ image = (../../Constants/ContainerImages.dhall).toolchainBase }
       }
     ]
   }

--- a/.buildkite/src/jobs/Sample2/Pipeline.dhall
+++ b/.buildkite/src/jobs/Sample2/Pipeline.dhall
@@ -13,7 +13,7 @@ Pipeline.build
         command = [ "echo \"hello2\"" ],
         label = "Test Echo2", key = "hello2",
         target = Size.Small,
-        docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
+        docker = Docker.Config::{ image = (../../Constants/ContainerImages.dhall).toolchainBase }
         }
     ]
   }

--- a/.buildkite/src/jobs/Sample2/Pipeline.dhall
+++ b/.buildkite/src/jobs/Sample2/Pipeline.dhall
@@ -1,5 +1,6 @@
 let Pipeline = ../../Lib/Pipeline.dhall
 let Command = ../../Lib/Command.dhall
+let Docker = ../../Lib/Docker.dhall
 let Size = ../../Lib/Size.dhall
 
 in
@@ -8,6 +9,11 @@ Pipeline.build
   Pipeline.Config::{
     spec = ./Spec.dhall,
     steps = [
-      Command.Config::{ command = [ "echo \"hello2\"" ], label = "Test Echo2", key = "hello2", target = Size.Small }
+      Command.Config::{
+        command = [ "echo \"hello2\"" ],
+        label = "Test Echo2", key = "hello2",
+        target = Size.Small,
+        docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent" }
+        }
     ]
   }

--- a/.buildkite/src/jobs/Sample2/Pipeline.dhall
+++ b/.buildkite/src/jobs/Sample2/Pipeline.dhall
@@ -13,7 +13,7 @@ Pipeline.build
         command = [ "echo \"hello2\"" ],
         label = "Test Echo2", key = "hello2",
         target = Size.Small,
-        docker = Docker.Config::{ image = "localhost:8080/bash/coreutils/git/buildkite-agent" }
+        docker = Docker.Config::{ image = "codaprotocol/ci-toolchain-base" }
         }
     ]
   }


### PR DESCRIPTION
## What

All jobs run in containers now. Builds remain quick and short-circuiting.

<img width="173" alt="Screen Shot 2020-05-02 at 10 36 21 PM" src="https://user-images.githubusercontent.com/515445/80897342-66d67c80-8cc5-11ea-8257-fcb374dffafe.png">

> This is with a single serial agent running on my laptop. It will be faster with parallel agents. Overhead of checking out with git, submodules etc, cleaning untracked files, and running in docker is ~5s per "command step".

## Details

So far all the jobs have minimal shell dependencies. `agent.nix` is extended to support both building of local shell environments and docker containers.

### Why use docker from nix instead of writing a dockerfile

1. Created images are `FROM scratch` by default (the output containers are _tiny_ )
2. They are layered using a [fancy algorithm to minimize annoying rebuilds](https://grahamc.com/blog/nix-and-layered-docker-images).
3. The same specification supports both a local virtualization-free environment (nix) and a containerized one (docker).
4. No extra dockerfile

### More details

### For more

The details for building and pushing is in a comment in `agent.nix`. 

### Future work

* Version pinning of packages

Pick a git commit hash for nixpkgs and you're done. The nixpkgs public cache stays warm for a few months at least, and we can keep caching ourselves if we're slow to upgrade if we use cachix. I like not pinning for now as it will force us to upgrade our scripts if required if the tip of the world changes.

* Collapsing docker image rebuilding steps into a simple script invocation

This wouldn't take more than an hour or so, but Brandon doesn't want to spend time on that if we're eventually moving to a bread-and-butter dockerfile.

* Pinning images with git sha tags

This can be fixed by adding one more file to our `make update-deps` job, namely something Dhall can read in. Then we can optionally apply this tag with a new field in Docker.Config.Type.

## Performance tricks

A few extra steps were taken to increase build performance:

1. Git diff from a bind-mounted volume is ridiculously slow on my machine (50x performance penalty) -- to fix I pushed the diff computation to a hook that runs post-checkout instead of as a step inside the container.
2. Dhall's cache has to be mounted in the volume -- once we have artifact up/down (in #4804 ) we should swap to that. Since auto-volume creation makes it difficult to specify uid/gid of the mounted directory, the temporary hack is to `chmod 777` the cache as root in the post-checkout hook (before the docker container is run with lowered permissions)

