### PR TITLE
Pending coinbase, hoist versioned types

### DIFF
--- a/src/lib/coda_base/pending_coinbase_intf.ml
+++ b/src/lib/coda_base/pending_coinbase_intf.ml
@@ -55,17 +55,8 @@ module type S = sig
     val var_of_t : t -> var
   end
 
-  module type Data_hash_binable_intf = sig
+  module type Data_hash_intf = sig
     type t = private Field.t [@@deriving sexp, compare, eq, yojson, hash]
-
-    module Stable : sig
-      module V1 : sig
-        type nonrec t = t
-        [@@deriving bin_io, sexp, compare, eq, yojson, version, hash]
-      end
-
-      module Latest = V1
-    end
 
     type var
 
@@ -85,7 +76,7 @@ module type S = sig
   end
 
   module rec Hash : sig
-    include Data_hash_binable_intf
+    include Data_hash_intf
 
     val merge : height:int -> t -> t -> t
 
@@ -94,15 +85,31 @@ module type S = sig
     val of_digest : Pedersen.Digest.t -> t
   end
 
-  and Stack : sig
+  module Hash_versioned : sig
     [%%versioned:
     module Stable : sig
       module V1 : sig
-        type t [@@deriving sexp, compare, eq, yojson, hash]
+        type nonrec t = Hash.t [@@deriving sexp, compare, eq, yojson, hash]
       end
     end]
 
-    type t = Stable.Latest.t [@@deriving sexp, compare, eq, yojson, hash]
+    type nonrec t = Stable.Latest.t
+    [@@deriving sexp, compare, eq, yojson, hash]
+  end
+
+  module Stack_versioned : sig
+    type t [@@deriving sexp, compare, eq, yojson, hash]
+
+    [%%versioned:
+    module Stable : sig
+      module V1 : sig
+        type nonrec t = t [@@deriving sexp, compare, eq, yojson, hash]
+      end
+    end]
+  end
+
+  module Stack : sig
+    type t = Stack_versioned.t [@@deriving sexp, compare, eq, yojson, hash]
 
     type var
 

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.ml
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.ml
@@ -1,5 +1,6 @@
-[%%import
+(* [%%import
 "../../config.mlh"]
+*)
 
 open Core
 open Coda_base
@@ -148,18 +149,19 @@ module Non_snark = struct
   let var_of_t t : var =
     List.map (Fold.to_list @@ fold t) ~f:Boolean.var_of_value
 
-  [%%if
+  (*  [%%if
   proof_level = "check"]
-
+*)
   let warn_improper_transport () = ()
 
+  (*
   [%%else]
 
   let warn_improper_transport () =
     printf "WARNING: improperly transporting staged-ledger-hash\n"
 
   [%%endif]
-
+*)
   let typ : (var, value) Typ.t =
     Typ.transport (Typ.list ~length:length_in_bits Boolean.typ)
       ~there:(Fn.compose Fold.to_list fold) ~back:(fun _ ->
@@ -196,7 +198,7 @@ module Stable = struct
       *)
     type t =
       ( Non_snark.Stable.V1.t
-      , Pending_coinbase.Hash.Stable.V1.t )
+      , Pending_coinbase.Hash_versioned.Stable.V1.t )
       Poly.Stable.V1.t
     [@@deriving sexp, eq, compare, hash, yojson]
 

--- a/src/lib/staged_ledger_hash/staged_ledger_hash.ml
+++ b/src/lib/staged_ledger_hash/staged_ledger_hash.ml
@@ -1,6 +1,5 @@
-(* [%%import
+[%%import
 "../../config.mlh"]
-*)
 
 open Core
 open Coda_base
@@ -149,19 +148,18 @@ module Non_snark = struct
   let var_of_t t : var =
     List.map (Fold.to_list @@ fold t) ~f:Boolean.var_of_value
 
-  (*  [%%if
+  [%%if
   proof_level = "check"]
-*)
+
   let warn_improper_transport () = ()
 
-  (*
   [%%else]
 
   let warn_improper_transport () =
     printf "WARNING: improperly transporting staged-ledger-hash\n"
 
   [%%endif]
-*)
+
   let typ : (var, value) Typ.t =
     Typ.transport (Typ.list ~length:length_in_bits Boolean.typ)
       ~there:(Fn.compose Fold.to_list fold) ~back:(fun _ ->

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -36,8 +36,8 @@ module Pending_coinbase_stack_state = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { source: Pending_coinbase.Stack.Stable.V1.t
-        ; target: Pending_coinbase.Stack.Stable.V1.t }
+        { source: Pending_coinbase.Stack_versioned.Stable.V1.t
+        ; target: Pending_coinbase.Stack_versioned.Stable.V1.t }
       [@@deriving sexp, hash, compare, eq, fields, yojson]
 
       let to_latest = Fn.id

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -18,8 +18,8 @@ module Pending_coinbase_stack_state : sig
   module Stable : sig
     module V1 : sig
       type t =
-        { source: Pending_coinbase.Stack.Stable.V1.t
-        ; target: Pending_coinbase.Stack.Stable.V1.t }
+        { source: Pending_coinbase.Stack_versioned.Stable.V1.t
+        ; target: Pending_coinbase.Stack_versioned.Stable.V1.t }
       [@@deriving bin_io, compare, eq, fields, hash, sexp, version, yojson]
     end
 
@@ -27,8 +27,7 @@ module Pending_coinbase_stack_state : sig
   end
 
   type t = Stable.Latest.t =
-    { source: Pending_coinbase.Stack.Stable.V1.t
-    ; target: Pending_coinbase.Stack.Stable.V1.t }
+    {source: Pending_coinbase.Stack.t; target: Pending_coinbase.Stack.t}
   [@@deriving sexp, hash, compare, eq]
 end
 


### PR DESCRIPTION
Hoist versioned modules, `Stack`, `Hash`, `Merkle_tree`, and the versioned type for `Pending_coinbase` itself outside `Pending_coinbase.Make`, to avoid linter warnings.

There remains one linter warning for `Coda_base`.