### PR TITLE
Move fake_accounts_target to genesis_constants

### DIFF
--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -107,7 +107,10 @@ let get_accounts accounts_json_file n =
   in
   let num_real_accounts = List.length real_accounts in
   let num_fake_accounts = max 0 (n - num_real_accounts) in
-  let num_accounts = num_real_accounts + num_fake_accounts in
+  let num_accounts =
+    Option.some_if (num_fake_accounts > 0)
+      (num_real_accounts + num_fake_accounts)
+  in
   let all_accounts =
     let fake_accounts =
       Account_config.Fake_accounts.generate num_fake_accounts

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -180,7 +180,7 @@ let main accounts_json_file dir num_accounts constants_file =
           read_write_constants constants_file constants_path
             ~f:(fun (genesis_constants : Genesis_constants.t) ->
               (* Store the true number of accounts in the configuration. *)
-              {genesis_constants with fake_accounts_target= num_accounts} )
+              {genesis_constants with num_accounts} )
           |> Result.ok_or_failwith
         in
         let%bind _base_hash, base_proof =

--- a/src/config/ledger_depth/full.mlh
+++ b/src/config/ledger_depth/full.mlh
@@ -1,2 +1,1 @@
 [%%define ledger_depth 30]
-[%%define fake_accounts_target 50]

--- a/src/config/ledger_depth/small.mlh
+++ b/src/config/ledger_depth/small.mlh
@@ -1,2 +1,1 @@
 [%%define ledger_depth 10]
-[%%define fake_accounts_target 50]

--- a/src/config/ledger_depth/tiny.mlh
+++ b/src/config/ledger_depth/tiny.mlh
@@ -1,2 +1,1 @@
 [%%define ledger_depth 6]
-[%%define fake_accounts_target 50]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -1,5 +1,4 @@
 [%%define ledger_depth 14]
-[%%define fake_accounts_target 50]
 [%%import "/src/config/curve/medium.mlh"]
 [%%import "/src/config/coinbase/realistic.mlh"]
 [%%import "/src/config/scan_state/point2tps.mlh"]

--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -15,7 +15,7 @@ let genesis_dir_name (genesis_constants : Genesis_constants.t) =
       ( List.map
           [ Coda_compile_config.curve_size
           ; Coda_compile_config.ledger_depth
-          ; Option.value ~default:0 genesis_constants.fake_accounts_target
+          ; Option.value ~default:0 genesis_constants.num_accounts
           ; Coda_compile_config.c
           ; genesis_constants.protocol.k ]
           ~f:Int.to_string

--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -15,7 +15,7 @@ let genesis_dir_name (genesis_constants : Genesis_constants.t) =
       ( List.map
           [ Coda_compile_config.curve_size
           ; Coda_compile_config.ledger_depth
-          ; Coda_compile_config.fake_accounts_target
+          ; genesis_constants.fake_accounts_target
           ; Coda_compile_config.c
           ; genesis_constants.protocol.k ]
           ~f:Int.to_string

--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -15,7 +15,7 @@ let genesis_dir_name (genesis_constants : Genesis_constants.t) =
       ( List.map
           [ Coda_compile_config.curve_size
           ; Coda_compile_config.ledger_depth
-          ; genesis_constants.fake_accounts_target
+          ; Option.value ~default:0 genesis_constants.fake_accounts_target
           ; Coda_compile_config.c
           ; genesis_constants.protocol.k ]
           ~f:Int.to_string

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -24,9 +24,6 @@ module Currency = Currency_nonconsensus.Currency
 "curve_size", curve_size]
 
 [%%inject
-"fake_accounts_target", fake_accounts_target]
-
-[%%inject
 "genesis_ledger", genesis_ledger]
 
 [%%inject

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -112,9 +112,7 @@ end
 
 module T = struct
   type t =
-    { protocol: Protocol.t
-    ; txpool_max_size: int
-    ; fake_accounts_target: int option }
+    {protocol: Protocol.t; txpool_max_size: int; num_accounts: int option}
   [@@deriving to_yojson]
 
   let hash (t : t) =
@@ -152,7 +150,7 @@ let compiled : t =
       ; genesis_state_timestamp=
           genesis_timestamp_of_string genesis_state_timestamp_string }
   ; txpool_max_size= pool_max_size
-  ; fake_accounts_target= None }
+  ; num_accounts= None }
 
 let for_unit_tests = compiled
 
@@ -170,7 +168,7 @@ module Config_file : Config_intf = struct
     ; delta: int option [@default None]
     ; txpool_max_size: int option [@default None]
     ; genesis_state_timestamp: string option [@default None]
-    ; fake_accounts_target: int option [@default None] }
+    ; num_accounts: int option [@default None] }
   [@@deriving yojson]
 
   let of_yojson s =
@@ -189,10 +187,10 @@ module Config_file : Config_intf = struct
     in
     { protocol
     ; txpool_max_size= opt default.txpool_max_size t.txpool_max_size
-    ; fake_accounts_target=
-        Option.value_map ~default:default.fake_accounts_target
+    ; num_accounts=
+        Option.value_map ~default:default.num_accounts
           ~f:(fun x -> Core_kernel.Option.some_if (x > 0) x)
-          t.fake_accounts_target }
+          t.num_accounts }
 
   let of_genesis_constants (genesis_constants : T.t) : t =
     { k= Some genesis_constants.protocol.k
@@ -202,7 +200,7 @@ module Config_file : Config_intf = struct
         Some
           (Core.Time.format genesis_constants.protocol.genesis_state_timestamp
              "%Y-%m-%d %H:%M:%S%z" ~zone:Core.Time.Zone.utc)
-    ; fake_accounts_target= genesis_constants.fake_accounts_target }
+    ; num_accounts= genesis_constants.num_accounts }
 end
 
 module Daemon_config : Config_intf = struct
@@ -224,7 +222,7 @@ module Daemon_config : Config_intf = struct
             Option.value_map genesis_state_timestamp
               ~default:default.protocol.genesis_state_timestamp
               ~f:genesis_timestamp_of_string }
-    ; fake_accounts_target= default.fake_accounts_target }
+    ; num_accounts= default.num_accounts }
 
   let of_genesis_constants (genesis_constants : T.t) : t =
     { txpool_max_size= Some genesis_constants.txpool_max_size

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -1,21 +1,7 @@
-[%%import
-"/src/config.mlh"]
-
 open Core_kernel
 open Currency
 open Signature_lib
 open Coda_base
-
-[%%inject
-"ledger_depth", ledger_depth]
-
-[%%inject
-"fake_accounts_target", fake_accounts_target]
-
-let _ =
-  if Base.Int.(fake_accounts_target > pow 2 ledger_depth) then
-    failwith "Genesis_ledger: fake_accounts_target >= 2**ledger_depth"
-
 module Intf = Intf
 
 module Private_accounts (Accounts : Intf.Private_accounts.S) = struct

--- a/src/lib/genesis_ledger/testnet_postake_ledger.ml
+++ b/src/lib/genesis_ledger/testnet_postake_ledger.ml
@@ -1,16 +1,9 @@
-[%%import
-"/src/config.mlh"]
-
 open Intf.Public_accounts
-open Core_kernel
 module Public_key = Signature_lib.Public_key
 
 let name = "testnet_postake"
 
-[%%inject
-"fake_accounts_target", fake_accounts_target]
-
-let real_accounts =
+let accounts =
   lazy
     [ { pk=
           Public_key.Compressed.of_base58_check_exn
@@ -375,16 +368,3 @@ let real_accounts =
             (Public_key.Compressed.of_base58_check_exn
                "4vsRCVWRSCQNrGSNoojhp258eeKCeXL8JVefQ8KpZ9DJhFE7AkcFm3czHcddUUbkmpavwuKW4o2QsexWzHnjwuD3ejGkGjqha3n2omrt1fCHN9NWN24jfrqrDTkoZDhm4RNKpRMX4jixX631")
       } ]
-
-let fake_accounts =
-  lazy
-    (let open Quickcheck in
-    random_value ~seed:(`Deterministic "fake accounts for testnet postake")
-      (Generator.list_with_length
-         (fake_accounts_target - List.length (Lazy.force real_accounts))
-         Fake_accounts.gen))
-
-let accounts =
-  let open Lazy.Let_syntax in
-  let%map real_accounts = real_accounts and fake_accounts = fake_accounts in
-  real_accounts @ fake_accounts


### PR DESCRIPTION
This PR
* removes the `fake_accounts_target` compile-time variable
* adds `fake_accounts_target` to `Genesis_constants.t`
* stores the number of accounts in a generated ledger as `fake_accounts_target`
* adds flexible parsing for the configuration file
  - ie. missing fields will now be set as none, instead of raising a JSON parsing error

This gives us a way of distinguishing configurations with the same 'base' ledger, but different numbers of fake accounts.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: