### PR TITLE
Move Binable.Of_stringable to versioned module

### DIFF
--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -138,25 +138,62 @@ struct
 end
 
 module T0 = struct
-  module Arg = struct
-    type t = Field.t [@@deriving sexp, compare, hash]
-
-    [%%define_locally
-    Field.(to_string, of_string)]
-  end
-
   [%%versioned_binable
   module Stable = struct
     module V1 = struct
       type t = Field.t [@@deriving sexp, compare, hash]
 
-      type _unused = unit constraint t = Arg.t
-
       let to_latest = Fn.id
+
+      module Arg = struct
+        type nonrec t = t
+
+        [%%define_locally Field.(to_string, of_string)]
+      end
 
       include Binable.Of_stringable (Arg)
     end
   end]
+
+  module Tests = struct
+    (* these test the stability of the serialization derived from the
+       string representation of Field.t, not the direct serialization of
+       Field.t
+    *)
+
+    let field =
+      Quickcheck.random_value ~seed:(`Deterministic "Data_hash.T0 tests")
+        Field.gen
+
+    [%%if
+    curve_size = 298]
+
+    let%test "Binable from stringable V1" =
+      let known_good_hash =
+        "\x6D\xB1\xAB\x5F\x4C\xA2\x8F\xBA\xF5\x31\x2D\xE9\xEB\x07\xD1\x78\x1F\x20\xD5\x22\xA6\x9F\x5E\x0B\x77\xE0\x00\x07\x78\x85\x90\x8B"
+      in
+      Module_version.Serialization.check_serialization
+        (module Stable.V1)
+        field known_good_hash
+
+    [%%elif
+    curve_size = 753]
+
+    let%test "Binable from stringable V1" =
+      let known_good_hash =
+        "\x68\xDA\x30\x2C\xD0\xE5\x71\x3C\xAB\x42\x02\x8B\x31\xC1\x2E\x93\xE3\xC0\x99\x6B\xF6\xAA\xE2\x11\xF4\x2F\x88\x97\x3C\xC2\xA2\xF0"
+      in
+      Module_version.Serialization.check_serialization
+        (module Stable.V1)
+        field known_good_hash
+
+    [%%else]
+
+    let%test "Binable from stringable V1" =
+      failwith "No test for this curve size"
+
+    [%%endif]
+  end
 end
 
 module Make_full_size (B58_data : Data_hash_intf.Data_hash_descriptor) = struct

--- a/src/lib/coda_base/dune
+++ b/src/lib/coda_base/dune
@@ -48,7 +48,7 @@
     )
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_snarky ppx_coda -lint-version-syntax-warnings ppx_deriving.eq ppx_deriving.enum ppx_deriving.ord
+  (pps ppx_snarky ppx_coda ppx_deriving.eq ppx_deriving.enum ppx_deriving.ord
     ppx_base ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test
     bisect_ppx -- -conditional))
  (synopsis "Snarks and friends necessary for keypair generation"))


### PR DESCRIPTION
The linter in `ppx_coda` flags `Binable.Of...` functor applications outside versioned modules, because those create serializations.

Moved `Binable.Of_stringable` inside `Data_hash.Make_full_size` to a versioned module outside the functor.

Removed the errors-as-warnings flag to `ppx_coda` in the `Coda_base` dune file.
