### PR TITLE
Add %%versioned to Transaction_snark_scan_state.t

### DIFF
--- a/src/lib/transaction_snark_scan_state/dune
+++ b/src/lib/transaction_snark_scan_state/dune
@@ -7,6 +7,6 @@
    yojson module_version)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_base ppx_coda -lint-version-syntax-warnings ppx_let ppx_sexp_conv ppx_bin_prot ppx_custom_printf
+  (pps ppx_base ppx_coda ppx_let ppx_sexp_conv ppx_bin_prot ppx_custom_printf
     ppx_deriving.eq ppx_deriving_yojson ppx_optcomp))
  (synopsis "Transaction-snark specialization of the parallel scan state"))


### PR DESCRIPTION
Replaced module registration with `%%versioned` in `Transaction_snark_scan_state`.

In dune file, removed errors-as-warnings flag to `ppx_coda`.