### PR TITLE
Allow flexible account JSON

### DIFF
--- a/src/lib/account_config/account_config.ml
+++ b/src/lib/account_config/account_config.ml
@@ -2,10 +2,21 @@ open Core_kernel
 
 type account_data =
   { pk: Signature_lib.Public_key.Compressed.t
-  ; sk: Signature_lib.Private_key.t option
+  ; sk: Signature_lib.Private_key.t option [@default None]
   ; balance: Currency.Balance.t
-  ; delegate: Signature_lib.Public_key.Compressed.t option }
+  ; delegate: Signature_lib.Public_key.Compressed.t option [@default None] }
 [@@deriving yojson]
+
+let account_data_of_yojson = function
+  | `Assoc l ->
+      account_data_of_yojson
+        (`Assoc
+          (List.filter l ~f:(fun (key, _) ->
+               Array.mem ~equal:String.equal
+                 [|"pk"; "sk"; "balance"; "delegate"|]
+                 key )))
+  | json ->
+      account_data_of_yojson json
 
 type t = account_data list [@@deriving yojson]
 


### PR DESCRIPTION
This PR makes account-config parsing more flexible. In particular
* `option`al fields now do not need to be present in the JSON
* fields that are not part of the record will be ignored

e.g.
```json
[ {"pk": "some_pk_here", "balance": 20000, "ID": "big account"}
, {"pk": "another_pk_here", "sk": "sk", "balance": 20, "TODO": "Do something"} ]
```

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: