### PR TITLE
Fix update-branch-protection CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
         steps:
             - run:
                 name: Install dependencies
-                command: pip install --user requests jinja2
+                command: pip install --user requests jinja2 readchar
             - checkout
             - run:
                   name: Update branch protection rule from test configuration

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -196,7 +196,7 @@ jobs:
         steps:
             - run:
                 name: Install dependencies
-                command: pip install --user requests jinja2
+                command: pip install --user requests jinja2 readchar
             - checkout
             - run:
                   name: Update branch protection rule from test configuration


### PR DESCRIPTION
Currently, the `update-branch-protection` job fails with an unmet python dependency. This job only runs on `develop`, see e.g. [here](https://app.circleci.com/pipelines/github/CodaProtocol/coda/20381/workflows/32c05370-8895-4ab0-a57c-9f6be2c7c2c7/jobs/383008/steps).

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
