### PR TITLE
Remove bin_io inside Location.Make

### DIFF
--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -23,12 +23,10 @@ module Ledger_inner = struct
     end
 
     type t = Arg.t =
-      | Generic of Location.Bigstring.Stable.Latest.t
-      | Account of Location0.Addr.Stable.Latest.t
-      | Hash of Location0.Addr.Stable.Latest.t
+      | Generic of Location.Bigstring.t
+      | Account of Location0.Addr.t
+      | Hash of Location0.Addr.t
     [@@deriving hash, sexp, compare]
-
-    type _unused = unit constraint t = Location_at_depth.t
 
     include Hashable.Make_binable (Arg) [@@deriving
                                           sexp, compare, hash, yojson]

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -13,6 +13,33 @@ module Ledger_inner = struct
 
   module Location_at_depth = Location0
 
+  module Location_binable = struct
+    module Arg = struct
+      type t = Location_at_depth.t =
+        | Generic of Location.Bigstring.Stable.Latest.t
+            [@printer
+              fun fmt bstr ->
+                Format.pp_print_string fmt (Bigstring.to_string bstr)]
+        | Account of Location0.Addr.Stable.Latest.t
+        | Hash of Location0.Addr.Stable.Latest.t
+      [@@deriving bin_io_unversioned, hash, sexp, compare]
+    end
+
+    type t = Arg.t =
+      | Generic of Location.Bigstring.Stable.Latest.t
+          [@printer
+            fun fmt bstr ->
+              Format.pp_print_string fmt (Bigstring.to_string bstr)]
+      | Account of Location0.Addr.Stable.Latest.t
+      | Hash of Location0.Addr.Stable.Latest.t
+    [@@deriving hash, sexp, compare]
+
+    type _unused = unit constraint t = Location_at_depth.t
+
+    include Hashable.Make_binable (Arg) [@@deriving
+                                          sexp, compare, hash, yojson]
+  end
+
   module Kvdb : Intf.Key_value_database with type config := string =
     Rocksdb.Database
 
@@ -85,6 +112,7 @@ module Ledger_inner = struct
     module Depth = Depth
     module Kvdb = Kvdb
     module Location = Location_at_depth
+    module Location_binable = Location_binable
     module Storage_locations = Storage_locations
   end
 

--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -17,9 +17,6 @@ module Ledger_inner = struct
     module Arg = struct
       type t = Location_at_depth.t =
         | Generic of Location.Bigstring.Stable.Latest.t
-            [@printer
-              fun fmt bstr ->
-                Format.pp_print_string fmt (Bigstring.to_string bstr)]
         | Account of Location0.Addr.Stable.Latest.t
         | Hash of Location0.Addr.Stable.Latest.t
       [@@deriving bin_io_unversioned, hash, sexp, compare]
@@ -27,9 +24,6 @@ module Ledger_inner = struct
 
     type t = Arg.t =
       | Generic of Location.Bigstring.Stable.Latest.t
-          [@printer
-            fun fmt bstr ->
-              Format.pp_print_string fmt (Bigstring.to_string bstr)]
       | Account of Location0.Addr.Stable.Latest.t
       | Hash of Location0.Addr.Stable.Latest.t
     [@@deriving hash, sexp, compare]

--- a/src/lib/merkle_ledger/database.ml
+++ b/src/lib/merkle_ledger/database.ml
@@ -5,6 +5,8 @@ module type Inputs_intf = sig
 
   module Location : Location_intf.S
 
+  module Location_binable : Hashable.S_binable with type t := Location.t
+
   module Kvdb : Intf.Key_value_database with type config := string
 
   module Storage_locations : Intf.Storage_locations
@@ -420,6 +422,7 @@ module Make (Inputs : Inputs_intf) :
     module Account_id = Account_id
     module Balance = Balance
     module Location = Location
+    module Location_binable = Location_binable
     module Account = Account
     module Hash = Hash
     module Depth = Depth

--- a/src/lib/merkle_ledger/dune
+++ b/src/lib/merkle_ledger/dune
@@ -6,5 +6,5 @@
    dyn_array merkle_address direction rocks key_value_database empty_hashes module_version
    visualization non_empty_list)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson))
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving.show ppx_deriving_yojson))
  (synopsis "Implementation of different account databases"))

--- a/src/lib/merkle_ledger/location.ml
+++ b/src/lib/merkle_ledger/location.ml
@@ -66,20 +66,13 @@ module Make (Depth : Intf.Depth) = struct
     let hash depth = UInt8.of_int (Depth.depth - depth)
   end
 
-  (* TODO : version *)
-  module T = struct
-    type t =
-      | Generic of Bigstring.Stable.V1.t
-          [@printer
-            fun fmt bstr ->
-              Format.pp_print_string fmt (Bigstring.to_string bstr)]
-      | Account of Addr.Stable.V1.t
-      | Hash of Addr.Stable.V1.t
-    [@@deriving hash, sexp, compare, eq, bin_io]
-  end
-
-  include T
-  include Hashable.Make_binable (T)
+  type t =
+    | Generic of Bigstring.t
+        [@printer
+          fun fmt bstr -> Format.pp_print_string fmt (Bigstring.to_string bstr)]
+    | Account of Addr.t
+    | Hash of Addr.t
+  [@@deriving hash, sexp, compare, eq]
 
   let is_generic = function Generic _ -> true | _ -> false
 

--- a/src/lib/merkle_ledger/location.ml
+++ b/src/lib/merkle_ledger/location.ml
@@ -66,12 +66,7 @@ module Make (Depth : Intf.Depth) = struct
     let hash depth = UInt8.of_int (Depth.depth - depth)
   end
 
-  type t =
-    | Generic of Bigstring.t
-        [@printer
-          fun fmt bstr -> Format.pp_print_string fmt (Bigstring.to_string bstr)]
-    | Account of Addr.t
-    | Hash of Addr.t
+  type t = Generic of Bigstring.t | Account of Addr.t | Hash of Addr.t
   [@@deriving hash, sexp, compare, eq]
 
   let is_generic = function Generic _ -> true | _ -> false

--- a/src/lib/merkle_ledger/location_intf.ml
+++ b/src/lib/merkle_ledger/location_intf.ml
@@ -14,9 +14,7 @@ module type S = sig
   end
 
   type t = Generic of Bigstring.t | Account of Addr.t | Hash of Addr.t
-  [@@deriving eq, sexp, bin_io, hash, compare]
-
-  include Hashable.S_binable with type t := t
+  [@@deriving eq, sexp, hash, compare]
 
   val is_generic : t -> bool
 

--- a/src/lib/merkle_ledger/util.ml
+++ b/src/lib/merkle_ledger/util.ml
@@ -3,6 +3,8 @@ open Core
 module type Inputs_intf = sig
   module Location : Location_intf.S
 
+  module Location_binable : Hashable.S_binable with type t := Location.t
+
   module Key : Intf.Key
 
   module Token_id : Intf.Token_id
@@ -84,7 +86,7 @@ end = struct
       let height = Inputs.Location.height @@ List.hd_exn locations in
       if height < Inputs.Depth.depth then
         let location_to_hash_table =
-          Inputs.Location.Table.of_alist_exn locations_and_hashes
+          Inputs.Location_binable.Table.of_alist_exn locations_and_hashes
         in
         let _, parent_locations_and_hashes =
           List.fold locations_and_hashes ~init:([], [])

--- a/src/lib/merkle_ledger_tests/test.ml
+++ b/src/lib/merkle_ledger_tests/test.ml
@@ -20,12 +20,10 @@ let%test_module "Database integration test" =
       end
 
       type t = Arg.t =
-        | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
-        | Account of Location.Addr.Stable.Latest.t
-        | Hash of Location.Addr.Stable.Latest.t
+        | Generic of Merkle_ledger.Location.Bigstring.t
+        | Account of Location.Addr.t
+        | Hash of Location.Addr.t
       [@@deriving hash, sexp, compare]
-
-      type _unused = unit constraint t = Location.t
 
       include Hashable.Make_binable (Arg) [@@deriving
                                             sexp, compare, hash, yojson]

--- a/src/lib/merkle_ledger_tests/test.ml
+++ b/src/lib/merkle_ledger_tests/test.ml
@@ -10,9 +10,31 @@ let%test_module "Database integration test" =
 
     module Location = Merkle_ledger.Location.Make (Depth)
 
+    module Location_binable = struct
+      module Arg = struct
+        type t = Location.t =
+          | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
+          | Account of Location.Addr.Stable.Latest.t
+          | Hash of Location.Addr.Stable.Latest.t
+        [@@deriving bin_io_unversioned, hash, sexp, compare]
+      end
+
+      type t = Arg.t =
+        | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
+        | Account of Location.Addr.Stable.Latest.t
+        | Hash of Location.Addr.Stable.Latest.t
+      [@@deriving hash, sexp, compare]
+
+      type _unused = unit constraint t = Location.t
+
+      include Hashable.Make_binable (Arg) [@@deriving
+                                            sexp, compare, hash, yojson]
+    end
+
     module Inputs = struct
       include Test_stubs.Base_inputs
       module Location = Location
+      module Location_binable = Location_binable
       module Kvdb = In_memory_kvdb
       module Storage_locations = Storage_locations
       module Depth = Depth

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -508,9 +508,31 @@ let%test_module "test functor on in memory databases" =
 
       module Location = Merkle_ledger.Location.Make (Depth)
 
+      module Location_binable = struct
+        module Arg = struct
+          type t = Location.t =
+            | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
+            | Account of Location.Addr.Stable.Latest.t
+            | Hash of Location.Addr.Stable.Latest.t
+          [@@deriving bin_io_unversioned, hash, sexp, compare]
+        end
+
+        type t = Arg.t =
+          | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
+          | Account of Location.Addr.Stable.Latest.t
+          | Hash of Location.Addr.Stable.Latest.t
+        [@@deriving hash, sexp, compare]
+
+        type _unused = unit constraint t = Location.t
+
+        include Hashable.Make_binable (Arg) [@@deriving
+                                              sexp, compare, hash, yojson]
+      end
+
       module Inputs = struct
         include Test_stubs.Base_inputs
         module Location = Location
+        module Location_binable = Location_binable
         module Kvdb = In_memory_kvdb
         module Storage_locations = Storage_locations
         module Depth = Depth

--- a/src/lib/merkle_ledger_tests/test_database.ml
+++ b/src/lib/merkle_ledger_tests/test_database.ml
@@ -523,8 +523,6 @@ let%test_module "test functor on in memory databases" =
           | Hash of Location.Addr.Stable.Latest.t
         [@@deriving hash, sexp, compare]
 
-        type _unused = unit constraint t = Location.t
-
         include Hashable.Make_binable (Arg) [@@deriving
                                               sexp, compare, hash, yojson]
       end

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -741,9 +741,31 @@ module Make_maskable_and_mask_with_depth (Depth : Depth_S) = struct
   module Location : Merkle_ledger.Location_intf.S =
     Merkle_ledger.Location.Make (Depth)
 
+  module Location_binable = struct
+    module Arg = struct
+      type t = Location.t =
+        | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
+        | Account of Location.Addr.Stable.Latest.t
+        | Hash of Location.Addr.Stable.Latest.t
+      [@@deriving bin_io_unversioned, hash, sexp, compare]
+    end
+
+    type t = Arg.t =
+      | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
+      | Account of Location.Addr.Stable.Latest.t
+      | Hash of Location.Addr.Stable.Latest.t
+    [@@deriving hash, sexp, compare]
+
+    type _unused = unit constraint t = Location.t
+
+    include Hashable.Make_binable (Arg) [@@deriving
+                                          sexp, compare, hash, yojson]
+  end
+
   module Inputs = struct
     include Test_stubs.Base_inputs
     module Location = Location
+    module Location_binable = Location_binable
     module Kvdb = In_memory_kvdb
     module Storage_locations = Storage_locations
     module Depth = Depth

--- a/src/lib/merkle_ledger_tests/test_mask.ml
+++ b/src/lib/merkle_ledger_tests/test_mask.ml
@@ -751,12 +751,10 @@ module Make_maskable_and_mask_with_depth (Depth : Depth_S) = struct
     end
 
     type t = Arg.t =
-      | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
-      | Account of Location.Addr.Stable.Latest.t
-      | Hash of Location.Addr.Stable.Latest.t
+      | Generic of Merkle_ledger.Location.Bigstring.t
+      | Account of Location.Addr.t
+      | Hash of Location.Addr.t
     [@@deriving hash, sexp, compare]
-
-    type _unused = unit constraint t = Location.t
 
     include Hashable.Make_binable (Arg) [@@deriving
                                           sexp, compare, hash, yojson]

--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -5,5 +5,5 @@
  (libraries core debug_assert bitstring integers immutable_array
    dyn_array merkle_ledger merkle_address yojson visualization)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving_yojson ppx_jane ppx_deriving.eq ppx_deriving.show))
+  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_jane ppx_deriving.eq ppx_deriving.show))
  (synopsis "Implementation of Merkle tree masks"))

--- a/src/lib/merkle_mask/inputs_intf.ml
+++ b/src/lib/merkle_mask/inputs_intf.ml
@@ -19,6 +19,9 @@ module type S = sig
 
   module Location : Merkle_ledger.Location_intf.S
 
+  module Location_binable :
+    Core_kernel.Hashable.S_binable with type t := Location.t
+
   module Base :
     Base_merkle_tree_intf.S
     with module Addr = Location.Addr

--- a/src/lib/merkle_mask/masking_merkle_tree_intf.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree_intf.ml
@@ -1,7 +1,7 @@
 (* masking_merkle_tree_intf.ml *)
 (* the type of a Merkle tree mask associated with a parent Merkle tree *)
 module type S = sig
-  type t [@@deriving bin_io]
+  type t
 
   type unattached = t
 

--- a/src/lib/syncable_ledger/test.ml
+++ b/src/lib/syncable_ledger/test.ml
@@ -187,10 +187,32 @@ module Db = struct
       let to_hash = Fn.id
     end
 
+    module Location = Merkle_ledger.Location.Make (Depth)
+
+    module Location_binable = struct
+      module Arg = struct
+        type t = Location.t =
+          | Generic of Merkle_ledger.Location.Bigstring.Stable.Latest.t
+          | Account of Location.Addr.Stable.Latest.t
+          | Hash of Location.Addr.Stable.Latest.t
+        [@@deriving bin_io_unversioned, hash, sexp, compare]
+      end
+
+      type t = Arg.t =
+        | Generic of Merkle_ledger.Location.Bigstring.t
+        | Account of Location.Addr.t
+        | Hash of Location.Addr.t
+      [@@deriving hash, sexp, compare]
+
+      include Hashable.Make_binable (Arg) [@@deriving
+                                            sexp, compare, hash, yojson]
+    end
+
     module Base_ledger_inputs = struct
       include Base_ledger_inputs
       module Depth = Depth
-      module Location = Merkle_ledger.Location.Make (Depth)
+      module Location = Location
+      module Location_binable = Location_binable
       module Kvdb = In_memory_kvdb
     end
 


### PR DESCRIPTION
Removed the `bin_io` on the type inside `Location.Make`. That serializability wasn't being used; further, removing `bin_io` from `Location_intf` doesn't affect compilation. We're also able to remove `bin_io` for `Masking_merkle_tree`.

We do need a `Table` for locations, so create a new module in `Coda_base.Ledger`, named `Location_binable` (`Table` is created via `Hashable.Of_binable`), and pass that through the functors in `Ledger`, ultimately used in `Merkle_ledger.Util`.

Remove the errors-as-warnings flag to `ppx_coda` in `Merkle_ledger` and `Merkle_mask`.