### PR TITLE
Properly configure minimum tx fee

### DIFF
--- a/src/config/amount_defaults/realistic.mlh
+++ b/src/config/amount_defaults/realistic.mlh
@@ -1,3 +1,3 @@
 [%%define default_transaction_fee "0.1"]
 [%%define default_snark_worker_fee "0.025"]
-
+[%%define minimum_user_command_fee "0.001"]

--- a/src/config/amount_defaults/standard.mlh
+++ b/src/config/amount_defaults/standard.mlh
@@ -1,3 +1,3 @@
 [%%define default_transaction_fee "5"]
 [%%define default_snark_worker_fee "1"]
-
+[%%define minimum_user_command_fee "2"]

--- a/src/lib/coda_base/import.ml
+++ b/src/lib/coda_base/import.ml
@@ -7,6 +7,8 @@
 consensus_mechanism]
 
 module Signature_lib = Signature_lib_nonconsensus
+module Coda_compile_config =
+  Coda_compile_config_nonconsensus.Coda_compile_config
 
 [%%endif]
 

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -78,7 +78,7 @@ let fee = Fn.compose Payload.fee payload
 let nonce = Fn.compose Payload.nonce payload
 
 (* for filtering *)
-let minimum_fee = Fee.of_int 2_000_000_000
+let minimum_fee = Coda_compile_config.minimum_user_command_fee
 
 let has_insufficient_fee t = Fee.(fee t < minimum_fee)
 

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -41,8 +41,14 @@ module Currency = Currency_nonconsensus.Currency
 [%%inject
 "default_snark_worker_fee_string", default_snark_worker_fee]
 
+[%%inject
+"minimum_user_command_fee_string", minimum_user_command_fee]
+
 let account_creation_fee =
   Currency.Fee.of_formatted_string account_creation_fee_string
+
+let minimum_user_command_fee =
+  Currency.Fee.of_formatted_string minimum_user_command_fee_string
 
 let coinbase = Currency.Amount.of_formatted_string coinbase_string
 


### PR DESCRIPTION
This was a required change to stabilize the testnet deployments which was somehow missed during the now-defunct release branch port to develop.