### PR TITLE
Perf_histograms, unversioned bin_io

### DIFF
--- a/src/lib/perf_histograms/histogram.ml
+++ b/src/lib/perf_histograms/histogram.ml
@@ -50,7 +50,7 @@ struct
       ; intervals: (Elem.t * Elem.t) list
       ; underflow: int
       ; overflow: int }
-    [@@deriving yojson, bin_io, fields]
+    [@@deriving yojson, bin_io_unversioned, fields]
   end
 
   let report {intervals; buckets; underflow; overflow; params= _} =
@@ -68,7 +68,7 @@ end
 
 module Exp_time_spans = Make (struct
   (** Note: All time spans are represented in JSON as floating point millis *)
-  type t = Time.Span.t [@@deriving bin_io]
+  type t = Time.Span.t [@@deriving bin_io_unversioned]
 
   let to_yojson t = `Float (Time.Span.to_ms t)
 


### PR DESCRIPTION
For the serialized types in `Perf_histogram`, allow `bin_io_unversioned`, because these types are not persisted, nor sent to other nodes. They're used for local observation of performance. In `Coda_networking`, each RPC type has hooks into the histogram machinery, but the serialization used by the RPC code is not affected.
