### PR TITLE
Remove serialization from Ledger_proof

### DIFF
--- a/src/lib/work_selector/dune
+++ b/src/lib/work_selector/dune
@@ -6,7 +6,7 @@
  (libraries core debug_assert logger coda_intf async async_extra
    unix_timestamp staged_ledger network_pool)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_assert ppx_base ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot
+  (pps ppx_coda ppx_assert ppx_base ppx_let ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot
     ppx_custom_printf ppx_inline_test ppx_optcomp bisect_ppx --
     -conditional))
  (preprocessor_deps ../../config.mlh)

--- a/src/lib/work_selector/inputs.ml
+++ b/src/lib/work_selector/inputs.ml
@@ -13,16 +13,7 @@ module Test_inputs = struct
   end
 
   module Ledger_proof = struct
-    module T = struct
-      type t = Fee.t [@@deriving hash, compare, sexp]
-
-      let of_binable = Fee.of_int
-
-      let to_binable = Fee.to_int
-    end
-
-    include Binable.Of_binable (Core_kernel.Int.Stable.V1) (T)
-    include T
+    type t = Fee.t [@@deriving hash, compare, sexp]
   end
 
   module Transaction_snark_work = struct


### PR DESCRIPTION
The serialization in `Work_selector.Test_inputs.Ledger_proof` was apparently unused, removed it here.

The errors-as-warnings flag to `ppx_coda` in the `dune` file is removed.