### PR TITLE
Sorts leaderboard by current testnet, not total

### DIFF
--- a/frontend/website/src/components/Leaderboard.re
+++ b/frontend/website/src/components/Leaderboard.re
@@ -24,14 +24,15 @@ let fetchLeaderboard = () => {
          Option.bind(Js.Json.decodeObject(r), o => Js.Dict.get(o, "values"));
 
        switch (Option.bind(results, Js.Json.decodeArray)) {
-       | Some(resultsArr) => {
-           let arr = Array.map(parseEntry, resultsArr);
-           arr |> Array.sort((e1, e2) => {
+       | Some(resultsArr) =>
+         let arr = Array.map(parseEntry, resultsArr);
+         arr
+         |> Array.sort((e1, e2) => {
               let len = Array.length;
-              int_of_string(e2[len(e2) - 1]) - int_of_string(e1[len(e1)-1])
-           })
-           arr
-       }
+              int_of_string(e2[len(e2) - 1])
+              - int_of_string(e1[len(e1) - 1]);
+            });
+         arr;
        | None => [||]
        };
      })

--- a/frontend/website/src/components/Leaderboard.re
+++ b/frontend/website/src/components/Leaderboard.re
@@ -24,7 +24,14 @@ let fetchLeaderboard = () => {
          Option.bind(Js.Json.decodeObject(r), o => Js.Dict.get(o, "values"));
 
        switch (Option.bind(results, Js.Json.decodeArray)) {
-       | Some(resultsArr) => Array.map(parseEntry, resultsArr)
+       | Some(resultsArr) => {
+           let arr = Array.map(parseEntry, resultsArr);
+           arr |> Array.sort((e1, e2) => {
+              let len = Array.length;
+              int_of_string(e2[len(e2) - 1]) - int_of_string(e1[len(e1)-1])
+           })
+           arr
+       }
        | None => [||]
        };
      })


### PR DESCRIPTION
## Why do we want to do this?

On our Testnet landing page we want the leaderboard to encourage and recognize participation in the current release. We intend for it to incentivize people who join midway in a phase and who will most likely not get on the top positions of the phase leaderboards that they could meaningfully make it close to the top for the current phase.

## Why are we sorting on the frontend?

We pull directly from the leaderboard spreadsheet, so you may ask: Why not sort in the spreadsheet. Well, we don't pull data from the individual phase sheet, but instead the top-level phase sheet. The purpose of this sheet is different! https://docs.google.com/spreadsheets/d/1CLX9DF7oFDWb1UiimQXgh_J6jO4fVLJEcEnPVAOfq24/edit#gid=1000546858 the front-page sheet is for the full phase, the leaderboard view on our website focuses on the "current" phase. We don't want to change the sort on that front-page sheet because that makes it harder to see overall position in the full phase.

We could pull from both the current phase sheet and the top-level sheet and use the sort from the current sheet to present the info from the top-level sheet, but the only thing we would gain from that is the sort, so it is certainly better to just perform that sort on the frontend.

## Screenshots

### Before

<img width="768" alt="Screen Shot 2020-05-07 at 1 55 13 PM" src="https://user-images.githubusercontent.com/515445/81328146-67c33180-906a-11ea-851a-3a8e598b3c45.png">

### After

<img width="768" alt="Screen Shot 2020-05-07 at 3 09 18 AM" src="https://user-images.githubusercontent.com/515445/81265041-649b5780-9010-11ea-884e-5c861b199e09.png">