### PR TITLE
Unrequire split_snarkless test, remove long-fork bootstrap test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -582,9 +582,6 @@ jobs:
             - run:
                   name: Running test -- test_postake_bootstrap:coda-bootstrap-test
                   command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && ./scripts/test.py run --non-interactive --collect-artifacts --yes "test_postake_bootstrap:coda-bootstrap-test"'
-            - run:
-                  name: Running test -- test_postake_bootstrap:coda-long-fork -num-block-producers 2
-                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && ./scripts/test.py run --non-interactive --collect-artifacts --yes "test_postake_bootstrap:coda-long-fork -num-block-producers 2"'
             - store_artifacts:
                   path: test_output/artifacts
     test--test_postake_catchup:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,7 +13,6 @@ pull_request_rules:
           - "status-success=ci/circleci: test--test_postake_five_even_txns"
           - "status-success=ci/circleci: test--test_postake_snarkless"
           - "status-success=ci/circleci: test--test_postake_split"
-          - "status-success=ci/circleci: test--test_postake_split_snarkless"
           - "status-success=ci/circleci: test--test_postake_txns"
           - "status-success=ci/circleci: test-unit--dev"
           - "status-success=ci/circleci: test-unit--nonconsensus_medium_curves"

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -57,7 +57,7 @@ small_curves_tests = {
     simple_tests,
     'test_postake_catchup': ['coda-restart-node-test'],
     'test_postake_bootstrap':
-    ['coda-bootstrap-test', 'coda-long-fork -num-block-producers 2'],
+    ['coda-bootstrap-test'],
     'test_postake_three_producers': ['coda-txns-and-restart-non-producers'],
     'test_postake_delegation': ['coda-delegation-test'],
     'test_postake_txns': ['coda-shared-state-test', 'coda-batch-payment-test'],
@@ -91,7 +91,8 @@ ci_excludes = [
 # of all the generated CI jobs, allow these specific ones to fail (extra excludes on top of ci_excludes)
 required_excludes = [
     'test_postake_catchup:*',
-    'test_postake_three_producers:*'
+    'test_postake_three_producers:*',
+    'test_postake_split_snarkless:*'
 ]
 
 # these extra jobs are not filters, they are full status check names
@@ -379,14 +380,14 @@ class CodaProject:
 class OutDirectory:
     def __init__(self, root):
         self.root = root
-        self.build_logs = os.path.join(self.root, 'build_logs') 
-        self.test_logs = os.path.join(self.root, 'test_logs') 
+        self.build_logs = os.path.join(self.root, 'build_logs')
+        self.test_logs = os.path.join(self.root, 'test_logs')
         self.test_configs = os.path.join(self.root, 'test_configs')
         self.artifacts = os.path.join(self.root, 'artifacts')
         self.all_directories = [
             self.root,
             self.build_logs,
-            self.test_logs, 
+            self.test_logs,
             self.test_configs,
             self.artifacts
         ]


### PR DESCRIPTION
Make `test_postake_split_snarkless` not required in CI, because it fails too often.

For `test_postake_bootstrap`, keep the required status, but remove the long-fork subtest, because it's not needed.

Closes #4853.