### PR TITLE
Move protocol constant 'c' to Genesis_constants

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -397,7 +397,10 @@ let daemon logger =
          in
          let%bind precomputed_values =
            let protocol_state_with_hash =
-             Coda_state.Genesis_protocol_state.t ~genesis_constants
+             Coda_state.Genesis_protocol_state.t
+               ~constraint_constants:
+                 Genesis_constants.Constraint_constants.compiled
+               ~genesis_constants
                ~genesis_ledger:(Genesis_ledger.Packed.t genesis_ledger)
            in
            let%map base_hash =
@@ -666,7 +669,10 @@ let daemon logger =
          let trust_system = Trust_system.create trust_dir in
          trace_database_initialization "trust_system" __LOC__ trust_dir ;
          let genesis_state_hash =
-           Coda_state.Genesis_protocol_state.t ~genesis_constants
+           Coda_state.Genesis_protocol_state.t
+             ~constraint_constants:
+               Genesis_constants.Constraint_constants.compiled
+             ~genesis_constants
              ~genesis_ledger:(Genesis_ledger.Packed.t genesis_ledger)
            |> With_hash.hash
          in
@@ -842,8 +848,10 @@ let daemon logger =
                 ~consensus_local_state ~transaction_database
                 ~external_transition_database ~is_archive_rocksdb
                 ~work_reassignment_wait ~archive_process_location
-                ~log_block_creation ~precomputed_values ~proof_level ())
-             ~precomputed_values
+                ~log_block_creation
+                ~constraint_constants:
+                  Genesis_constants.Constraint_constants.compiled
+                ~precomputed_values ~proof_level ())
          in
          {Coda_initialization.coda; client_trustlist; rest_server_port}
        in
@@ -976,6 +984,8 @@ let internal_commands =
                  let%bind prover =
                    Prover.create ~logger
                      ~proof_level:Genesis_constants.Proof_level.compiled
+                     ~constraint_constants:
+                       Genesis_constants.Constraint_constants.compiled
                      ~pids:(Pid.Table.create ()) ~conf_dir
                  in
                  Prover.prove_from_input_sexp prover sexp >>| ignore

--- a/src/app/cli/src/init/snark_flame_graphs.ml
+++ b/src/app/cli/src/init/snark_flame_graphs.ml
@@ -19,7 +19,11 @@ let main () =
   let logs =
     [ ( "step"
       , L_Tick.log
-          (log (M.Step_base.main ~logger ~proof_level:Full) Tick.Field.typ) )
+          (log
+             (M.Step_base.main ~logger ~proof_level:Full
+                ~constraint_constants:
+                  Genesis_constants.Constraint_constants.compiled)
+             Tick.Field.typ) )
     ; ("wrap", L_Tock.log (log W.main Crypto_params.Wrap_input.typ)) ]
   in
   List.iter logs ~f:(fun (name, log) ->

--- a/src/app/cli/src/tests/coda_long_fork.ml
+++ b/src/app/cli/src/tests/coda_long_fork.ml
@@ -6,6 +6,7 @@ let name = "coda-long-fork"
 let main n waiting_time () =
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       ~protocol_constants:Genesis_constants.compiled.protocol
   in
   let logger = Logger.create () in

--- a/src/app/cli/src/tests/coda_peers_test.ml
+++ b/src/app/cli/src/tests/coda_peers_test.ml
@@ -6,6 +6,7 @@ let name = "coda-peers-test"
 let main () =
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       ~protocol_constants:Genesis_constants.compiled.protocol
   in
   let%bind program_dir = Unix.getcwd () in

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -59,6 +59,7 @@ let local_configs ?block_production_interval
   let args = List.zip_exn addrs_and_ports_list peers in
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       ~protocol_constants:Genesis_constants.compiled.protocol
   in
   let configs =

--- a/src/app/cli/src/tests/coda_receipt_chain_test.ml
+++ b/src/app/cli/src/tests/coda_receipt_chain_test.ml
@@ -15,6 +15,7 @@ let restart_node worker ~config ~logger =
 let main () =
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       ~protocol_constants:Genesis_constants.compiled.protocol
   in
   let open Keypair in

--- a/src/app/cli/src/tests/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/tests/coda_transitive_peers_test.ml
@@ -6,6 +6,7 @@ let name = "coda-transitive-peers-test"
 let main () =
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       ~protocol_constants:Genesis_constants.compiled.protocol
   in
   let%bind program_dir = Unix.getcwd () in

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -563,8 +563,9 @@ module T = struct
                       ~f:(fun host_and_port ->
                         Cli_lib.Flag.Types.
                           {name= "dummy"; value= host_and_port} ))
+                 ~constraint_constants:
+                   Genesis_constants.Constraint_constants.compiled
                  ~proof_level:Genesis_constants.Proof_level.compiled ())
-              ~precomputed_values
           in
           let coda_ref : Coda_lib.t option ref = ref None in
           Coda_run.handle_shutdown ~monitor ~time_controller ~conf_dir

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -217,6 +217,7 @@ end
 
 let consensus_constants =
   Consensus.Constants.create
+    ~constraint_constants:Genesis_constants.Constraint_constants.compiled
     ~protocol_constants:Genesis_constants.compiled.protocol
 
 module Constants = struct

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -89,6 +89,7 @@ let run_test () : unit Deferred.t =
   let pids = Child_processes.Termination.create_pid_table () in
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       ~protocol_constants:Genesis_constants.compiled.protocol
   in
   setup_time_offsets consensus_constants ;
@@ -216,8 +217,9 @@ let run_test () : unit Deferred.t =
              ~consensus_local_state ~transaction_database
              ~external_transition_database ~work_reassignment_wait:420000
              ~precomputed_values
+             ~constraint_constants:
+               Genesis_constants.Constraint_constants.compiled
              ~proof_level:Genesis_constants.Proof_level.compiled ())
-          ~precomputed_values
       in
       don't_wait_for
         (Strict_pipe.Reader.iter_without_pushback

--- a/src/app/runtime_genesis_ledger/gen/gen.ml
+++ b/src/app/runtime_genesis_ledger/gen/gen.ml
@@ -4,6 +4,7 @@ let main genesis_constants =
   Out_channel.write_all "genesis_filename.txt"
     ~data:
       (Cache_dir.genesis_dir_name ~genesis_constants
+         ~constraint_constants:Genesis_constants.Constraint_constants.compiled
          ~proof_level:Genesis_constants.Proof_level.compiled) ;
   exit 0
 

--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -70,6 +70,7 @@ let main accounts_json_file dir num_accounts proof_level constants_file =
   let top_dir = Option.value ~default:Cache_dir.autogen_path dir in
   let genesis_dirname =
     Cache_dir.genesis_dir_name ~genesis_constants:Genesis_constants.compiled
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       ~proof_level:Genesis_constants.Proof_level.compiled
   in
   let%bind genesis_dir =
@@ -104,6 +105,8 @@ let main accounts_json_file dir num_accounts proof_level constants_file =
         in
         let%bind _base_hash, base_proof =
           Genesis_ledger_helper.Genesis_proof.generate ~proof_level ~ledger
+            ~constraint_constants:
+              Genesis_constants.Constraint_constants.compiled
             ~genesis_constants
         in
         Deferred.Or_error.ok_exn

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -101,9 +101,10 @@ end = struct
     t.timeout <- Some timeout
 end
 
-let generate_next_state ~previous_protocol_state ~time_controller
-    ~staged_ledger ~transactions ~get_completed_work ~logger ~coinbase_receiver
-    ~(keypair : Keypair.t) ~block_data ~scheduled_time ~log_block_creation =
+let generate_next_state ~constraint_constants ~previous_protocol_state
+    ~time_controller ~staged_ledger ~transactions ~get_completed_work ~logger
+    ~coinbase_receiver ~(keypair : Keypair.t) ~block_data ~scheduled_time
+    ~log_block_creation =
   let open Interruptible.Let_syntax in
   let self = Public_key.compress keypair.public_key in
   let previous_protocol_state_body_hash =
@@ -207,7 +208,7 @@ let generate_next_state ~previous_protocol_state ~time_controller
                       .user_commands diff
                       :> User_command.t list )
                   ~snarked_ledger_hash:previous_ledger_hash ~supply_increase
-                  ~logger ) )
+                  ~logger ~constraint_constants ) )
       in
       lift_sync (fun () ->
           measure "making Snark and Internal transitions" (fun () ->
@@ -251,11 +252,11 @@ let generate_next_state ~previous_protocol_state ~time_controller
 let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
     ~transaction_resource_pool ~time_controller ~keypairs ~coinbase_receiver
     ~consensus_local_state ~frontier_reader ~transition_writer
-    ~set_next_producer_timing ~log_block_creation
+    ~set_next_producer_timing ~log_block_creation ~constraint_constants
     ~(genesis_constants : Genesis_constants.t) =
   trace "block_producer" (fun () ->
       let consensus_constants =
-        Consensus.Constants.create
+        Consensus.Constants.create ~constraint_constants
           ~protocol_constants:genesis_constants.protocol
       in
       let log_bootstrap_mode () =
@@ -296,8 +297,9 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
               Interruptible.lift (Deferred.return ()) (Ivar.read ivar)
             in
             let%bind next_state_opt =
-              generate_next_state ~scheduled_time ~coinbase_receiver
-                ~block_data ~previous_protocol_state ~time_controller
+              generate_next_state ~constraint_constants ~scheduled_time
+                ~coinbase_receiver ~block_data ~previous_protocol_state
+                ~time_controller
                 ~staged_ledger:(Breadcrumb.staged_ledger crumb)
                 ~transactions ~get_completed_work ~logger ~keypair
                 ~log_block_creation

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -11,6 +11,7 @@ module type Update_intf = sig
     val update :
          logger:Logger.t
       -> proof_level:Genesis_constants.Proof_level.t
+      -> constraint_constants:Genesis_constants.Constraint_constants.t
       -> State_hash.var * State_body_hash.var * Protocol_state.var
       -> Snark_transition.var
       -> ( State_hash.var * Protocol_state.var * [`Success of Boolean.var]
@@ -49,6 +50,7 @@ module Make_update (T : Transaction_snark.Verification.S) = struct
           fun _ _ _ _ _ _ _ -> Checked.return Boolean.true_
 
     let%snarkydef update ~(logger : Logger.t) ~proof_level
+        ~constraint_constants
         ((previous_state_hash, previous_state_body_hash, previous_state) :
           State_hash.var * State_body_hash.var * Protocol_state.var)
         (transition : Snark_transition.var) :
@@ -58,8 +60,9 @@ module Make_update (T : Transaction_snark.Verification.S) = struct
       let supply_increase = Snark_transition.supply_increase transition in
       let%bind `Success updated_consensus_state, consensus_state =
         with_label __LOC__
-          (Consensus_state_hooks.next_state_checked ~prev_state:previous_state
-             ~prev_state_hash:previous_state_hash transition supply_increase)
+          (Consensus_state_hooks.next_state_checked ~constraint_constants
+             ~prev_state:previous_state ~prev_state_hash:previous_state_hash
+             transition supply_increase)
       in
       let prev_pending_coinbase_root =
         previous_state |> Protocol_state.blockchain_state

--- a/src/lib/blockchain_snark/blockchain_snark_state.mli
+++ b/src/lib/blockchain_snark/blockchain_snark_state.mli
@@ -7,6 +7,7 @@ module type Update_intf = sig
     val update :
          logger:Logger.t
       -> proof_level:Genesis_constants.Proof_level.t
+      -> constraint_constants:Genesis_constants.Constraint_constants.t
       -> State_hash.var * State_body_hash.var * Protocol_state.var
       -> Snark_transition.var
       -> ( State_hash.var * Protocol_state.var * [`Success of Boolean.var]

--- a/src/lib/blockchain_snark/blockchain_transition.ml
+++ b/src/lib/blockchain_snark/blockchain_transition.ml
@@ -247,7 +247,9 @@ module Make (T : Transaction_snark.Verification.S) = struct
         ~input:
           (Tick.constraint_system ~exposing:(Step_base.input ())
              (Step_base.main ~logger:(Logger.null ())
-                ~proof_level:Genesis_constants.Proof_level.compiled))
+                ~proof_level:Genesis_constants.Proof_level.compiled
+                ~constraint_constants:
+                  Genesis_constants.Constraint_constants.compiled))
 
     let cached () =
       let open Cached.Deferred_with_track_generated.Let_syntax in
@@ -328,6 +330,8 @@ let constraint_system_digests () =
         M.Step_base.(
           Tick.constraint_system ~exposing:(input ())
             (main ~logger:(Logger.null ())
-               ~proof_level:Genesis_constants.Proof_level.compiled)) )
+               ~proof_level:Genesis_constants.Proof_level.compiled
+               ~constraint_constants:
+                 Genesis_constants.Constraint_constants.compiled)) )
   ; ("blockchain-wrap", digest' W.(Tock.constraint_system ~exposing:input main))
   ]

--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -15,6 +15,7 @@ val run :
   -> persistent_root:Transition_frontier.Persistent_root.t
   -> persistent_frontier:Transition_frontier.Persistent_frontier.t
   -> initial_root_transition:External_transition.Validated.t
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> precomputed_values:Precomputed_values.t
   -> ( Transition_frontier.t
      * External_transition.Initial_validated.t Envelope.Incoming.t list )

--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -7,7 +7,9 @@ let s3_install_path = "/tmp/s3_cache_dir"
 
 let manual_install_path = "/var/lib/coda"
 
-let genesis_dir_name ~(genesis_constants : Genesis_constants.t) ~proof_level =
+let genesis_dir_name
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+    ~(genesis_constants : Genesis_constants.t) ~proof_level =
   let digest =
     (*include all the time constants that would affect the genesis
     ledger and the proof*)
@@ -16,7 +18,7 @@ let genesis_dir_name ~(genesis_constants : Genesis_constants.t) ~proof_level =
           [ Coda_compile_config.curve_size
           ; Coda_compile_config.ledger_depth
           ; Option.value ~default:0 genesis_constants.num_accounts
-          ; Coda_compile_config.c
+          ; constraint_constants.c
           ; genesis_constants.protocol.k ]
           ~f:Int.to_string
       |> String.concat ~sep:"" )

--- a/src/lib/coda_base/transition_system.ml
+++ b/src/lib/coda_base/transition_system.ml
@@ -34,7 +34,9 @@ module type S = sig
 
     type value [@@deriving sexp]
 
-    val typ : (var, value) Typ.t
+    val typ :
+         constraint_constants:Genesis_constants.Constraint_constants.t
+      -> (var, value) Typ.t
 
     module Checked : sig
       val hash : var -> (Hash.var * Body_hash.var, _) Checked.t
@@ -44,6 +46,7 @@ module type S = sig
       val update :
            logger:Logger.t
         -> proof_level:Genesis_constants.Proof_level.t
+        -> constraint_constants:Genesis_constants.Constraint_constants.t
         -> Hash.var * Body_hash.var * var
            (*Previous state hash, previous state body hash, previous state*)
         -> Update.var
@@ -149,16 +152,17 @@ struct
 
     let exists' typ ~f = exists typ ~compute:As_prover.(map get_state ~f)
 
-    let%snarkydef main ~(logger : Logger.t) ~proof_level
+    let%snarkydef main ~constraint_constants ~(logger : Logger.t) ~proof_level
         (top_hash : Digest.Tick.Packed.var) =
-      let%bind prev_state = exists' State.typ ~f:Prover_state.prev_state
+      let%bind prev_state =
+        exists' (State.typ ~constraint_constants) ~f:Prover_state.prev_state
       and update = exists' Update.typ ~f:Prover_state.update in
       let%bind prev_state_hash, prev_state_body_hash =
         State.Checked.hash prev_state
       in
       let%bind next_state_hash, next_state, `Success success =
         with_label __LOC__
-          (State.Checked.update ~logger ~proof_level
+          (State.Checked.update ~logger ~proof_level ~constraint_constants
              (prev_state_hash, prev_state_body_hash, prev_state)
              update)
       in
@@ -181,7 +185,9 @@ struct
               let%bind prover_state = get_state in
               match Prover_state.expected_next_state prover_state with
               | Some expected_next_state ->
-                  let%bind in_snark_next_state = read State.typ next_state in
+                  let%bind in_snark_next_state =
+                    read (State.typ ~constraint_constants) next_state
+                  in
                   let%bind next_top_hash = read Field.typ next_top_hash in
                   let%bind top_hash = read Field.typ top_hash in
                   let updated = State.sexp_of_value in_snark_next_state in

--- a/src/lib/coda_commands/coda_commands.ml
+++ b/src/lib/coda_commands/coda_commands.ml
@@ -217,7 +217,10 @@ let get_status ~flag t =
   let protocol_constants =
     config.precomputed_values.genesis_constants.protocol
   in
-  let consensus_constants = Consensus.Constants.create ~protocol_constants in
+  let consensus_constants =
+    Consensus.Constants.create
+      ~constraint_constants:config.constraint_constants ~protocol_constants
+  in
   let uptime_secs =
     Time_ns.diff (Time_ns.now ()) start_time
     |> Time_ns.Span.to_sec |> Int.of_float
@@ -245,7 +248,8 @@ let get_status ~flag t =
       (Block_time.now time_controller)
   in
   let consensus_configuration =
-    Consensus.Configuration.t ~protocol_constants
+    Consensus.Configuration.t ~constraint_constants:config.constraint_constants
+      ~protocol_constants
   in
   let r = Perf_histograms.report in
   let histograms =

--- a/src/lib/coda_compile_config/coda_compile_config.ml
+++ b/src/lib/coda_compile_config/coda_compile_config.ml
@@ -103,15 +103,5 @@ let pending_coinbase_depth =
   Core_kernel.Int.ceil_log2
     (((transaction_capacity_log_2 + 1) * (work_delay + 1)) + 1)
 
-[%%ifdef
-consensus_mechanism]
-
-(** Consensus constants *)
-
-[%%inject
-"c", c]
-
-[%%endif]
-
 (* This is a bit of a hack, see #3232. *)
 let inactivity_ms = block_window_duration_ms * 8

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -154,6 +154,8 @@ module Types = struct
             ~resolve:(fun {ctx= coda; _} global_slot ->
               let constants =
                 Consensus.Constants.create
+                  ~constraint_constants:
+                    (Coda_lib.config coda).constraint_constants
                   ~protocol_constants:
                     (Coda_lib.config coda).precomputed_values.genesis_constants
                       .protocol
@@ -164,6 +166,8 @@ module Types = struct
             ~resolve:(fun {ctx= coda; _} global_slot ->
               let constants =
                 Consensus.Constants.create
+                  ~constraint_constants:
+                    (Coda_lib.config coda).constraint_constants
                   ~protocol_constants:
                     (Coda_lib.config coda).precomputed_values.genesis_constants
                       .protocol
@@ -186,6 +190,8 @@ module Types = struct
             ~resolve:(fun {ctx= coda; _} ->
               let consensus_constants =
                 Consensus.Constants.create
+                  ~constraint_constants:
+                    (Coda_lib.config coda).constraint_constants
                   ~protocol_constants:
                     (Coda_lib.config coda).precomputed_values.genesis_constants
                       .protocol

--- a/src/lib/coda_intf/transition_frontier_components_intf.ml
+++ b/src/lib/coda_intf/transition_frontier_components_intf.ml
@@ -366,6 +366,7 @@ module type Transition_router_intf = sig
                                Broadcast_pipe.Reader.t
                                * External_transition.Initial_validated.t
                                  Broadcast_pipe.Writer.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> ( [`Transition of External_transition.Validated.t]
        * [`Source of [`Gossip | `Catchup | `Internal]] )

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -669,6 +669,7 @@ let staking_ledger t =
   let open Option.Let_syntax in
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:t.config.constraint_constants
       ~protocol_constants:
         (Precomputed_values.protocol_constants t.config.precomputed_values)
   in
@@ -726,15 +727,17 @@ let start t =
     ~frontier_reader:t.components.transition_frontier
     ~transition_writer:t.pipes.producer_transition_writer
     ~log_block_creation:t.config.log_block_creation
+    ~constraint_constants:t.config.constraint_constants
     ~genesis_constants:
       (Precomputed_values.genesis_constants t.config.precomputed_values) ;
   Snark_worker.start t
 
-let create (config : Config.t) ~precomputed_values =
+let create (config : Config.t) =
   let consensus_constants =
     Consensus.Constants.create
+      ~constraint_constants:config.constraint_constants
       ~protocol_constants:
-        (Precomputed_values.protocol_constants precomputed_values)
+        (Precomputed_values.protocol_constants config.precomputed_values)
   in
   let monitor = Option.value ~default:(Monitor.create ()) config.monitor in
   Async.Scheduler.within' ~monitor (fun () ->
@@ -751,8 +754,9 @@ let create (config : Config.t) ~precomputed_values =
               (fun () ->
                 trace "prover" (fun () ->
                     Prover.create ~logger:config.logger
-                      ~proof_level:config.proof_level ~pids:config.pids
-                      ~conf_dir:config.conf_dir ) )
+                      ~proof_level:config.proof_level
+                      ~constraint_constants:config.constraint_constants
+                      ~pids:config.pids ~conf_dir:config.conf_dir ) )
             >>| Result.ok_exn
           in
           let%bind verifier =
@@ -1014,7 +1018,8 @@ let create (config : Config.t) ~precomputed_values =
           let ((most_recent_valid_block_reader, _) as most_recent_valid_block)
               =
             Broadcast_pipe.create
-              ( External_transition.genesis ~precomputed_values
+              ( External_transition.genesis
+                  ~precomputed_values:config.precomputed_values
               |> External_transition.Validated.to_initial_validated )
           in
           let valid_transitions, initialization_finish_signal =
@@ -1073,7 +1078,9 @@ let create (config : Config.t) ~precomputed_values =
                                @@ External_transition.Validation
                                   .forget_validation et ) ;
                          breadcrumb ))
-                  ~most_recent_valid_block ~precomputed_values )
+                  ~most_recent_valid_block
+                  ~constraint_constants:config.constraint_constants
+                  ~precomputed_values:config.precomputed_values )
           in
           let ( valid_transitions_for_network
               , valid_transitions_for_api

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -128,8 +128,7 @@ val start : t -> unit Deferred.t
 
 val stop_snark_worker : ?should_wait_kill:bool -> t -> unit Deferred.t
 
-val create :
-  Config.t -> precomputed_values:Precomputed_values.t -> t Deferred.t
+val create : Config.t -> t Deferred.t
 
 val staged_ledger_ledger_proof : t -> Ledger_proof.t option
 

--- a/src/lib/coda_lib/config.ml
+++ b/src/lib/coda_lib/config.ml
@@ -49,5 +49,6 @@ type t =
         [@default None]
   ; demo_mode: bool [@default false]
   ; log_block_creation: bool [@default false]
+  ; constraint_constants: Genesis_constants.Constraint_constants.t
   ; precomputed_values: Precomputed_values.t }
 [@@deriving make]

--- a/src/lib/coda_state/genesis_protocol_state.ml
+++ b/src/lib/coda_state/genesis_protocol_state.ml
@@ -1,47 +1,19 @@
 open Core_kernel
 open Coda_base
 
-let create_with_custom_ledger ~genesis_consensus_state ~genesis_ledger
+let t ~genesis_ledger ~constraint_constants
     ~(genesis_constants : Genesis_constants.t) =
-  let protocol_constants = genesis_constants.protocol in
-  let negative_one_protocol_state_hash =
-    Protocol_state.(hash (negative_one ~genesis_ledger ~protocol_constants))
-  in
-  let root_ledger_hash = Ledger.merkle_root (Lazy.force genesis_ledger) in
-  let staged_ledger_hash =
-    Staged_ledger_hash.of_aux_ledger_and_coinbase_hash
-      Staged_ledger_hash.Aux_hash.dummy root_ledger_hash
-      (Or_error.ok_exn (Pending_coinbase.create ()))
-  in
-  let snarked_ledger_hash =
-    Frozen_ledger_hash.of_ledger_hash root_ledger_hash
-  in
-  let blockchain_state =
-    Blockchain_state.create_value
-      ~timestamp:
-        Blockchain_state.(
-          timestamp (genesis ~genesis_ledger_hash:root_ledger_hash))
-      ~staged_ledger_hash ~snarked_ledger_hash
-  in
-  let state =
-    Protocol_state.create_value
-      ~genesis_state_hash:
-        (State_hash.of_hash Snark_params.Tick.Pedersen.zero_hash)
-      ~previous_state_hash:negative_one_protocol_state_hash ~blockchain_state
-      ~consensus_state:genesis_consensus_state
-      ~constants:(Protocol_constants_checked.value_of_t protocol_constants)
-  in
-  With_hash.of_data ~hash_data:Protocol_state.hash state
-
-let t ~genesis_ledger ~(genesis_constants : Genesis_constants.t) =
   let genesis_ledger_hash = Ledger.merkle_root (Lazy.force genesis_ledger) in
   let protocol_constants = genesis_constants.protocol in
   let negative_one_protocol_state_hash =
-    Protocol_state.(hash (negative_one ~genesis_ledger ~protocol_constants))
+    Protocol_state.(
+      hash
+        (negative_one ~genesis_ledger ~constraint_constants ~protocol_constants))
   in
   let genesis_consensus_state =
     Consensus.Data.Consensus_state.create_genesis
-      ~negative_one_protocol_state_hash ~genesis_ledger ~protocol_constants
+      ~negative_one_protocol_state_hash ~genesis_ledger ~constraint_constants
+      ~protocol_constants
   in
   let state =
     Protocol_state.create_value
@@ -56,6 +28,7 @@ let t ~genesis_ledger ~(genesis_constants : Genesis_constants.t) =
 let compile_time_genesis =
   lazy
     (t ~genesis_ledger:Test_genesis_ledger.t
+       ~constraint_constants:Genesis_constants.Constraint_constants.compiled
        ~genesis_constants:Genesis_constants.compiled)
 
 module For_tests = struct

--- a/src/lib/coda_state/genesis_protocol_state.mli
+++ b/src/lib/coda_state/genesis_protocol_state.mli
@@ -1,13 +1,8 @@
 open Coda_base
 
-val create_with_custom_ledger :
-     genesis_consensus_state:Consensus.Data.Consensus_state.Value.t
-  -> genesis_ledger:Ledger.t Lazy.t
-  -> genesis_constants:Genesis_constants.t
-  -> (Protocol_state.Value.t, State_hash.t) With_hash.t
-
 val t :
      genesis_ledger:Ledger.t Lazy.t
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> genesis_constants:Genesis_constants.t
   -> (Protocol_state.Value.t, State_hash.t) With_hash.t
 

--- a/src/lib/coda_state/protocol_state.ml
+++ b/src/lib/coda_state/protocol_state.ml
@@ -104,16 +104,18 @@ module Body = struct
          [genesis_state_hash; blockchain_state; consensus_state; constants] ->
     {genesis_state_hash; blockchain_state; consensus_state; constants}
 
-  let data_spec =
+  let data_spec ~constraint_constants =
     Data_spec.
       [ State_hash.typ
       ; Blockchain_state.typ
-      ; Consensus.Data.Consensus_state.typ
+      ; Consensus.Data.Consensus_state.typ ~constraint_constants
       ; Protocol_constants_checked.typ ]
 
-  let typ =
-    Typ.of_hlistable data_spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
-      ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+  let typ ~constraint_constants =
+    Typ.of_hlistable
+      (data_spec ~constraint_constants)
+      ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+      ~value_of_hlist:of_hlist
 
   let to_input
       { Poly.genesis_state_hash: State_hash.t
@@ -224,11 +226,14 @@ let to_hlist {Poly.Stable.Latest.previous_state_hash; body} =
 let of_hlist : (unit, 'psh -> 'body -> unit) H_list.t -> ('psh, 'body) Poly.t =
  fun H_list.[previous_state_hash; body] -> {previous_state_hash; body}
 
-let data_spec = Data_spec.[State_hash.typ; Body.typ]
+let data_spec ~constraint_constants =
+  Data_spec.[State_hash.typ; Body.typ ~constraint_constants]
 
-let typ =
-  Typ.of_hlistable data_spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
-    ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
+let typ ~constraint_constants =
+  Typ.of_hlistable
+    (data_spec ~constraint_constants)
+    ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+    ~value_of_hlist:of_hlist
 
 let hash_checked ({previous_state_hash; body} : var) =
   let%bind body = Body.hash_checked body in
@@ -271,7 +276,7 @@ let hash s =
 
 [%%endif]
 
-let negative_one ~genesis_ledger ~protocol_constants =
+let negative_one ~genesis_ledger ~constraint_constants ~protocol_constants =
   { Poly.Stable.Latest.previous_state_hash=
       State_hash.of_hash Snark_params.Tick.Pedersen.zero_hash
   ; body=
@@ -283,6 +288,6 @@ let negative_one ~genesis_ledger ~protocol_constants =
           State_hash.of_hash Snark_params.Tick.Pedersen.zero_hash
       ; consensus_state=
           Consensus.Data.Consensus_state.negative_one ~genesis_ledger
-            ~protocol_constants
+            ~constraint_constants ~protocol_constants
       ; constants= Protocol_constants_checked.value_of_t protocol_constants }
   }

--- a/src/lib/coda_state/protocol_state.mli
+++ b/src/lib/coda_state/protocol_state.mli
@@ -84,7 +84,9 @@ type value = Value.t [@@deriving sexp, to_yojson]
 
 type var = (State_hash.var, Body.var) Poly.t
 
-include Snarkable.S with type value := Value.t and type var := var
+val typ :
+     constraint_constants:Genesis_constants.Constraint_constants.t
+  -> (var, value) Typ.t
 
 val create : previous_state_hash:'a -> body:'b -> ('a, 'b) Poly.t
 
@@ -122,6 +124,7 @@ val constants : (_, (_, _, _, 'a) Body.t) Poly.t -> 'a
 
 val negative_one :
      genesis_ledger:Coda_base.Ledger.t Lazy.t
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> protocol_constants:Genesis_constants.Protocol.t
   -> Value.t
 

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -614,10 +614,11 @@ let skip_genesis_protocol_state_validation
     `This_transition_was_generated_internally (t, validation) =
   (t, Validation.Unsafe.set_valid_genesis_state validation)
 
-let validate_time_received (t, validation) ~time_received =
+let validate_time_received ~constraint_constants (t, validation) ~time_received
+    =
   let protocol_state = With_hash.data t |> protocol_state in
   let constants =
-    Consensus.Constants.create
+    Consensus.Constants.create ~constraint_constants
       ~protocol_constants:
         ( Protocol_state.constants protocol_state
         |> Protocol_constants_checked.t_of_value )

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -310,7 +310,8 @@ module type S = sig
        Validation.with_transition
 
   val validate_time_received :
-       ( [`Time_received] * unit Truth.false_t
+       constraint_constants:Genesis_constants.Constraint_constants.t
+    -> ( [`Time_received] * unit Truth.false_t
        , 'genesis_state
        , 'proof
        , 'delta_transition_chain

--- a/src/lib/consensus/constants.ml
+++ b/src/lib/consensus/constants.ml
@@ -186,10 +186,11 @@ let create' (type a b c)
       with type length = a
        and type time = b
        and type timespan = c)
+    ~(constraint_constants : Genesis_constants.Constraint_constants.t)
     ~(protocol_constants : (a, a, b) Genesis_constants.Protocol.Poly.t) :
     (a, b, c) Poly.t =
   let open M in
-  let c = constant Coda_compile_config.c in
+  let c = constant constraint_constants.c in
   let block_window_duration_ms =
     constant Coda_compile_config.block_window_duration_ms
   in
@@ -231,11 +232,14 @@ let create' (type a b c)
   in
   res
 
-let create ~(protocol_constants : Genesis_constants.Protocol.t) : t =
+let create ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+    ~(protocol_constants : Genesis_constants.Protocol.t) : t =
   let protocol_constants =
     Coda_base.Protocol_constants_checked.value_of_t protocol_constants
   in
-  let constants = create' (module Constants_UInt32) ~protocol_constants in
+  let constants =
+    create' (module Constants_UInt32) ~constraint_constants ~protocol_constants
+  in
   let checkpoint_window_slots_per_year, checkpoint_window_size_in_slots =
     let per_year = 12 in
     let slots_per_year =
@@ -254,7 +258,9 @@ let create ~(protocol_constants : Genesis_constants.Protocol.t) : t =
   ; checkpoint_window_slots_per_year }
 
 let for_unit_tests =
-  create ~protocol_constants:Genesis_constants.for_unit_tests.protocol
+  create
+    ~constraint_constants:Genesis_constants.Constraint_constants.for_unit_tests
+    ~protocol_constants:Genesis_constants.for_unit_tests.protocol
 
 let to_hlist
     ({ k
@@ -426,12 +432,15 @@ module Checked = struct
           ; delta_duration
           ; genesis_state_timestamp |])
 
-  let create ~(protocol_constants : Coda_base.Protocol_constants_checked.var) :
+  let create ~(constraint_constants : Genesis_constants.Constraint_constants.t)
+      ~(protocol_constants : Coda_base.Protocol_constants_checked.var) :
       (var, _) Checked.t =
     let open Snarky_integer in
     let%bind constants =
       make_checked (fun () ->
-          create' (module Constants_checked) ~protocol_constants )
+          create'
+            (module Constants_checked)
+            ~constraint_constants ~protocol_constants )
     in
     let%map checkpoint_window_slots_per_year, checkpoint_window_size_in_slots =
       let constant c = Integer.constant ~m (Bignum_bigint.of_int c) in
@@ -464,11 +473,15 @@ end
 let%test_unit "checked = unchecked" =
   let open Coda_base in
   let for_unit_tests = Genesis_constants.for_unit_tests.protocol in
+  let constraint_constants =
+    Genesis_constants.Constraint_constants.for_unit_tests
+  in
   let test =
     Test_util.test_equal Protocol_constants_checked.typ typ
-      (fun protocol_constants -> Checked.create ~protocol_constants)
       (fun protocol_constants ->
-        create
+        Checked.create ~constraint_constants ~protocol_constants )
+      (fun protocol_constants ->
+        create ~constraint_constants
           ~protocol_constants:
             (Protocol_constants_checked.t_of_value protocol_constants) )
   in

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -243,6 +243,7 @@ module type State_hooks = sig
     -> snarked_ledger_hash:Coda_base.Frozen_ledger_hash.t
     -> supply_increase:Currency.Amount.t
     -> logger:Logger.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> protocol_state * consensus_transition
 
   (**
@@ -250,7 +251,8 @@ module type State_hooks = sig
    * a given consensus state and snark transition.
   *)
   val next_state_checked :
-       prev_state:protocol_state_var
+       constraint_constants:Genesis_constants.Constraint_constants.t
+    -> prev_state:protocol_state_var
     -> prev_state_hash:Coda_base.State_hash.var
     -> snark_transition_var
     -> Currency.Amount.var
@@ -314,7 +316,10 @@ module type S = sig
       ; acceptable_network_delay: int }
     [@@deriving yojson, fields]
 
-    val t : protocol_constants:Genesis_constants.Protocol.t -> t
+    val t :
+         constraint_constants:Genesis_constants.Constraint_constants.t
+      -> protocol_constants:Genesis_constants.Protocol.t
+      -> t
   end
 
   module Data : sig
@@ -431,10 +436,15 @@ module type S = sig
 
       type display [@@deriving yojson]
 
-      include Snark_params.Tick.Snarkable.S with type value := Value.t
+      type var
+
+      val typ :
+           constraint_constants:Genesis_constants.Constraint_constants.t
+        -> (var, Value.t) Snark_params.Tick.Typ.t
 
       val negative_one :
            genesis_ledger:Ledger.t Lazy.t
+        -> constraint_constants:Genesis_constants.Constraint_constants.t
         -> protocol_constants:Genesis_constants.Protocol.t
         -> Value.t
 
@@ -442,12 +452,14 @@ module type S = sig
            negative_one_protocol_state_hash:Coda_base.State_hash.t
         -> consensus_transition:Consensus_transition.Value.t
         -> genesis_ledger:Ledger.t Lazy.t
+        -> constraint_constants:Genesis_constants.Constraint_constants.t
         -> protocol_constants:Genesis_constants.Protocol.t
         -> Value.t
 
       val create_genesis :
            negative_one_protocol_state_hash:Coda_base.State_hash.t
         -> genesis_ledger:Ledger.t Lazy.t
+        -> constraint_constants:Genesis_constants.Constraint_constants.t
         -> protocol_constants:Genesis_constants.Protocol.t
         -> Value.t
 

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -106,8 +106,10 @@ module Configuration = struct
     ; acceptable_network_delay: int }
   [@@deriving yojson, fields]
 
-  let t ~protocol_constants =
-    let constants = Constants.create ~protocol_constants in
+  let t ~constraint_constants ~protocol_constants =
+    let constants =
+      Constants.create ~constraint_constants ~protocol_constants
+    in
     let of_int32 = UInt32.to_int in
     let of_span = Fn.compose Int64.to_int Block_time.Span.to_ms in
     { delta= of_int32 constants.delta
@@ -1883,9 +1885,10 @@ module Data = struct
       ; next_epoch_data
       ; has_ancestor_in_same_checkpoint_window }
 
-    let data_spec =
+    let data_spec
+        ~(constraint_constants : Genesis_constants.Constraint_constants.t) =
       let open Snark_params.Tick.Data_spec in
-      let sub_windows_per_window = Coda_compile_config.c in
+      let sub_windows_per_window = constraint_constants.c in
       [ Length.typ
       ; Length.typ
       ; Length.typ
@@ -1897,9 +1900,10 @@ module Data = struct
       ; Epoch_data.Next.typ
       ; Boolean.typ ]
 
-    let typ : (var, Value.t) Typ.t =
-      Snark_params.Tick.Typ.of_hlistable data_spec ~var_to_hlist:to_hlist
-        ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
+    let typ ~constraint_constants : (var, Value.t) Typ.t =
+      Snark_params.Tick.Typ.of_hlistable
+        (data_spec ~constraint_constants)
+        ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
         ~value_of_hlist:of_hlist
 
     let to_input
@@ -2079,9 +2083,11 @@ module Data = struct
     let same_checkpoint_window ~constants ~prev ~next =
       make_checked (fun () -> same_checkpoint_window ~constants ~prev ~next)
 
-    let negative_one ~genesis_ledger
+    let negative_one ~genesis_ledger ~constraint_constants
         ~(protocol_constants : Genesis_constants.Protocol.t) =
-      let constants = Constants.create ~protocol_constants in
+      let constants =
+        Constants.create ~constraint_constants ~protocol_constants
+      in
       let max_sub_window_density = constants.slots_per_sub_window in
       let max_window_density = constants.slots_per_window in
       { Poly.blockchain_length= Length.zero
@@ -2100,7 +2106,8 @@ module Data = struct
       ; has_ancestor_in_same_checkpoint_window= false }
 
     let create_genesis_from_transition ~negative_one_protocol_state_hash
-        ~consensus_transition ~genesis_ledger ~protocol_constants : Value.t =
+        ~consensus_transition ~genesis_ledger ~constraint_constants
+        ~protocol_constants : Value.t =
       let producer_vrf_result =
         let _, sk = Vrf.Precomputed.genesis_winner in
         Vrf.eval ~private_key:sk
@@ -2114,19 +2121,21 @@ module Data = struct
       in
       Or_error.ok_exn
         (update
-           ~constants:(Constants.create ~protocol_constants)
+           ~constants:
+             (Constants.create ~constraint_constants ~protocol_constants)
            ~producer_vrf_result
            ~previous_consensus_state:
-             (negative_one ~genesis_ledger ~protocol_constants)
+             (negative_one ~genesis_ledger ~constraint_constants
+                ~protocol_constants)
            ~previous_protocol_state_hash:negative_one_protocol_state_hash
            ~consensus_transition ~supply_increase:Currency.Amount.zero
            ~snarked_ledger_hash)
 
     let create_genesis ~negative_one_protocol_state_hash ~genesis_ledger
-        ~protocol_constants : Value.t =
+        ~constraint_constants ~protocol_constants : Value.t =
       create_genesis_from_transition ~negative_one_protocol_state_hash
         ~consensus_transition:Consensus_transition.genesis ~genesis_ledger
-        ~protocol_constants
+        ~constraint_constants ~protocol_constants
 
     (* Check that both epoch and slot are zero.
     *)
@@ -2146,10 +2155,12 @@ module Data = struct
         (previous_protocol_state_hash : Coda_base.State_hash.var)
         ~(supply_increase : Currency.Amount.var)
         ~(previous_blockchain_state_ledger_hash :
-           Coda_base.Frozen_ledger_hash.var)
+           Coda_base.Frozen_ledger_hash.var) ~constraint_constants
         ~(protocol_constants : Coda_base.Protocol_constants_checked.var) =
       let open Snark_params.Tick in
-      let%bind constants = Constants.Checked.create protocol_constants in
+      let%bind constants =
+        Constants.Checked.create ~constraint_constants ~protocol_constants
+      in
       let {Poly.curr_global_slot= prev_global_slot; _} = previous_state in
       let next_global_slot =
         Global_slot.Checked.of_slot_number ~constants transition_data
@@ -3066,10 +3077,14 @@ module Hooks = struct
     |> Unix_timestamp.of_int64
 
   let%test "Receive a valid consensus_state with a bit of delay" =
+    let constraint_constants =
+      Genesis_constants.Constraint_constants.for_unit_tests
+    in
+    let protocol_constants = Genesis_constants.for_unit_tests.protocol in
     let curr_epoch, curr_slot =
       Consensus_state.curr_epoch_and_slot
         (Consensus_state.negative_one ~genesis_ledger:Test_genesis_ledger.t
-           ~protocol_constants:Genesis_constants.for_unit_tests.protocol)
+           ~constraint_constants ~protocol_constants)
     in
     let constants = Constants.for_unit_tests in
     let delay = UInt32.(div constants.delta (of_int 2)) in
@@ -3077,13 +3092,16 @@ module Hooks = struct
     let time_received = Epoch.slot_start_time ~constants curr_epoch new_slot in
     received_at_valid_time ~constants
       (Consensus_state.negative_one ~genesis_ledger:Test_genesis_ledger.t
-         ~protocol_constants:Genesis_constants.for_unit_tests.protocol)
+         ~constraint_constants ~protocol_constants)
       ~time_received:(to_unix_timestamp time_received)
     |> Result.is_ok
 
   let%test "Receive an invalid consensus_state" =
     let epoch = Epoch.of_int 5 in
     let constants = Constants.for_unit_tests in
+    let constraint_constants =
+      Genesis_constants.Constraint_constants.for_unit_tests
+    in
     let protocol_constants = Genesis_constants.for_unit_tests.protocol in
     let start_time = Epoch.start_time ~constants epoch in
     let ((curr_epoch, curr_slot) as curr) =
@@ -3091,7 +3109,7 @@ module Hooks = struct
     in
     let consensus_state =
       { (Consensus_state.negative_one ~genesis_ledger:Test_genesis_ledger.t
-           ~protocol_constants)
+           ~constraint_constants ~protocol_constants)
         with
         curr_global_slot= Global_slot.of_epoch_and_slot ~constants curr }
     in
@@ -3100,7 +3118,7 @@ module Hooks = struct
       Epoch.start_time ~constants
         (Consensus_state.curr_slot
            (Consensus_state.negative_one ~genesis_ledger:Test_genesis_ledger.t
-              ~protocol_constants))
+              ~constraint_constants ~protocol_constants))
     in
     let too_late =
       let delay = UInt32.(mul constants.delta (of_int 2)) in
@@ -3161,12 +3179,13 @@ module Hooks = struct
 
     let generate_transition ~(previous_protocol_state : Protocol_state.Value.t)
         ~blockchain_state ~current_time ~(block_data : Block_data.t)
-        ~transactions:_ ~snarked_ledger_hash ~supply_increase ~logger =
+        ~transactions:_ ~snarked_ledger_hash ~supply_increase ~logger
+        ~constraint_constants =
       let previous_consensus_state =
         Protocol_state.consensus_state previous_protocol_state
       in
       let constants =
-        Constants.create
+        Constants.create ~constraint_constants
           ~protocol_constants:
             ( Protocol_state.constants previous_protocol_state
             |> Coda_base.Protocol_constants_checked.t_of_value )
@@ -3203,10 +3222,11 @@ module Hooks = struct
       (protocol_state, consensus_transition)
 
     include struct
-      let%snarkydef next_state_checked ~(prev_state : Protocol_state.var)
+      let%snarkydef next_state_checked ~constraint_constants
+          ~(prev_state : Protocol_state.var)
           ~(prev_state_hash : Coda_base.State_hash.var) transition
           supply_increase =
-        Consensus_state.update_var
+        Consensus_state.update_var ~constraint_constants
           (Protocol_state.consensus_state prev_state)
           (Snark_transition.consensus_transition transition)
           prev_state_hash ~supply_increase
@@ -3302,10 +3322,13 @@ let%test_module "Proof of stake tests" =
           (Ledger.merkle_root (Lazy.force Test_genesis_ledger.t))
       in
       let previous_protocol_state_hash = State_hash.(of_hash zero) in
+      let constraint_constants =
+        Genesis_constants.Constraint_constants.for_unit_tests
+      in
       let previous_consensus_state =
         Consensus_state.create_genesis
           ~negative_one_protocol_state_hash:previous_protocol_state_hash
-          ~genesis_ledger:Test_genesis_ledger.t
+          ~genesis_ledger:Test_genesis_ledger.t ~constraint_constants
           ~protocol_constants:Genesis_constants.for_unit_tests.protocol
       in
       let constants = Constants.for_unit_tests in
@@ -3362,7 +3385,9 @@ let%test_module "Proof of stake tests" =
         let open Snark_params.Tick in
         (* work in Checked monad *)
         let%bind previous_state =
-          exists typ ~compute:(As_prover.return previous_consensus_state)
+          exists
+            (typ ~constraint_constants)
+            ~compute:(As_prover.return previous_consensus_state)
         in
         let%bind transition_data =
           exists Consensus_transition.typ
@@ -3389,7 +3414,7 @@ let%test_module "Proof of stake tests" =
         let result =
           update_var previous_state transition_data
             previous_protocol_state_hash ~supply_increase
-            ~previous_blockchain_state_ledger_hash
+            ~previous_blockchain_state_ledger_hash ~constraint_constants
             ~protocol_constants:constants_checked
         in
         (* setup handler *)
@@ -3408,7 +3433,7 @@ let%test_module "Proof of stake tests" =
               {Pending_coinbase_witness.pending_coinbases; is_new_stack= true}
         in
         let%map `Success _, var = Snark_params.Tick.handle result handler in
-        As_prover.read typ var
+        As_prover.read (typ ~constraint_constants) var
       in
       let (), checked_value =
         Or_error.ok_exn

--- a/src/lib/fake_network/fake_network.ml
+++ b/src/lib/fake_network/fake_network.ml
@@ -144,11 +144,13 @@ module Generator = struct
 
   type peer_config =
        proof_level:Genesis_constants.Proof_level.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> max_frontier_length:int
     -> peer_state Generator.t
 
-  let fresh_peer ~proof_level ~precomputed_values ~max_frontier_length =
+  let fresh_peer ~proof_level ~constraint_constants ~precomputed_values
+      ~max_frontier_length =
     let genesis_ledger =
       Precomputed_values.genesis_ledger precomputed_values
     in
@@ -157,13 +159,14 @@ module Generator = struct
         ~genesis_ledger
     in
     let%map frontier =
-      Transition_frontier.For_tests.gen ~proof_level ~precomputed_values
-        ~consensus_local_state ~max_length:max_frontier_length ~size:0 ()
+      Transition_frontier.For_tests.gen ~proof_level ~constraint_constants
+        ~precomputed_values ~consensus_local_state
+        ~max_length:max_frontier_length ~size:0 ()
     in
     {frontier; consensus_local_state}
 
-  let peer_with_branch ~frontier_branch_size ~proof_level ~precomputed_values
-      ~max_frontier_length =
+  let peer_with_branch ~frontier_branch_size ~proof_level ~constraint_constants
+      ~precomputed_values ~max_frontier_length =
     let genesis_ledger =
       Precomputed_values.genesis_ledger precomputed_values
     in
@@ -173,7 +176,8 @@ module Generator = struct
     in
     let%map frontier, branch =
       Transition_frontier.For_tests.gen_with_branch ~proof_level
-        ~precomputed_values ~max_length:max_frontier_length ~frontier_size:0
+        ~constraint_constants ~precomputed_values
+        ~max_length:max_frontier_length ~frontier_size:0
         ~branch_size:frontier_branch_size ~consensus_local_state ()
     in
     Async.Thread_safe.block_on_async_exn (fun () ->
@@ -181,11 +185,13 @@ module Generator = struct
           ~f:(Transition_frontier.add_breadcrumb_exn frontier) ) ;
     {frontier; consensus_local_state}
 
-  let gen ~proof_level ~precomputed_values ~max_frontier_length configs =
+  let gen ~proof_level ~constraint_constants ~precomputed_values
+      ~max_frontier_length configs =
     let open Quickcheck.Generator.Let_syntax in
     let%map states =
       Vect.Quickcheck_generator.map configs ~f:(fun config ->
-          config ~proof_level ~precomputed_values ~max_frontier_length )
+          config ~proof_level ~constraint_constants ~precomputed_values
+            ~max_frontier_length )
     in
     setup states
 end

--- a/src/lib/fake_network/fake_network.mli
+++ b/src/lib/fake_network/fake_network.mli
@@ -28,6 +28,7 @@ module Generator : sig
 
   type peer_config =
        proof_level:Genesis_constants.Proof_level.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> max_frontier_length:int
     -> peer_state Generator.t
@@ -38,6 +39,7 @@ module Generator : sig
 
   val gen :
        proof_level:Genesis_constants.Proof_level.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> max_frontier_length:int
     -> (peer_config, 'n num_peers) Vect.t

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -34,6 +34,13 @@ module Proof_level = struct
   let compiled = of_string compiled
 end
 
+(** Constants that affect the constraint systems for proofs (and thus also key
+    generation).
+
+    Care must be taken to ensure that these match against the proving/
+    verification keys when [proof_level=Full], otherwise generated proofs will
+    be invalid.
+*)
 module Constraint_constants = struct
   [%%versioned
   module Stable = struct

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -34,6 +34,36 @@ module Proof_level = struct
   let compiled = of_string compiled
 end
 
+module Constraint_constants = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t = {c: int}
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  type t = Stable.Latest.t = {c: int}
+
+  [%%ifdef
+  consensus_mechanism]
+
+  [%%inject
+  "c", c]
+
+  [%%else]
+
+  (* Invalid value, this should not be used by nonconsensus nodes. *)
+  let c = -1
+
+  [%%endif]
+
+  let compiled = {c}
+
+  let for_unit_tests = compiled
+end
+
 (*Constants that can be specified for generating the base proof (that are not required for key-generation) in runtime_genesis_ledger.exe and that can be configured at runtime.
 The types are defined such that this module doesn't depend on any of the coda libraries (except blake2 and module_version) to avoid dependency cycles.
 TODO: #4659 move key generation to runtime_genesis_ledger.exe to include scan_state constants, consensus constants (c and  block_window_duration) and ledger depth here*)

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -118,8 +118,8 @@ end
 module Genesis_proof = struct
   let path ~root = root ^/ "genesis_proof"
 
-  let generate ~proof_level ~ledger ~(genesis_constants : Genesis_constants.t)
-      =
+  let generate ~proof_level ~ledger ~constraint_constants
+      ~(genesis_constants : Genesis_constants.t) =
     (* TODO(4829): Runtime proof-level. *)
     match proof_level with
     | Genesis_constants.Proof_level.Full ->
@@ -127,13 +127,13 @@ module Genesis_proof = struct
         let protocol_state_with_hash =
           Coda_state.Genesis_protocol_state.t
             ~genesis_ledger:(Genesis_ledger.Packed.t ledger)
-            ~genesis_constants
+            ~constraint_constants ~genesis_constants
         in
         let base_hash =
           Keys.Step.instance_hash protocol_state_with_hash.data
         in
         let computed_values =
-          Genesis_proof.create_values ~proof_level ~keys
+          Genesis_proof.create_values ~constraint_constants ~proof_level ~keys
             { genesis_ledger= ledger
             ; protocol_state_with_hash
             ; base_hash
@@ -195,7 +195,9 @@ let retrieve_genesis_state dir_opt ~logger ~conf_dir ~daemon_conf :
     (Genesis_ledger.Packed.t * Proof.t * Genesis_constants.t) Deferred.t =
   let open Cache_dir in
   let genesis_dir_name =
-    Cache_dir.genesis_dir_name ~genesis_constants:Genesis_constants.compiled
+    Cache_dir.genesis_dir_name
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
+      ~genesis_constants:Genesis_constants.compiled
       ~proof_level:Genesis_constants.Proof_level.compiled
   in
   let tar_filename = genesis_dir_name ^ ".tar.gz" in

--- a/src/lib/keys_lib/keys.ml
+++ b/src/lib/keys_lib/keys.ml
@@ -37,6 +37,7 @@ module type S = sig
     val main :
          logger:Logger.t
       -> proof_level:Genesis_constants.Proof_level.t
+      -> constraint_constants:Genesis_constants.Constraint_constants.t
       -> Tick.Field.Var.t
       -> (unit, Prover_state.t) Tick.Checked.t
   end
@@ -111,7 +112,7 @@ let create () : (module S) Async.Deferred.t =
               (Blockchain_snark.Blockchain_transition.instance_hash
                  (Tock.Keypair.vk Wrap.keys))
 
-          let main ~logger ~proof_level x =
+          let main ~logger ~proof_level ~constraint_constants x =
             let there
                 { Prover_state.wrap_vk
                 ; prev_proof
@@ -144,7 +145,7 @@ let create () : (module S) Async.Deferred.t =
             with_state
               ~and_then:(fun s -> As_prover.set_state (back s))
               As_prover.(map get_state ~f:there)
-              (main ~logger ~proof_level x)
+              (main ~logger ~proof_level ~constraint_constants x)
         end
 
         module Wrap = struct

--- a/src/lib/keys_lib/keys.mli
+++ b/src/lib/keys_lib/keys.mli
@@ -36,6 +36,7 @@ module type S = sig
     val main :
          logger:Logger.t
       -> proof_level:Genesis_constants.Proof_level.t
+      -> constraint_constants:Genesis_constants.Constraint_constants.t
       -> Tick.Field.Var.t
       -> (unit, Prover_state.t) Tick.Checked.t
   end

--- a/src/lib/ledger_catchup/ledger_catchup.ml
+++ b/src/lib/ledger_catchup/ledger_catchup.ml
@@ -410,6 +410,9 @@ let%test_module "Ledger_catchup tests" =
 
     let proof_level = Genesis_constants.Proof_level.Check
 
+    let constraint_constants =
+      Genesis_constants.Constraint_constants.for_unit_tests
+
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
     let trust_system = Trust_system.null ()
@@ -533,7 +536,8 @@ let%test_module "Ledger_catchup tests" =
           let%bind peer_branch_size =
             Int.gen_incl (max_frontier_length / 2) (max_frontier_length - 1)
           in
-          gen ~proof_level ~precomputed_values ~max_frontier_length
+          gen ~proof_level ~constraint_constants ~precomputed_values
+            ~max_frontier_length
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:peer_branch_size ])
         ~f:(fun network ->
@@ -552,7 +556,8 @@ let%test_module "Ledger_catchup tests" =
                    in the frontier" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          gen ~proof_level ~precomputed_values ~max_frontier_length
+          gen ~proof_level ~constraint_constants ~precomputed_values
+            ~max_frontier_length
             [fresh_peer; peer_with_branch ~frontier_branch_size:1])
         ~f:(fun network ->
           let open Fake_network in
@@ -566,7 +571,8 @@ let%test_module "Ledger_catchup tests" =
     let%test_unit "catchup fails if one of the parent transitions fail" =
       Quickcheck.test ~trials:1
         Fake_network.Generator.(
-          gen ~proof_level ~precomputed_values ~max_frontier_length
+          gen ~proof_level ~constraint_constants ~precomputed_values
+            ~max_frontier_length
             [ fresh_peer
             ; peer_with_branch ~frontier_branch_size:(max_frontier_length * 2)
             ])

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -46,6 +46,7 @@ module Make_real (Keys : Keys_lib.Keys.S) = struct
     Genesis_proof.create_values
       ~keys:(module Keys : Keys_lib.Keys.S)
       ~proof_level:Full
+      ~constraint_constants:Genesis_constants.Constraint_constants.compiled
       { genesis_constants= Genesis_constants.compiled
       ; genesis_ledger= (module Test_genesis_ledger)
       ; protocol_state_with_hash

--- a/src/lib/prover/intf.ml
+++ b/src/lib/prover/intf.ml
@@ -20,6 +20,7 @@ module type S = sig
     -> pids:Child_processes.Termination.t
     -> conf_dir:string
     -> proof_level:Genesis_constants.Proof_level.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> t Deferred.t
 
   val initialized : t -> [`Initialized] Deferred.Or_error.t

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -54,12 +54,14 @@ module Worker_state = struct
   type init_arg =
     { conf_dir: string
     ; logger: Logger.Stable.Latest.t
-    ; proof_level: Genesis_constants.Proof_level.Stable.Latest.t }
+    ; proof_level: Genesis_constants.Proof_level.Stable.Latest.t
+    ; constraint_constants:
+        Genesis_constants.Constraint_constants.Stable.Latest.t }
   [@@deriving bin_io_unversioned]
 
   type t = (module S) Deferred.t
 
-  let create {logger; proof_level; _} : t Deferred.t =
+  let create {logger; proof_level; constraint_constants; _} : t Deferred.t =
     Deferred.return
       (let%map (module Keys) = Keys_lib.Keys.create () in
        let module Transaction_snark =
@@ -99,7 +101,8 @@ module Worker_state = struct
                  in
                  let main x =
                    Tick.handle
-                     (Keys.Step.main ~logger ~proof_level x)
+                     (Keys.Step.main ~logger ~proof_level ~constraint_constants
+                        x)
                      (Consensus.Data.Prover_state.handler state_for_handler
                         ~pending_coinbase)
                  in
@@ -150,7 +153,8 @@ module Worker_state = struct
                  in
                  let main x =
                    Tick.handle
-                     (Keys.Step.main ~logger ~proof_level x)
+                     (Keys.Step.main ~logger ~proof_level ~constraint_constants
+                        x)
                      (Consensus.Data.Prover_state.handler state_for_handler
                         ~pending_coinbase)
                  in
@@ -255,7 +259,8 @@ module Worker = struct
         ; extend_blockchain= f extend_blockchain
         ; verify_blockchain= f verify_blockchain }
 
-      let init_worker_state Worker_state.{conf_dir; logger; proof_level} =
+      let init_worker_state
+          Worker_state.{conf_dir; logger; proof_level; constraint_constants} =
         let max_size = 256 * 1024 * 512 in
         Logger.Consumer_registry.register ~id:"default"
           ~processor:(Logger.Processor.raw ())
@@ -264,7 +269,8 @@ module Worker = struct
                ~log_filename:"coda-prover.log" ~max_size) ;
         Logger.info logger ~module_:__MODULE__ ~location:__LOC__
           "Prover started" ;
-        Worker_state.create {conf_dir; logger; proof_level}
+        Worker_state.create
+          {conf_dir; logger; proof_level; constraint_constants}
 
       let init_connection_state ~connection:_ ~worker_state:_ () =
         Deferred.unit
@@ -276,7 +282,7 @@ end
 
 type t = {connection: Worker.Connection.t; process: Process.t; logger: Logger.t}
 
-let create ~logger ~pids ~conf_dir ~proof_level =
+let create ~logger ~pids ~conf_dir ~proof_level ~constraint_constants =
   let on_failure err =
     Logger.error logger ~module_:__MODULE__ ~location:__LOC__
       "Prover process failed with error $err"
@@ -287,7 +293,7 @@ let create ~logger ~pids ~conf_dir ~proof_level =
     (* HACK: Need to make connection_timeout long since creating a prover can take a long time*)
     Worker.spawn_in_foreground_exn ~connection_timeout:(Time.Span.of_min 1.)
       ~on_failure ~shutdown_on:Disconnect ~connection_state_init_arg:()
-      {conf_dir; logger; proof_level}
+      {conf_dir; logger; proof_level; constraint_constants}
   in
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__
     "Daemon started process of kind $process_kind with pid $prover_pid"

--- a/src/lib/transaction_status/transaction_status.ml
+++ b/src/lib/transaction_status/transaction_status.ml
@@ -73,6 +73,9 @@ let%test_module "transaction_status" =
 
     let proof_level = Genesis_constants.Proof_level.Check
 
+    let constraint_constants =
+      Genesis_constants.Constraint_constants.for_unit_tests
+
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
     let trust_system = Trust_system.null ()
@@ -92,7 +95,8 @@ let%test_module "transaction_status" =
 
     let gen_frontier =
       Transition_frontier.For_tests.gen ~logger ~proof_level
-        ~precomputed_values ~trust_system ~max_length ~size:frontier_size ()
+        ~constraint_constants ~precomputed_values ~trust_system ~max_length
+        ~size:frontier_size ()
 
     let gen_user_command =
       User_command.Gen.payment ~sign_type:`Real ~max_amount:100 ~max_fee:10

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -65,7 +65,8 @@ type t =
       Protocol_states_for_root_scan_state.t
   ; consensus_local_state: Consensus.Data.Local_state.t
   ; max_length: int
-  ; genesis_constants: Genesis_constants.t }
+  ; genesis_constants: Genesis_constants.t
+  ; constraint_constants: Genesis_constants.Constraint_constants.t }
 
 let consensus_local_state {consensus_local_state; _} = consensus_local_state
 
@@ -105,7 +106,7 @@ let close t =
        (Breadcrumb.mask (root t)))
 
 let create ~logger ~root_data ~root_ledger ~base_hash ~consensus_local_state
-    ~max_length ~genesis_constants =
+    ~max_length ~constraint_constants ~genesis_constants =
   let open Root_data in
   let root_hash =
     External_transition.Validated.state_hash root_data.transition
@@ -145,6 +146,7 @@ let create ~logger ~root_data ~root_ledger ~base_hash ~consensus_local_state
     ; consensus_local_state
     ; max_length
     ; genesis_constants
+    ; constraint_constants
     ; protocol_states_for_root_scan_state }
   in
   t
@@ -567,7 +569,8 @@ let apply_diffs t diffs ~ignore_consensus_local_state =
     "Applying %d diffs to full frontier (%s --> ?)" (List.length diffs)
     (Frontier_hash.to_string t.hash) ;
   let consensus_constants =
-    Consensus.Constants.create ~protocol_constants:t.genesis_constants.protocol
+    Consensus.Constants.create ~constraint_constants:t.constraint_constants
+      ~protocol_constants:t.genesis_constants.protocol
   in
   let local_state_was_synced_at_start =
     Consensus.Hooks.required_local_state_sync ~constants:consensus_constants

--- a/src/lib/transition_frontier/full_frontier/full_frontier.mli
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.mli
@@ -32,6 +32,7 @@ val create :
   -> base_hash:Frontier_hash.t
   -> consensus_local_state:Consensus.Data.Local_state.t
   -> max_length:int
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> genesis_constants:Genesis_constants.t
   -> t
 

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -147,7 +147,7 @@ module Instance = struct
       Error `Bootstrap_required )
 
   let load_full_frontier t ~root_ledger ~consensus_local_state ~max_length
-      ~ignore_consensus_local_state ~genesis_constants =
+      ~ignore_consensus_local_state ~constraint_constants ~genesis_constants =
     let open Deferred.Result.Let_syntax in
     let downgrade_transition transition genesis_state_hash :
         ( External_transition.Almost_validated.t
@@ -219,7 +219,8 @@ module Instance = struct
               List.map protocol_states ~f:(fun s -> (Protocol_state.hash s, s))
           }
         ~root_ledger:(Ledger.Any_ledger.cast (module Ledger.Db) root_ledger)
-        ~consensus_local_state ~max_length ~genesis_constants
+        ~consensus_local_state ~max_length ~constraint_constants
+        ~genesis_constants
     in
     let%bind extensions =
       Deferred.map

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -16,6 +16,9 @@ let%test_module "Full_frontier tests" =
 
     let proof_level = Genesis_constants.Proof_level.Check
 
+    let constraint_constants =
+      Genesis_constants.Constraint_constants.for_unit_tests
+
     let accounts_with_secret_keys = Lazy.force Test_genesis_ledger.accounts
 
     let max_length = 5
@@ -67,7 +70,7 @@ let%test_module "Full_frontier tests" =
     let%test_unit "Should be able to find a breadcrumbs after adding them" =
       Quickcheck.test gen_breadcrumb ~trials:4 ~f:(fun make_breadcrumb ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier = create_frontier ~constraint_constants () in
               let root = Full_frontier.root frontier in
               let%map breadcrumb = make_breadcrumb root in
               add_breadcrumb frontier breadcrumb ;
@@ -87,7 +90,7 @@ let%test_module "Full_frontier tests" =
       Quickcheck.test gen_branches ~trials:4
         ~f:(fun (make_short_branch, make_long_branch) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier = create_frontier ~constraint_constants () in
               let test_best_tip ?message breadcrumb =
                 [%test_eq: State_hash.t] ?message
                   (Breadcrumb.state_hash breadcrumb)
@@ -126,7 +129,7 @@ let%test_module "Full_frontier tests" =
         ~trials:4
         ~f:(fun make_seq ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier = create_frontier ~constraint_constants () in
               let root = Full_frontier.root frontier in
               let%map seq = make_seq root in
               ignore
@@ -153,7 +156,7 @@ let%test_module "Full_frontier tests" =
         ~trials:2
         ~f:(fun make_seq ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier = create_frontier ~constraint_constants () in
               let root = Full_frontier.root frontier in
               let%map rest = make_seq root in
               List.iter rest ~f:(fun breadcrumb ->
@@ -177,7 +180,7 @@ let%test_module "Full_frontier tests" =
       in
       Quickcheck.test gen ~trials:4 ~f:(fun make_seq ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier = create_frontier ~constraint_constants () in
               let root = Full_frontier.root frontier in
               let%map breadcrumbs = make_seq root in
               List.iter breadcrumbs ~f:(fun b ->
@@ -204,7 +207,7 @@ let%test_module "Full_frontier tests" =
       Quickcheck.test gen ~trials:4
         ~f:(fun (make_ancestors, make_branch_a, make_branch_b) ->
           Async.Thread_safe.block_on_async_exn (fun () ->
-              let frontier = create_frontier () in
+              let frontier = create_frontier ~constraint_constants () in
               let root = Full_frontier.root frontier in
               let%bind ancestors = make_ancestors root in
               let youngest_ancestor = List.last_exn ancestors in

--- a/src/lib/transition_frontier/transition_frontier.ml
+++ b/src/lib/transition_frontier/transition_frontier.ml
@@ -40,7 +40,7 @@ let genesis_root_data ~precomputed_values =
 
 let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
     ~max_length ~persistent_root ~persistent_root_instance ~persistent_frontier
-    ~persistent_frontier_instance ~precomputed_values
+    ~persistent_frontier_instance ~constraint_constants ~precomputed_values
     ignore_consensus_local_state =
   let open Deferred.Result.Let_syntax in
   let root_identifier =
@@ -89,6 +89,7 @@ let load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
          ~root_ledger:
            (Persistent_root.Instance.snarked_ledger persistent_root_instance)
          ~consensus_local_state ~ignore_consensus_local_state
+         ~constraint_constants
          ~genesis_constants:
            (Precomputed_values.genesis_constants precomputed_values))
       ~f:
@@ -129,6 +130,7 @@ let rec load_with_max_length :
     -> consensus_local_state:Consensus.Data.Local_state.t
     -> persistent_root:Persistent_root.t
     -> persistent_frontier:Persistent_frontier.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> unit
     -> ( t
@@ -138,7 +140,7 @@ let rec load_with_max_length :
        Deferred.Result.t =
  fun ~max_length ?(retry_with_fresh_db = true) ~logger ~verifier
      ~consensus_local_state ~persistent_root ~persistent_frontier
-     ~precomputed_values () ->
+     ~constraint_constants ~precomputed_values () ->
   let open Deferred.Let_syntax in
   (* TODO: #3053 *)
   let continue persistent_frontier_instance ~ignore_consensus_local_state =
@@ -148,8 +150,8 @@ let rec load_with_max_length :
     match%bind
       load_from_persistence_and_start ~logger ~verifier ~consensus_local_state
         ~max_length ~persistent_root ~persistent_root_instance
-        ~persistent_frontier ~persistent_frontier_instance ~precomputed_values
-        ignore_consensus_local_state
+        ~persistent_frontier ~persistent_frontier_instance
+        ~constraint_constants ~precomputed_values ignore_consensus_local_state
     with
     | Ok _ as result ->
         return result
@@ -208,7 +210,8 @@ let rec load_with_max_length :
         in
         load_with_max_length ~max_length ~logger ~verifier
           ~consensus_local_state ~persistent_root ~persistent_frontier
-          ~retry_with_fresh_db:false () ~precomputed_values
+          ~retry_with_fresh_db:false () ~constraint_constants
+          ~precomputed_values
         >>| Result.map_error ~f:(function
               | `Persistent_frontier_malformed ->
                   `Failure
@@ -221,13 +224,14 @@ let rec load_with_max_length :
       continue persistent_frontier_instance ~ignore_consensus_local_state:true
 
 let load ?(retry_with_fresh_db = true) ~logger ~verifier ~consensus_local_state
-    ~persistent_root ~persistent_frontier ~precomputed_values () =
+    ~persistent_root ~persistent_frontier ~constraint_constants
+    ~precomputed_values () =
   let max_length =
     global_max_length (Precomputed_values.genesis_constants precomputed_values)
   in
   load_with_max_length ~max_length ~retry_with_fresh_db ~logger ~verifier
     ~consensus_local_state ~persistent_root ~persistent_frontier
-    ~precomputed_values ()
+    ~constraint_constants ~precomputed_values ()
 
 (* The persistent root and persistent frontier as safe to ignore here
  * because their lifecycle is longer than the transition frontier's *)
@@ -512,7 +516,7 @@ module For_tests = struct
     (root, protocol_states)
 
   let gen ?(logger = Logger.null ()) ~proof_level ?verifier ?trust_system
-      ?consensus_local_state ~precomputed_values
+      ?consensus_local_state ~constraint_constants ~precomputed_values
       ?(root_ledger_and_accounts =
         ( Lazy.force (Precomputed_values.genesis_ledger precomputed_values)
         , Lazy.force (Precomputed_values.accounts precomputed_values) ))
@@ -584,7 +588,8 @@ module For_tests = struct
       Async.Thread_safe.block_on_async_exn (fun () ->
           load_with_max_length ~max_length ~retry_with_fresh_db:false ~logger
             ~verifier ~consensus_local_state ~persistent_root
-            ~persistent_frontier ~precomputed_values () )
+            ~persistent_frontier ~constraint_constants ~precomputed_values ()
+      )
     in
     let frontier =
       let fail msg = failwith ("failed to load transition frontier: " ^ msg) in
@@ -604,7 +609,7 @@ module For_tests = struct
     frontier
 
   let gen_with_branch ?logger ~proof_level ?verifier ?trust_system
-      ?consensus_local_state ~precomputed_values
+      ?consensus_local_state ~constraint_constants ~precomputed_values
       ?(root_ledger_and_accounts =
         ( Lazy.force (Precomputed_values.genesis_ledger precomputed_values)
         , Lazy.force (Precomputed_values.accounts precomputed_values) ))
@@ -613,8 +618,8 @@ module For_tests = struct
     let open Quickcheck.Generator.Let_syntax in
     let%bind frontier =
       gen ?logger ~proof_level ?verifier ?trust_system ?consensus_local_state
-        ~precomputed_values ?gen_root_breadcrumb ~root_ledger_and_accounts
-        ~max_length ~size:frontier_size ()
+        ~constraint_constants ~precomputed_values ?gen_root_breadcrumb
+        ~root_ledger_and_accounts ~max_length ~size:frontier_size ()
     in
     let%map make_branch =
       Breadcrumb.For_tests.gen_seq ?logger ~proof_level ?verifier ?trust_system

--- a/src/lib/transition_frontier/transition_frontier.mli
+++ b/src/lib/transition_frontier/transition_frontier.mli
@@ -30,6 +30,7 @@ val load :
   -> consensus_local_state:Consensus.Data.Local_state.t
   -> persistent_root:Persistent_root.t
   -> persistent_frontier:Persistent_frontier.t
+  -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> precomputed_values:Precomputed_values.t
   -> unit
   -> ( t
@@ -65,6 +66,7 @@ module For_tests : sig
     -> consensus_local_state:Consensus.Data.Local_state.t
     -> persistent_root:Persistent_root.t
     -> persistent_frontier:Persistent_frontier.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> unit
     -> ( t
@@ -94,6 +96,7 @@ module For_tests : sig
     -> ?verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> ?root_ledger_and_accounts:Ledger.t
                                  * (Private_key.t option * Account.t) list
@@ -113,6 +116,7 @@ module For_tests : sig
     -> ?verifier:Verifier.t
     -> ?trust_system:Trust_system.t
     -> ?consensus_local_state:Consensus.Data.Local_state.t
+    -> constraint_constants:Genesis_constants.Constraint_constants.t
     -> precomputed_values:Precomputed_values.t
     -> ?root_ledger_and_accounts:Ledger.t
                                  * (Private_key.t option * Account.t) list

--- a/src/lib/transition_frontier_controller/transition_frontier_controller.ml
+++ b/src/lib/transition_frontier_controller/transition_frontier_controller.ml
@@ -5,7 +5,8 @@ open O1trace
 
 let run ~logger ~trust_system ~verifier ~network ~time_controller
     ~collected_transitions ~frontier ~network_transition_reader
-    ~producer_transition_reader ~clear_reader ~genesis_constants =
+    ~producer_transition_reader ~clear_reader ~constraint_constants
+    ~genesis_constants =
   let valid_transition_pipe_capacity = 30 in
   let valid_transition_reader, valid_transition_writer =
     Strict_pipe.create ~name:"valid transitions"
@@ -49,8 +50,8 @@ let run ~logger ~trust_system ~verifier ~network ~time_controller
   |> don't_wait_for ;
   let clean_up_catchup_scheduler = Ivar.create () in
   trace_recurring "processor" (fun () ->
-      Transition_handler.Processor.run ~logger ~genesis_constants
-        ~time_controller ~trust_system ~verifier ~frontier
+      Transition_handler.Processor.run ~logger ~constraint_constants
+        ~genesis_constants ~time_controller ~trust_system ~verifier ~frontier
         ~primary_transition_reader ~producer_transition_reader
         ~clean_up_catchup_scheduler ~catchup_job_writer
         ~catchup_breadcrumbs_reader ~catchup_breadcrumbs_writer

--- a/src/lib/transition_handler/catchup_scheduler.ml
+++ b/src/lib/transition_handler/catchup_scheduler.ml
@@ -279,6 +279,9 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
 
     let proof_level = Genesis_constants.Proof_level.Check
 
+    let constraint_constants =
+      Genesis_constants.Constraint_constants.for_unit_tests
+
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
     let trust_system = Trust_system.null ()
@@ -310,8 +313,8 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
       in
       Quickcheck.test ~trials:3
         (Transition_frontier.For_tests.gen_with_branch ~proof_level
-           ~precomputed_values ~verifier ~max_length ~frontier_size:1
-           ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
+           ~constraint_constants ~precomputed_values ~verifier ~max_length
+           ~frontier_size:1 ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
           let catchup_job_reader, catchup_job_writer =
             Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
               (Buffered (`Capacity 10, `Overflow Crash))
@@ -364,8 +367,8 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
       in
       Quickcheck.test ~trials:3
         (Transition_frontier.For_tests.gen_with_branch ~proof_level
-           ~precomputed_values ~verifier ~max_length ~frontier_size:1
-           ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
+           ~constraint_constants ~precomputed_values ~verifier ~max_length
+           ~frontier_size:1 ~branch_size:2 ()) ~f:(fun (frontier, branch) ->
           let cache = Unprocessed_transition_cache.create ~logger in
           let register_breadcrumb breadcrumb =
             Unprocessed_transition_cache.register_exn cache
@@ -449,8 +452,8 @@ let%test_module "Transition_handler.Catchup_scheduler tests" =
       in
       Quickcheck.test ~trials:3
         (Transition_frontier.For_tests.gen_with_branch ~proof_level
-           ~precomputed_values ~verifier ~max_length ~frontier_size:1
-           ~branch_size:5 ()) ~f:(fun (frontier, branch) ->
+           ~constraint_constants ~precomputed_values ~verifier ~max_length
+           ~frontier_size:1 ~branch_size:5 ()) ~f:(fun (frontier, branch) ->
           let catchup_job_reader, catchup_job_writer =
             Strict_pipe.create ~name:(__MODULE__ ^ __LOC__)
               (Buffered (`Capacity 10, `Overflow Crash))

--- a/src/lib/transition_handler/processor.ml
+++ b/src/lib/transition_handler/processor.ml
@@ -34,13 +34,15 @@ let cached_transform_deferred_result ~transform_cached ~transform_result cached
 (* add a breadcrumb and perform post processing *)
 let add_and_finalize ~logger ~frontier ~catchup_scheduler
     ~processed_transition_writer ~only_if_present ~time_controller ~source
-    cached_breadcrumb ~(genesis_constants : Genesis_constants.t) =
+    cached_breadcrumb ~constraint_constants
+    ~(genesis_constants : Genesis_constants.t) =
   let breadcrumb =
     if Cached.is_pure cached_breadcrumb then Cached.peek cached_breadcrumb
     else Cached.invalidate_with_success cached_breadcrumb
   in
   let consensus_constants =
-    Consensus.Constants.create ~protocol_constants:genesis_constants.protocol
+    Consensus.Constants.create ~constraint_constants
+      ~protocol_constants:genesis_constants.protocol
   in
   let transition =
     Transition_frontier.Breadcrumb.validated_transition breadcrumb
@@ -83,7 +85,8 @@ let add_and_finalize ~logger ~frontier ~catchup_scheduler
 
 let process_transition ~logger ~trust_system ~verifier ~frontier
     ~catchup_scheduler ~processed_transition_writer ~time_controller
-    ~transition:cached_initially_validated_transition ~genesis_constants =
+    ~transition:cached_initially_validated_transition ~constraint_constants
+    ~genesis_constants =
   let enveloped_initially_validated_transition =
     Cached.peek cached_initially_validated_transition
   in
@@ -207,10 +210,10 @@ let process_transition ~logger ~trust_system ~verifier ~frontier
     Deferred.map ~f:Result.return
       (add_and_finalize ~logger ~frontier ~catchup_scheduler
          ~processed_transition_writer ~only_if_present:false ~time_controller
-         ~source:`Gossip breadcrumb ~genesis_constants))
+         ~source:`Gossip breadcrumb ~constraint_constants ~genesis_constants))
 
-let run ~logger ~genesis_constants ~verifier ~trust_system ~time_controller
-    ~frontier
+let run ~logger ~constraint_constants ~genesis_constants ~verifier
+    ~trust_system ~time_controller ~frontier
     ~(primary_transition_reader :
        ( External_transition.Initial_validated.t Envelope.Incoming.t
        , State_hash.t )
@@ -247,12 +250,12 @@ let run ~logger ~genesis_constants ~verifier ~trust_system ~time_controller
   in
   let add_and_finalize =
     add_and_finalize ~frontier ~catchup_scheduler ~processed_transition_writer
-      ~time_controller ~genesis_constants
+      ~time_controller ~constraint_constants ~genesis_constants
   in
   let process_transition =
     process_transition ~logger ~trust_system ~verifier ~frontier
       ~catchup_scheduler ~processed_transition_writer ~time_controller
-      ~genesis_constants
+      ~constraint_constants ~genesis_constants
   in
   ignore
     (Reader.Merge.iter
@@ -361,6 +364,9 @@ let%test_module "Transition_handler.Processor tests" =
 
     let proof_level = Genesis_constants.Proof_level.Check
 
+    let constraint_constants =
+      Genesis_constants.Constraint_constants.for_unit_tests
+
     let precomputed_values = Lazy.force Precomputed_values.for_unit_tests
 
     let time_controller = Block_time.Controller.basic ~logger
@@ -382,8 +388,8 @@ let%test_module "Transition_handler.Processor tests" =
       let max_length = frontier_size + branch_size in
       Quickcheck.test ~trials:4
         (Transition_frontier.For_tests.gen_with_branch ~proof_level
-           ~precomputed_values ~max_length ~frontier_size ~branch_size ())
-        ~f:(fun (frontier, branch) ->
+           ~constraint_constants ~precomputed_values ~max_length ~frontier_size
+           ~branch_size ()) ~f:(fun (frontier, branch) ->
           assert (
             Thread_safe.block_on_async_exn (fun () ->
                 let pids = Child_processes.Termination.create_pid_table () in
@@ -415,7 +421,7 @@ let%test_module "Transition_handler.Processor tests" =
                   ~primary_transition_reader:valid_transition_reader
                   ~producer_transition_reader ~catchup_job_writer
                   ~catchup_breadcrumbs_reader ~catchup_breadcrumbs_writer
-                  ~processed_transition_writer
+                  ~processed_transition_writer ~constraint_constants
                   ~genesis_constants:Genesis_constants.compiled ;
                 List.iter branch ~f:(fun breadcrumb ->
                     downcast_breadcrumb breadcrumb

--- a/src/lib/transition_router/transition_router.ml
+++ b/src/lib/transition_router/transition_router.ml
@@ -9,8 +9,8 @@ open Network_peer
 let create_bufferred_pipe ?name () =
   Strict_pipe.create ?name (Buffered (`Capacity 50, `Overflow Crash))
 
-let is_transition_for_bootstrap ~logger frontier new_transition
-    ~(genesis_constants : Genesis_constants.t) =
+let is_transition_for_bootstrap ~logger ~constraint_constants frontier
+    new_transition ~(genesis_constants : Genesis_constants.t) =
   let root_state =
     Transition_frontier.root frontier
     |> Transition_frontier.Breadcrumb.protocol_state
@@ -20,7 +20,7 @@ let is_transition_for_bootstrap ~logger frontier new_transition
   in
   Consensus.Hooks.should_bootstrap
     ~constants:
-      (Consensus.Constants.create
+      (Consensus.Constants.create ~constraint_constants
          ~protocol_constants:genesis_constants.protocol)
     ~existing:(Protocol_state.consensus_state root_state)
     ~candidate:(Protocol_state.consensus_state new_state)
@@ -33,7 +33,7 @@ let start_transition_frontier_controller ~logger ~trust_system ~verifier
     ~network ~time_controller ~producer_transition_reader
     ~verified_transition_writer ~clear_reader ~collected_transitions
     ~transition_reader_ref ~transition_writer_ref ~frontier_w
-    ~genesis_constants frontier =
+    ~constraint_constants ~genesis_constants frontier =
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__
     "Starting Transition Frontier Controller phase" ;
   let ( transition_frontier_controller_reader
@@ -48,7 +48,8 @@ let start_transition_frontier_controller ~logger ~trust_system ~verifier
         Transition_frontier_controller.run ~logger ~trust_system ~verifier
           ~network ~time_controller ~collected_transitions ~frontier
           ~network_transition_reader:!transition_reader_ref
-          ~producer_transition_reader ~clear_reader ~genesis_constants )
+          ~producer_transition_reader ~clear_reader ~constraint_constants
+          ~genesis_constants )
   in
   Strict_pipe.Reader.iter new_verified_transition_reader
     ~f:
@@ -61,7 +62,7 @@ let start_bootstrap_controller ~logger ~trust_system ~verifier ~network
     ~clear_reader ~transition_reader_ref ~transition_writer_ref
     ~consensus_local_state ~frontier_w ~initial_root_transition
     ~persistent_root ~persistent_frontier ~best_seen_transition
-    ~precomputed_values =
+    ~constraint_constants ~precomputed_values =
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__
     "Starting Bootstrap Controller phase" ;
   let bootstrap_controller_reader, bootstrap_controller_writer =
@@ -78,12 +79,14 @@ let start_bootstrap_controller ~logger ~trust_system ~verifier ~network
         (Bootstrap_controller.run ~logger ~trust_system ~verifier ~network
            ~consensus_local_state ~transition_reader:!transition_reader_ref
            ~persistent_frontier ~persistent_root ~initial_root_transition
-           ~precomputed_values) (fun (new_frontier, collected_transitions) ->
+           ~constraint_constants ~precomputed_values)
+        (fun (new_frontier, collected_transitions) ->
           Strict_pipe.Writer.kill !transition_writer_ref ;
           start_transition_frontier_controller ~logger ~trust_system ~verifier
             ~network ~time_controller ~producer_transition_reader
             ~verified_transition_writer ~clear_reader ~collected_transitions
             ~transition_reader_ref ~transition_writer_ref ~frontier_w
+            ~constraint_constants
             ~genesis_constants:
               (Precomputed_values.genesis_constants precomputed_values)
             new_frontier ) )
@@ -165,10 +168,11 @@ let download_best_tip ~logger ~network ~verifier ~trust_system
   best_tip
 
 let load_frontier ~logger ~verifier ~persistent_frontier ~persistent_root
-    ~consensus_local_state ~precomputed_values =
+    ~consensus_local_state ~constraint_constants ~precomputed_values =
   match%map
     Transition_frontier.load ~logger ~verifier ~consensus_local_state
-      ~persistent_root ~persistent_frontier ~precomputed_values ()
+      ~persistent_root ~persistent_frontier ~constraint_constants
+      ~precomputed_values ()
   with
   | Ok frontier ->
       Some frontier
@@ -223,7 +227,7 @@ let initialize ~logger ~network ~is_seed ~verifier ~trust_system
     ~time_controller ~frontier_w ~producer_transition_reader ~clear_reader
     ~verified_transition_writer ~transition_reader_ref ~transition_writer_ref
     ~most_recent_valid_block_writer ~persistent_root ~persistent_frontier
-    ~consensus_local_state ~precomputed_values =
+    ~consensus_local_state ~constraint_constants ~precomputed_values =
   let%bind () = wait_for_high_connectivity ~logger ~network ~is_seed in
   let genesis_constants =
     Precomputed_values.genesis_constants precomputed_values
@@ -233,7 +237,7 @@ let initialize ~logger ~network ~is_seed ~verifier ~trust_system
       (download_best_tip ~logger ~network ~verifier ~trust_system
          ~most_recent_valid_block_writer ~genesis_constants)
       (load_frontier ~logger ~verifier ~persistent_frontier ~persistent_root
-         ~consensus_local_state ~precomputed_values)
+         ~consensus_local_state ~constraint_constants ~precomputed_values)
   with
   | best_tip, None ->
       let%map initial_root_transition =
@@ -246,19 +250,20 @@ let initialize ~logger ~network ~is_seed ~verifier ~trust_system
         ~verified_transition_writer ~clear_reader ~transition_reader_ref
         ~consensus_local_state ~transition_writer_ref ~frontier_w
         ~persistent_root ~persistent_frontier ~initial_root_transition
-        ~best_seen_transition:best_tip ~precomputed_values
+        ~best_seen_transition:best_tip ~constraint_constants
+        ~precomputed_values
   | None, Some frontier ->
       return
       @@ start_transition_frontier_controller ~logger ~trust_system ~verifier
            ~network ~time_controller ~producer_transition_reader
            ~verified_transition_writer ~clear_reader ~collected_transitions:[]
            ~transition_reader_ref ~transition_writer_ref ~frontier_w
-           ~genesis_constants frontier
+           ~constraint_constants ~genesis_constants frontier
   | Some best_tip, Some frontier ->
       if
         is_transition_for_bootstrap ~logger frontier
           (best_tip |> Envelope.Incoming.data)
-          ~genesis_constants
+          ~constraint_constants ~genesis_constants
       then
         let initial_root_transition =
           Transition_frontier.(Breadcrumb.validated_transition (root frontier))
@@ -269,14 +274,15 @@ let initialize ~logger ~network ~is_seed ~verifier ~trust_system
           ~verified_transition_writer ~clear_reader ~transition_reader_ref
           ~consensus_local_state ~transition_writer_ref ~frontier_w
           ~persistent_root ~persistent_frontier ~initial_root_transition
-          ~best_seen_transition:(Some best_tip) ~precomputed_values
+          ~best_seen_transition:(Some best_tip) ~constraint_constants
+          ~precomputed_values
       else
         let root = Transition_frontier.root frontier in
         let%map () =
           match
             Consensus.Hooks.required_local_state_sync
               ~constants:
-                (Consensus.Constants.create
+                (Consensus.Constants.create ~constraint_constants
                    ~protocol_constants:genesis_constants.protocol)
               ~consensus_state:
                 (Transition_frontier.Breadcrumb.consensus_state root)
@@ -306,14 +312,16 @@ let initialize ~logger ~network ~is_seed ~verifier ~trust_system
           ~network ~time_controller ~producer_transition_reader
           ~verified_transition_writer ~clear_reader
           ~collected_transitions:[best_tip] ~transition_reader_ref
-          ~transition_writer_ref ~frontier_w ~genesis_constants frontier
+          ~transition_writer_ref ~frontier_w ~constraint_constants
+          ~genesis_constants frontier
 
-let wait_till_genesis ~logger ~time_controller
+let wait_till_genesis ~logger ~time_controller ~constraint_constants
     ~(genesis_constants : Genesis_constants.t) =
   let module Time = Block_time in
   let now = Time.now time_controller in
   let consensus_constants =
-    Consensus.Constants.create ~protocol_constants:genesis_constants.protocol
+    Consensus.Constants.create ~constraint_constants
+      ~protocol_constants:genesis_constants.protocol
   in
   let genesis_state_timestamp = consensus_constants.genesis_state_timestamp in
   try
@@ -354,7 +362,7 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~time_controller
     ~network_transition_reader ~producer_transition_reader
     ~most_recent_valid_block:( most_recent_valid_block_reader
                              , most_recent_valid_block_writer )
-    ~precomputed_values =
+    ~constraint_constants ~precomputed_values =
   let initialization_finish_signal = Ivar.create () in
   let clear_reader, clear_writer =
     Strict_pipe.create ~name:"clear" Synchronous
@@ -370,14 +378,15 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~time_controller
   let genesis_constants =
     Precomputed_values.genesis_constants precomputed_values
   in
-  upon (wait_till_genesis ~logger ~time_controller ~genesis_constants)
-    (fun () ->
+  upon
+    (wait_till_genesis ~logger ~time_controller ~constraint_constants
+       ~genesis_constants) (fun () ->
       let valid_transition_reader, valid_transition_writer =
         create_bufferred_pipe ~name:"valid transitions" ()
       in
       Initial_validator.run ~logger ~trust_system ~verifier
         ~transition_reader:network_transition_reader ~valid_transition_writer
-        ~initialization_finish_signal ~precomputed_values ;
+        ~initialization_finish_signal ~constraint_constants ~precomputed_values ;
       let persistent_frontier =
         Transition_frontier.Persistent_frontier.create ~logger ~verifier
           ~time_controller ~directory:persistent_frontier_location
@@ -392,7 +401,8 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~time_controller
            ~producer_transition_reader ~clear_reader
            ~verified_transition_writer ~transition_reader_ref
            ~transition_writer_ref ~most_recent_valid_block_writer
-           ~consensus_local_state ~precomputed_values) (fun () ->
+           ~consensus_local_state ~constraint_constants ~precomputed_values)
+        (fun () ->
           Ivar.fill_if_empty initialization_finish_signal () ;
           let valid_transition_reader1, valid_transition_reader2 =
             Strict_pipe.Reader.Fork.two valid_transition_reader
@@ -434,7 +444,8 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~time_controller
                  | Some frontier ->
                      if
                        is_transition_for_bootstrap ~logger frontier
-                         incoming_transition ~genesis_constants
+                         incoming_transition ~constraint_constants
+                         ~genesis_constants
                      then (
                        Strict_pipe.Writer.kill !transition_writer_ref ;
                        let initial_root_transition =
@@ -453,7 +464,7 @@ let run ~logger ~trust_system ~verifier ~network ~is_seed ~time_controller
                          ~consensus_local_state ~frontier_w ~persistent_root
                          ~persistent_frontier ~initial_root_transition
                          ~best_seen_transition:(Some enveloped_transition)
-                         ~precomputed_values )
+                         ~constraint_constants ~precomputed_values )
                      else Deferred.unit
                  | None ->
                      Deferred.unit ) ) ) ;


### PR DESCRIPTION
This PR
* removes `c` from `Coda_compile_config`
* adds a `Constraints_constants.t` type for storing variables that affect the generation of proving keys
* routes `Constraints_constants.t` values through the code

Currently `c` is not configurable; that will follow in a later PR.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
