### PR TITLE
Remove some unneeded code

### DIFF
--- a/src/lib/coda_base/ledger.ml
+++ b/src/lib/coda_base/ledger.ml
@@ -8,24 +8,22 @@ module Ledger_inner = struct
     let depth = Coda_compile_config.ledger_depth
   end
 
-  module Location0 : Merkle_ledger.Location_intf.S =
+  module Location_at_depth : Merkle_ledger.Location_intf.S =
     Merkle_ledger.Location.Make (Depth)
-
-  module Location_at_depth = Location0
 
   module Location_binable = struct
     module Arg = struct
       type t = Location_at_depth.t =
         | Generic of Location.Bigstring.Stable.Latest.t
-        | Account of Location0.Addr.Stable.Latest.t
-        | Hash of Location0.Addr.Stable.Latest.t
+        | Account of Location_at_depth.Addr.Stable.Latest.t
+        | Hash of Location_at_depth.Addr.Stable.Latest.t
       [@@deriving bin_io_unversioned, hash, sexp, compare]
     end
 
     type t = Arg.t =
       | Generic of Location.Bigstring.t
-      | Account of Location0.Addr.t
-      | Hash of Location0.Addr.t
+      | Account of Location_at_depth.Addr.t
+      | Hash of Location_at_depth.Addr.t
     [@@deriving hash, sexp, compare]
 
     include Hashable.Make_binable (Arg) [@@deriving

--- a/src/lib/merkle_ledger/location.ml
+++ b/src/lib/merkle_ledger/location.ml
@@ -27,25 +27,6 @@ module Bigstring = struct
   include Hashable.Make (Stable.Latest)
 end
 
-module T = struct
-  [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type ('bigstring, 'addr) t =
-        | Generic of 'bigstring
-        | Account of 'addr
-        | Hash of 'addr
-      [@@deriving hash, sexp, compare, eq]
-    end
-  end]
-
-  type ('bigstring, 'addr) t = ('bigstring, 'addr) Stable.Latest.t =
-    | Generic of 'bigstring
-    | Account of 'addr
-    | Hash of 'addr
-  [@@deriving hash, sexp, compare, eq]
-end
-
 module Make (Depth : Intf.Depth) = struct
   (* Locations are a bitstring prefixed by a byte. In the case of accounts, the prefix
    * byte is 0xfe. In the case of a hash node in the merkle tree, the prefix is between


### PR DESCRIPTION
Remove dead-code module `T` in `Location`.

In `Ledger`, rename `Location0` to `Location_at_depth`, remove the alias.

