### PR TITLE
Secret_box, rename Stable module

### DIFF
--- a/src/lib/secrets/dune
+++ b/src/lib/secrets/dune
@@ -6,6 +6,6 @@
  (libraries core async_unix sodium ppx_deriving_yojson.runtime yojson
    coda_base coda_net2)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_deriving_yojson ppx_deriving.make bisect_ppx --
     -conditional))
  (synopsis "Managing secrets including passwords and keypairs"))

--- a/src/lib/secrets/secret_box.ml
+++ b/src/lib/secrets/secret_box.ml
@@ -25,27 +25,23 @@ module BytesWr = struct
         Error "Bytes.of_yojson needs a string"
 end
 
-module Stable = struct
-  module V1 = struct
-    type t =
-      { box_primitive: string
-      ; pw_primitive: string
-      ; nonce: Bytes.t
-      ; pwsalt: Bytes.t
-      ; pwdiff: Int64.t * int
-      ; ciphertext: Bytes.t }
-    [@@deriving sexp]
-  end
-
-  module Latest = V1
+module T = struct
+  type t =
+    { box_primitive: string
+    ; pw_primitive: string
+    ; nonce: Bytes.t
+    ; pwsalt: Bytes.t
+    ; pwdiff: Int64.t * int
+    ; ciphertext: Bytes.t }
+  [@@deriving sexp]
 end
 
 module Json : sig
   type t [@@deriving yojson]
 
-  val of_stable : Stable.V1.t -> t
+  val of_stable : T.t -> t
 
-  val to_stable : t -> Stable.V1.t
+  val to_stable : t -> T.t
 end = struct
   type t =
     { box_primitive: string
@@ -57,16 +53,15 @@ end = struct
   [@@deriving yojson]
 
   let of_stable
-      {Stable.V1.box_primitive; pw_primitive; nonce; pwsalt; pwdiff; ciphertext}
-      =
+      {T.box_primitive; pw_primitive; nonce; pwsalt; pwdiff; ciphertext} =
     {box_primitive; pw_primitive; nonce; pwsalt; pwdiff; ciphertext}
 
   let to_stable {box_primitive; pw_primitive; nonce; pwsalt; pwdiff; ciphertext}
       =
-    {Stable.V1.box_primitive; pw_primitive; nonce; pwsalt; pwdiff; ciphertext}
+    {T.box_primitive; pw_primitive; nonce; pwsalt; pwdiff; ciphertext}
 end
 
-type t = Stable.Latest.t =
+type t = T.t =
   { box_primitive: string
   ; pw_primitive: string
   ; nonce: Bytes.t

--- a/src/lib/secrets/secret_box.mli
+++ b/src/lib/secrets/secret_box.mli
@@ -16,12 +16,6 @@ open Core_kernel
 
 type t [@@deriving sexp, yojson]
 
-module Stable : sig
-  module V1 : sig
-    type nonrec t = t [@@deriving sexp]
-  end
-end
-
 (** Password-protect some plaintext. *)
 val encrypt : password:Bytes.t -> plaintext:Bytes.t -> t
 


### PR DESCRIPTION
`Secret_box` had a module `Stable` that did not have a type with `bin_io`, resulting in a linter warning.

Rename that module to `T` and remove the `V1` contained in it. The `Stable` module wasn't being used elsewhere, so remove that from the interface.

Remove the errors-as-warnings flag to `ppx_coda` in the dune file.