### PR TITLE
[TRIVIAL] Move ledger_depth into Genesis_constants.Constraint_constants.t

### DIFF
--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -13,7 +13,10 @@ end
 
 let create_ledger_and_transactions num_transitions =
   let num_accounts = 4 in
-  let ledger = Ledger.create ~depth:Genesis_constants.ledger_depth () in
+  let ledger =
+    Ledger.create
+      ~depth:Genesis_constants.Constraint_constants.compiled.ledger_depth ()
+  in
   let keys =
     Array.init num_accounts ~f:(fun _ -> Signature_lib.Keypair.create ())
   in

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -109,7 +109,8 @@ let%test_unit "of_ledger_subset_exn with keys that don't exist works" =
     let privkey = Private_key.create () in
     (privkey, Public_key.of_private_key_exn privkey |> Public_key.compress)
   in
-  Ledger.with_ledger ~depth:Genesis_constants.ledger_depth_for_unit_tests
+  Ledger.with_ledger
+    ~depth:Genesis_constants.Constraint_constants.for_unit_tests.ledger_depth
     ~f:(fun ledger ->
       let _, pub1 = keygen () in
       let _, pub2 = keygen () in

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -45,13 +45,13 @@ module Constraint_constants = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = {c: int}
+      type t = {c: int; ledger_depth: int}
 
       let to_latest = Fn.id
     end
   end]
 
-  type t = Stable.Latest.t = {c: int}
+  type t = Stable.Latest.t = {c: int; ledger_depth: int}
 
   [%%ifdef
   consensus_mechanism]
@@ -66,7 +66,10 @@ module Constraint_constants = struct
 
   [%%endif]
 
-  let compiled = {c}
+  [%%inject
+  "ledger_depth", ledger_depth]
+
+  let compiled = {c; ledger_depth}
 
   let for_unit_tests = compiled
 end
@@ -206,11 +209,6 @@ include T
 
 [%%inject
 "pool_max_size", pool_max_size]
-
-[%%inject
-"ledger_depth", ledger_depth]
-
-let ledger_depth_for_unit_tests = ledger_depth
 
 let compiled : t =
   { protocol=

--- a/src/lib/genesis_ledger/genesis_ledger.ml
+++ b/src/lib/genesis_ledger/genesis_ledger.ml
@@ -207,7 +207,8 @@ module Unit_test_ledger = Make (struct
 
   let directory = `Ephemeral
 
-  let depth = Genesis_constants.ledger_depth_for_unit_tests
+  let depth =
+    Genesis_constants.Constraint_constants.for_unit_tests.ledger_depth
 end)
 
 let for_unit_tests : Packed.t = (module Unit_test_ledger)

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -107,7 +107,8 @@ module Ledger = struct
           | None ->
               `New
 
-        let depth = Genesis_constants.ledger_depth
+        let depth =
+          Genesis_constants.Constraint_constants.compiled.ledger_depth
       end) )
     in
     packed |> Genesis_ledger.Packed.t |> Lazy.force |> Ledger.commit ;
@@ -115,7 +116,7 @@ module Ledger = struct
 
   let load directory_name : Genesis_ledger.Packed.t =
     ( module Genesis_ledger.Of_ledger (struct
-      let depth = Genesis_constants.ledger_depth
+      let depth = Genesis_constants.Constraint_constants.compiled.ledger_depth
 
       let t = lazy (Ledger.create ~depth ~directory_name ())
     end) )

--- a/src/lib/staged_ledger/staged_ledger.ml
+++ b/src/lib/staged_ledger/staged_ledger.ml
@@ -1532,6 +1532,9 @@ let%test_module "test" =
 
     let proof_level = Genesis_constants.Proof_level.Check
 
+    let ledger_depth =
+      Genesis_constants.Constraint_constants.for_unit_tests.ledger_depth
+
     (* Functor for testing with different instantiated staged ledger modules. *)
     let create_and_apply_with_state_body_hash state_body_hash sl logger pids
         txns stmt_to_work =
@@ -1575,8 +1578,7 @@ let%test_module "test" =
       *)
     let async_with_ledgers ledger_init_state
         (f : Sl.t ref -> Ledger.Mask.Attached.t -> unit Deferred.t) =
-      Ledger.with_ephemeral_ledger
-        ~depth:Genesis_constants.ledger_depth_for_unit_tests ~f:(fun ledger ->
+      Ledger.with_ephemeral_ledger ~depth:ledger_depth ~f:(fun ledger ->
           Ledger.apply_initial_ledger_state ledger ledger_init_state ;
           let casted = Ledger.Any_ledger.cast (module Ledger) ledger in
           let test_mask =

--- a/src/lib/test_genesis_ledger/test_genesis_ledger.ml
+++ b/src/lib/test_genesis_ledger/test_genesis_ledger.ml
@@ -12,7 +12,8 @@ include Genesis_ledger.Make (struct
 
   let directory = `Ephemeral
 
-  let depth = Genesis_constants.ledger_depth_for_unit_tests
+  let depth =
+    Genesis_constants.Constraint_constants.for_unit_tests.ledger_depth
 end)
 
 [%%else]

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2256,8 +2256,10 @@ let%test_module "transaction_snark" =
 
     type wallet = {private_key: Private_key.t; account: Account.t}
 
-    let random_wallets
-        ?(n = min (Int.pow 2 Coda_compile_config.ledger_depth) (1 lsl 10)) () =
+    let ledger_depth =
+      Genesis_constants.Constraint_constants.for_unit_tests.ledger_depth
+
+    let random_wallets ?(n = min (Int.pow 2 ledger_depth) (1 lsl 10)) () =
       let random_wallet () : wallet =
         let private_key = Private_key.create () in
         let public_key =
@@ -2394,8 +2396,7 @@ let%test_module "transaction_snark" =
         pending_coinbase_stack_target txn_in_block.transaction
           state_body_hash_opt pending_coinbase_init
       in
-      Ledger.with_ledger ~depth:Genesis_constants.ledger_depth_for_unit_tests
-        ~f:(fun ledger ->
+      Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
           Ledger.create_new_account_exn ledger producer_id
             (Account.create receiver_id Balance.zero) ;
           let sparse_ledger =
@@ -2433,9 +2434,7 @@ let%test_module "transaction_snark" =
     let%test_unit "new_account" =
       Test_util.with_randomness 123456789 (fun () ->
           let wallets = random_wallets () in
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               Array.iter
                 (Array.sub wallets ~pos:1 ~len:(Array.length wallets - 1))
                 ~f:(fun {account; private_key= _} ->
@@ -2527,9 +2526,7 @@ let%test_module "transaction_snark" =
               (Test_util.arbitrary_string
                  ~len:User_command_memo.max_digestible_string_length)
           in
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let _, ucs =
                 let receivers =
                   List.fold ~init:receivers
@@ -2571,9 +2568,7 @@ let%test_module "transaction_snark" =
           let receivers = random_wallets ~n:3 () |> Array.to_list in
           let txns_per_receiver = 3 in
           let fee = 8_000_000_000 in
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let fts =
                 let receivers =
                   List.fold ~init:receivers
@@ -2611,9 +2606,7 @@ let%test_module "transaction_snark" =
           let fee = Fee.to_int Coda_compile_config.account_creation_fee in
           let coinbase_count = 3 in
           let ft_count = 2 in
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let _, cbs =
                 let fts =
                   List.map (List.init ft_count ~f:Fn.id) ~f:(fun _ ->
@@ -2652,9 +2645,7 @@ let%test_module "transaction_snark" =
     let%test "base_and_merge" =
       Test_util.with_randomness 123456789 (fun () ->
           let wallets = random_wallets () in
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               Array.iter wallets ~f:(fun {account; private_key= _} ->
                   Ledger.create_new_account_exn ledger
                     (Account.identifier account)
@@ -2775,9 +2766,7 @@ let%test_module "transaction_snark" =
 
     let%test_unit "transfer non-default tokens to a new account" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:2 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -2848,9 +2837,7 @@ let%test_module "transaction_snark" =
 
     let%test_unit "transfer non-default tokens to an existing account" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:2 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -2922,9 +2909,7 @@ let%test_module "transaction_snark" =
     let%test_unit "insufficient account creation fee for non-default token \
                    transfer" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:2 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -2985,9 +2970,7 @@ let%test_module "transaction_snark" =
     let%test_unit "insufficient source balance for non-default token transfer"
         =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:2 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -3045,9 +3028,7 @@ let%test_module "transaction_snark" =
 
     let%test_unit "transfer non-existing source" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:2 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -3100,9 +3081,7 @@ let%test_module "transaction_snark" =
 
     let%test_unit "payment predicate failure" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:3 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -3160,9 +3139,7 @@ let%test_module "transaction_snark" =
 
     let%test_unit "delegation predicate failure" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:3 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -3220,9 +3197,7 @@ let%test_module "transaction_snark" =
 
     let%test_unit "delegation delegatee does not exist" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:2 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key
@@ -3276,9 +3251,7 @@ let%test_module "transaction_snark" =
 
     let%test_unit "delegation delegator does not exist" =
       Test_util.with_randomness 123456789 (fun () ->
-          Ledger.with_ledger
-            ~depth:Genesis_constants.ledger_depth_for_unit_tests
-            ~f:(fun ledger ->
+          Ledger.with_ledger ~depth:ledger_depth ~f:(fun ledger ->
               let wallets = random_wallets ~n:3 () in
               let signer =
                 Keypair.of_private_key_exn wallets.(0).private_key

--- a/src/lib/transition_frontier/tests/full_frontier_tests.ml
+++ b/src/lib/transition_frontier/tests/full_frontier_tests.ml
@@ -19,7 +19,7 @@ let%test_module "Full_frontier tests" =
     let constraint_constants =
       Genesis_constants.Constraint_constants.for_unit_tests
 
-    let ledger_depth = Genesis_constants.ledger_depth_for_unit_tests
+    let ledger_depth = constraint_constants.ledger_depth
 
     let accounts_with_secret_keys = Lazy.force Test_genesis_ledger.accounts
 


### PR DESCRIPTION
Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: