### PR TITLE
Add functions to collect 3 more metrics for leaderboard

### DIFF
--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -121,19 +121,19 @@ let highestSnarkFeeCollected = blocks => {
 
 // Loop through the transactions in each block
 // fold left and increment map with the public key and when a transaction's toAccount is the same as address
-let calculateTransactionsSentToAddress =
-    (map, block: Types.NewBlock.data, address) => {
-  block.transactions.userCommands
-  |> Array.fold_left(
-       (transactionMap, userCommand: Types.NewBlock.userCommands) =>
-         userCommand.toAccount === address
-           ? incrementMapValue(
-               userCommand.fromAccount.publicKey,
-               transactionMap,
-             )
-           : transactionMap,
-       map,
-     );
+let calculateTransactionsSentToAddress = (blocks, address) => {
+  blocks
+  |> Array.fold_left((map, block: Types.NewBlock.data) => {
+       block.transactions.userCommands
+       |> Array.fold_left(
+            (map, userCommand: Types.NewBlock.userCommands) => {
+              userCommand.toAccount.publicKey === address
+                ? incrementMapValue(userCommand.fromAccount.publicKey, map)
+                : map
+            },
+            map,
+          )
+     });
 };
 
 // Calculate users and metrics

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -119,22 +119,21 @@ let highestSnarkFeeCollected = blocks => {
   );
 };
 
-let transactionsSentToAddress = blocks => {
-  Array.fold_left(
-    (map, block: Types.NewBlock.t) => {
-      StringMap.update(
-        block.data.newBlock.transactions.feeTransfer.recipient,
-        value =>
-          switch (value) {
-          | Some(transactionCount) => Some(transactionCount + 1)
-          | None => Some(1)
-          },
-        map,
-      )
-    },
-    StringMap.empty,
-    blocks,
-  );
+// Loop through the transactions in each block
+// fold left and increment map with the public key and when a transaction's toAccount is the same as address
+let calculateTransactionsSentToAddress =
+    (map, block: Types.NewBlock.data, address) => {
+  block.transactions.userCommands
+  |> Array.fold_left(
+       (transactionMap, userCommand: Types.NewBlock.userCommands) =>
+         userCommand.toAccount === address
+           ? incrementMapValue(
+               userCommand.fromAccount.publicKey,
+               transactionMap,
+             )
+           : transactionMap,
+       map,
+     );
 };
 
 // Calculate users and metrics

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -37,11 +37,15 @@ module Metrics = {
   type t =
     | BlocksCreated
     | TransactionsSent
-    | SnarkWorkCreated;
+    | SnarkWorkCreated
+    | SnarkFeesCollected
+    | HighestSnarkFeeCollected;
 
   type metricRecord = {
     blocksCreated: option(int),
     transactionSent: option(int),
     snarkWorkCreated: option(int),
+    snarkFeesCollected: option(int64),
+    highestSnarkFeeCollected: option(int64),
   };
 };

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -39,7 +39,8 @@ module Metrics = {
     | TransactionsSent
     | SnarkWorkCreated
     | SnarkFeesCollected
-    | HighestSnarkFeeCollected;
+    | HighestSnarkFeeCollected
+    | TransactionsReceivedByEcho;
 
   type metricRecord = {
     blocksCreated: option(int),
@@ -47,5 +48,6 @@ module Metrics = {
     snarkWorkCreated: option(int),
     snarkFeesCollected: option(int64),
     highestSnarkFeeCollected: option(int64),
+    transactionsReceivedByEcho: option(int),
   };
 };

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -6,7 +6,10 @@ module NewBlock = {
     fee: int64,
   };
 
-  type userCommands = {fromAccount: account};
+  type userCommands = {
+    fromAccount: account,
+    toAccount: account,
+  };
 
   type feeTransfer = {
     fee: int64,
@@ -14,7 +17,7 @@ module NewBlock = {
   };
   type transactions = {
     userCommands: array(userCommands),
-    feeTransfer,
+    feeTransfer: array(feeTransfer),
   };
 
   type data = {

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -1,10 +1,21 @@
 module NewBlock = {
   type account = {publicKey: string};
 
-  type snarkJobs = {prover: string};
+  type snarkJobs = {
+    prover: string,
+    fee: int64,
+  };
 
   type userCommands = {fromAccount: account};
-  type transactions = {userCommands: array(userCommands)};
+
+  type feeTransfer = {
+    fee: int64,
+    recipient: string,
+  };
+  type transactions = {
+    userCommands: array(userCommands),
+    feeTransfer,
+  };
 
   type data = {
     creatorAccount: account,


### PR DESCRIPTION
This PR adds three new functions to collect metrics for the leaderboard: 

1) Snark Fees collected by each user 
2) Highest snark fee awarded to each user 
3) Transactions received by each user 

I edited some of the types and added some comments to break up reading the Challenges file. 
