### PR TITLE
include a state_hash in broadcast log

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -1076,7 +1076,7 @@ let create (config : Config.t) =
                              if v then
                                Coda_networking.broadcast_state net
                                @@ External_transition.Validation
-                                  .forget_validation et ) ;
+                                  .forget_validation_with_hash et ) ;
                          breadcrumb ))
                   ~most_recent_valid_block
                   ~constraint_constants:config.constraint_constants

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1103,14 +1103,19 @@ let fill_first_received_message_signal {first_received_message_signal; _} =
   Ivar.fill_if_empty first_received_message_signal ()
 
 (* TODO: Have better pushback behavior *)
-let broadcast t msg =
+let broadcast ?(extra_metadata = []) t msg =
   Logger.trace t.logger ~module_:__MODULE__ ~location:__LOC__
-    ~metadata:[("message", Gossip_net.Message.msg_to_yojson msg)]
+    ~metadata:
+      (("message", Gossip_net.Message.msg_to_yojson msg) :: extra_metadata)
     !"Broadcasting %s over gossip net"
     (Gossip_net.Message.summary msg) ;
   Gossip_net.Any.broadcast t.gossip_net msg
 
-let broadcast_state t state = broadcast t (Gossip_net.Message.New_state state)
+let broadcast_state t state =
+  broadcast t
+    (Gossip_net.Message.New_state (With_hash.data state))
+    ~extra_metadata:
+      [("state_hash", With_hash.hash state |> State_hash.to_yojson)]
 
 let broadcast_transaction_pool_diff t diff =
   broadcast t (Gossip_net.Message.Transaction_pool_diff diff)

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -220,7 +220,8 @@ val transaction_pool_diffs :
      * (bool -> unit) )
      Strict_pipe.Reader.t
 
-val broadcast_state : t -> External_transition.t -> unit
+val broadcast_state :
+  t -> (External_transition.t, State_hash.t) With_hash.t -> unit
 
 val broadcast_snark_pool_diff : t -> Snark_pool.Resource_pool.Diff.t -> unit
 

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -49,7 +49,6 @@ module Stable = struct
         ; validation_callback= _ } =
       `Assoc
         [ ("protocol_state", Protocol_state.value_to_yojson protocol_state)
-        ; ("state_hash", Protocol_state.hash protocol_state)
         ; ("protocol_state_proof", `String "<opaque>")
         ; ("staged_ledger_diff", `String "<opaque>")
         ; ("delta_transition_chain_proof", `String "<opaque>")
@@ -360,6 +359,8 @@ module Validation = struct
         failwith "why can't this be refuted?"
 
   let forget_validation (t, _) = With_hash.data t
+
+  let forget_validation_with_hash (t, _) = t
 
   module Unsafe = struct
     let set_valid_time_received :

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -49,6 +49,7 @@ module Stable = struct
         ; validation_callback= _ } =
       `Assoc
         [ ("protocol_state", Protocol_state.value_to_yojson protocol_state)
+        ; ("state_hash", Protocol_state.hash protocol_state)
         ; ("protocol_state_proof", `String "<opaque>")
         ; ("staged_ledger_diff", `String "<opaque>")
         ; ("delta_transition_chain_proof", `String "<opaque>")

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -223,6 +223,17 @@ module type S = sig
          , 'protocol_versions )
          with_transition
       -> external_transition
+
+    val forget_validation_with_hash :
+         ( 'time_received
+         , 'genesis_state
+         , 'proof
+         , 'delta_transition_chain
+         , 'frontier_dependencies
+         , 'staged_ledger_diff
+         , 'protocol_versions )
+         with_transition
+      -> (external_transition, State_hash.t) With_hash.t
   end
 
   module Initial_validated : sig


### PR DESCRIPTION
we basically _never_ care about a protocol state independent of its hash.
this will do some extra hashing, hopefully that's not too expensive? :\