### PR TITLE
Snark_worker, versioned RPCs outside functors

### DIFF
--- a/src/app/cli/src/init/coda_run.ml
+++ b/src/app/cli/src/init/coda_run.ml
@@ -448,7 +448,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
     ]
   in
   let snark_worker_impls =
-    [ implement Snark_worker.Rpcs.Get_work.Latest.rpc (fun () () ->
+    [ implement Snark_worker.Rpcs_versioned.Get_work.Latest.rpc (fun () () ->
           Deferred.return
             (let open Option.Let_syntax in
             let%bind snark_worker_key = Coda_lib.snark_worker_key coda in
@@ -461,7 +461,7 @@ let setup_local_server ?(client_trustlist = []) ?rest_server_port
               "responding to a Get_work request with some new work" ;
             Coda_metrics.(Counter.inc_one Snark_work.snark_work_assigned_rpc) ;
             (r, snark_worker_key)) )
-    ; implement Snark_worker.Rpcs.Submit_work.Latest.rpc
+    ; implement Snark_worker.Rpcs_versioned.Submit_work.Latest.rpc
         (fun () (work : Snark_worker.Work.Result.t) ->
           Coda_metrics.(
             Counter.inc_one Snark_work.completed_snark_work_received_rpc) ;

--- a/src/lib/snark_worker/debug.ml
+++ b/src/lib/snark_worker/debug.ml
@@ -23,5 +23,3 @@ module Inputs = struct
         , Coda_base.Sok_message.digest message )
       , Time.Span.zero )
 end
-
-module Worker = Functor.Make (Inputs)

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -7,7 +7,7 @@
    blockchain_snark transaction_snark keys_lib perf_histograms
    core_kernel.hash_heap sparse_ledger_lib ledger_proof)
  (preprocess (pps
-   ppx_coda -lint-version-syntax-warnings ppx_sexp_conv ppx_optcomp
+   ppx_coda ppx_sexp_conv ppx_optcomp
    ppx_sexp_conv ppx_bin_prot ppx_let ppx_custom_printf
    ppx_inline_test bisect_ppx -- -conditional))
  (preprocessor_deps "../../config.mlh")

--- a/src/lib/snark_worker/intf.ml
+++ b/src/lib/snark_worker/intf.ml
@@ -1,7 +1,6 @@
 open Core
 open Coda_base
 open Async
-open Signature_lib
 
 let command_name = "snark-worker"
 
@@ -29,63 +28,128 @@ module type Inputs_intf = sig
     -> (Ledger_proof.t * Time.Span.t) Or_error.t
 end
 
-module type S = sig
+module type Rpc_master = sig
+  module Master : sig
+    module T : sig
+      type query
+
+      type response
+    end
+
+    module Caller = T
+    module Callee = T
+  end
+
+  module Register (Version : sig
+    val version : int
+
+    type query [@@deriving bin_io]
+
+    type response [@@deriving bin_io]
+
+    val query_of_caller_model : Master.Caller.query -> query
+
+    val callee_model_of_query : query -> Master.Callee.query
+
+    val response_of_callee_model : Master.Callee.response -> response
+
+    val caller_model_of_response : response -> Master.Caller.response
+  end) : sig
+    val rpc : (Version.query, Version.response) Rpc.Rpc.t
+  end
+end
+
+module type Work_S = sig
+  open Snark_work_lib
+
   type ledger_proof
 
-  module Work : sig
-    open Snark_work_lib
-
-    module Single : sig
-      module Spec : sig
-        type t =
-          ( Transaction.t Transaction_protocol_state.t
-          , Transaction_witness.t
-          , ledger_proof )
-          Work.Single.Spec.t
-        [@@deriving sexp]
-      end
-    end
-
+  module Single : sig
     module Spec : sig
-      type t = Single.Spec.t Work.Spec.t [@@deriving sexp]
-    end
-
-    module Result : sig
-      type t = (Spec.t, ledger_proof) Work.Result.t
+      type t =
+        ( Transaction.t Transaction_protocol_state.t
+        , Transaction_witness.t
+        , ledger_proof )
+        Work.Single.Spec.t
+      [@@deriving sexp]
     end
   end
+
+  module Spec : sig
+    type t = Single.Spec.t Work.Spec.t [@@deriving sexp]
+  end
+
+  module Result : sig
+    type t = (Spec.t, ledger_proof) Work.Result.t
+  end
+end
+
+module type Rpcs_versioned_S = sig
+  module Work : Work_S
+
+  module Get_work : sig
+    module V1 : sig
+      type query = unit [@@deriving bin_io]
+
+      type response =
+        (Work.Spec.t * Signature_lib.Public_key.Compressed.t) option
+      [@@deriving bin_io]
+
+      val rpc : (query, response) Rpc.Rpc.t
+    end
+
+    module Latest = V1
+  end
+
+  module Submit_work : sig
+    module V1 : sig
+      type query = Work.Result.t [@@deriving bin_io]
+
+      type response = unit [@@deriving bin_io]
+
+      val rpc : (query, response) Rpc.Rpc.t
+    end
+
+    module Latest = V1
+  end
+end
+
+(* result of Functor.Make *)
+module type S0 = sig
+  type ledger_proof
+
+  module Work : Work_S with type ledger_proof := ledger_proof
 
   module Rpcs : sig
-    module Get_work : sig
-      module V1 : sig
-        type query = unit
+    module Get_work :
+      Rpc_master
+      with type Master.T.query = unit
+       and type Master.T.response =
+                  (Work.Spec.t * Signature_lib.Public_key.Compressed.t) option
 
-        type response = (Work.Spec.t * Public_key.Compressed.t) option
-
-        val rpc : (query, response) Rpc.Rpc.t
-      end
-
-      module Latest = V1
-    end
-
-    module Submit_work : sig
-      module V1 : sig
-        type query = Work.Result.t
-
-        type response = unit
-
-        val rpc : (query, response) Rpc.Rpc.t
-      end
-
-      module Latest = V1
-    end
+    module Submit_work :
+      Rpc_master
+      with type Master.T.query = Work.Result.t
+       and type Master.T.response = unit
   end
 
-  val command : Command.t
+  val command_from_rpcs :
+       (module Rpcs_versioned_S with type Work.ledger_proof = ledger_proof)
+    -> Command.t
 
   val arguments :
        proof_level:Genesis_constants.Proof_level.t
     -> daemon_address:Host_and_port.t
     -> shutdown_on_disconnect:bool
     -> string list
+end
+
+(* add in versioned Rpc modules *)
+module type S = sig
+  include S0
+
+  module Rpcs_versioned :
+    Rpcs_versioned_S with type Work.ledger_proof = ledger_proof
+
+  val command : Command.t
 end

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -129,5 +129,3 @@ module Inputs = struct
                  ~proof:Precomputed_values.unit_test_base_proof
              , Time.Span.zero )
 end
-
-module Worker = Functor.Make (Inputs)

--- a/src/lib/snark_worker/rpcs.ml
+++ b/src/lib/snark_worker/rpcs.ml
@@ -1,4 +1,3 @@
-open Core_kernel
 open Async
 open Coda_base
 open Signature_lib
@@ -11,6 +10,10 @@ open Signature_lib
 
 *)
 
+(* for each RPC, return the Master module only, and not the versioned modules, because the functor should not
+   return types with bin_io; the versioned modules are defined in snark_worker.ml
+*)
+
 module Make (Inputs : Intf.Inputs_intf) = struct
   open Inputs
   open Snark_work_lib
@@ -20,8 +23,6 @@ module Make (Inputs : Intf.Inputs_intf) = struct
       let name = "get_work"
 
       module T = struct
-        (* "master" types, do not change *)
-
         type query = unit
 
         type response =
@@ -39,37 +40,7 @@ module Make (Inputs : Intf.Inputs_intf) = struct
     end
 
     include Master.T
-    module M = Versioned_rpc.Both_convert.Plain.Make (Master)
-    include M
-
-    module V1 = struct
-      module T = struct
-        type query = unit [@@deriving bin_io, version {rpc}]
-
-        type response =
-          ( ( Transaction.Stable.V1.t Transaction_protocol_state.Stable.V1.t
-            , Transaction_witness.Stable.V1.t
-            , Ledger_proof.Stable.V1.t )
-            Work.Single.Spec.Stable.V1.t
-            Work.Spec.Stable.V1.t
-          * Public_key.Compressed.Stable.V1.t )
-          option
-        [@@deriving bin_io, version {rpc}]
-
-        let query_of_caller_model = Fn.id
-
-        let callee_model_of_query = Fn.id
-
-        let response_of_callee_model = Fn.id
-
-        let caller_model_of_response = Fn.id
-      end
-
-      include T
-      include Register (T)
-    end
-
-    module Latest = V1
+    include Versioned_rpc.Both_convert.Plain.Make (Master)
   end
 
   module Submit_work = struct
@@ -77,7 +48,6 @@ module Make (Inputs : Intf.Inputs_intf) = struct
       let name = "submit_work"
 
       module T = struct
-        (* "master" types, do not change *)
         type query =
           ( ( Transaction.t Transaction_protocol_state.t
             , Transaction_witness.t
@@ -96,34 +66,5 @@ module Make (Inputs : Intf.Inputs_intf) = struct
 
     include Master.T
     include Versioned_rpc.Both_convert.Plain.Make (Master)
-
-    module V1 = struct
-      module T = struct
-        type query =
-          ( ( Transaction.Stable.V1.t Transaction_protocol_state.Stable.V1.t
-            , Transaction_witness.Stable.V1.t
-            , Ledger_proof.Stable.V1.t )
-            Work.Single.Spec.Stable.V1.t
-            Work.Spec.Stable.V1.t
-          , Ledger_proof.Stable.V1.t )
-          Work.Result.Stable.V1.t
-        [@@deriving bin_io, version {rpc}]
-
-        type response = unit [@@deriving bin_io, version {rpc}]
-
-        let query_of_caller_model : Master.Caller.query -> query = Fn.id
-
-        let callee_model_of_query = Fn.id
-
-        let response_of_callee_model = Fn.id
-
-        let caller_model_of_response = Fn.id
-      end
-
-      include T
-      include Register (T)
-    end
-
-    module Latest = V1
   end
 end

--- a/src/lib/snark_worker/snark_worker.ml
+++ b/src/lib/snark_worker/snark_worker.ml
@@ -6,10 +6,92 @@ module Intf = Intf
 [%%if
 proof_level = "full"]
 
-include Prod.Worker
+module Inputs = Prod.Inputs
 
 [%%else]
 
-include Debug.Worker
+module Inputs = Debug.Inputs
 
 [%%endif]
+
+module Worker = struct
+  include Functor.Make (Inputs)
+
+  module Rpcs_versioned = struct
+    open Core_kernel
+    open Coda_base
+    open Signature_lib
+
+    module Work = struct
+      type ledger_proof = Inputs.Ledger_proof.t
+
+      include Work
+    end
+
+    module Get_work = struct
+      module V1 = struct
+        module T = struct
+          type query = unit [@@deriving bin_io, version {rpc}]
+
+          type response =
+            ( ( Transaction.Stable.V1.t Transaction_protocol_state.Stable.V1.t
+              , Transaction_witness.Stable.V1.t
+              , Inputs.Ledger_proof.Stable.V1.t )
+              Snark_work_lib.Work.Single.Spec.Stable.V1.t
+              Snark_work_lib.Work.Spec.Stable.V1.t
+            * Public_key.Compressed.Stable.V1.t )
+            option
+          [@@deriving bin_io, version {rpc}]
+
+          let query_of_caller_model = Fn.id
+
+          let callee_model_of_query = Fn.id
+
+          let response_of_callee_model = Fn.id
+
+          let caller_model_of_response = Fn.id
+        end
+
+        include T
+        include Rpcs.Get_work.Register (T)
+      end
+
+      module Latest = V1
+    end
+
+    module Submit_work = struct
+      module V1 = struct
+        module T = struct
+          type query =
+            ( ( Transaction.Stable.V1.t Transaction_protocol_state.Stable.V1.t
+              , Transaction_witness.Stable.V1.t
+              , Ledger_proof.Stable.V1.t )
+              Snark_work_lib.Work.Single.Spec.Stable.V1.t
+              Snark_work_lib.Work.Spec.Stable.V1.t
+            , Ledger_proof.Stable.V1.t )
+            Snark_work_lib.Work.Result.Stable.V1.t
+          [@@deriving bin_io, version {rpc}]
+
+          type response = unit [@@deriving bin_io, version {rpc}]
+
+          let query_of_caller_model = Fn.id
+
+          let callee_model_of_query = Fn.id
+
+          let response_of_callee_model = Fn.id
+
+          let caller_model_of_response = Fn.id
+        end
+
+        include T
+        include Rpcs.Submit_work.Register (T)
+      end
+
+      module Latest = V1
+    end
+  end
+
+  let command = command_from_rpcs (module Rpcs_versioned)
+end
+
+include Worker


### PR DESCRIPTION
In `Snark_worker`, the `Rpcs.Make` functor was returning versioned Rpc modules with `bin_io` types, generating linter warnings.

Change the functor to return only the non-`bin-io` Master modules, and create the versioned modules after the functor applications (`Functor.Make` calls `Rpcs.Make`).

Remove the errors-as-warnings flag to `ppx_coda` in `dune`.