### PR TITLE
Blake2, use %%versioned_binable

### DIFF
--- a/src/lib/blake2/blake2.ml
+++ b/src/lib/blake2/blake2.ml
@@ -34,7 +34,7 @@ module Make () = struct
       let to_latest = Fn.id
 
       module Arg = struct
-        type t = T1.t
+        type nonrec t = t
 
         [%%define_locally T1.(to_string, of_string)]
       end

--- a/src/lib/blake2/blake2.ml
+++ b/src/lib/blake2/blake2.ml
@@ -26,26 +26,29 @@ module Make () = struct
     include Sexpable.Of_stringable (T0)
   end
 
+  [%%versioned_binable
   module Stable = struct
     module V1 = struct
-      module T = struct
+      type t = T1.t [@@deriving hash, sexp, compare]
+
+      let to_latest = Fn.id
+
+      module Arg = struct
         type t = T1.t
-        [@@deriving version {asserted; unnumbered}, hash, sexp, compare]
+
+        [%%define_locally T1.(to_string, of_string)]
       end
 
-      include T
-      include Binable.Of_stringable (T1)
+      include Binable.Of_stringable (Arg)
     end
-
-    module Latest = V1
-  end
+  end]
 
   type t = T1.t [@@deriving hash, sexp, compare]
 
   [%%define_locally
   T1.(to_raw_string, digest_string, to_hex)]
 
-  (* do not use Binable.Of_stringable *)
+  (* do not create bin_io serialization *)
   include Hashable.Make (T1)
   include Comparable.Make (T1)
 
@@ -72,6 +75,18 @@ module Make () = struct
 end
 
 include Make ()
+
+(* values come from external library digestif, and serialization relies on raw string functions in that library,
+   so check serialization is stable
+ *)
+let%test "serialization test V1" =
+  let blake2s = T0.digest_string "serialization test V1" in
+  let known_good_hash =
+    "\xFF\x16\xAB\xDC\xE7\x1D\x0F\x7A\xE7\x0E\xF6\xBE\xB5\x76\x3B\x86\xDC\xCE\xDD\xC8\xD1\x9C\x80\x22\xD5\x25\xD5\x34\x7E\xA6\xB0\x1C"
+  in
+  Module_version.Serialization.check_serialization
+    (module Stable.V1)
+    blake2s known_good_hash
 
 let%test_unit "bits_to_string" =
   [%test_eq: string]

--- a/src/lib/blake2/dune
+++ b/src/lib/blake2/dune
@@ -1,9 +1,10 @@
 (library
   (name blake2)
   (public_name blake2)
-  (preprocess (pps ppx_jane ppx_coda -lint-version-syntax-warnings ppx_deriving.eq ppx_deriving_yojson))
+  (preprocess (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson))
   (inline_tests)
   (libraries
     core_kernel
     coda_digestif
-    ))
+    module_version
+  ))


### PR DESCRIPTION
For the `Stable` module in `Blake2`, use `%%versioned_binable`. 

Add a serialization test, because the type comes from an external library, and its serialization depends on string functions in the library.

In `ppx_coda`, make sure we don't add `deriving bin_io` for verisioned-binable types.