### PR TITLE
Remove most lint warnings flags

### DIFF
--- a/src/app/cli/src/tests/dune
+++ b/src/app/cli/src/tests/dune
@@ -12,6 +12,6 @@
     init)
   (preprocessor_deps ../../../../config.mlh)
   (preprocess (pps
-    ppx_coda -lint-version-syntax-warnings
+    ppx_coda
     ppx_optcomp ppx_bin_prot ppx_let
     ppx_custom_printf)))

--- a/src/lib/coda_transition/dune
+++ b/src/lib/coda_transition/dune
@@ -1,5 +1,5 @@
 (library
   (name coda_transition)
   (public_name coda_transition)
-  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.std ppx_deriving_yojson))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson))
   (libraries core_kernel staged_ledger transition_chain_verifier truth coda_base coda_state precomputed_values consensus protocol_version staged_ledger_diff verifier))

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -26,7 +26,7 @@
     coda_metrics
     graphql_lib)
    (preprocessor_deps "../../config.mlh")
-   (preprocess (pps ppx_base ppx_coda -lint-version-syntax-warnings ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx -conditional))
+   (preprocess (pps ppx_base ppx_coda ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv bisect_ppx -conditional))
    (synopsis "Consensus mechanisms"))
 
 (executable

--- a/src/lib/currency/dune
+++ b/src/lib/currency/dune
@@ -7,6 +7,6 @@
    unsigned_extended test_util codable module_version)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_let ppx_assert ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_custom_printf ppx_deriving.std ppx_deriving_yojson ppx_inline_test bisect_ppx --
+  (pps ppx_coda ppx_let ppx_assert ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_custom_printf ppx_deriving.std ppx_deriving_yojson ppx_inline_test bisect_ppx --
     -conditional))
  (synopsis "Currency types"))

--- a/src/lib/gossip_net/dune
+++ b/src/lib/gossip_net/dune
@@ -6,5 +6,5 @@
  (libraries perf_histograms core coda_base coda_transition coda_net2 network_pool trust_system pipe_lib logger async async_extra o1trace node_addrs_and_ports coda_metrics)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_inline_test ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson bisect_ppx ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_custom_printf ppx_pipebang -- -conditional))
+  (pps ppx_coda ppx_inline_test ppx_deriving.eq ppx_deriving.make ppx_deriving_yojson bisect_ppx ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_fields_conv ppx_let ppx_custom_printf ppx_pipebang -- -conditional))
  (synopsis "Gossip Network"))

--- a/src/lib/group_map/dune
+++ b/src/lib/group_map/dune
@@ -1,7 +1,7 @@
 (library
   (name group_map)
   (public_name group_map)
-  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (inline_tests)
   (libraries
     snarkette ; This is actually just needed in tests

--- a/src/lib/merkle_address/dune
+++ b/src/lib/merkle_address/dune
@@ -5,6 +5,6 @@
  (inline_tests)
  (libraries core bitstring direction module_version)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_hash ppx_deriving.eq ppx_deriving_yojson bitstring.ppx bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_hash ppx_deriving.eq ppx_deriving_yojson bitstring.ppx bisect_ppx --
     -conditional))
  (synopsis "Address for merkle database representations"))

--- a/src/lib/merkle_ledger_tests/test_stubs.ml
+++ b/src/lib/merkle_ledger_tests/test_stubs.ml
@@ -4,11 +4,11 @@ module Balance = Currency.Balance
 
 module Account = struct
   (* want bin_io, not available with Account.t *)
-  type t = Coda_base.Account.Stable.V1.t
-  [@@deriving bin_io, sexp, eq, compare, hash, yojson]
+  type t = Coda_base.Account.Stable.Latest.t
+  [@@deriving bin_io_unversioned, sexp, eq, compare, hash, yojson]
 
-  type key = Coda_base.Account.Key.Stable.V1.t
-  [@@deriving bin_io, sexp, eq, compare, hash]
+  type key = Coda_base.Account.Key.Stable.Latest.t
+  [@@deriving bin_io_unversioned, sexp, eq, compare, hash]
 
   (* use Account items needed *)
   let empty = Coda_base.Account.empty
@@ -55,15 +55,16 @@ module Balance_not_used = struct
 end
 
 module Account_not_used = struct
-  type key = string [@@deriving sexp, show, bin_io, eq, compare, hash]
+  type key = string
+  [@@deriving sexp, show, bin_io_unversioned, eq, compare, hash]
 
   type t =
     { public_key: key
-    ; balance: Balance.Stable.V1.t
+    ; balance: Balance.Stable.Latest.t
           [@printer
             fun fmt balance ->
               Format.pp_print_string fmt (Balance.to_string balance)] }
-  [@@deriving bin_io, eq, show, fields]
+  [@@deriving bin_io_unversioned, eq, show, fields]
 
   let sexp_of_t {public_key; balance} =
     [%sexp_of: string * string] (public_key, Balance.to_string balance)
@@ -95,7 +96,7 @@ module Receipt = Coda_base.Receipt
 
 module Hash = struct
   module T = struct
-    type t = Md5.t [@@deriving sexp, hash, compare, bin_io, eq]
+    type t = Md5.t [@@deriving sexp, hash, compare, bin_io_unversioned, eq]
 
     let to_string = Md5.to_hex
 
@@ -183,13 +184,15 @@ module Storage_locations : Intf.Storage_locations = struct
 end
 
 module Key = struct
+  [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = Account.key [@@deriving sexp, bin_io, eq, compare, hash]
-    end
+      type t = Coda_base.Account.Key.Stable.V1.t
+      [@@deriving sexp, eq, compare, hash]
 
-    module Latest = V1
-  end
+      let to_latest = Fn.id
+    end
+  end]
 
   type t = Stable.Latest.t [@@deriving sexp, compare, hash]
 
@@ -214,7 +217,7 @@ module Account_id = struct
   module Stable = struct
     module V1 = struct
       type t = Coda_base.Account_id.Stable.V1.t
-      [@@deriving sexp, bin_io, eq, compare, hash]
+      [@@deriving sexp, eq, compare, hash]
 
       let to_latest = Fn.id
     end

--- a/src/lib/perf_histograms/dune
+++ b/src/lib/perf_histograms/dune
@@ -6,6 +6,6 @@
  (inline_tests)
  (libraries coda_metrics core async core_kernel yojson ppx_deriving_yojson.runtime)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
+  (pps ppx_coda ppx_jane ppx_deriving.eq ppx_deriving_yojson bisect_ppx --
     -conditional))
  (synopsis "Performance monitoring with histograms"))

--- a/src/lib/pokolog/dune
+++ b/src/lib/pokolog/dune
@@ -1,7 +1,7 @@
 (library
   (name pokolog)
   (public_name pokolog)
-  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.eq))
+  (preprocess (pps ppx_coda ppx_jane ppx_deriving.eq))
   (libraries
     snarky
     core_kernel ))

--- a/src/lib/receipt_chain_database/dune
+++ b/src/lib/receipt_chain_database/dune
@@ -4,6 +4,6 @@
   (library_flags (-linkall))
   (libraries core key_value_database ppx_deriving_yojson.runtime yojson merkle_list_prover merkle_list_verifier coda_base)
   (inline_tests)
-  (preprocess (pps ppx_coda -lint-version-syntax-warnings bisect_ppx -conditional ppx_jane ppx_deriving.eq ppx_deriving_yojson ppx_fields_conv))
+  (preprocess (pps ppx_coda bisect_ppx -conditional ppx_jane ppx_deriving.eq ppx_deriving_yojson ppx_fields_conv))
   (synopsis "A library that contains a database that records sent payments for an individual account and generates a proof of a payment.
   Also, the library contains a verifier that proves the correctness of the proof of payments"))

--- a/src/lib/signature_lib/dune
+++ b/src/lib/signature_lib/dune
@@ -15,7 +15,7 @@
    yojson)
  (preprocessor_deps ../../config.mlh)
  (preprocess (pps
-   ppx_snarky ppx_coda -lint-version-syntax-warnings ppx_custom_printf ppx_optcomp ppx_sexp_conv
+   ppx_snarky ppx_coda ppx_custom_printf ppx_optcomp ppx_sexp_conv
    ppx_bin_prot ppx_hash ppx_compare ppx_deriving.eq ppx_deriving_yojson
    ppx_inline_test ppx_let))
  (synopsis "Schnorr signatures using the tick and tock curves"))

--- a/src/lib/storage/dune
+++ b/src/lib/storage/dune
@@ -5,5 +5,5 @@
  (library_flags -linkall)
  (libraries core async async_extra logger)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_jane bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_jane bisect_ppx -- -conditional))
  (synopsis "Storage module checksums data and stores it"))

--- a/src/lib/transaction_protocol_state/dune
+++ b/src/lib/transaction_protocol_state/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core snarky coda_base sgn module_version)
  (preprocess
-  (pps ppx_snarky ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_snarky ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Transaction protocol state library"))

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -5,5 +5,5 @@
  (inline_tests)
  (libraries core cache_dir cached snarky coda_base sgn bignum module_version transaction_protocol_state)
  (preprocess
-  (pps ppx_snarky ppx_coda -lint-version-syntax-warnings ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_snarky ppx_coda ppx_jane ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Transaction state transition snarking library"))

--- a/src/lib/transaction_snark_work/dune
+++ b/src/lib/transaction_snark_work/dune
@@ -2,4 +2,4 @@
   (name transaction_snark_work)
   (public_name transaction_snark_work)
   (libraries core_kernel coda_base ledger_proof one_or_two transaction_snark)
-  (preprocess (pps ppx_jane ppx_coda -lint-version-syntax-warnings ppx_deriving.eq ppx_deriving_yojson)))
+  (preprocess (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson)))

--- a/src/lib/transition_frontier/dune
+++ b/src/lib/transition_frontier/dune
@@ -2,4 +2,4 @@
   (name transition_frontier)
   (public_name transition_frontier)
   (libraries transition_frontier_base transition_frontier_persistent_root transition_frontier_persistent_frontier transition_frontier_full_frontier transition_frontier_extensions)
-  (preprocess (pps ppx_jane ppx_coda -lint-version-syntax-warnings ppx_deriving.eq ppx_deriving_yojson bisect_ppx -conditional)))
+  (preprocess (pps ppx_jane ppx_coda ppx_deriving.eq ppx_deriving_yojson bisect_ppx -conditional)))

--- a/src/lib/unsigned_extended/dune
+++ b/src/lib/unsigned_extended/dune
@@ -6,5 +6,5 @@
  (libraries core integers snark_params)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_inline_test ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
+  (pps ppx_coda ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_inline_test ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Unsigned integer functions"))

--- a/src/nonconsensus/coda_base/dune
+++ b/src/nonconsensus/coda_base/dune
@@ -17,7 +17,7 @@
     )
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_deriving.eq ppx_deriving.enum ppx_deriving.ord
+  (pps ppx_coda ppx_deriving.eq ppx_deriving.enum ppx_deriving.ord
     ppx_base ppx_bench ppx_let ppx_optcomp ppx_sexp_conv ppx_bin_prot ppx_fields_conv ppx_custom_printf ppx_assert ppx_deriving_yojson ppx_inline_test
     bisect_ppx -- -conditional))
  (synopsis "Snarks and friends necessary for keypair generation"))

--- a/src/nonconsensus/currency/dune
+++ b/src/nonconsensus/currency/dune
@@ -7,6 +7,6 @@
    unsigned_extended_nonconsensus codable module_version)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_let ppx_assert ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_custom_printf ppx_deriving.std ppx_deriving_yojson ppx_inline_test bisect_ppx --
+  (pps ppx_coda ppx_let ppx_assert ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_optcomp ppx_custom_printf ppx_deriving.std ppx_deriving_yojson ppx_inline_test bisect_ppx --
     -conditional))
  (synopsis "Currency types"))

--- a/src/nonconsensus/signature_lib/dune
+++ b/src/nonconsensus/signature_lib/dune
@@ -15,7 +15,7 @@
    yojson)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_optcomp ppx_sexp_conv
+  (pps ppx_coda ppx_optcomp ppx_sexp_conv
        ppx_custom_printf ppx_bin_prot ppx_hash ppx_compare ppx_deriving.eq ppx_deriving_yojson
        ppx_inline_test ppx_let))
  (synopsis "Schnorr signatures using the tick and tock curves"))

--- a/src/nonconsensus/snark_params/dune
+++ b/src/nonconsensus/snark_params/dune
@@ -4,5 +4,5 @@
  (library_flags -linkall)
  (libraries core_kernel bignum_bigint snarkette)
  (preprocessor_deps ../../config.mlh)
- (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_let))
+ (preprocess (pps ppx_coda ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_let))
  (synopsis "Field definition for nonconsensus code"))

--- a/src/nonconsensus/snark_params/snark_params_nonconsensus.ml
+++ b/src/nonconsensus/snark_params/snark_params_nonconsensus.ml
@@ -80,9 +80,8 @@ module Inner_curve = struct
   module Scalar = struct
     (* though we have bin_io, not versioned here; this type exists for Private_key.t,
        where it is versioned-asserted and its serialization tested
-       we make linter error a warning
      *)
-    type t = Mnt4.Fq.t [@@deriving bin_io, sexp]
+    type t = Mnt4.Fq.t [@@deriving bin_io_unversioned, sexp]
 
     type _unused = unit constraint t = Tock.Field.t
 

--- a/src/nonconsensus/unsigned_extended/dune
+++ b/src/nonconsensus/unsigned_extended/dune
@@ -6,6 +6,6 @@
  (libraries core_kernel integers snark_params_nonconsensus module_version)
  (preprocessor_deps ../../config.mlh)
  (preprocess
-  (pps ppx_coda -lint-version-syntax-warnings ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_hash ppx_compare
+  (pps ppx_coda ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_hash ppx_compare
        ppx_inline_test ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))
  (synopsis "Unsigned integer functions"))


### PR DESCRIPTION
Remove most of the remaining errors-as-warnings flag to `ppx_coda` in dune files.

Fix some warnings.