### PR TITLE
GraphQL: Add more detail to the coinbase transaction

### DIFF
--- a/frontend/points-hack-april20/lib.js
+++ b/frontend/points-hack-april20/lib.js
@@ -146,6 +146,9 @@ subscription Blocks {
     }
     transactions {
       coinbase
+      coinbaseReceiverAccount {
+        publicKey
+      }
       feeTransfer {
         fee
         recipient

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -100,48 +100,6 @@
         },
         {
           "kind": "INPUT_OBJECT",
-          "name": "CreateHDAccountInput",
-          "description": null,
-          "fields": [
-            {
-              "name": "index",
-              "description": "Index of the account in hardware wallet",
-              "args": [],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "UInt32",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": [
-            {
-              "name": "index",
-              "description": "Index of the account in hardware wallet",
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "UInt32",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null
-            }
-          ],
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "INPUT_OBJECT",
           "name": "SetSnarkWorkFee",
           "description": null,
           "fields": [
@@ -1865,37 +1823,6 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
-            },
-            {
-              "name": "createHDAccount",
-              "description": "Create an account with hardware wallet - this will let the hardware wallet generate a keypair corresponds to the HD-index you give and store this HD-index and the generated public key in the daemon. Calling this command with the same HD-index and the same hardware wallet will always generate the same keypair.",
-              "args": [
-                {
-                  "name": "input",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "CreateHDAccountInput",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "AddAccountPayload",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -2791,6 +2718,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "coinbaseReceiverAccount",
+              "description": "Account to which the coinbase for this block was granted",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Account",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,
@@ -3365,6 +3308,22 @@
             {
               "name": "date",
               "description": "date (stringified Unix time - number of milliseconds since January 1, 1970)",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "utcDate",
+              "description": "utcDate (stringified Unix time - number of milliseconds since January 1, 1970). Time offsets are adjusted to reflect true wall-clock time instead of genesis time.",
               "args": [],
               "type": {
                 "kind": "NON_NULL",
@@ -4128,16 +4087,6 @@
           "possibleTypes": null
         },
         {
-          "kind": "SCALAR",
-          "name": "Time",
-          "description": null,
-          "fields": null,
-          "inputFields": null,
-          "interfaces": null,
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
           "kind": "OBJECT",
           "name": "ConsensusConfiguration",
           "description": null,
@@ -4263,7 +4212,7 @@
                 "name": null,
                 "ofType": {
                   "kind": "SCALAR",
-                  "name": "Time",
+                  "name": "String",
                   "ofType": null
                 }
               },

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -2797,13 +2797,9 @@
               "description": "Account to which the coinbase for this block was granted",
               "args": [],
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Account",
-                  "ofType": null
-                }
+                "kind": "OBJECT",
+                "name": "Account",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -1254,6 +1254,48 @@
         },
         {
           "kind": "INPUT_OBJECT",
+          "name": "CreateHDAccountInput",
+          "description": null,
+          "fields": [
+            {
+              "name": "index",
+              "description": "Index of the account in hardware wallet",
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UInt32",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": [
+            {
+              "name": "index",
+              "description": "Index of the account in hardware wallet",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "UInt32",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
           "name": "AddAccountInput",
           "description": null,
           "fields": [
@@ -1386,6 +1428,37 @@
                     "ofType": {
                       "kind": "INPUT_OBJECT",
                       "name": "AddAccountInput",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "AddAccountPayload",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "createHDAccount",
+              "description": "Create an account with hardware wallet - this will let the hardware wallet generate a keypair corresponds to the HD-index you give and store this HD-index and the generated public key in the daemon. Calling this command with the same HD-index and the same hardware wallet will always generate the same keypair.",
+              "args": [
+                {
+                  "name": "input",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "CreateHDAccountInput",
                       "ofType": null
                     }
                   },

--- a/src/lib/auxiliary_database/filtered_external_transition.ml
+++ b/src/lib/auxiliary_database/filtered_external_transition.ml
@@ -10,7 +10,8 @@ module Transactions = struct
       type t =
         { user_commands: User_command.Stable.V1.t list
         ; fee_transfers: Fee_transfer.Single.Stable.V1.t list
-        ; coinbase: Currency.Amount.Stable.V1.t }
+        ; coinbase: Currency.Amount.Stable.V1.t
+        ; coinbase_receiver: Public_key.Compressed.Stable.V1.t }
 
       let to_latest = Fn.id
     end
@@ -19,7 +20,8 @@ module Transactions = struct
   type t = Stable.Latest.t =
     { user_commands: User_command.t list
     ; fee_transfers: Fee_transfer.Single.t list
-    ; coinbase: Currency.Amount.t }
+    ; coinbase: Currency.Amount.t
+    ; coinbase_receiver: Public_key.Compressed.t }
 end
 
 module Protocol_state = struct
@@ -116,7 +118,9 @@ let of_transition external_transition tracked_participants
       ~init:
         { Transactions.user_commands= []
         ; fee_transfers= []
-        ; coinbase= Currency.Amount.zero } ~f:(fun acc_transactions -> function
+        ; coinbase= Currency.Amount.zero
+        ; coinbase_receiver= Public_key.Compressed.empty }
+      ~f:(fun acc_transactions -> function
       | User_command checked_user_command -> (
           let user_command = User_command.forget_check checked_user_command in
           let should_include_transaction user_command participants =
@@ -149,9 +153,19 @@ let of_transition external_transition tracked_participants
           in
           { acc_transactions with
             fee_transfers= fee_transfers @ acc_transactions.fee_transfers }
-      | Coinbase {Coinbase.amount; _} ->
+      | Coinbase {Coinbase.amount; fee_transfer; receiver} ->
+          let fee_transfer =
+            Option.map ~f:Coinbase_fee_transfer.to_fee_transfer fee_transfer
+          in
+          let fee_transfers =
+            List.append
+              (Option.to_list fee_transfer)
+              acc_transactions.fee_transfers
+          in
           { acc_transactions with
-            coinbase=
+            fee_transfers
+          ; coinbase_receiver= receiver
+          ; coinbase=
               Currency.Amount.(
                 Option.value_exn (add amount acc_transactions.coinbase)) } )
   in

--- a/src/lib/auxiliary_database/filtered_external_transition.ml
+++ b/src/lib/auxiliary_database/filtered_external_transition.ml
@@ -11,7 +11,7 @@ module Transactions = struct
         { user_commands: User_command.Stable.V1.t list
         ; fee_transfers: Fee_transfer.Single.Stable.V1.t list
         ; coinbase: Currency.Amount.Stable.V1.t
-        ; coinbase_receiver: Public_key.Compressed.Stable.V1.t }
+        ; coinbase_receiver: Public_key.Compressed.Stable.V1.t option }
 
       let to_latest = Fn.id
     end
@@ -21,7 +21,7 @@ module Transactions = struct
     { user_commands: User_command.t list
     ; fee_transfers: Fee_transfer.Single.t list
     ; coinbase: Currency.Amount.t
-    ; coinbase_receiver: Public_key.Compressed.t }
+    ; coinbase_receiver: Public_key.Compressed.t option }
 end
 
 module Protocol_state = struct
@@ -119,8 +119,7 @@ let of_transition external_transition tracked_participants
         { Transactions.user_commands= []
         ; fee_transfers= []
         ; coinbase= Currency.Amount.zero
-        ; coinbase_receiver= Public_key.Compressed.empty }
-      ~f:(fun acc_transactions -> function
+        ; coinbase_receiver= None } ~f:(fun acc_transactions -> function
       | User_command checked_user_command -> (
           let user_command = User_command.forget_check checked_user_command in
           let should_include_transaction user_command participants =
@@ -164,7 +163,7 @@ let of_transition external_transition tracked_participants
           in
           { acc_transactions with
             fee_transfers
-          ; coinbase_receiver= receiver
+          ; coinbase_receiver= Some receiver
           ; coinbase=
               Currency.Amount.(
                 Option.value_exn (add amount acc_transactions.coinbase)) } )

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -880,7 +880,12 @@ module Types = struct
             ~doc:"Amount of coda granted to the producer of this block"
             ~args:Arg.[]
             ~resolve:(fun _ {coinbase; _} -> Currency.Amount.to_uint64 coinbase)
-        ] )
+        ; field "coinbaseReceiverAccount"
+            ~typ:(non_null AccountObj.account)
+            ~doc:"Account to which the coinbase for this block was granted"
+            ~args:Arg.[]
+            ~resolve:(fun {ctx= coda; _} {coinbase_receiver; _} ->
+              AccountObj.get_best_ledger_account coda coinbase_receiver ) ] )
 
   let protocol_state_proof : (Coda_lib.t, Proof.t option) typ =
     let display_g1_elem (g1 : Crypto_params.Tick_backend.Inner_curve.t) =

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1820,6 +1820,7 @@ module Mutations = struct
   let commands =
     [ add_wallet
     ; create_account
+    ; create_hd_account
     ; unlock_account
     ; unlock_wallet
     ; lock_account

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -880,12 +880,13 @@ module Types = struct
             ~doc:"Amount of coda granted to the producer of this block"
             ~args:Arg.[]
             ~resolve:(fun _ {coinbase; _} -> Currency.Amount.to_uint64 coinbase)
-        ; field "coinbaseReceiverAccount"
-            ~typ:(non_null AccountObj.account)
+        ; field "coinbaseReceiverAccount" ~typ:AccountObj.account
             ~doc:"Account to which the coinbase for this block was granted"
             ~args:Arg.[]
             ~resolve:(fun {ctx= coda; _} {coinbase_receiver; _} ->
-              AccountObj.get_best_ledger_account coda coinbase_receiver ) ] )
+              Option.map
+                ~f:(AccountObj.get_best_ledger_account coda)
+                coinbase_receiver ) ] )
 
   let protocol_state_proof : (Coda_lib.t, Proof.t option) typ =
     let display_g1_elem (g1 : Crypto_params.Tick_backend.Inner_curve.t) =


### PR DESCRIPTION
The main goal of this is to add coinbaseReceiverAccount, which is necessary for calculating some leaderboard metrics.

Included in PR:
- Adds coinbaseReceiverAccount, representing who the coinbase for that block went to
- Adds the coinbase fee transfer to the list of fee transfers (cc @deepthiskumar can you let me know if you think this is right/wrong? I just noticed it wasn't being exposed at all)
- Regenerates the graphql schema, looks like several things have been removed since it's been generated last.
- Expose create_hd_account since otherwise the cli doesn't build

Verified using GraphiQL that the new field was added to the schema, will test to see that the value looks sane with the sandbox container when that builds.

Potentially breaking change -- this changes the shape of the data we store in rocksdb, but we seem to wipe out the .coda-config whenever there's a version mismatch sooo I don't think this will break anything