### PR TITLE
Remove some 27 errors-as-warnings

### DIFF
--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -127,7 +127,6 @@ module Poly = struct
     ; timing: 'timing }
   [@@deriving sexp, eq, compare, hash, yojson, fields]
 end
-[@@warning "-27"]
 
 module Key = struct
   [%%versioned

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -177,7 +177,6 @@ module Common = struct
 
   [%%endif]
 end
-[@@warning "-27"]
 
 module Body = struct
   [%%versioned

--- a/src/lib/pickles_types/dlog_marlin_types.ml
+++ b/src/lib/pickles_types/dlog_marlin_types.ml
@@ -1,4 +1,3 @@
-open Tuple_lib
 open Core_kernel
 
 module Evals = struct
@@ -129,8 +128,6 @@ module Openings = struct
         ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
         ~value_of_hlist:of_hlist
   end
-
-  open Evals
 
   [%%versioned
   module Stable = struct

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -2,7 +2,7 @@
   (inline_tests)
   (name pickles_types)
   (public_name pickles_types)
-  (preprocess (pps ppx_deriving_yojson ppx_coda ppx_jane ppx_deriving.std))
+  (preprocess (pps ppx_coda -lint-version-syntax-warnings ppx_deriving_yojson ppx_jane ppx_deriving.std))
   (libraries
     snarky
     core_kernel

--- a/src/lib/pickles_types/dune
+++ b/src/lib/pickles_types/dune
@@ -2,7 +2,6 @@
   (inline_tests)
   (name pickles_types)
   (public_name pickles_types)
-  (flags -warn-error -27)
   (preprocess (pps ppx_deriving_yojson ppx_coda ppx_jane ppx_deriving.std))
   (libraries
     snarky

--- a/src/lib/pickles_types/hlist.ml
+++ b/src/lib/pickles_types/hlist.ml
@@ -196,7 +196,7 @@ module H1 = struct
   end
 
   module To_vector (X : T0) = struct
-    let rec f : type e xs ys length.
+    let rec f : type xs length.
         (xs, length) Length.t -> xs T(E01(X)).t -> (X.t, length) Vector.t =
      fun l1 v ->
       match (l1, v) with Z, [] -> [] | S n1, x :: xs -> x :: f n1 xs
@@ -272,7 +272,7 @@ module H2 = struct
   end
 
   module Zip (F : T2) (G : T2) = struct
-    let rec f : type a b c.
+    let rec f : type a b.
         (a, b) T(F).t -> (a, b) T(G).t -> (a, b) T(Tuple2(F)(G)).t =
      fun xs ys ->
       match (xs, ys) with
@@ -543,7 +543,7 @@ module H3 = struct
           ('a1, 'a2, 'a3) F.t * ('b1, 'b2, 'b3) t
           -> ('a1 * 'b1, 'a2 * 'b2, 'a3 * 'b3) t
 
-    let rec length : type tail1 tail2 tail3 e.
+    let rec length : type tail1 tail2 tail3.
         (tail1, tail2, tail3) t -> tail1 Length.n = function
       | [] ->
           T (Z, Z)

--- a/src/lib/pickles_types/nat.ml
+++ b/src/lib/pickles_types/nat.ml
@@ -196,7 +196,7 @@ let rec compare : type n m.
         `Gt (function S pi -> gt pi) )
 
 let lte_exn n m =
-  match compare n m with `Lte pi -> pi | `Gt gt -> failwith "lte_exn"
+  match compare n m with `Lte pi -> pi | `Gt _gt -> failwith "lte_exn"
 
 let rec gt_implies_gte : type n m.
     n nat -> m nat -> (n, m) Lte.t Not.t -> (m, n) Lte.t =

--- a/src/lib/pickles_types/pairing_marlin_types.ml
+++ b/src/lib/pickles_types/pairing_marlin_types.ml
@@ -311,7 +311,7 @@ module Accumulator = struct
                 Some (add x y)
             | `Left x ->
                 Some x
-            | `Right y ->
+            | `Right _y ->
                 failwith "shift not present in accumulating map" ) }
   end
 
@@ -428,8 +428,6 @@ module Opening = struct
 end
 
 module Openings = struct
-  open Evals
-
   [%%versioned
   module Stable = struct
     module V1 = struct

--- a/src/lib/pickles_types/pcs_batch.ml
+++ b/src/lib/pickles_types/pcs_batch.ml
@@ -5,7 +5,7 @@ type ('a, 'n, 'm) t =
 
 let map t ~f = {t with with_degree_bound= Vector.map t.with_degree_bound ~f}
 
-let pow ~one ~mul ~add x n =
+let pow ~one ~mul ~add:_ x n =
   let k = Int.ceil_log2 n in
   let rec go acc i =
     if i < 0 then acc
@@ -22,7 +22,7 @@ let pow ~one ~mul ~add x n =
 let create ~without_degree_bound ~with_degree_bound =
   {without_degree_bound; with_degree_bound}
 
-let combine_commitments t ~scale ~add ~xi (type n)
+let combine_commitments _t ~scale ~add ~xi (type n)
     (without_degree_bound : (_, n) Vector.t) with_degree_bound =
   match without_degree_bound with
   | [] ->
@@ -36,8 +36,8 @@ let combine_commitments t ~scale ~add ~xi (type n)
       List.fold_left polys ~init ~f:(fun acc p -> add p (scale acc xi))
 
 let combine_evaluations' (type a n m)
-    ({without_degree_bound; with_degree_bound} : (a, n Nat.s, m) t)
-    ~shifted_pow ~mul ~add ~one ~evaluation_point ~xi
+    ({without_degree_bound= _; with_degree_bound} : (a, n Nat.s, m) t)
+    ~shifted_pow ~mul ~add ~one:_ ~evaluation_point ~xi
     (init :: evals0 : (_, n Nat.s) Vector.t) (evals1 : (_, m) Vector.t) =
   let evals =
     Vector.to_list evals0

--- a/src/lib/pickles_types/vector.ml
+++ b/src/lib/pickles_types/vector.ml
@@ -35,7 +35,7 @@ let rec map2 : type a b c n.
   | x :: xs, y :: ys ->
       f x y :: map2 xs ys ~f
 
-let rec hhead_off : type xs y n.
+let rec hhead_off : type xs n.
        (xs, n s) Hlist0.H1_1(T).t
     -> xs Hlist0.HlistId.t * (xs, n) Hlist0.H1_1(T).t =
  fun xss ->
@@ -50,7 +50,7 @@ let rec mapn : type xs y n.
     (xs, n) Hlist0.H1_1(T).t -> f:(xs Hlist0.HlistId.t -> y) -> (y, n) t =
  fun xss ~f ->
   match xss with
-  | [] :: xss ->
+  | [] :: _xss ->
       []
   | (_ :: _) :: _ ->
       let hds, tls = hhead_off xss in
@@ -367,7 +367,7 @@ let rec extend_exn : type n m a. (a, n) t -> m Nat.t -> a -> (a, m) t =
       []
   | [], S n ->
       default :: extend_exn [] n default
-  | x :: xs, Z ->
+  | _x :: _xs, Z ->
       failwith "extend_exn: list too long"
   | x :: xs, S m ->
       let extended = extend_exn xs m default in


### PR DESCRIPTION
Removed a couple of `[@@warning "-27"]` from the code, which had no effect.

Removed that flag from a `dune` file, because that masks potential errors in the entire library. Changed a variable name for the one unused variable case.

Update: there were a number of other unused variables and opens that showed up in the unit tests, fixed.
