### PR TITLE
Lint versioned types in extension expressions

### DIFF
--- a/src/lib/ppx_coda/lint_version_syntax.ml
+++ b/src/lib/ppx_coda/lint_version_syntax.ml
@@ -300,7 +300,7 @@ let lint_ast =
       | Pexp_extension (_, PTyp core_type) ->
           (* misuses like [%bin_type_class: Foo.Stable.V1.t] *)
           let errs = get_core_type_versioned_type_misuses core_type in
-          acc_with_errors acc errs
+          acc_with_accum_errors acc errs
       | _ ->
           super#expression expr acc
 

--- a/src/lib/transition_frontier/persistent_frontier/database.ml
+++ b/src/lib/transition_frontier/persistent_frontier/database.ml
@@ -70,17 +70,17 @@ module Schema = struct
     | Db_version ->
         [%bin_type_class: int]
     | Transition _ ->
-        [%bin_type_class: External_transition.Stable.V1.t]
+        [%bin_type_class: External_transition.Stable.Latest.t]
     | Arcs _ ->
-        [%bin_type_class: State_hash.Stable.V1.t list]
+        [%bin_type_class: State_hash.Stable.Latest.t list]
     | Root ->
-        [%bin_type_class: Root_data.Minimal.Stable.V1.t]
+        [%bin_type_class: Root_data.Minimal.Stable.Latest.t]
     | Best_tip ->
-        [%bin_type_class: State_hash.Stable.V1.t]
+        [%bin_type_class: State_hash.Stable.Latest.t]
     | Frontier_hash ->
-        [%bin_type_class: Frontier_hash.Stable.V1.t]
+        [%bin_type_class: Frontier_hash.Stable.Latest.t]
     | Protocol_states_for_root_scan_state ->
-        [%bin_type_class: Coda_state.Protocol_state.Value.Stable.V1.t list]
+        [%bin_type_class: Coda_state.Protocol_state.Value.Stable.Latest.t list]
 
   (* HACK: a simple way to derive Bin_prot.Type_class.t for each case of a GADT *)
   let gadt_input_type_class (type data a) :
@@ -115,12 +115,12 @@ module Schema = struct
           ~of_gadt:(fun Db_version -> "db_version")
     | Transition _ ->
         gadt_input_type_class
-          (module Keys.Prefixed_state_hash.Stable.V1)
+          (module Keys.Prefixed_state_hash.Stable.Latest)
           ~to_gadt:(fun (_, hash) -> Transition hash)
           ~of_gadt:(fun (Transition hash) -> ("transition", hash))
     | Arcs _ ->
         gadt_input_type_class
-          (module Keys.Prefixed_state_hash.Stable.V1)
+          (module Keys.Prefixed_state_hash.Stable.Latest)
           ~to_gadt:(fun (_, hash) -> Arcs hash)
           ~of_gadt:(fun (Arcs hash) -> ("arcs", hash))
     | Root ->

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -124,7 +124,8 @@ module Worker = struct
         ; verify_transaction_snark=
             f
               ( [%bin_type_class:
-                  Transaction_snark.Stable.V1.t * Sok_message.Stable.V1.t]
+                  Transaction_snark.Stable.Latest.t
+                  * Sok_message.Stable.Latest.t]
               , Bool.bin_t
               , verify_transaction_snark ) }
 


### PR DESCRIPTION
Types may appear in OCaml extensions. Versioned types should not appear in them.

There were several instances like:
```ocaml
[%bin_type_class: Foo.Stable.V1.t]
```
We should use `Foo.Stable.Latest.t` in such instances.

The linter now flags these, and all violations were fixed.
