### PR TITLE
Added atleast n functionality and slight refactor

### DIFF
--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -1,149 +1,5 @@
 module StringMap = Map.Make(String);
 
-// Helper functions for gathering metrics
-let printMap = map => {
-  StringMap.mapi(
-    (key, value) => {
-      Js.log(key);
-      Js.log(Int64.to_string(value));
-    },
-    map,
-  );
-};
-
-let calculateProperty = (f, blocks) => {
-  blocks
-  |> Array.fold_left((map, block) => {f(map, block)}, StringMap.empty);
-};
-
-let incrementMapValue = (key, map) => {
-  map
-  |> StringMap.update(key, value => {
-       switch (value) {
-       | Some(valueCount) => Some(Int64.add(valueCount, Int64.one))
-       | None => Some(Int64.one)
-       }
-     });
-};
-
-// Gather metrics
-let getBlocksCreatedByUser = blocks => {
-  blocks
-  |> Array.fold_left(
-       (map, block: Types.NewBlock.data) => {
-         incrementMapValue(block.creatorAccount.publicKey, map)
-       },
-       StringMap.empty,
-     );
-};
-
-let calculateTransactionSent = (map, block: Types.NewBlock.data) => {
-  block.transactions.userCommands
-  |> Array.fold_left(
-       (transactionMap, userCommand: Types.NewBlock.userCommands) => {
-         incrementMapValue(userCommand.fromAccount.publicKey, transactionMap)
-       },
-       map,
-     );
-};
-
-let getTransactionSentByUser = blocks => {
-  blocks |> calculateProperty(calculateTransactionSent);
-};
-
-let calculateSnarkWorkCount = (map, block: Types.NewBlock.data) => {
-  block.snarkJobs
-  |> Array.fold_left(
-       (snarkMap, snarkJob: Types.NewBlock.snarkJobs) => {
-         incrementMapValue(snarkJob.prover, snarkMap)
-       },
-       map,
-     );
-};
-
-let getSnarkWorkCreatedByUser = blocks => {
-  blocks |> calculateProperty(calculateSnarkWorkCount);
-};
-
-let getSnarkFeesCollected = blocks => {
-  Array.fold_left(
-    (map, block: Types.NewBlock.data) => {
-      Array.fold_left(
-        (map, snarkJob: Types.NewBlock.snarkJobs) => {
-          StringMap.update(
-            snarkJob.prover,
-            feeCount =>
-              switch (feeCount) {
-              | Some(feeCount) => Some(Int64.add(feeCount, snarkJob.fee))
-              | None => Some(snarkJob.fee)
-              },
-            map,
-          )
-        },
-        map,
-        block.snarkJobs,
-      )
-    },
-    StringMap.empty,
-    blocks,
-  );
-};
-
-let max = (a, b) => {
-  a > b ? a : b;
-};
-
-let getHighestSnarkFeeCollected = blocks => {
-  Array.fold_left(
-    (map, block: Types.NewBlock.data) => {
-      Array.fold_left(
-        (map, snarkJob: Types.NewBlock.snarkJobs) => {
-          StringMap.update(
-            snarkJob.prover,
-            feeCount =>
-              switch (feeCount) {
-              | Some(feeCount) => Some(max(feeCount, snarkJob.fee))
-              | None => Some(snarkJob.fee)
-              },
-            map,
-          )
-        },
-        map,
-        block.snarkJobs,
-      )
-    },
-    StringMap.empty,
-    blocks,
-  );
-};
-
-let calculateTransactionsSentToAddress = (blocks, address) => {
-  Array.fold_left(
-    (map, block: Types.NewBlock.data) => {
-      block.transactions.userCommands
-      |> Array.fold_left(
-           (map, userCommand: Types.NewBlock.userCommands) => {
-             userCommand.toAccount.publicKey === address
-               ? incrementMapValue(userCommand.fromAccount.publicKey, map)
-               : map
-           },
-           map,
-         )
-    },
-    StringMap.empty,
-    blocks,
-  );
-};
-
-// Calculate users and metrics
-let calculateAllUsers = metrics => {
-  List.fold_left(
-    StringMap.merge((_, _, _) => {Some()}),
-    StringMap.empty,
-    metrics,
-  );
-};
-
 let addPointsToUsersWithAtleastN =
     (getMetricValue, threshold, pointsToReward, metricsMap) => {
   StringMap.fold(
@@ -152,8 +8,8 @@ let addPointsToUsersWithAtleastN =
       | Some(metricValue) =>
         metricValue >= threshold
           ? StringMap.add(key, pointsToReward, map)
-          : StringMap.add(key, Int64.zero, map)
-      | None => StringMap.add(key, Int64.zero, map)
+          : StringMap.add(key, 0, map)
+      | None => map
       }
     },
     metricsMap,
@@ -167,28 +23,28 @@ let calculatePoints = metricsMap => {
     addPointsToUsersWithAtleastN(
       (metricRecord: Types.Metrics.metricRecord) =>
         metricRecord.transactionsReceivedByEcho,
-      1L,
-      500L,
+      1,
+      500,
       metricsMap,
     );
 
-  // Earn 3 fees by producing and selling zk-SNARKs on the snarketplace: 1000 pts*
+  //Earn 3 fees by producing and selling zk-SNARKs on the snarketplace: 1000 pts*
   let zkSnark3FeesPoints =
     addPointsToUsersWithAtleastN(
       (metricRecord: Types.Metrics.metricRecord) =>
         metricRecord.snarkFeesCollected,
       3L,
-      1000L,
+      1000,
       metricsMap,
     );
 
-  // Anyone who earned 50 fees will be rewarded with an additional 1000 pts
+  //Anyone who earned 50 fees will be rewarded with an additional 1000 pts
   let zkSnark50FeesPoints =
     addPointsToUsersWithAtleastN(
       (metricRecord: Types.Metrics.metricRecord) =>
         metricRecord.snarkFeesCollected,
       50L,
-      1000L,
+      1000,
       metricsMap,
     );
 
@@ -197,42 +53,9 @@ let calculatePoints = metricsMap => {
     addPointsToUsersWithAtleastN(
       (metricRecord: Types.Metrics.metricRecord) =>
         metricRecord.blocksCreated,
-      3L,
-      1000L,
+      3,
+      1000,
       metricsMap,
     );
   ();
-};
-
-let echoBotPublicKey = "4vsRCVNep7JaFhtySu6vZCjnArvoAhkRscTy5TQsGTsKM4tJcYVc3uNUMRxQZAwVzSvkHDGWBmvhFpmCeiPASGnByXqvKzmHt4aR5uAWAQf3kqhwDJ2ZY3Hw4Dzo6awnJkxY338GEp12LE4x";
-let calculateMetrics = blocks => {
-  let blocksCreated = getBlocksCreatedByUser(blocks);
-  let transactionSent = getTransactionSentByUser(blocks);
-  let snarkWorkCreated = getSnarkWorkCreatedByUser(blocks);
-  let snarkFeesCollected = getSnarkFeesCollected(blocks);
-  let highestSnarkFeeCollected = getHighestSnarkFeeCollected(blocks);
-  let transactionsReceivedByEcho =
-    calculateTransactionsSentToAddress(blocks, echoBotPublicKey);
-
-  calculateAllUsers([
-    blocksCreated,
-    transactionSent,
-    snarkWorkCreated,
-    snarkFeesCollected,
-    highestSnarkFeeCollected,
-    transactionsReceivedByEcho,
-  ])
-  |> StringMap.mapi((key, _) =>
-       {
-         Types.Metrics.blocksCreated: StringMap.find_opt(key, blocksCreated),
-         transactionSent: StringMap.find_opt(key, transactionSent),
-         snarkWorkCreated: StringMap.find_opt(key, snarkWorkCreated),
-         snarkFeesCollected: StringMap.find_opt(key, snarkFeesCollected),
-         highestSnarkFeeCollected:
-           StringMap.find_opt(key, highestSnarkFeeCollected),
-         transactionsReceivedByEcho:
-           StringMap.find_opt(key, transactionsReceivedByEcho),
-       }
-     )
-  |> calculatePoints;
 };

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -172,20 +172,68 @@ let calculateMetrics = blocks => {
     calculateTransactionsSentToAddress(blocks, echoBotPublicKey);
 
   // TODO: Calculate users for all metrics
-  let users = calculateAllUsers([blocksCreated, transactionSent]);
+  let users =
+    calculateAllUsers([
+      blocksCreated,
+      transactionSent,
+      snarkWorkCreated,
+      transactionsReceivedByEcho,
+    ]);
 
-  StringMap.mapi(
-    (key, _) =>
-      {
-        Types.Metrics.blocksCreated: StringMap.find_opt(key, blocksCreated),
-        transactionSent: StringMap.find_opt(key, transactionSent),
-        snarkWorkCreated: StringMap.find_opt(key, snarkWorkCreated),
-        snarkFeesCollected: StringMap.find_opt(key, snarkFeesCollected),
-        highestSnarkFeeCollected:
-          StringMap.find_opt(key, highestSnarkFeeCollected),
-        transactionsReceivedByEcho:
-          StringMap.find_opt(key, transactionsReceivedByEcho),
-      },
-    users,
-  );
+  let metricsMap =
+    StringMap.mapi(
+      (key, _) =>
+        {
+          Types.Metrics.blocksCreated: StringMap.find_opt(key, blocksCreated),
+          transactionSent: StringMap.find_opt(key, transactionSent),
+          snarkWorkCreated: StringMap.find_opt(key, snarkWorkCreated),
+          snarkFeesCollected: StringMap.find_opt(key, snarkFeesCollected),
+          highestSnarkFeeCollected:
+            StringMap.find_opt(key, highestSnarkFeeCollected),
+          transactionsReceivedByEcho:
+            StringMap.find_opt(key, transactionsReceivedByEcho),
+        },
+      users,
+    );
+
+  // Get 500 pts if you send txn to the echo service
+  let echoTransactionPoints =
+    addPointsToUsersWithAtleastN(
+      (metricRecord: Types.Metrics.metricRecord) =>
+        metricRecord.transactionsReceivedByEcho,
+      1,
+      500,
+      metricsMap,
+    );
+
+  // Earn 3 fees by producing and selling zk-SNARKs on the snarketplace: 1000 pts*
+  let zkSnark3FeesPoints =
+    addPointsToUsersWithAtleastN(
+      (metricRecord: Types.Metrics.metricRecord) =>
+        metricRecord.snarkFeesCollected,
+      3,
+      1000,
+      metricsMap,
+    );
+
+  // Anyone who earned 50 fees will be rewarded with an additional 1000 pts
+  let zkSnark50FeesPoints =
+    addPointsToUsersWithAtleastN(
+      (metricRecord: Types.Metrics.metricRecord) =>
+        metricRecord.snarkFeesCollected,
+      50,
+      1000,
+      metricsMap,
+    );
+
+  // Producing at least 3 blocks will earn an additional 1000 pts
+  let blocksCreatedPoints =
+    addPointsToUsersWithAtleastN(
+      (metricRecord: Types.Metrics.metricRecord) =>
+        metricRecord.blocksCreated,
+      3,
+      1000,
+      metricsMap,
+    );
+  ();
 };

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -148,9 +148,13 @@ let addPointsToUsersWithAtleastN =
     (getMetricValue, threshold, pointsToReward, metricsMap) => {
   StringMap.fold(
     (key, metric, map) => {
-      Belt.Option.getExn(getMetricValue(metric)) >= threshold
-        ? StringMap.add(key, pointsToReward, map)
-        : StringMap.add(key, 0, map)
+      switch (getMetricValue(metric)) {
+      | Some(metricValue) =>
+        metricValue >= threshold
+          ? StringMap.add(key, pointsToReward, map)
+          : StringMap.add(key, 0, map)
+      | None => StringMap.add(key, 0, map)
+      }
     },
     metricsMap,
     StringMap.empty,

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -206,26 +206,6 @@ let calculateMetrics = blocks => {
       metricsMap,
     );
 
-  // Earn 3 fees by producing and selling zk-SNARKs on the snarketplace: 1000 pts*
-  let zkSnark3FeesPoints =
-    addPointsToUsersWithAtleastN(
-      (metricRecord: Types.Metrics.metricRecord) =>
-        metricRecord.snarkFeesCollected,
-      3,
-      1000,
-      metricsMap,
-    );
-
-  // Anyone who earned 50 fees will be rewarded with an additional 1000 pts
-  let zkSnark50FeesPoints =
-    addPointsToUsersWithAtleastN(
-      (metricRecord: Types.Metrics.metricRecord) =>
-        metricRecord.snarkFeesCollected,
-      50,
-      1000,
-      metricsMap,
-    );
-
   // Producing at least 3 blocks will earn an additional 1000 pts
   let blocksCreatedPoints =
     addPointsToUsersWithAtleastN(

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -7,8 +7,7 @@ let addPointsToUsersWithAtleastN =
       switch (getMetricValue(metric)) {
       | Some(metricValue) =>
         metricValue >= threshold
-          ? StringMap.add(key, pointsToReward, map)
-          : StringMap.add(key, 0, map)
+          ? StringMap.add(key, pointsToReward, map) : map
       | None => map
       }
     },

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -144,16 +144,31 @@ let calculateAllUsers = metrics => {
   );
 };
 
+let addPointsToUsersWithAtleastN =
+    (getMetricValue, threshold, pointsToReward, metricsMap) => {
+  StringMap.fold(
+    (key, metric, map) => {
+      Belt.Option.getExn(getMetricValue(metric)) >= threshold
+        ? StringMap.add(key, pointsToReward, map)
+        : StringMap.add(key, 0, map)
+    },
+    metricsMap,
+    StringMap.empty,
+  );
+};
+
 let echoBotPublicKey = "4vsRCVNep7JaFhtySu6vZCjnArvoAhkRscTy5TQsGTsKM4tJcYVc3uNUMRxQZAwVzSvkHDGWBmvhFpmCeiPASGnByXqvKzmHt4aR5uAWAQf3kqhwDJ2ZY3Hw4Dzo6awnJkxY338GEp12LE4x";
 let calculateMetrics = blocks => {
-  let blocksCreated = blocks |> getBlocksCreatedByUser;
-  let transactionSent = blocks |> getTransactionSentByUser;
-  let snarkWorkCreated = blocks |> getSnarkWorkCreatedByUser;
-  let users = calculateAllUsers([blocksCreated, transactionSent]);
-  let snarkFeesCollected = blocks |> getSnarkFeesCollected;
-  let highestSnarkFeeCollected = blocks |> getHighestSnarkFeeCollected;
+  let blocksCreated = getBlocksCreatedByUser(blocks);
+  let transactionSent = getTransactionSentByUser(blocks);
+  let snarkWorkCreated = getSnarkWorkCreatedByUser(blocks);
+  let snarkFeesCollected = getSnarkFeesCollected(blocks);
+  let highestSnarkFeeCollected = getHighestSnarkFeeCollected(blocks);
   let transactionsReceivedByEcho =
     calculateTransactionsSentToAddress(blocks, echoBotPublicKey);
+
+  // TODO: Calculate users for all metrics
+  let users = calculateAllUsers([blocksCreated, transactionSent]);
 
   StringMap.mapi(
     (key, _) =>

--- a/frontend/leaderboard/src/Main.re
+++ b/frontend/leaderboard/src/Main.re
@@ -15,4 +15,4 @@ let blocks =
     files,
   );
 
-let results = Challenges.calculateMetrics(blocks);
+let results = blocks |> Metrics.calculateMetrics |> Challenges.calculatePoints;

--- a/frontend/leaderboard/src/Metrics.re
+++ b/frontend/leaderboard/src/Metrics.re
@@ -136,11 +136,7 @@ let calculateTransactionsSentToAddress = (blocks, address) => {
 };
 
 let throwAwayValues = metric => {
-  StringMap.fold(
-    (key, _, map) => {StringMap.add(key, Some(), map)},
-    metric,
-    StringMap.empty,
-  );
+  StringMap.map(_ => {()}, metric);
 };
 
 let calculateAllUsers = metrics => {

--- a/frontend/leaderboard/src/Metrics.re
+++ b/frontend/leaderboard/src/Metrics.re
@@ -1,0 +1,184 @@
+module StringMap = Map.Make(String);
+
+// Helper functions for gathering metrics
+let printMap = map => {
+  StringMap.mapi(
+    (key, value) => {
+      Js.log(key);
+      Js.log(value);
+    },
+    map,
+  );
+};
+
+let calculateProperty = (f, blocks) => {
+  blocks
+  |> Array.fold_left((map, block) => {f(map, block)}, StringMap.empty);
+};
+
+let incrementMapValue = (key, map) => {
+  map
+  |> StringMap.update(key, value => {
+       switch (value) {
+       | Some(valueCount) => Some(valueCount + 1)
+       | None => Some(1)
+       }
+     });
+};
+
+// Gather metrics
+let getBlocksCreatedByUser = blocks => {
+  blocks
+  |> Array.fold_left(
+       (map, block: Types.NewBlock.data) => {
+         incrementMapValue(block.creatorAccount.publicKey, map)
+       },
+       StringMap.empty,
+     );
+};
+
+let calculateTransactionSent = (map, block: Types.NewBlock.data) => {
+  block.transactions.userCommands
+  |> Array.fold_left(
+       (transactionMap, userCommand: Types.NewBlock.userCommands) => {
+         incrementMapValue(userCommand.fromAccount.publicKey, transactionMap)
+       },
+       map,
+     );
+};
+
+let getTransactionSentByUser = blocks => {
+  blocks |> calculateProperty(calculateTransactionSent);
+};
+
+let calculateSnarkWorkCount = (map, block: Types.NewBlock.data) => {
+  block.snarkJobs
+  |> Array.fold_left(
+       (snarkMap, snarkJob: Types.NewBlock.snarkJobs) => {
+         incrementMapValue(snarkJob.prover, snarkMap)
+       },
+       map,
+     );
+};
+
+let getSnarkWorkCreatedByUser = blocks => {
+  blocks |> calculateProperty(calculateSnarkWorkCount);
+};
+
+let getSnarkFeesCollected = blocks => {
+  Array.fold_left(
+    (map, block: Types.NewBlock.data) => {
+      Array.fold_left(
+        (map, snarkJob: Types.NewBlock.snarkJobs) => {
+          StringMap.update(
+            snarkJob.prover,
+            feeCount =>
+              switch (feeCount) {
+              | Some(feeCount) => Some(Int64.add(feeCount, snarkJob.fee))
+              | None => Some(snarkJob.fee)
+              },
+            map,
+          )
+        },
+        map,
+        block.snarkJobs,
+      )
+    },
+    StringMap.empty,
+    blocks,
+  );
+};
+
+let max = (a, b) => {
+  a > b ? a : b;
+};
+
+let getHighestSnarkFeeCollected = blocks => {
+  Array.fold_left(
+    (map, block: Types.NewBlock.data) => {
+      Array.fold_left(
+        (map, snarkJob: Types.NewBlock.snarkJobs) => {
+          StringMap.update(
+            snarkJob.prover,
+            feeCount =>
+              switch (feeCount) {
+              | Some(feeCount) => Some(max(feeCount, snarkJob.fee))
+              | None => Some(snarkJob.fee)
+              },
+            map,
+          )
+        },
+        map,
+        block.snarkJobs,
+      )
+    },
+    StringMap.empty,
+    blocks,
+  );
+};
+
+let calculateTransactionsSentToAddress = (blocks, address) => {
+  Array.fold_left(
+    (map, block: Types.NewBlock.data) => {
+      block.transactions.userCommands
+      |> Array.fold_left(
+           (map, userCommand: Types.NewBlock.userCommands) => {
+             userCommand.toAccount.publicKey === address
+               ? incrementMapValue(userCommand.fromAccount.publicKey, map)
+               : map
+           },
+           map,
+         )
+    },
+    StringMap.empty,
+    blocks,
+  );
+};
+
+let throwAwayValues = metric => {
+  StringMap.fold(
+    (key, _, map) => {StringMap.add(key, Some(), map)},
+    metric,
+    StringMap.empty,
+  );
+};
+
+let calculateAllUsers = metrics => {
+  List.fold_left(
+    StringMap.merge((_, _, _) => {Some()}),
+    StringMap.empty,
+    metrics,
+  );
+};
+
+let echoBotPublicKey = "4vsRCVNep7JaFhtySu6vZCjnArvoAhkRscTy5TQsGTsKM4tJcYVc3uNUMRxQZAwVzSvkHDGWBmvhFpmCeiPASGnByXqvKzmHt4aR5uAWAQf3kqhwDJ2ZY3Hw4Dzo6awnJkxY338GEp12LE4x";
+let calculateMetrics = blocks => {
+  let blocksCreated = getBlocksCreatedByUser(blocks);
+  let transactionSent = getTransactionSentByUser(blocks);
+  let snarkWorkCreated = getSnarkWorkCreatedByUser(blocks);
+  let snarkFeesCollected = getSnarkFeesCollected(blocks);
+  let highestSnarkFeeCollected = getHighestSnarkFeeCollected(blocks);
+  let transactionsReceivedByEcho =
+    calculateTransactionsSentToAddress(blocks, echoBotPublicKey);
+
+  calculateAllUsers([
+    throwAwayValues(blocksCreated),
+    throwAwayValues(transactionSent),
+    throwAwayValues(snarkWorkCreated),
+    throwAwayValues(snarkFeesCollected),
+    throwAwayValues(highestSnarkFeeCollected),
+    throwAwayValues(transactionsReceivedByEcho),
+  ])
+  |> StringMap.mapi((key, _) =>
+       {
+         Types.Metrics.blocksCreated: StringMap.find_opt(key, blocksCreated),
+         transactionSent: StringMap.find_opt(key, transactionSent),
+         snarkWorkCreated: StringMap.find_opt(key, snarkWorkCreated),
+         snarkFeesCollected: StringMap.find_opt(key, snarkFeesCollected),
+         highestSnarkFeeCollected:
+           StringMap.find_opt(key, highestSnarkFeeCollected),
+         transactionsReceivedByEcho:
+           StringMap.find_opt(key, transactionsReceivedByEcho),
+       }
+     );
+};

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -43,11 +43,11 @@ module Metrics = {
     | TransactionsReceivedByEcho;
 
   type metricRecord = {
-    blocksCreated: option(int),
-    transactionSent: option(int),
-    snarkWorkCreated: option(int),
+    blocksCreated: option(int64),
+    transactionSent: option(int64),
+    snarkWorkCreated: option(int64),
     snarkFeesCollected: option(int64),
     highestSnarkFeeCollected: option(int64),
-    transactionsReceivedByEcho: option(int),
+    transactionsReceivedByEcho: option(int64),
   };
 };

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -43,11 +43,11 @@ module Metrics = {
     | TransactionsReceivedByEcho;
 
   type metricRecord = {
-    blocksCreated: option(int64),
-    transactionSent: option(int64),
-    snarkWorkCreated: option(int64),
+    blocksCreated: option(int),
+    transactionSent: option(int),
+    snarkWorkCreated: option(int),
     snarkFeesCollected: option(int64),
     highestSnarkFeeCollected: option(int64),
-    transactionsReceivedByEcho: option(int64),
+    transactionsReceivedByEcho: option(int),
   };
 };


### PR DESCRIPTION
Implemented functionality for calculating points of users that have completed _atleast n_ of a metric. (example: Producing at least 3 blocks will earn an additional 1000 pts)

Also included a slight refactor of calculating all metrics.

The usage of _addPointsToUsersWithAtleastN_ is:
`let blockCreatedPoints =
    addPointsToUsersWithAtleastN(
      (metricRecord) => metricRecord.blocksCreated,
      10,
      1000,
      map
    );`

**Testing methods:**

To test the output of calculating metrics and challenges, manual testing was done. Block data was pulled in from an S3 bucket and was slightly modified to add additional properties to the blocks. Once the data was mocked, the script is executed and logged output throughout multiple points of the program. 

The output of `calculateMetrics` is a binding of users in the form of public keys and a metricRecord. A metric record holds information on the number of completed metrics we want to compute. 

The output of `calculatePoints` is a binding of all users in the form of public keys and a number value that represents the points earned for completing a metric. Users that do not meet a metric threshold are not shown in the bindings. 
For example, a user that has created at least 3 blocks is rewarded 1000 points, thus a mapping of `username : 1000` is produced. 