### PR TITLE
Pickles_types, don't include Stable.Latest

### DIFF
--- a/src/lib/pickles_types/pairing_marlin_types.ml
+++ b/src/lib/pickles_types/pairing_marlin_types.ml
@@ -20,11 +20,25 @@ module Evals = struct
         ; col: 'a Abc.t
         ; value: 'a Abc.t
         ; rc: 'a Abc.t }
-      [@@deriving fields, version, bin_io, sexp, compare, yojson]
+      [@@deriving fields, sexp, compare, yojson]
     end
   end]
 
-  include Stable.Latest
+  type 'a t = 'a Stable.Latest.t =
+    { w_hat: 'a
+    ; z_hat_a: 'a
+    ; z_hat_b: 'a
+    ; g_1: 'a
+    ; h_1: 'a
+    ; g_2: 'a
+    ; h_2: 'a
+    ; g_3: 'a
+    ; h_3: 'a
+    ; row: 'a Abc.t
+    ; col: 'a Abc.t
+    ; value: 'a Abc.t
+    ; rc: 'a Abc.t }
+
   open Vector
 
   (* This is just the order used for iterating when absorbing the evaluations
@@ -233,11 +247,11 @@ module Accumulator = struct
       module Stable = struct
         module V1 = struct
           type 'a t = 'a Shift.Map.t
-          [@@deriving sexp, version {asserted}, bin_io, compare]
+          [@@deriving sexp, version {asserted}, compare]
         end
       end]
 
-      include Stable.Latest
+      type 'a t = 'a Stable.Latest.t
 
       let to_yojson f t = Alist.to_yojson f (Map.to_alist t)
 
@@ -256,11 +270,13 @@ module Accumulator = struct
       module V1 = struct
         type ('g, 'unshifted) t =
           {shifted_accumulator: 'g; unshifted_accumulators: 'unshifted}
-        [@@deriving fields, version, bin_io, sexp, yojson, compare]
+        [@@deriving fields, sexp, yojson, compare]
       end
     end]
 
-    include Stable.Latest
+    type ('g, 'unshifted) t = ('g, 'unshifted) Stable.Latest.t =
+      {shifted_accumulator: 'g; unshifted_accumulators: 'unshifted}
+    [@@deriving fields, sexp, yojson, compare]
 
     let to_hlist {shifted_accumulator; unshifted_accumulators} =
       H_list.[shifted_accumulator; unshifted_accumulators]
@@ -330,11 +346,12 @@ module Accumulator = struct
     module Stable = struct
       module V1 = struct
         type 'g t = {r_f_minus_r_v_plus_rz_pi: 'g; r_pi: 'g}
-        [@@deriving fields, version, bin_io, sexp, compare, yojson]
+        [@@deriving fields, sexp, compare, yojson]
       end
     end]
 
-    include Stable.Latest
+    type 'g t = 'g Stable.Latest.t = {r_f_minus_r_v_plus_rz_pi: 'g; r_pi: 'g}
+    [@@deriving fields, sexp, compare, yojson]
 
     let to_hlist {r_f_minus_r_v_plus_rz_pi; r_pi} =
       H_list.[r_f_minus_r_v_plus_rz_pi; r_pi]
@@ -364,13 +381,17 @@ module Accumulator = struct
   module Stable = struct
     module V1 = struct
       type ('g, 'unshifted) t =
-        { opening_check: 'g Opening_check.t
-        ; degree_bound_checks: ('g, 'unshifted) Degree_bound_checks.t }
-      [@@deriving fields, version, bin_io, sexp, compare, yojson]
+        { opening_check: 'g Opening_check.Stable.V1.t
+        ; degree_bound_checks: ('g, 'unshifted) Degree_bound_checks.Stable.V1.t
+        }
+      [@@deriving fields, sexp, compare, yojson]
     end
   end]
 
-  include Stable.Latest
+  type ('g, 'unshifted) t = ('g, 'unshifted) Stable.Latest.t =
+    { opening_check: 'g Opening_check.t
+    ; degree_bound_checks: ('g, 'unshifted) Degree_bound_checks.t }
+  [@@deriving fields, sexp, compare, yojson]
 
   let to_hlist {opening_check; degree_bound_checks} =
     H_list.[opening_check; degree_bound_checks]
@@ -412,11 +433,13 @@ module Opening = struct
   module Stable = struct
     module V1 = struct
       type ('proof, 'values) t = {proof: 'proof; values: 'values}
-      [@@deriving fields, version, bin_io]
+      [@@deriving fields]
     end
   end]
 
-  include Stable.Latest
+  type ('proof, 'values) t = ('proof, 'values) Stable.Latest.t =
+    {proof: 'proof; values: 'values}
+  [@@deriving fields]
 
   let to_hlist {proof; values} = H_list.[proof; values]
 
@@ -432,12 +455,12 @@ module Openings = struct
   module Stable = struct
     module V1 = struct
       type ('proof, 'fp) t =
-        {proofs: 'proof * 'proof * 'proof; evals: 'fp Evals.t}
-      [@@deriving version, bin_io]
+        {proofs: 'proof * 'proof * 'proof; evals: 'fp Evals.Stable.V1.t}
     end
   end]
 
-  include Stable.Latest
+  type ('proof, 'fp) t = ('proof, 'fp) Stable.Latest.t =
+    {proofs: 'proof * 'proof * 'proof; evals: 'fp Evals.t}
 
   let to_hlist {proofs; evals} = H_list.[proofs; evals]
 
@@ -456,12 +479,11 @@ module Messages = struct
     [%%versioned
     module Stable = struct
       module V1 = struct
-        type 'pc t = 'pc * 'pc
-        [@@deriving version, bin_io, sexp, compare, yojson]
+        type 'pc t = 'pc * 'pc [@@deriving sexp, compare, yojson]
       end
     end]
 
-    include Stable.Latest
+    type 'pc t = 'pc Stable.Latest.t [@@deriving sexp, compare, yojson]
   end
 
   [%%versioned
@@ -474,11 +496,18 @@ module Messages = struct
         ; gh_1: 'pc Degree_bounded.Stable.V1.t * 'pc
         ; sigma_gh_2: 'fp * ('pc Degree_bounded.Stable.V1.t * 'pc)
         ; sigma_gh_3: 'fp * ('pc Degree_bounded.Stable.V1.t * 'pc) }
-      [@@deriving fields, version, bin_io, sexp, compare, yojson]
+      [@@deriving fields, sexp, compare, yojson]
     end
   end]
 
-  include Stable.Latest
+  type ('pc, 'fp) t = ('pc, 'fp) Stable.Latest.t =
+    { w_hat: 'pc
+    ; z_hat_a: 'pc
+    ; z_hat_b: 'pc
+    ; gh_1: 'pc Degree_bounded.t * 'pc
+    ; sigma_gh_2: 'fp * ('pc Degree_bounded.t * 'pc)
+    ; sigma_gh_3: 'fp * ('pc Degree_bounded.t * 'pc) }
+  [@@deriving fields, sexp, compare, yojson]
 
   let to_hlist {w_hat; z_hat_a; z_hat_b; gh_1; sigma_gh_2; sigma_gh_3} =
     H_list.[w_hat; z_hat_a; z_hat_b; gh_1; sigma_gh_2; sigma_gh_3]
@@ -502,12 +531,14 @@ module Proof = struct
   module Stable = struct
     module V1 = struct
       type ('pc, 'fp, 'openings) t =
-        {messages: ('pc, 'fp) Messages.t; openings: 'openings}
-      [@@deriving fields, version, bin_io, sexp, compare, yojson]
+        {messages: ('pc, 'fp) Messages.Stable.V1.t; openings: 'openings}
+      [@@deriving fields, sexp, compare, yojson]
     end
   end]
 
-  include Stable.Latest
+  type ('pc, 'fp, 'openings) t =
+    {messages: ('pc, 'fp) Messages.t; openings: 'openings}
+  [@@deriving fields, sexp, compare, yojson]
 
   let to_hlist {messages; openings} = H_list.[messages; openings]
 

--- a/src/lib/pickles_types/pairing_marlin_types.ml
+++ b/src/lib/pickles_types/pairing_marlin_types.ml
@@ -38,6 +38,7 @@ module Evals = struct
     ; col: 'a Abc.t
     ; value: 'a Abc.t
     ; rc: 'a Abc.t }
+  [@@deriving fields, sexp, compare, yojson]
 
   open Vector
 
@@ -251,7 +252,7 @@ module Accumulator = struct
         end
       end]
 
-      type 'a t = 'a Stable.Latest.t
+      type 'a t = 'a Stable.Latest.t [@@deriving sexp, compare]
 
       let to_yojson f t = Alist.to_yojson f (Map.to_alist t)
 


### PR DESCRIPTION
In `Pickles_types.Pairing_marlin_types`, there were several instances of `include Stable.Latest`. That has the effect of making unversioned types serializable.

(The linter used to catch these, will look again into re-instating that.)

Fixed these instances; removed some unneeded `deriving` items.
