### PR TITLE
Pickles_types, fix more Stable.Latest

### DIFF
--- a/src/lib/pickles_types/abc.ml
+++ b/src/lib/pickles_types/abc.ml
@@ -4,11 +4,13 @@ open Core_kernel
 module Stable = struct
   module V1 = struct
     type 'a t = {a: 'a; b: 'a; c: 'a}
-    [@@deriving fields, version, bin_io, sexp, compare, yojson]
+    [@@deriving fields, sexp, compare, yojson]
   end
 end]
 
-include Stable.Latest
+type 'a t = 'a Stable.Latest.t = {a: 'a; b: 'a; c: 'a}
+[@@deriving fields, sexp, compare, yojson]
+
 module H_list = Snarky.H_list
 
 let to_hlist {a; b; c} = H_list.[a; b; c]

--- a/src/lib/pickles_types/dlog_marlin_types.ml
+++ b/src/lib/pickles_types/dlog_marlin_types.ml
@@ -18,11 +18,25 @@ module Evals = struct
         ; g_1: 'a
         ; g_2: 'a
         ; g_3: 'a }
-      [@@deriving fields, bin_io, version, sexp, compare, yojson]
+      [@@deriving fields, sexp, compare, yojson]
     end
   end]
 
-  include Stable.Latest
+  type 'a t = 'a Stable.Latest.t =
+    { w_hat: 'a
+    ; z_hat_a: 'a
+    ; z_hat_b: 'a
+    ; h_1: 'a
+    ; h_2: 'a
+    ; h_3: 'a
+    ; row: 'a Abc.t
+    ; col: 'a Abc.t
+    ; value: 'a Abc.t
+    ; rc: 'a Abc.t
+    ; g_1: 'a
+    ; g_2: 'a
+    ; g_3: 'a }
+  [@@deriving fields, sexp, compare, yojson]
 
   let to_vectors
       { w_hat
@@ -109,11 +123,14 @@ module Openings = struct
       module V1 = struct
         type ('fq, 'g) t =
           {lr: ('g * 'g) array; z_1: 'fq; z_2: 'fq; delta: 'g; sg: 'g}
-        [@@deriving bin_io, version, sexp, compare, yojson]
+        [@@deriving sexp, compare, yojson]
       end
     end]
 
-    include Stable.Latest
+    type ('fq, 'g) t = ('fq, 'g) Stable.Latest.t =
+      {lr: ('g * 'g) array; z_1: 'fq; z_2: 'fq; delta: 'g; sg: 'g}
+    [@@deriving sexp, compare, yojson]
+
     open Snarky.H_list
 
     let to_hlist {lr; z_1; z_2; delta; sg} = [lr; z_1; z_2; delta; sg]
@@ -138,11 +155,14 @@ module Openings = struct
             'fq Evals.Stable.V1.t
             * 'fq Evals.Stable.V1.t
             * 'fq Evals.Stable.V1.t }
-      [@@deriving bin_io, version, sexp, compare, yojson]
+      [@@deriving sexp, compare, yojson]
     end
   end]
 
-  include Stable.Latest
+  type ('fq, 'g) t =
+    { proof: ('fq, 'g) Bulletproof.t
+    ; evals: 'fq Evals.t * 'fq Evals.t * 'fq Evals.t }
+  [@@deriving sexp, compare, yojson]
 
   let to_hlist {proof; evals} = Snarky.H_list.[proof; evals]
 

--- a/src/lib/pickles_types/matrix_evals.ml
+++ b/src/lib/pickles_types/matrix_evals.ml
@@ -4,12 +4,12 @@ module H_list = Snarky.H_list
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type 'a t = {row: 'a; col: 'a; value: 'a; rc: 'a}
-    [@@deriving version, bin_io, sexp]
+    type 'a t = {row: 'a; col: 'a; value: 'a; rc: 'a} [@@deriving sexp]
   end
 end]
 
-include Stable.Latest
+type 'a t = 'a Stable.Latest.t = {row: 'a; col: 'a; value: 'a; rc: 'a}
+[@@deriving sexp]
 
 let to_hlist {row; col; value; rc} = H_list.[row; col; value; rc]
 

--- a/src/lib/pickles_types/pairing_marlin_types.ml
+++ b/src/lib/pickles_types/pairing_marlin_types.ml
@@ -16,10 +16,10 @@ module Evals = struct
         ; h_2: 'a
         ; g_3: 'a
         ; h_3: 'a
-        ; row: 'a Abc.t
-        ; col: 'a Abc.t
-        ; value: 'a Abc.t
-        ; rc: 'a Abc.t }
+        ; row: 'a Abc.Stable.V1.t
+        ; col: 'a Abc.Stable.V1.t
+        ; value: 'a Abc.Stable.V1.t
+        ; rc: 'a Abc.Stable.V1.t }
       [@@deriving fields, sexp, compare, yojson]
     end
   end]

--- a/src/lib/pickles_types/scalar_challenge.ml
+++ b/src/lib/pickles_types/scalar_challenge.ml
@@ -4,11 +4,12 @@ open Core_kernel
 module Stable = struct
   module V1 = struct
     type 'f t = Scalar_challenge of 'f
-    [@@deriving bin_io, version, sexp, compare, eq, yojson]
+    [@@deriving version, sexp, compare, eq, yojson]
   end
 end]
 
-include Stable.Latest
+type 'f t = 'f Stable.Latest.t = Scalar_challenge of 'f
+[@@deriving sexp, compare, eq, yojson]
 
 let create t = Scalar_challenge t
 


### PR DESCRIPTION
Fix more uses of `include Stable.Latest` in `Pickles_types`.

See #4891 for justification.