### PR TITLE
Lint include Stable.Latest

### DIFF
--- a/src/lib/group_map/bw19.ml
+++ b/src/lib/group_map/bw19.ml
@@ -17,11 +17,18 @@ module Params = struct
         ; sqrt_neg_three_u_squared: 'f
         ; inv_three_u_squared: 'f
         ; b: 'f }
-      [@@deriving fields, bin_io, version]
+      [@@deriving fields]
     end
   end]
 
-  include Stable.Latest
+  type 'f t = 'f Stable.Latest.t =
+    { u: 'f
+    ; fu: 'f
+    ; sqrt_neg_three_u_squared_minus_u_over_2: 'f
+    ; sqrt_neg_three_u_squared: 'f
+    ; inv_three_u_squared: 'f
+    ; b: 'f }
+  [@@deriving fields]
 
   let spec {b; _} = {Spec.b}
 

--- a/src/lib/group_map/group_map.ml
+++ b/src/lib/group_map/group_map.ml
@@ -146,11 +146,11 @@ module Spec = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type 'f t = {a: 'f; b: 'f} [@@deriving fields, bin_io, version]
+      type 'f t = {a: 'f; b: 'f} [@@deriving fields]
     end
   end]
 
-  include Stable.Latest
+  type 'f t = 'f Stable.Latest.t = {a: 'f; b: 'f} [@@deriving fields]
 end
 
 module Params = struct

--- a/src/lib/group_map/group_map.ml
+++ b/src/lib/group_map/group_map.ml
@@ -83,7 +83,7 @@ module type S = sig
     [%%versioned:
     module Stable : sig
       module V1 : sig
-        type _ t [@@deriving bin_io]
+        type _ t
       end
     end]
 

--- a/src/lib/group_map/group_map.mli
+++ b/src/lib/group_map/group_map.mli
@@ -21,7 +21,7 @@ module type S = sig
     [%%versioned:
     module Stable : sig
       module V1 : sig
-        type _ t [@@deriving bin_io]
+        type _ t
       end
     end]
 

--- a/src/lib/transition_frontier/frontier_base/diff.ml
+++ b/src/lib/transition_frontier/frontier_base/diff.ml
@@ -64,7 +64,7 @@ module Node_list = struct
       end
     end]
 
-    include Stable.Latest
+    type t = Stable.Latest.t
   end
 end
 
@@ -124,7 +124,7 @@ module Root_transition = struct
       end
     end]
 
-    include Stable.Latest
+    type t = Stable.Latest.t
   end
 end
 


### PR DESCRIPTION
Some time ago, I'd removed the linter code to detect `include Stable.Latest`, because I'd found instances where I didn't see a better way.

I'm reviving that check, and I've fixed all instances detected on build. The new Snarky backend has instances detected on unit tests, to be fixed later.
