### PR TITLE
Logging events ppx, examples

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,7 @@
 /src/lib/crs/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/crypto_params/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/dummy_values/ @CodaProtocol/crypto-eng-reviewers
+/src/lib/logging_events/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/group_map/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/hash_prefixes/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/integers_stubs_js @CodaProtocol/crypto-eng-reviewers

--- a/src/lib/logging_events/dune
+++ b/src/lib/logging_events/dune
@@ -1,0 +1,6 @@
+(library
+ (name logging_events)
+ (public_name logging_events)
+ (preprocess (pps ppx_coda ppx_version))
+ (inline_tests)
+ (libraries core_kernel))

--- a/src/lib/logging_events/logging_events.ml
+++ b/src/lib/logging_events/logging_events.ml
@@ -1,0 +1,23 @@
+(* logging_events.ml -- structured logging events *)
+
+(* metadata is a list of pairs (field,types), where field is a string naming the metadata item, and
+    types is a list of strings representing type constructors
+   id is the SHA1 hash of name
+*)
+type t =
+  { name: string
+  ; message: string
+  ; metadata: (string * string list) list
+  ; id: string }
+
+(* examples, not real events; TODO: populate with real events *)
+
+(* with metadata *)
+[%%declare_event
+Received_blocks
+, "Received blocks $blocks from $node"
+, [(blocks : string list); (node : string)]]
+
+(* no metadata *)
+[%%declare_event
+Bootstrap_complete, "Bootstrap_complete"]

--- a/src/lib/ppx_coda/declare_event.ml
+++ b/src/lib/ppx_coda/declare_event.ml
@@ -1,0 +1,127 @@
+(* declare_event.ml -- ppx to declare log events *)
+
+(* Example usage:
+
+   [%declare_event (Received_block,"Received blocks $blocks from $node",[(blocks: string list); (node : string); (height : int)]]
+
+   which expands to:
+
+   let received_block_event =
+    { name = "Received_block"
+    ; message = "Received block from $node"
+    ; medata = [("blocks",["string"; "list"];("node",["string"]);("height",["int"])]
+    ; id = ... (* SHA1 hash of name (20-character string) *)
+    }
+
+   Note:
+
+    - the types in the metadata are a space-separated sequence of type constructors; the generated types are lists
+
+    - the metadata list is optional
+
+*)
+
+open Core_kernel
+open Ppxlib
+open Asttypes
+
+let name = "declare_event"
+
+let print_hash hash =
+  printf "\"" ;
+  String.iter hash ~f:(fun c -> printf "\\x%02X" (Char.to_int c)) ;
+  printf "\"\n%!"
+
+let calc_name_hash name =
+  let open Digestif.SHA256 in
+  let ctx0 = init () in
+  let ctx1 = feed_string ctx0 name in
+  get ctx1 |> to_raw_string
+
+let rec make_type_list = function
+  | {ptyp_desc= Ptyp_constr ({txt= Lident type_name; _}, core_types); _} ->
+      List.rev (type_name :: List.concat_map core_types ~f:make_type_list)
+  | ty ->
+      Location.raise_errorf ~loc:ty.ptyp_loc "Expected type constructor"
+
+let get_constraint_desc = function
+  | { pexp_desc=
+        Pexp_constraint
+          ({pexp_desc= Pexp_ident {txt= Lident id; _}; _}, core_type)
+    ; _ } ->
+      (id, make_type_list core_type)
+  | exp ->
+      Location.raise_errorf ~loc:exp.pexp_loc
+        "Expected constrained type, where the type is named by an identifier"
+
+let get_name_message_hash ~name ~message =
+  let name_str =
+    match name.pexp_desc with
+    | Pexp_construct ({txt= Lident id; _}, None) ->
+        id
+    | _ ->
+        Location.raise_errorf ~loc:name.pexp_loc "Expected constructor"
+  in
+  let message_str =
+    match message.pexp_desc with
+    | Pexp_constant (Pconst_string (msg, None)) ->
+        msg
+    | _ ->
+        Location.raise_errorf ~loc:name.pexp_loc "Expected string constant"
+  in
+  let hash = calc_name_hash name_str in
+  (name_str, message_str, hash)
+
+let list_of_metadata metadata =
+  let rec loop md acc =
+    match md.pexp_desc with
+    | Pexp_construct
+        ({txt= Lident "::"; _}, Some {pexp_desc= Pexp_tuple [exp; rest]; _}) ->
+        loop rest (exp :: acc)
+    | Pexp_construct ({txt= Lident "[]"; _}, None) ->
+        List.rev acc
+    | _ ->
+        Location.raise_errorf ~loc:metadata.pexp_loc
+          "Expected a list of (item : type) pairs for metadata"
+  in
+  loop metadata []
+
+let make_stri ~loc ~name_str ~message_str ~metadata_pairs ~hash =
+  let (module Ast_builder) = Ast_builder.make loc in
+  let open Ast_builder in
+  let metadata =
+    List.map metadata_pairs ~f:(fun (item, types) ->
+        let type_exprs = List.map types ~f:estring in
+        pexp_tuple [estring item; elist type_exprs] )
+  in
+  let event_name = String.lowercase name_str ^ "_event" in
+  [%stri
+    let [%p pvar event_name] =
+      { name= [%e estring name_str]
+      ; message= [%e estring message_str]
+      ; metadata= [%e elist metadata]
+      ; id= [%e estring hash] }]
+
+let expand ~loc ~path:_ exprs =
+  match exprs with
+  | [name; message] ->
+      (* explicitly, no metadata *)
+      let name_str, message_str, hash = get_name_message_hash ~name ~message in
+      make_stri ~loc ~name_str ~message_str ~metadata_pairs:[] ~hash
+  | [name; message; metadata] ->
+      let name_str, message_str, hash = get_name_message_hash ~name ~message in
+      let metadata_list = list_of_metadata metadata in
+      let metadata_pairs = List.map metadata_list ~f:get_constraint_desc in
+      make_stri ~loc ~name_str ~message_str ~metadata_pairs ~hash
+  | _ ->
+      Location.raise_errorf ~loc
+        "Expected a tuple of name (a constructor), message (string constant), \
+         and optional metadata (list of (identifier : type))"
+
+let ext =
+  Extension.declare name Extension.Context.structure_item
+    Ast_pattern.(single_expr_payload (pexp_tuple __))
+    expand
+
+let () =
+  Driver.register_transformation name ~rules:[Context_free.Rule.extension ext]

--- a/src/lib/ppx_coda/dune
+++ b/src/lib/ppx_coda/dune
@@ -2,6 +2,6 @@
  (name ppx_coda)
  (public_name ppx_coda)
  (kind ppx_deriver)
- (libraries compiler-libs.common ppxlib ppx_deriving.api ppx_bin_prot core_kernel)
+ (libraries coda_digestif compiler-libs.common ppxlib ppx_deriving.api ppx_bin_prot core_kernel)
  (preprocessor_deps ../../config.mlh)
  (preprocess (pps ppx_version ppxlib.metaquot ppx_optcomp)))

--- a/src/logging_events.opam
+++ b/src/logging_events.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
Add a ppx to implement the structured event specification described in #4759, provide a couple of examples.

The implementation is in `Ppx_coda.Declare_event`. A comment there describes usage and the expansion.

(Not sure if expanding the type to a list of strings is the best, maybe the expansion should be a single string.)

The examples are in a new library, `Logging_events`. Uses of the ppx expand to instances of the type `t` in that library. The examples there are dummies. If this PR is merged, we'll create actual instances at a later date.