### PR TITLE
Fix mac build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,8 +295,10 @@ jobs:
                     mkdir -p package/keys
                     echo 'keys and genesis'
                     cp /tmp/s3_cache_dir/* package/keys/. ||:
-                    cp $TMPDIR/coda_cache_dir/genesis_ledger_*.tar.gz package/keys/.
-                    cp $TMPDIR/coda_cache_dir/genesis_proof_* package/keys/.
+                    cp $TMPDIR/coda_cache_dir/genesis_ledger_*.tar.gz package/keys/. ||:
+                    cp $TMPDIR/coda_cache_dir/genesis_proof_* package/keys/. ||:
+                    cp /tmp/s3_cache_dir/genesis_ledger_*.tar.gz package/keys/. ||:
+                    cp /tmp/s3_cache_dir/genesis_proof_* package/keys/. ||:
                     echo 'coda'
                     cp _build/default/src/app/cli/src/coda.exe package/coda
                     echo 'libp2p_helper'

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -295,8 +295,10 @@ jobs:
                     mkdir -p package/keys
                     echo 'keys and genesis'
                     cp /tmp/s3_cache_dir/* package/keys/. ||:
-                    cp $TMPDIR/coda_cache_dir/genesis_ledger_*.tar.gz package/keys/.
-                    cp $TMPDIR/coda_cache_dir/genesis_proof_* package/keys/.
+                    cp $TMPDIR/coda_cache_dir/genesis_ledger_*.tar.gz package/keys/. ||:
+                    cp $TMPDIR/coda_cache_dir/genesis_proof_* package/keys/. ||:
+                    cp /tmp/s3_cache_dir/genesis_ledger_*.tar.gz package/keys/. ||:
+                    cp /tmp/s3_cache_dir/genesis_proof_* package/keys/. ||:
                     echo 'coda'
                     cp _build/default/src/app/cli/src/coda.exe package/coda
                     echo 'libp2p_helper'


### PR DESCRIPTION
Genesis ledger/proof may now have come from S3, look in the S3 cache dir for them.

Note that the S3 cache dir has `/tmp` hardcoded as a prefix, but the autogen dir uses `$TMPDIR`. This matches the behaviour of `src/lib/cache_dir/cach_dir.ml`. We should probably change it, but not in this PR.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: