### PR TITLE
Use deb-s3 --lock to ensure that parallel CI jobs do not race

### DIFF
--- a/scripts/publish-deb.sh
+++ b/scripts/publish-deb.sh
@@ -8,7 +8,7 @@ DEBS3='deb-s3 upload '\
 '--s3-region=us-west-2 '\
 '--bucket packages.o1test.net '\
 '--preserve-versions '\
-'--lock'\
+'--lock '\
 '--cache-control=max-age=120 '\
 '--component main'
 

--- a/scripts/publish-deb.sh
+++ b/scripts/publish-deb.sh
@@ -8,6 +8,7 @@ DEBS3='deb-s3 upload '\
 '--s3-region=us-west-2 '\
 '--bucket packages.o1test.net '\
 '--preserve-versions '\
+'--lock'\
 '--cache-control=max-age=120 '\
 '--component main'
 


### PR DESCRIPTION
This fixes a race condition where the CI jobs for 2 branches may both try to modify the `packages.o1test.net` repo, and the packages for one of the jobs are therefore not added to the deb manifests.

See for example [this failed `build-artifacts` run](https://app.circleci.com/pipelines/github/CodaProtocol/coda/21091/workflows/beaa43ba-da8e-44c5-b3c0-ea6879a13dc2/jobs/397357/steps), where the docker file could not find the `.deb` file because the deb manifests were clobbered another simultaneous job.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: