### PR TITLE
Points: Truncate the state hash in the block name

### DIFF
--- a/frontend/points-hack-april20/lib.js
+++ b/frontend/points-hack-april20/lib.js
@@ -66,11 +66,15 @@ const storage = new Storage({
   keyFilename: json_file_path,
 });
 
+function truncate(s, len) {
+  return s.substring(0, Math.min(len, s.length));
+}
+
 function uploadFile(result) {
   const bucketName = "points-data-hack-april20";
   const filename =
     result.data && result.data.newBlock && result.data.newBlock.stateHash
-      ? "block-success-" + result.data.newBlock.stateHash + ".json"
+      ? "block-success-" + truncate(result.data.newBlock.stateHash, 200) + ".json"
       : "block-error-" + Date.now() + ".json";
 
   const bucket = storage.bucket(bucketName);

--- a/frontend/points-hack-april20/lib.js
+++ b/frontend/points-hack-april20/lib.js
@@ -78,7 +78,7 @@ function uploadFile(result) {
       : "block-error-" + Date.now() + ".json";
 
   const bucket = storage.bucket(bucketName);
-  const file = bucket.file("32b-" + CODA_TESTNET_NAME + "/" + filename);
+  const file = bucket.file("v1/32b-" + CODA_TESTNET_NAME + "/" + filename);
 
   const buffer = Buffer.from(JSON.stringify(result), "utf8");
   const readable = new Readable();


### PR DESCRIPTION
The filenames are too long to actually download, so we need to truncate the hash.

Tested the truncate function though I haven't run the full script