### PR TITLE
Skip genesis-upload if frontend/rfc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -519,7 +519,7 @@ jobs:
                 no_output_timeout: 20m
             - run:
                 name: Upload genesis data
-                command: ./scripts/upload-genesis.sh
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c './scripts/upload-genesis.sh'
             - run:
                   name: Build deb package with PV keys and PV key tar
                   command:  ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make deb'

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -419,7 +419,7 @@ jobs:
                 no_output_timeout: 20m
             - run:
                 name: Upload genesis data
-                command: ./scripts/upload-genesis.sh
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c './scripts/upload-genesis.sh'
             - run:
                   name: Build deb package with PV keys and PV key tar
                   command:  ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make deb'


### PR DESCRIPTION
build-artifacts was failing for frontend changes and it's a required CI check.
Example: https://app.circleci.com/pipelines/github/CodaProtocol/coda/21239/workflows/585a87ef-e92a-4ed7-8962-39bf8bf8125a/jobs/399754/steps

This adds the check for frontend-only changes to the genesis upload step.