### PR TITLE
Leaderboard: add coinbase receiver metric 

### DIFF
--- a/frontend/leaderboard/src/Metrics.re
+++ b/frontend/leaderboard/src/Metrics.re
@@ -149,6 +149,23 @@ let filterBlocksByTimeWindow = (startTime, endTime, blocks) => {
   Array.of_list(filteredBlocksList);
 };
 
+let calculateCoinbaseReceiverChallenge = blocks => {
+  Array.fold_left(
+    (map, block: Types.NewBlock.data) => {
+      let coinbaseReceiver =
+        block.transactions.coinbaseReceiverAccount.publicKey;
+      let creatorAccount = block.creatorAccount.publicKey;
+      StringMap.update(
+        block.creatorAccount.publicKey,
+        _ => Some(coinbaseReceiver !== creatorAccount),
+        map,
+      );
+    },
+    StringMap.empty,
+    blocks,
+  );
+};
+
 let throwAwayValues = metric => {
   StringMap.map(_ => {()}, metric);
 };

--- a/frontend/leaderboard/src/Metrics.re
+++ b/frontend/leaderboard/src/Metrics.re
@@ -203,6 +203,7 @@ let calculateMetrics = blocks => {
   let highestSnarkFeeCollected = getHighestSnarkFeeCollected(blocks);
   let transactionsReceivedByEcho =
     calculateTransactionsSentToAddress(blocks, echoBotPublicKey);
+  let coinbaseReceiverChallenge = calculateCoinbaseReceiverChallenge(blocks);
 
   calculateAllUsers([
     throwAwayValues(blocksCreated),
@@ -211,6 +212,7 @@ let calculateMetrics = blocks => {
     throwAwayValues(snarkFeesCollected),
     throwAwayValues(highestSnarkFeeCollected),
     throwAwayValues(transactionsReceivedByEcho),
+    throwAwayValues(coinbaseReceiverChallenge),
   ])
   |> StringMap.mapi((key, _) =>
        {
@@ -222,6 +224,7 @@ let calculateMetrics = blocks => {
            StringMap.find_opt(key, highestSnarkFeeCollected),
          transactionsReceivedByEcho:
            StringMap.find_opt(key, transactionsReceivedByEcho),
+         coinbaseReceiver: StringMap.find_opt(key, coinbaseReceiverChallenge),
        }
      );
 };

--- a/frontend/leaderboard/src/Metrics.re
+++ b/frontend/leaderboard/src/Metrics.re
@@ -155,7 +155,7 @@ let calculateCoinbaseReceiverChallenge = blocks => {
       let coinbaseReceiver =
         block.transactions.coinbaseReceiverAccount.publicKey;
       let creatorAccount = block.creatorAccount.publicKey;
-      StringMap.update(
+      StringMap.add(
         block.creatorAccount.publicKey,
         _ => Some(coinbaseReceiver !== creatorAccount),
         map,

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -18,9 +18,11 @@ module NewBlock = {
   type transactions = {
     userCommands: array(userCommands),
     feeTransfer: array(feeTransfer),
+    coinbaseReceiverAccount: account,
   };
 
   type blockchainState = {date: string};
+  
   type data = {
     creatorAccount: account,
     snarkJobs: array(snarkJobs),

--- a/frontend/leaderboard/src/Types.re
+++ b/frontend/leaderboard/src/Types.re
@@ -22,7 +22,7 @@ module NewBlock = {
   };
 
   type blockchainState = {date: string};
-  
+
   type data = {
     creatorAccount: account,
     snarkJobs: array(snarkJobs),
@@ -44,7 +44,8 @@ module Metrics = {
     | SnarkWorkCreated
     | SnarkFeesCollected
     | HighestSnarkFeeCollected
-    | TransactionsReceivedByEcho;
+    | TransactionsReceivedByEcho
+    | CoinbaseReceiver;
 
   type metricRecord = {
     blocksCreated: option(int),
@@ -53,5 +54,6 @@ module Metrics = {
     snarkFeesCollected: option(int64),
     highestSnarkFeeCollected: option(int64),
     transactionsReceivedByEcho: option(int),
+    coinbaseReceiver: option(bool),
   };
 };


### PR DESCRIPTION
This adds a function that will process all blocks and return a mapping between public keys and whether or not they completed the coinbase receiver challenge by sending a coinbase to a different address. 

