### PR TITLE
Handle > 1 attribute when deriving register_event

### DIFF
--- a/src/lib/logging_events/event_declarations.ml
+++ b/src/lib/logging_events/event_declarations.ml
@@ -18,7 +18,8 @@ type Structured_events.t += Proof_failure of {why: string}
 (* constructor without record argument *)
 type Structured_events.t += Block_finalized [@@deriving register_event]
 
-(* arbitrary string-valued expression for msg *)
+(* arbitrary string-valued expression for msg; extra attribute *)
 type Structured_events.t += Donuts_are_ready
+  [@@warning "-22"]
   [@@deriving
     register_event {msg= sprintf "My favorite flavor is: %s" "maple glazed"}]

--- a/src/lib/ppx_register_event/register_event.ml
+++ b/src/lib/ppx_register_event/register_event.ml
@@ -89,12 +89,14 @@ let type_ext_str ~options ~path (ty_ext : type_extension) =
           failwith
             (sprintf "Expected structure item in payload for %s" deriver)
     in
-    List.find_map_exn ty_ext.ptyext_attributes ~f:(fun (_, payload) ->
-        match payload with
-        | PStr stris ->
-            Some (List.find_map_exn stris ~f:find_deriver)
-        | _ ->
-            failwith (sprintf "Expected structure payload for %s" deriver) )
+    List.find_map_exn ty_ext.ptyext_attributes ~f:(fun ({txt; _}, payload) ->
+        if String.equal txt "deriving" then
+          match payload with
+          | PStr stris ->
+              Some (List.find_map_exn stris ~f:find_deriver)
+          | _ ->
+              failwith (sprintf "Expected structure payload for %s" deriver)
+        else None )
   in
   let (module Ast_builder) = Ast_builder.make deriver_loc in
   let open Ast_builder in


### PR DESCRIPTION
When `deriving register_event`, the location calculation failed when there was an additional attribute besides the `deriving`.

Added an additional `warning` attribute in one of the example event declarations.