### PR TITLE
Never fail if generated genesis isn't found

### DIFF
--- a/scripts/upload-genesis.sh
+++ b/scripts/upload-genesis.sh
@@ -6,6 +6,7 @@ GENESIS_DIR="/tmp/coda_cache_dir/"
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
     echo "WARNING: AWS_ACCESS_KEY_ID is missing, not uploading files for genesis"
 else
-    ls -l ${GENESIS_DIR}genesis_* && \
-    aws s3 sync --exclude "*" --include "genesis_*" --acl public-read ${GENESIS_DIR} s3://snark-keys.o1test.net/
+    if ls -l ${GENESIS_DIR}genesis_*; then
+        aws s3 sync --exclude "*" --include "genesis_*" --acl public-read ${GENESIS_DIR} s3://snark-keys.o1test.net/
+    fi
 fi


### PR DESCRIPTION
This ports the fix from d76165f in PR #4949 to `develop`. It's not currently needed because of a quirk of the build system, but better safe than sorry.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: