### PR TITLE
Runtime_config, fix typos in field names

### DIFF
--- a/src/lib/runtime_config/runtime_config.ml
+++ b/src/lib/runtime_config/runtime_config.ml
@@ -214,7 +214,7 @@ type t =
   ; ledger: Ledger.t option [@default None] }
 [@@deriving yojson]
 
-let fields = [|"ledger"; "genesis_constants"; "proof_constants"|]
+let fields = [|"ledger"; "genesis"; "proof"|]
 
 let of_yojson json = of_yojson @@ yojson_strip_fields ~fields json
 


### PR DESCRIPTION
In `Runtime_config`,the field names to be retained via a `filter` operation differed from the actual fields in the record type.
