### PR TITLE
Added unit tests to leaderboard

### DIFF
--- a/frontend/leaderboard/__tests__/blocks/block1.json
+++ b/frontend/leaderboard/__tests__/blocks/block1.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey2",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey3",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block10.json
+++ b/frontend/leaderboard/__tests__/blocks/block10.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey4",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey4",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block2.json
+++ b/frontend/leaderboard/__tests__/blocks/block2.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block3.json
+++ b/frontend/leaderboard/__tests__/blocks/block3.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey4",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block4.json
+++ b/frontend/leaderboard/__tests__/blocks/block4.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey2",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block5.json
+++ b/frontend/leaderboard/__tests__/blocks/block5.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey2",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block6.json
+++ b/frontend/leaderboard/__tests__/blocks/block6.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey3",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block7.json
+++ b/frontend/leaderboard/__tests__/blocks/block7.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey2",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey5",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block8.json
+++ b/frontend/leaderboard/__tests__/blocks/block8.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey5",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block9.json
+++ b/frontend/leaderboard/__tests__/blocks/block9.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey3",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey5",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/leaderboard_test.re
+++ b/frontend/leaderboard/__tests__/leaderboard_test.re
@@ -1,0 +1,157 @@
+open Jest;
+open Expect;
+module StringMap = Map.Make(String);
+
+let blockDirectory =
+  ([%bs.node __dirname] |> Belt.Option.getExn |> Filename.dirname)
+  ++ "/../../__tests__/blocks/";
+
+let blocks =
+  blockDirectory
+  |> Node.Fs.readdirSync
+  |> Array.map(file => {
+       let fileContents = Node.Fs.readFileAsUtf8Sync(blockDirectory ++ file);
+       let blockData = Js.Json.parseExn(fileContents);
+       let block = Types.NewBlock.unsafeJSONToNewBlock(blockData);
+       block.data.newBlock;
+     });
+
+describe("Metrics", () => {
+  describe("blocksCreatedMetric", () => {
+    let blockMetrics = Metrics.getBlocksCreatedByUser(blocks);
+    test("correct number of users", () => {
+      expect(StringMap.cardinal(blockMetrics)) |> toBe(4)
+    });
+    test("correct number of blocks for publickey1", () => {
+      expect(StringMap.find("publickey1", blockMetrics)) |> toBe(4)
+    });
+    test("correct number of blocks for publickey2", () => {
+      expect(StringMap.find("publickey2", blockMetrics)) |> toBe(3)
+    });
+    test("correct number of blocks for publickey3", () => {
+      expect(StringMap.find("publickey3", blockMetrics)) |> toBe(2)
+    });
+    test("correct number of blocks for publickey4", () => {
+      expect(StringMap.find("publickey4", blockMetrics)) |> toBe(1)
+    });
+    test("publickey5 does not exist in metrics map", () => {
+      expect(() =>
+        StringMap.find("publickey5", blockMetrics)
+      )
+      |> toThrowException(Not_found)
+    });
+  })
+});
+
+describe("Challenges", () => {
+  describe("Blocks Challenge", () => {
+    let blockPoints =
+      blocks
+      |> Metrics.calculateMetrics
+      |> Challenges.calculatePoints("Blocks")
+      |> Belt.Option.getExn;
+
+    test("correct number of users", () => {
+      expect(StringMap.cardinal(blockPoints)) |> toBe(2)
+    });
+    test("publickey1 gets 1000 points", () => {
+      expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+    });
+    test("publickey2 gets 1000 points", () => {
+      expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+    });
+    test("publickey3 does not exist in points map", () => {
+      expect(() =>
+        StringMap.find("publickey3", blockPoints)
+      )
+      |> toThrowException(Not_found)
+    });
+  })
+});
+
+describe("Points functions", () => {
+  let blockMetrics = blocks |> Metrics.calculateMetrics;
+
+  describe("addPointsToAtleastN", () => {
+    describe("adds correct number of points with atleast 1", () => {
+      let blockPoints =
+        Challenges.addPointsToUsersWithAtleastN(
+          (metricRecord: Types.Metrics.metricRecord) =>
+            metricRecord.blocksCreated,
+          1,
+          1000,
+          blockMetrics,
+        );
+
+      test("correct number of points given to publickey1", () => {
+        expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+      });
+      test("correct number of points given to publickey2", () => {
+        expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+      });
+      test("correct number of points given to publickey3", () => {
+        expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
+      });
+      test("publickey8 does not exist in points map", () => {
+        expect(() =>
+          StringMap.find("publickey8", blockPoints)
+        )
+        |> toThrowException(Not_found)
+      });
+    });
+
+    describe("adds correct number of points with atleast 3", () => {
+      let blockPoints =
+        Challenges.addPointsToUsersWithAtleastN(
+          (metricRecord: Types.Metrics.metricRecord) =>
+            metricRecord.blocksCreated,
+          3,
+          1000,
+          blockMetrics,
+        );
+
+      test("correct number of points given to publickey1", () => {
+        expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+      });
+
+      test("correct number of points given to publickey2", () => {
+        expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+      });
+
+      test("publickey3 does not exist in points map", () => {
+        expect(() =>
+          StringMap.find("publickey3", blockPoints)
+        )
+        |> toThrowException(Not_found)
+      });
+    });
+    describe("applyTopNPoints", () => {
+      describe("adds correct number of points to top 3", () => {
+        let blockPoints =
+          Challenges.applyTopNPoints(
+            3, 1000, blockMetrics, (metricRecord: Types.Metrics.metricRecord) =>
+            metricRecord.blocksCreated
+          );
+
+        test("correct number of points given to publickey1", () => {
+          expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+        });
+
+        test("correct number of points given to publickey2", () => {
+          expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+        });
+
+        test("correct number of points given to publickey3", () => {
+          expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
+        });
+
+        test("publickey4 does not exist in points map", () => {
+          expect(() =>
+            StringMap.find("publickey4", blockPoints)
+          )
+          |> toThrowException(Not_found)
+        });
+      })
+    });
+  });
+});

--- a/frontend/leaderboard/bsconfig.json
+++ b/frontend/leaderboard/bsconfig.json
@@ -4,12 +4,13 @@
     {
       "dir": "src",
       "subdirs": true
+    },
+    {
+      "dir": "__tests__",
+      "type": "dev"
     }
   ],
-  "bs-dependencies": [
-    "bsc-stdlib-polyfill",
-    "bs-fetch"
-  ],
+  "bs-dependencies": ["bsc-stdlib-polyfill", "bs-fetch"],
   "reason": {
     "react-jsx": 3
   },
@@ -17,9 +18,7 @@
     "module": "commonjs"
   },
   "suffix": ".bs.js",
-  "bsc-flags": [
-    "-bs-super-errors",
-    "-open BscStdlibPolyfill"
-  ],
+  "bsc-flags": ["-bs-super-errors", "-open BscStdlibPolyfill"],
+  "bs-dev-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3
 }

--- a/frontend/leaderboard/package.json
+++ b/frontend/leaderboard/package.json
@@ -5,14 +5,16 @@
     "dev": "bsb -clean-world -make-world -w",
     "build": "bsb -clean-world -make-world",
     "clean": "bsb -clean-world",
-    "reformat": "bsrefmt --in-place src/**/*.re"
+    "reformat": "bsrefmt --in-place src/**/*.re",
+    "test": "yarn run build && jest --root-dir lib/js/"
   },
   "license": "ISC",
   "dependencies": {
     "bs-fetch": "^0.5.0",
     "bsc-stdlib-polyfill": "Schmavery/bsc-stdlib-polyfill",
     "googleapis": "^50.0.0",
-    "isomorphic-unfetch": "^3.0.0"
+    "isomorphic-unfetch": "^3.0.0",
+    "@glennsl/bs-jest": "^0.4.8"
   },
   "devDependencies": {
     "bs-platform": "7.0.0-dev.1"

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -21,6 +21,7 @@ let applyTopNPoints = (n, points, metricsMap, getMetricValue) => {
     compare(getMetricValue(metricValue1), getMetricValue(metricValue2));
   };
   Array.sort(f, metricsArray);
+  Belt.Array.reverseInPlace(metricsArray);
   let topNArray =
     Array.sub(metricsArray, 0, min(n, Array.length(metricsArray)));
   let topNArrayWithPoints =


### PR DESCRIPTION
Added unit tests to the leaderboard project with bs-jest.

I found that as I was implementing the challenge requirements from the notion page, I was unsure if the implementation code was rewarded points correctly based on the massive block data that is pulled in. Writing these unit tests is a way to confirm that these challenges are being implemented correctly on the block data is given.

Not all metrics/challenges are included in this PR. This is because I was implementing the specified challenges in a different git branch and wanted the tests to be a separate PR. As more functionality to metrics/challenges is written, we can now write tests.

Note: This PR also includes a small bug fix that was found by writing these initial tests.