### PR TITLE
Adds unit tests to leaderboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,13 +192,13 @@ jobs:
                   command: ./scripts/test.py render --check .circleci/config.yml.jinja .mergify.yml.jinja
             - run:
                   name: OCamlformat (make check-format)
-                  command: eval `opam config env` && LIBP2P_NIXLESS=1 make check-format
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'eval `opam config env` && LIBP2P_NIXLESS=1 make check-format'
             - run:
                   name: Snarky tracks master (make check-snarky-submodule)
-                  command: LIBP2P_NIXLESS=1 make check-snarky-submodule
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make check-snarky-submodule'
             - run:
                   name: Check ppx_optcomp preprocessor_deps
-                  command: ./scripts/lint_preprocessor_deps.sh
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c './scripts/lint_preprocessor_deps.sh'
             - run:
                   name: Check CODEOWNERS file format
                   command: ./scripts/lint_codeowners.sh
@@ -207,7 +207,7 @@ jobs:
                   command: ./scripts/lint_rfcs.sh
             - run:
                   name: Require ppx_version preprocessing for linting
-                  command: ./scripts/require-ppx-version.py
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c './scripts/require-ppx-version.py'
     lint-opt:
         docker:
             - image: codaprotocol/coda:toolchain-ff342e8e78343bf409b94817a0f96bae57914cea

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -158,13 +158,13 @@ jobs:
                   command: ./scripts/test.py render --check .circleci/config.yml.jinja .mergify.yml.jinja
             - run:
                   name: OCamlformat (make check-format)
-                  command: eval `opam config env` && LIBP2P_NIXLESS=1 make check-format
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'eval `opam config env` && LIBP2P_NIXLESS=1 make check-format'
             - run:
                   name: Snarky tracks master (make check-snarky-submodule)
-                  command: LIBP2P_NIXLESS=1 make check-snarky-submodule
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make check-snarky-submodule'
             - run:
                   name: Check ppx_optcomp preprocessor_deps
-                  command: ./scripts/lint_preprocessor_deps.sh
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c './scripts/lint_preprocessor_deps.sh'
             - run:
                   name: Check CODEOWNERS file format
                   command: ./scripts/lint_codeowners.sh
@@ -173,7 +173,7 @@ jobs:
                   command: ./scripts/lint_rfcs.sh
             - run:
                   name: Require ppx_version preprocessing for linting
-                  command: ./scripts/require-ppx-version.py
+                  command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c './scripts/require-ppx-version.py'
     lint-opt:
         docker:
             - image: codaprotocol/coda:toolchain-ff342e8e78343bf409b94817a0f96bae57914cea

--- a/frontend/leaderboard/__tests__/blocks/block1.json
+++ b/frontend/leaderboard/__tests__/blocks/block1.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey2",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey3",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block10.json
+++ b/frontend/leaderboard/__tests__/blocks/block10.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey4",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey4",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block2.json
+++ b/frontend/leaderboard/__tests__/blocks/block2.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block3.json
+++ b/frontend/leaderboard/__tests__/blocks/block3.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey4",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block4.json
+++ b/frontend/leaderboard/__tests__/blocks/block4.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey2",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block5.json
+++ b/frontend/leaderboard/__tests__/blocks/block5.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey2",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block6.json
+++ b/frontend/leaderboard/__tests__/blocks/block6.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey3",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block7.json
+++ b/frontend/leaderboard/__tests__/blocks/block7.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey2",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey1",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey5",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block8.json
+++ b/frontend/leaderboard/__tests__/blocks/block8.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey1",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey2",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey5",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/blocks/block9.json
+++ b/frontend/leaderboard/__tests__/blocks/block9.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "newBlock": {
+      "creatorAccount": {
+        "publicKey": "publickey3",
+        "__typename": "Account"
+      },
+      "protocolState": {
+        "blockchainState": {
+          "date": "1590500100000",
+          "__typename": "BlockchainState"
+        },
+        "__typename": "ProtocolState"
+      },
+      "snarkJobs": [
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        },
+        {
+          "fee": "2500",
+          "prover": "publickey1",
+          "__typename": "CompletedWork"
+        }
+      ],
+      "transactions": {
+        "coinbase": "200000000000",
+        "coinbaseReceiverAccount": {
+          "publicKey": "publickey1",
+          "__typename": "Account"
+        },
+        "feeTransfer": [
+          {
+            "fee": "5000",
+            "recipient": "publickey1",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "1000",
+            "recipient": "publickey2",
+            "__typename": "FeeTransfer"
+          },
+          {
+            "fee": "2500",
+            "recipient": "publickey3",
+            "__typename": "FeeTransfer"
+          }
+        ],
+        "userCommands": [
+          {
+            "fromAccount": {
+              "publicKey": "publickey3",
+              "__typename": "Account"
+            },
+            "toAccount": {
+              "publicKey": "publickey5",
+              "__typename": "Account"
+            },
+            "__typename": "UserCommand"
+          }
+        ],
+        "__typename": "Transactions"
+      },
+      "__typename": "Block"
+    }
+  }
+}

--- a/frontend/leaderboard/__tests__/leaderboard_test.re
+++ b/frontend/leaderboard/__tests__/leaderboard_test.re
@@ -1,0 +1,80 @@
+open Jest;
+open Expect;
+module StringMap = Map.Make(String);
+
+let blockDirectory =
+  ([%bs.node __dirname] |> Belt.Option.getExn |> Filename.dirname)
+  ++ "/../../__tests__/blocks/";
+
+let blocks =
+  blockDirectory
+  |> Node.Fs.readdirSync
+  |> Array.map(file => {
+       let fileContents = Node.Fs.readFileAsUtf8Sync(blockDirectory ++ file);
+       let blockData = Js.Json.parseExn(fileContents);
+       let block = Types.NewBlock.unsafeJSONToNewBlock(blockData);
+       block.data.newBlock;
+     });
+
+describe("Metrics", () => {
+  describe("blocksCreatedMetric", () => {
+    let blockMetrics = Metrics.getBlocksCreatedByUser(blocks);
+    test("correct number of users", () => {
+      expect(StringMap.cardinal(blockMetrics)) |> toBe(7)
+    });
+    test("correct number of blocks for publickey1", () => {
+      expect(StringMap.find("publickey1", blockMetrics)) |> toBe(3)
+    });
+    test("correct number of blocks for publickey2", () => {
+      expect(StringMap.find("publickey2", blockMetrics)) |> toBe(2)
+    });
+    test("correct number of blocks for publickey3", () => {
+      expect(StringMap.find("publickey3", blockMetrics)) |> toBe(1)
+    });
+  })
+});
+
+describe("Challenges", () => {
+  describe("Blocks Challenge", () => {
+    let blocksPoints =
+      blocks
+      |> Metrics.calculateMetrics
+      |> Challenges.calculatePoints("Blocks")
+      |> Belt.Option.getExn;
+
+    test("1000 points given to publickey1", () => {
+      expect(StringMap.find("publickey1", blocksPoints)) |> toBe(1000)
+    });
+  });
+
+  describe("Points functions", () => {
+    let blockMetrics = blocks |> Metrics.calculateMetrics;
+    describe(
+      "addPointsToAtleastN adds correct number of points with atleast 1", () => {
+      let blockPoints =
+        Challenges.addPointsToUsersWithAtleastN(
+          (metricRecord: Types.Metrics.metricRecord) =>
+            metricRecord.blocksCreated,
+          1,
+          1000,
+          blockMetrics,
+        );
+
+      test("correct number of points given to publickey1", () => {
+        expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+      });
+      test("correct number of points given to publickey2", () => {
+        expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+      });
+      test("correct number of points given to publickey3", () => {
+        expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
+      });
+      test("no points exist for publickey8", () => {
+        expect(() =>
+          StringMap.find("publickey8", blockPoints)
+        )
+        |> toThrowException(Not_found)
+      });
+    });
+  });
+});

--- a/frontend/leaderboard/__tests__/leaderboard_test.re
+++ b/frontend/leaderboard/__tests__/leaderboard_test.re
@@ -20,16 +20,16 @@ describe("Metrics", () => {
   describe("blocksCreatedMetric", () => {
     let blockMetrics = Metrics.getBlocksCreatedByUser(blocks);
     test("correct number of users", () => {
-      expect(StringMap.cardinal(blockMetrics)) |> toBe(7)
+      expect(StringMap.cardinal(blockMetrics)) |> toBe(4)
     });
     test("correct number of blocks for publickey1", () => {
-      expect(StringMap.find("publickey1", blockMetrics)) |> toBe(3)
+      expect(StringMap.find("publickey1", blockMetrics)) |> toBe(4)
     });
     test("correct number of blocks for publickey2", () => {
-      expect(StringMap.find("publickey2", blockMetrics)) |> toBe(2)
+      expect(StringMap.find("publickey2", blockMetrics)) |> toBe(3)
     });
     test("correct number of blocks for publickey3", () => {
-      expect(StringMap.find("publickey3", blockMetrics)) |> toBe(1)
+      expect(StringMap.find("publickey3", blockMetrics)) |> toBe(2)
     });
   })
 });
@@ -49,31 +49,86 @@ describe("Challenges", () => {
 
   describe("Points functions", () => {
     let blockMetrics = blocks |> Metrics.calculateMetrics;
-    describe(
-      "addPointsToAtleastN adds correct number of points with atleast 1", () => {
-      let blockPoints =
-        Challenges.addPointsToUsersWithAtleastN(
-          (metricRecord: Types.Metrics.metricRecord) =>
-            metricRecord.blocksCreated,
-          1,
-          1000,
-          blockMetrics,
-        );
 
-      test("correct number of points given to publickey1", () => {
-        expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+    describe("addPointsToAtleastN", () => {
+      describe("adds correct number of points with atleast 1", () => {
+        let blockPoints =
+          Challenges.addPointsToUsersWithAtleastN(
+            (metricRecord: Types.Metrics.metricRecord) =>
+              metricRecord.blocksCreated,
+            1,
+            1000,
+            blockMetrics,
+          );
+
+        test("correct number of points given to publickey1", () => {
+          expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+        });
+        test("correct number of points given to publickey2", () => {
+          expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+        });
+        test("correct number of points given to publickey3", () => {
+          expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
+        });
+        test("no points exist for publickey8", () => {
+          expect(() =>
+            StringMap.find("publickey8", blockPoints)
+          )
+          |> toThrowException(Not_found)
+        });
       });
-      test("correct number of points given to publickey2", () => {
-        expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+
+      describe("adds correct number of points with atleast 3", () => {
+        let blockPoints =
+          Challenges.addPointsToUsersWithAtleastN(
+            (metricRecord: Types.Metrics.metricRecord) =>
+              metricRecord.blocksCreated,
+            3,
+            1000,
+            blockMetrics,
+          );
+
+        test("correct number of points given to publickey1", () => {
+          expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+        });
+
+        test("no points exist for publickey2", () => {
+          expect(() =>
+            StringMap.find("publickey2", blockPoints)
+          )
+          |> toThrowException(Not_found)
+        });
       });
-      test("correct number of points given to publickey3", () => {
-        expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
-      });
-      test("no points exist for publickey8", () => {
-        expect(() =>
-          StringMap.find("publickey8", blockPoints)
-        )
-        |> toThrowException(Not_found)
+      describe("applyTopNPoints", () => {
+        describe("adds correct number of points to top 3", () => {
+          let blockPoints =
+            Challenges.applyTopNPoints(
+              3,
+              1000,
+              blockMetrics,
+              (metricRecord: Types.Metrics.metricRecord) =>
+              metricRecord.blocksCreated
+            );
+
+          test("correct number of points given to publickey1", () => {
+            expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+          });
+
+          test("correct number of points given to publickey2", () => {
+            expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+          });
+
+          test("correct number of points given to publickey3", () => {
+            expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
+          });
+
+          test("no points exist for publickey4", () => {
+            expect(() =>
+              StringMap.find("publickey4", blockPoints)
+            )
+            |> toThrowException(Not_found)
+          });
+        })
       });
     });
   });

--- a/frontend/leaderboard/__tests__/leaderboard_test.re
+++ b/frontend/leaderboard/__tests__/leaderboard_test.re
@@ -31,105 +31,127 @@ describe("Metrics", () => {
     test("correct number of blocks for publickey3", () => {
       expect(StringMap.find("publickey3", blockMetrics)) |> toBe(2)
     });
+    test("correct number of blocks for publickey4", () => {
+      expect(StringMap.find("publickey4", blockMetrics)) |> toBe(1)
+    });
+    test("publickey5 does not exist in metrics map", () => {
+      expect(() =>
+        StringMap.find("publickey5", blockMetrics)
+      )
+      |> toThrowException(Not_found)
+    });
   })
 });
 
 describe("Challenges", () => {
   describe("Blocks Challenge", () => {
-    let blocksPoints =
+    let blockPoints =
       blocks
       |> Metrics.calculateMetrics
       |> Challenges.calculatePoints("Blocks")
       |> Belt.Option.getExn;
 
-    test("1000 points given to publickey1", () => {
-      expect(StringMap.find("publickey1", blocksPoints)) |> toBe(1000)
+    test("correct number of users", () => {
+      expect(StringMap.cardinal(blockPoints)) |> toBe(2)
     });
-  });
+    test("publickey1 gets 1000 points", () => {
+      expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+    });
+    test("publickey2 gets 1000 points", () => {
+      expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+    });
+    test("publickey3 does not exist in points map", () => {
+      expect(() =>
+        StringMap.find("publickey3", blockPoints)
+      )
+      |> toThrowException(Not_found)
+    });
+  })
+});
 
-  describe("Points functions", () => {
-    let blockMetrics = blocks |> Metrics.calculateMetrics;
+describe("Points functions", () => {
+  let blockMetrics = blocks |> Metrics.calculateMetrics;
 
-    describe("addPointsToAtleastN", () => {
-      describe("adds correct number of points with atleast 1", () => {
+  describe("addPointsToAtleastN", () => {
+    describe("adds correct number of points with atleast 1", () => {
+      let blockPoints =
+        Challenges.addPointsToUsersWithAtleastN(
+          (metricRecord: Types.Metrics.metricRecord) =>
+            metricRecord.blocksCreated,
+          1,
+          1000,
+          blockMetrics,
+        );
+
+      test("correct number of points given to publickey1", () => {
+        expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+      });
+      test("correct number of points given to publickey2", () => {
+        expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+      });
+      test("correct number of points given to publickey3", () => {
+        expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
+      });
+      test("publickey8 does not exist in points map", () => {
+        expect(() =>
+          StringMap.find("publickey8", blockPoints)
+        )
+        |> toThrowException(Not_found)
+      });
+    });
+
+    describe("adds correct number of points with atleast 3", () => {
+      let blockPoints =
+        Challenges.addPointsToUsersWithAtleastN(
+          (metricRecord: Types.Metrics.metricRecord) =>
+            metricRecord.blocksCreated,
+          3,
+          1000,
+          blockMetrics,
+        );
+
+      test("correct number of points given to publickey1", () => {
+        expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
+      });
+
+      test("correct number of points given to publickey2", () => {
+        expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
+      });
+
+      test("publickey3 does not exist in points map", () => {
+        expect(() =>
+          StringMap.find("publickey3", blockPoints)
+        )
+        |> toThrowException(Not_found)
+      });
+    });
+    describe("applyTopNPoints", () => {
+      describe("adds correct number of points to top 3", () => {
         let blockPoints =
-          Challenges.addPointsToUsersWithAtleastN(
-            (metricRecord: Types.Metrics.metricRecord) =>
-              metricRecord.blocksCreated,
-            1,
-            1000,
-            blockMetrics,
+          Challenges.applyTopNPoints(
+            3, 1000, blockMetrics, (metricRecord: Types.Metrics.metricRecord) =>
+            metricRecord.blocksCreated
           );
 
         test("correct number of points given to publickey1", () => {
           expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
         });
+
         test("correct number of points given to publickey2", () => {
           expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
         });
+
         test("correct number of points given to publickey3", () => {
           expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
         });
-        test("no points exist for publickey8", () => {
+
+        test("publickey4 does not exist in points map", () => {
           expect(() =>
-            StringMap.find("publickey8", blockPoints)
+            StringMap.find("publickey4", blockPoints)
           )
           |> toThrowException(Not_found)
         });
-      });
-
-      describe("adds correct number of points with atleast 3", () => {
-        let blockPoints =
-          Challenges.addPointsToUsersWithAtleastN(
-            (metricRecord: Types.Metrics.metricRecord) =>
-              metricRecord.blocksCreated,
-            3,
-            1000,
-            blockMetrics,
-          );
-
-        test("correct number of points given to publickey1", () => {
-          expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
-        });
-
-        test("no points exist for publickey2", () => {
-          expect(() =>
-            StringMap.find("publickey2", blockPoints)
-          )
-          |> toThrowException(Not_found)
-        });
-      });
-      describe("applyTopNPoints", () => {
-        describe("adds correct number of points to top 3", () => {
-          let blockPoints =
-            Challenges.applyTopNPoints(
-              3,
-              1000,
-              blockMetrics,
-              (metricRecord: Types.Metrics.metricRecord) =>
-              metricRecord.blocksCreated
-            );
-
-          test("correct number of points given to publickey1", () => {
-            expect(StringMap.find("publickey1", blockPoints)) |> toBe(1000)
-          });
-
-          test("correct number of points given to publickey2", () => {
-            expect(StringMap.find("publickey2", blockPoints)) |> toBe(1000)
-          });
-
-          test("correct number of points given to publickey3", () => {
-            expect(StringMap.find("publickey3", blockPoints)) |> toBe(1000)
-          });
-
-          test("no points exist for publickey4", () => {
-            expect(() =>
-              StringMap.find("publickey4", blockPoints)
-            )
-            |> toThrowException(Not_found)
-          });
-        })
-      });
+      })
     });
   });
 });

--- a/frontend/leaderboard/bsconfig.json
+++ b/frontend/leaderboard/bsconfig.json
@@ -4,12 +4,13 @@
     {
       "dir": "src",
       "subdirs": true
+    },
+    {
+      "dir": "__tests__",
+      "type": "dev"
     }
   ],
-  "bs-dependencies": [
-    "bsc-stdlib-polyfill",
-    "bs-fetch"
-  ],
+  "bs-dependencies": ["bsc-stdlib-polyfill", "bs-fetch"],
   "reason": {
     "react-jsx": 3
   },
@@ -17,9 +18,7 @@
     "module": "commonjs"
   },
   "suffix": ".bs.js",
-  "bsc-flags": [
-    "-bs-super-errors",
-    "-open BscStdlibPolyfill"
-  ],
+  "bsc-flags": ["-bs-super-errors", "-open BscStdlibPolyfill"],
+  "bs-dev-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3
 }

--- a/frontend/leaderboard/package.json
+++ b/frontend/leaderboard/package.json
@@ -5,14 +5,16 @@
     "dev": "bsb -clean-world -make-world -w",
     "build": "bsb -clean-world -make-world",
     "clean": "bsb -clean-world",
-    "reformat": "bsrefmt --in-place src/**/*.re"
+    "reformat": "bsrefmt --in-place src/**/*.re",
+    "test": "yarn run build && jest --root-dir lib/js/"
   },
   "license": "ISC",
   "dependencies": {
     "bs-fetch": "^0.5.0",
     "bsc-stdlib-polyfill": "Schmavery/bsc-stdlib-polyfill",
     "googleapis": "^50.0.0",
-    "isomorphic-unfetch": "^3.0.0"
+    "isomorphic-unfetch": "^3.0.0",
+    "@glennsl/bs-jest": "^0.4.8"
   },
   "devDependencies": {
     "bs-platform": "7.0.0-dev.1"

--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -20,9 +20,13 @@ let applyTopNPoints = (n, points, metricsMap, getMetricValue) => {
   let f = ((_, metricValue1), (_, metricValue2)) => {
     compare(getMetricValue(metricValue1), getMetricValue(metricValue2));
   };
+
   Array.sort(f, metricsArray);
+  Belt.Array.reverseInPlace(metricsArray);
+
   let topNArray =
     Array.sub(metricsArray, 0, min(n, Array.length(metricsArray)));
+
   let topNArrayWithPoints =
     Array.map(((user, _)) => {(user, points)}, topNArray);
 


### PR DESCRIPTION
Resurrected from https://github.com/CodaProtocol/coda/pull/4965 by @MartinMinkov 

===

Added unit tests to the leaderboard project with bs-jest.

I found that as I was implementing the challenge requirements from the notion page, I was unsure if the implementation code was rewarded points correctly based on the massive block data that is pulled in. Writing these unit tests is a way to confirm that these challenges are being implemented correctly on the block data is given.

Not all metrics/challenges are included in this PR. This is because I was implementing the specified challenges in a different git branch and wanted the tests to be a separate PR. As more functionality to metrics/challenges is written, we can now write tests.

Note: This PR also includes a small bug fix that was found by writing these initial tests.