### PR TITLE
Runtime_genesis_ledger, rm unused var

### DIFF
--- a/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
+++ b/src/app/runtime_genesis_ledger/runtime_genesis_ledger.ml
@@ -30,9 +30,6 @@ let main ~config_file ~genesis_dir ~proof_level () =
        ~proof_level ~genesis_constants:Genesis_constants.compiled config
 
 let () =
-  let compiled_ledger_depth =
-    Genesis_constants.Constraint_constants.compiled.ledger_depth
-  in
   Command.run
     (Command.async
        ~summary:


### PR DESCRIPTION
In CI, building `runtime_genesis_ledger.exe` generated an unused variable warning.

Locally, using the `dev` profile, it's a fatal error.