### PR TITLE
Website: Fix links to CoC

### DIFF
--- a/frontend/website/pages/docs/contributing.mdx
+++ b/frontend/website/pages/docs/contributing.mdx
@@ -31,6 +31,6 @@ Currently, the projects are mostly programming focused, but more will be added i
 
 ## Reporting Issues
 
-If you notice any [Code of Conduct](../code-of-conduct) violations, please follow the [Reporting Guidelines](../reporting-guidelines) to file a report and alert the community to any bad behavior.
+If you notice any [Code of Conduct](https://github.com/CodaProtocol/coda/blob/develop/CODE_OF_CONDUCT.md) violations, please follow the Reporting Guidelines in that document to file a report and alert the community to any bad behavior.
 
 If you encounter any critical bugs or vulnerabilities in the protocol, please report them to security@codaprotocol.com. For minor bugs and issues, please create a issue on Github.


### PR DESCRIPTION
Small link fix for CoC. There's no separate doc for the reporting guidelines so I just referred to the section in the document. A better fix might be promoting the coc to its own full page in the docs and then linking to the header but this was faster for now.