### PR TITLE
add Summon Command Type for Buildkite Summon secrets management plugin integration

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -109,7 +109,7 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
               toMap { `docker#v3.5.0` = Plugins.Docker docker })
             c.docker)
       let summonPart =
-        [ toMap { `angaza/summon#0.1.0` = Plugins.Summon c.summon } ]
+        [ toMap { `angaza/summon#v0.1.0` = Plugins.Summon c.summon } ]
       -- Add more plugins here as needed, empty list omits that part from the
       -- plugins map
       let allPlugins =

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -14,6 +14,7 @@ let Docker = ./Docker/Type.dhall
 let Size = ./Size.dhall
 
 -- We assume we're only using the Docker plugin for now
+-- TODO: enable variable plugin loading
 let B/Command = B.definitions/commandStep/Type Text Text Docker.Type Docker.Type
 let B/Plugins = B/Plugins/Partial Docker.Type Docker.Type
 

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -120,10 +120,8 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
 
       -- Add more plugins here as needed, empty list omits that part from the
       -- plugins map
-      let allPlugins =
-        List/concat (Map.Entry Text Plugins) (dockerPart # summonPart)
-      in
-      Some (B/Plugins.Plugins/Type allPlugins)
+      let allPlugins = List/concat (Map.Entry Text Plugins) (dockerPart # summonPart) in
+      if Prelude.List.null (Map.Entry Text Plugins) allPlugins then None B/Plugins else Some (B/Plugins.Plugins/Type allPlugins)
   }
 
 in {Config = Config, build = build, Type = B/Command.Type, TaggedKey = TaggedKey}

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -109,7 +109,7 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
               toMap { `docker#v3.5.0` = Plugins.Docker docker })
             c.docker)
       let summonPart =
-        [ toMap { `summoner#0.1.0` = Plugins.Summon c.summon } ]
+        [ toMap { `angaza/summon#0.1.0` = Plugins.Summon c.summon } ]
       -- Add more plugins here as needed, empty list omits that part from the
       -- plugins map
       let allPlugins =

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -2,7 +2,9 @@
 
 let Prelude = ../External/Prelude.dhall
 let List/map = Prelude.List.map
+let List/concat = Prelude.List.concat
 let Optional/map = Prelude.Optional.map
+let Optional/toList = Prelude.Optional.toList
 let B = ../External/Buildkite.dhall
 let B/Plugins/Partial = B.definitions/commandStep/properties/plugins/Type
 let Map = Prelude.Map
@@ -11,12 +13,17 @@ let Cmd = ../Lib/Cmds.dhall
 let Decorate = ../Lib/Decorate.dhall
 
 let Docker = ./Docker/Type.dhall
+let Summon= ./Summon/Type.dhall
 let Size = ./Size.dhall
 
--- We assume we're only using the Docker plugin for now
--- TODO: enable variable plugin loading
-let B/Command = B.definitions/commandStep/Type Text Text Docker.Type Docker.Type
-let B/Plugins = B/Plugins/Partial Docker.Type Docker.Type
+-- If you are adding a new type of plugin, stick it here
+let Plugins =
+  < Docker : Docker.Type
+  | Summon : Summon.Type
+  >
+
+let B/Command = B.definitions/commandStep/Type Text Text Plugins Plugins
+let B/Plugins = B/Plugins/Partial Plugins Plugins
 
 -- Depends on takes several layers of unions, but we can just choose the most
 -- general of them
@@ -55,10 +62,12 @@ let Config =
       , key : Text
       , target : Size
       , docker : Optional Docker.Type
+      , summon : Summon.Type
       }
   , default =
     { depends_on = [] : List TaggedKey.Type
     , docker = None Docker.Type
+    , summon = Summon::{=}
     }
   }
 
@@ -90,7 +99,23 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
     key = Some c.key,
     label = Some c.label,
     plugins =
-      Optional/map Docker.Type B/Plugins (\(docker: Docker.Type) -> B/Plugins.Plugins/Type (toMap { `docker#v3.5.0` = docker })) c.docker
+      let dockerPart =
+        Optional/toList
+          (Map.Type Text Plugins)
+          (Optional/map
+            Docker.Type
+            (Map.Type Text Plugins)
+            (\(docker: Docker.Type) ->
+              toMap { `docker#v3.5.0` = Plugins.Docker docker })
+            c.docker)
+      let summonPart =
+        [ toMap { `summoner#0.1.0` = Plugins.Summon c.summon } ]
+      -- Add more plugins here as needed, empty list omits that part from the
+      -- plugins map
+      let allPlugins =
+        List/concat (Map.Entry Text Plugins) (dockerPart # summonPart)
+      in
+      Some (B/Plugins.Plugins/Type allPlugins)
   }
 
 in {Config = Config, build = build, Type = B/Command.Type, TaggedKey = TaggedKey}

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -62,12 +62,12 @@ let Config =
       , key : Text
       , target : Size
       , docker : Optional Docker.Type
-      , summon : Summon.Type
+      , summon : Optional Summon.Type
       }
   , default =
     { depends_on = [] : List TaggedKey.Type
     , docker = None Docker.Type
-    , summon = Summon::{=}
+    , summon = None Summon.Type
     }
   }
 
@@ -109,7 +109,15 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
               toMap { `docker#v3.5.0` = Plugins.Docker docker })
             c.docker)
       let summonPart =
-        [ toMap { `angaza/summon#v0.1.0` = Plugins.Summon c.summon } ]
+        Optional/toList
+          (Map.Type Text Plugins)
+          (Optional/map
+            Summon.Type
+            (Map.Type Text Plugins)
+            (\(summon: Summon.Type) ->
+              toMap { `angaza/summon#v0.1.0` = Plugins.Summon summon })
+            c.summon)
+
       -- Add more plugins here as needed, empty list omits that part from the
       -- plugins map
       let allPlugins =

--- a/buildkite/src/Command/Coda.dhall
+++ b/buildkite/src/Command/Coda.dhall
@@ -6,6 +6,7 @@ let Map = Prelude.Map
 
 let Cmd = ../Lib/Cmds.dhall
 let Docker = ./Docker/Type.dhall
+let Summon = ./Summon/Type.dhall
 let Base = ./Base.dhall
 
 let Size = ./Size.dhall

--- a/buildkite/src/Command/Summon/Type.dhall
+++ b/buildkite/src/Command/Summon/Type.dhall
@@ -1,0 +1,19 @@
+-- Summon plugin specific settings for commands
+--
+-- See https://github.com/angaza/summon-buildkite-plugin for options
+-- if you'd like to extend this definition for example
+
+{
+  Type = {
+    `secrets-file`: Text,
+    provider: Text,
+    environment: Text,
+    substitutions: List Text
+  },
+  default = {
+    `secrets-file` = "./secrets.yml",
+    provider = "summon-aws-secrets",
+    environment = "dev",
+    substitutions = [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
+  }
+}

--- a/buildkite/src/Command/Summon/Type.dhall
+++ b/buildkite/src/Command/Summon/Type.dhall
@@ -13,7 +13,7 @@
   default = {
     `secrets-file` = "./secrets.yml",
     provider = "summon-aws-secrets",
-    environment = "dev",
-    substitutions = [ "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY" ]
+    environment = "",
+    substitutions = [] : List Text
   }
 }


### PR DESCRIPTION
This change adds a Summon dhall type to represent configuration for Buildkite's Summon secrets management plugin.

**Checklist:**
- [x] Tests were added for the new behavior
- [x] All tests pass (CI will check this if you didn't)

Closes #4993
