### PR TITLE
add wrap function to snarky group map

### DIFF
--- a/src/lib/snarky_group_map/checked_map.ml
+++ b/src/lib/snarky_group_map/checked_map.ml
@@ -1,11 +1,7 @@
-module Make
-    (M : Snarky.Snark_intf.Run) (P : sig
-        val params : M.field Group_map.Params.t
-    end) =
-struct
-  open P
-  module B = Group_map.Make (M.Field.Constant) (M.Field) (P)
-  open M
+open Core_kernel
+
+module Aux (Impl : Snarky.Snark_intf.Run) = struct
+  open Impl
 
   let non_residue : Field.Constant.t Lazy.t =
     let open Field.Constant in
@@ -40,23 +36,40 @@ struct
     let m = Lazy.force non_residue in
     ( sqrt_exn (Field.if_ is_square ~then_:x ~else_:(Field.scale x m))
     , is_square )
+end
 
-  (* with (x1, b1), (x2, b2), (x3, b3), we need to take only 
-   * the first square. this means we can do
-   * x1 * f1 + (x2 * f2 * not f1) + (x3 * f3 * not f1 * not f2)
-   *)
+let wrap (type f) ((module Impl) : f Snarky.Snark0.m) ~potential_xs ~y_squared
+    =
+  let open Impl in
+  let module A = Aux (Impl) in
+  let open A in
+  stage (fun x ->
+      let x1, x2, x3 = potential_xs x in
+      let y1, b1 = sqrt_flagged (y_squared ~x:x1)
+      and y2, b2 = sqrt_flagged (y_squared ~x:x2)
+      and y3, b3 = sqrt_flagged (y_squared ~x:x3) in
+      Boolean.Assert.any [b1; b2; b3] ;
+      let x1_is_first = (b1 :> Field.t)
+      and x2_is_first = (Boolean.((not b1) && b2) :> Field.t)
+      and x3_is_first = (Boolean.((not b1) && (not b2) && b3) :> Field.t) in
+      ( Field.((x1_is_first * x1) + (x2_is_first * x2) + (x3_is_first * x3))
+      , Field.((x1_is_first * y1) + (x2_is_first * y2) + (x3_is_first * y3)) )
+  )
 
-  let to_group x =
+module Make
+    (M : Snarky.Snark_intf.Run) (P : sig
+        val params : M.field Group_map.Params.t
+    end) =
+struct
+  open P
+  include Group_map.Make (M.Field.Constant) (M.Field) (P)
+  open M
+
+  let to_group =
     let {Group_map.Spec.a; b} = Group_map.Params.spec params in
-    let f x = Field.((x * x * x) + scale x a + constant b) in
-    let x1, x2, x3 = B.potential_xs x in
-    let y1, b1 = sqrt_flagged (f x1)
-    and y2, b2 = sqrt_flagged (f x2)
-    and y3, b3 = sqrt_flagged (f x3) in
-    Boolean.Assert.any [b1; b2; b3] ;
-    let x1_is_first = (b1 :> Field.t)
-    and x2_is_first = (Boolean.((not b1) && b2) :> Field.t)
-    and x3_is_first = (Boolean.((not b1) && (not b2) && b3) :> Field.t) in
-    ( Field.((x1_is_first * x1) + (x2_is_first * x2) + (x3_is_first * x3))
-    , Field.((x1_is_first * y1) + (x2_is_first * y2) + (x3_is_first * y3)) )
+    unstage
+      (wrap
+         (module M)
+         ~potential_xs
+         ~y_squared:Field.(fun ~x -> (x * x * x) + scale x a + constant b))
 end

--- a/src/lib/snarky_group_map/checked_map.mli
+++ b/src/lib/snarky_group_map/checked_map.mli
@@ -1,3 +1,12 @@
+open Core_kernel
+open Snarky
+
+val wrap :
+     'f Snark.m
+  -> potential_xs:('input -> 'f Cvar.t * 'f Cvar.t * 'f Cvar.t)
+  -> y_squared:(x:'f Cvar.t -> 'f Cvar.t)
+  -> ('input -> 'f Cvar.t * 'f Cvar.t) Staged.t
+
 module Make
     (M : Snarky.Snark_intf.Run) (Params : sig
         val params : M.field Group_map.Params.t

--- a/src/lib/snarky_group_map/dune
+++ b/src/lib/snarky_group_map/dune
@@ -6,5 +6,4 @@
   (libraries
     group_map
     snarky
-    snarkette
     core_kernel ))

--- a/src/lib/snarky_group_map/snarky_group_map.ml
+++ b/src/lib/snarky_group_map/snarky_group_map.ml
@@ -27,6 +27,8 @@ let to_group (type t)
 module Checked = struct
   open Snarky
 
+  let wrap = Checked_map.wrap
+
   let to_group (type f) (module M : Snark_intf.Run with type field = f) ~params
       t =
     let module G =

--- a/src/lib/snarky_group_map/snarky_group_map.mli
+++ b/src/lib/snarky_group_map/snarky_group_map.mli
@@ -16,6 +16,12 @@ val to_group :
 module Checked : sig
   open Snarky
 
+  val wrap :
+       'f Snark.m
+    -> potential_xs:('input -> 'f Cvar.t * 'f Cvar.t * 'f Cvar.t)
+    -> y_squared:(x:'f Cvar.t -> 'f Cvar.t)
+    -> ('input -> 'f Cvar.t * 'f Cvar.t) Core_kernel.Staged.t
+
   val to_group :
        (module Snark_intf.Run with type field = 'f)
     -> params:'f Params.t


### PR DESCRIPTION
This refactors the snarky group map module to have a `wrap` function for turning any "partial group map" -- which returns a choice of three possible x coordinates -- into a full checked group map that returns a single group element.