### PR TITLE
Corrected link in the docs to the waitlist of release 3.2b

### DIFF
--- a/frontend/website/pages/docs/my-first-transaction.mdx
+++ b/frontend/website/pages/docs/my-first-transaction.mdx
@@ -8,7 +8,7 @@ In this section, we'll make our first transaction on the Coda network. After [in
 
 ## Get the network information
 
-Because only 200 participants can join testnet 3.2b, you'll first need to get the peer addresses of the seed nodes. The 200 participants have already been selected, but you can sign up for the waitlist [here](https://docs.google.com/forms/d/e/1FAIpQLSfjfd8Tr9iy1gObKrfiI8upauksFpe5Tf_0ApZHri9jj4YIEA/viewform) in case a spot opens up. 
+Because only 200 participants can join testnet 3.2b, you'll first need to get the peer addresses of the seed nodes. The 200 participants have already been selected, but you can sign up for the waitlist [here](http://bit.ly/StakingSignup) in case a spot opens up. 
 
 Once you're in, you'll receive an email close to release 3.2b launch date with the seed node addresses and updated commands. We can start by storing the seed addresses as environment variables to help with the next steps:
 


### PR DESCRIPTION
The docs were still pointing users to the old waitlist for 3.2.
