### PR TITLE
Add ready-to-merge-into-develop to mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,3 +24,29 @@ pull_request_rules:
               method: squash
               strict: smart
           delete_head_branch: {}
+    - name: automatically merge approved PRs into develop with the ready-to-merge-into-develop label
+      conditions:
+          - "status-success=ci/circleci: build-artifacts--testnet_postake_medium_curves"
+          - "status-success=ci/circleci: build-client-sdk"
+          - "status-success=ci/circleci: build-wallet"
+          - "status-success=ci/circleci: compare-test-signatures"
+          - "status-success=ci/circleci: lint"
+          - "status-success=ci/circleci: test--fake_hash"
+          - "status-success=ci/circleci: test--test_postake"
+          - "status-success=ci/circleci: test--test_postake_bootstrap"
+          - "status-success=ci/circleci: test--test_postake_delegation"
+          - "status-success=ci/circleci: test--test_postake_five_even_txns"
+          - "status-success=ci/circleci: test--test_postake_snarkless"
+          - "status-success=ci/circleci: test--test_postake_split"
+          - "status-success=ci/circleci: test--test_postake_txns"
+          - "status-success=ci/circleci: test-unit--dev"
+          - "status-success=ci/circleci: test-unit--nonconsensus_medium_curves"
+          - "status-success=ci/circleci: tracetool"
+          - "#approved-reviews-by>=1"
+          - label=ready-to-merge-into-develop
+          - base=develop
+      actions:
+          merge:
+              method: squash
+              strict: smart
+          delete_head_branch: {}

--- a/.mergify.yml.jinja
+++ b/.mergify.yml.jinja
@@ -11,3 +11,16 @@ pull_request_rules:
               method: squash
               strict: smart
           delete_head_branch: {}
+    - name: automatically merge approved PRs into develop with the ready-to-merge-into-develop label
+      conditions:
+          {%- for status in required_status | sort %}
+          - "status-success={{status}}"
+          {%- endfor %}
+          - "#approved-reviews-by>=1"
+          - label=ready-to-merge-into-develop
+          - base=develop
+      actions:
+          merge:
+              method: squash
+              strict: smart
+          delete_head_branch: {}


### PR DESCRIPTION
This PR adds support for the `ready-to-merge-into-develop` label to mergify.

This is designed to handle the case of 'PR chains', where we have a pull request from branch `b2` with base `b1` and a pull request from branch `b1` with base `b0`. For example, see the chain #5086 #5088 #5089 #5090 #5091.

### Current behaviour

Adding the existing `ready-to-merge` label would fold the PRs through eachother down into the root PR (potentially racing on CI, so the order of merges isn't deterministic), so for example all of the above PRs would be combined into #5086, which would then be merged into `develop`.

### New behaviour

By using the new `ready-to-merge-into-develop` label, the PR with base `develop` will get merged and have its branch deleted, then the base of the next PR will be reset to `develop` and that will get merged, etc. This behaviour is (I think) what we actually want, not least because squash-to-merge will otherwise hide all of the dependent PRs in the chain behind a single commit.

#### Short rant about squash-to-merge

These kinds of PR chains would be a good way to maintain small PRs, even as they accumulate to a larger feature.

The remaining pain point of using these is squashing PRs before merge: if any of the PRs in the chain contain changes that haven't been propagated down-chain, they will usually become merge conflicts when squashed into develop. If we want `ready-to-merge-into-develop` to work automatically, we should migrate away from squash-to-merge so that git retains the commit information that it needs to automatically merge correctly.

If we are deeply concerned about keeping a 'pretty' git history, it would be easy to run a parallel branch `develop-pretty` with only the merge commits, by 'squashing' each commit with
```
git co develop-pretty
git diff develop~ develop | git apply
git commit -C develop
```

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: