### PR TITLE
Use CircleCI cache for _build directory in integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,6 +709,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--fake_hash-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: fake_hash
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--fake_hash-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -741,6 +755,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -776,6 +804,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_bootstrap-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_bootstrap
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_bootstrap-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -808,6 +850,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_catchup-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_catchup
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_catchup-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -840,6 +896,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_delegation-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_delegation
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_delegation-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -872,6 +942,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_five_even_txns-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_five_even_txns
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_five_even_txns-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -904,6 +988,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_snarkless-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_snarkless
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_snarkless-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -939,6 +1037,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_split-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_split
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_split-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -971,6 +1083,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_split_snarkless-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_split_snarkless
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_split_snarkless-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -1021,6 +1147,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_three_producers-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_three_producers
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_three_producers-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -1053,6 +1193,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_txns-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_txns
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_txns-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -1088,6 +1242,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_full_epoch-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_full_epoch
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_full_epoch-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -1120,6 +1288,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_medium_curves-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_medium_curves
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_medium_curves-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -1157,6 +1339,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_snarkless_medium_curves-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_snarkless_medium_curves
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_snarkless_medium_curves-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -1192,6 +1388,20 @@ jobs:
                 name: Install opam dependencies - opam -- LIBP2P_NIXLESS=1 make setup-opam
                 command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'LIBP2P_NIXLESS=1 make setup-opam'
 
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--test_postake_split_medium_curves-{{ .Branch }}-{{ .Revision }}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: test_postake_split_medium_curves
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--test_postake_split_medium_curves-{{ .Branch }}-{{ .Revision }}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -720,8 +720,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--fake_hash-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--fake_hash-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -766,8 +767,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -815,8 +817,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_bootstrap-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_bootstrap-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -861,8 +864,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_catchup-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_catchup-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -907,8 +911,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_delegation-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_delegation-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -953,8 +958,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_five_even_txns-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_five_even_txns-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -999,8 +1005,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_snarkless-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_snarkless-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1048,8 +1055,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_split-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_split-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1094,8 +1102,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_split_snarkless-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_split_snarkless-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1158,8 +1167,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_three_producers-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_three_producers-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1204,8 +1214,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_txns-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_txns-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1253,8 +1264,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_full_epoch-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_full_epoch-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1299,8 +1311,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_medium_curves-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_medium_curves-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1350,8 +1363,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_snarkless_medium_curves-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_snarkless_medium_curves-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -1399,8 +1413,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--test_postake_split_medium_curves-{{ .Branch }}-{{ .Revision }}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--test_postake_split_medium_curves-{{ .Branch }}-{{ .Revision }}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -563,8 +563,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper
@@ -597,8 +598,9 @@ jobs:
                     LIBP2P_NIXLESS: 1
                     GO: /usr/lib/go/bin/go
             - save_cache:
-              - key: dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
-              - paths:
+                name: Save cache - _build directory
+                key: dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
+                paths:
                   - _build
             - run:
                 name: Build libp2p_helper

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -552,6 +552,20 @@ jobs:
         steps:
             - checkout
             {{ opam_init_linux }}
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: {{profile}}
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper
@@ -572,6 +586,20 @@ jobs:
         steps:
             - checkout
             {{ opam_init_linux }}
+            - restore_cache:
+                keys:
+                  - dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
+            - run:
+                name: Build ocaml
+                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'source ~/.profile && make build'
+                environment:
+                    DUNE_PROFILE: {{profile}}
+                    LIBP2P_NIXLESS: 1
+                    GO: /usr/lib/go/bin/go
+            - save_cache:
+              - key: dune-build-cache-test--{{profile}}-{{'{{'}} .Branch {{'}}'}}-{{'{{'}} .Revision {{'}}'}}
+              - paths:
+                  - _build
             - run:
                 name: Build libp2p_helper
                 command: LIBP2P_NIXLESS=1 GO=/usr/lib/go/bin/go make libp2p_helper


### PR DESCRIPTION
This PR tweaks the CircleCI config to use caching for `_build` in integration test jobs. The cache is per-branch per-commit, so it is usually useless, but re-running a flaky test will use the cache and should avoid the entirety of build time.

We could also potentially use this for the build jobs, but this seems like a high impact, low effort place to start and test with.

Once CI finishes on this branch, I will rerun it from scratch as a test. **Please do not merge before I've done this test!!**

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: