### PR TITLE
Move docker jobs out of build-artifacts CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1262,11 +1262,11 @@ workflows:
             - build-client-sdk
             - build-artifacts--testnet_postake_medium_curves
             - build-artifacts-docker--testnet_postake_medium_curves--coda-daemon:
-                - requires:
-                    - build-artifacts--testnet_postake_medium_curves
+                requires:
+                  - build-artifacts--testnet_postake_medium_curves
             - build-artifacts-docker--testnet_postake_medium_curves--coda-demo:
-                - requires:
-                    - build-artifacts--testnet_postake_medium_curves
+                requires:
+                  - build-artifacts--testnet_postake_medium_curves
             - test-unit--dev
             - test-unit--nonconsensus_medium_curves
             - test--fake_hash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ jobs:
                 key: docker-deploy-env-v1-testnet_postake_medium_curves-{{ .Revision }}
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
-                    - "home/opam/scripts"
+                    - "scripts"
             - store_artifacts:
                   path: /tmp/artifacts
     build-artifacts-docker--testnet_postake_medium_curves--coda-daemon:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -576,7 +576,6 @@ jobs:
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
 
-                              echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
                         fi
                     fi
             - store_artifacts:
@@ -608,7 +607,6 @@ jobs:
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
 
-                              echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
                         fi
                     fi
             - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -547,6 +547,7 @@ jobs:
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
                     - "scripts"
+                    - "dockerfiles"
             - store_artifacts:
                   path: /tmp/artifacts
     build-artifacts-docker--testnet_postake_medium_curves--coda-daemon:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,6 +546,7 @@ jobs:
                 key: docker-deploy-env-v1-testnet_postake_medium_curves-{{ .Revision }}
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
+                    - "home/opam/scripts/run-demo.sh"
             - store_artifacts:
                   path: /tmp/artifacts
     build-artifacts-docker--testnet_postake_medium_curves--coda-daemon:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,6 +541,21 @@ jobs:
             - run:
                   name: Copy artifacts to cloud
                   command: ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/artifacts.sh
+            - save_cache:
+                name: Save cache - docker deploy env
+                key: docker-deploy-env-v1-testnet_postake_medium_curves-{{ .Revision }}
+                paths:
+                    - "/tmp/DOCKER_DEPLOY_ENV"
+            - store_artifacts:
+                  path: /tmp/artifacts
+    build-artifacts-docker--testnet_postake_medium_curves--coda-daemon:
+        resource_class: xlarge
+        docker:
+            - image: codaprotocol/coda:toolchain-ff342e8e78343bf409b94817a0f96bae57914cea
+        steps:
+            - restore_cache:
+                name: Restore cache - docker deploy env
+                key: docker-deploy-env-v1-testnet_postake_medium_curves-{{ .Revision }}
             - setup_remote_docker
             - run:
                   name: Build and Upload Docker
@@ -561,10 +576,38 @@ jobs:
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
 
                               echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
+                        fi
+                    fi
+            - store_artifacts:
+                  path: /tmp/artifacts
+    build-artifacts-docker--testnet_postake_medium_curves--coda-demo:
+        resource_class: xlarge
+        docker:
+            - image: codaprotocol/coda:toolchain-ff342e8e78343bf409b94817a0f96bae57914cea
+        steps:
+            - restore_cache:
+                name: Restore cache - docker deploy env
+                key: docker-deploy-env-v1-testnet_postake_medium_curves-{{ .Revision }}
+            - setup_remote_docker
+            - run:
+                  name: Build and Upload Docker
+                  command: |
+                    # Check if we should deploy this build
+                    FILE=/tmp/DOCKER_DEPLOY_ENV
+                    if test -f "$FILE"; then
+                        source $FILE
+                        echo "Publishing Docker"
+                        echo "Should Publish Docker: $CODA_WAS_PUBLISHED"
+                        set -x
+                        if [[ "$CODA_WAS_PUBLISHED" = true  ]]; then
+
+                              echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
                               ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/release-docker.sh \
                               -s coda-demo \
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
+
+                              echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
                         fi
                     fi
             - store_artifacts:
@@ -1219,6 +1262,12 @@ workflows:
             - build-macos
             - build-client-sdk
             - build-artifacts--testnet_postake_medium_curves
+            - build-artifacts-docker--testnet_postake_medium_curves-coda-daemon:
+                - requires:
+                    - build-artifacts--testnet_postake_medium_curves
+            - build-artifacts-docker--testnet_postake_medium_curves-coda-demo:
+                - requires:
+                    - build-artifacts--testnet_postake_medium_curves
             - test-unit--dev
             - test-unit--nonconsensus_medium_curves
             - test--fake_hash

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -546,7 +546,7 @@ jobs:
                 key: docker-deploy-env-v1-testnet_postake_medium_curves-{{ .Revision }}
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
-                    - "home/opam/scripts/run-demo.sh"
+                    - "home/opam/scripts"
             - store_artifacts:
                   path: /tmp/artifacts
     build-artifacts-docker--testnet_postake_medium_curves--coda-daemon:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,7 +571,7 @@ jobs:
                         if [[ "$CODA_WAS_PUBLISHED" = true  ]]; then
 
                               echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
-                              ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/release-docker.sh \
+                              scripts/release-docker.sh \
                               -s coda-daemon \
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
@@ -602,7 +602,7 @@ jobs:
                         if [[ "$CODA_WAS_PUBLISHED" = true  ]]; then
 
                               echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
-                              ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/release-docker.sh \
+                              scripts/release-docker.sh \
                               -s coda-demo \
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1261,10 +1261,10 @@ workflows:
             - build-macos
             - build-client-sdk
             - build-artifacts--testnet_postake_medium_curves
-            - build-artifacts-docker--testnet_postake_medium_curves-coda-daemon:
+            - build-artifacts-docker--testnet_postake_medium_curves--coda-daemon:
                 - requires:
                     - build-artifacts--testnet_postake_medium_curves
-            - build-artifacts-docker--testnet_postake_medium_curves-coda-demo:
+            - build-artifacts-docker--testnet_postake_medium_curves--coda-demo:
                 - requires:
                     - build-artifacts--testnet_postake_medium_curves
             - test-unit--dev

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -478,7 +478,7 @@ jobs:
                         if [[ "$CODA_WAS_PUBLISHED" = true  ]]; then
 
                               echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
-                              ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/release-docker.sh \
+                              scripts/release-docker.sh \
                               -s {{docker_image}} \
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -442,6 +442,27 @@ jobs:
                   name: Copy artifacts to cloud
                   command: ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/artifacts.sh
             {%- if profile in medium_curve_profiles %}
+            - save_cache:
+                name: Save cache - docker deploy env
+                key: docker-deploy-env-v1-{{profile}}-{{'{{'}} .Revision {{'}}'}}
+                paths:
+                    - "/tmp/DOCKER_DEPLOY_ENV"
+            - store_artifacts:
+                  path: /tmp/artifacts
+            {%- endif %}
+    {%- endfor %}
+
+    {%- for profile in build_artifact_profiles %}
+    {%- if profile in medium_curve_profiles %}
+    {%- for docker_image in ['coda-daemon', 'coda-demo'] %}
+    build-artifacts-docker--{{profile}}--{{docker_image}}:
+        resource_class: xlarge
+        docker:
+            - image: codaprotocol/coda:toolchain-ff342e8e78343bf409b94817a0f96bae57914cea
+        steps:
+            - restore_cache:
+                name: Restore cache - docker deploy env
+                key: docker-deploy-env-v1-{{profile}}-{{'{{'}} .Revision {{'}}'}}
             - setup_remote_docker
             - run:
                   name: Build and Upload Docker
@@ -457,20 +478,17 @@ jobs:
 
                               echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
                               ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/release-docker.sh \
-                              -s coda-daemon \
+                              -s {{docker_image}} \
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
 
                               echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
-                              ./scripts/skip_if_only_frontend_or_rfcs.sh scripts/release-docker.sh \
-                              -s coda-demo \
-                              -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
-                              --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
                         fi
                     fi
             - store_artifacts:
                   path: /tmp/artifacts
-            {%- endif %}
+    {%- endfor %}
+    {%- endif %}
     {%- endfor %}
 
     {%- for profile in unit_test_profiles %}
@@ -606,6 +624,15 @@ workflows:
             - build-client-sdk
             {%- for profile in build_artifact_profiles %}
             - build-artifacts--{{profile}}
+            {%- endfor %}
+            {%- for profile in build_artifact_profiles %}
+            {%- if profile in medium_curve_profiles %}
+            {%- for docker_image in ['coda-daemon', 'coda-demo'] %}
+            - build-artifacts-docker--{{profile}}-{{docker_image}}:
+                - requires:
+                    - build-artifacts--{{profile}}
+            {%- endfor %}
+            {%- endif %}
             {%- endfor %}
             {%- for profile in unit_test_profiles %}
             - test-unit--{{profile}}

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -447,6 +447,7 @@ jobs:
                 key: docker-deploy-env-v1-{{profile}}-{{'{{'}} .Revision {{'}}'}}
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
+                    - "home/opam/scripts/run-demo.sh"
             - store_artifacts:
                   path: /tmp/artifacts
             {%- endif %}

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -447,7 +447,7 @@ jobs:
                 key: docker-deploy-env-v1-{{profile}}-{{'{{'}} .Revision {{'}}'}}
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
-                    - "home/opam/scripts/run-demo.sh"
+                    - "home/opam/scripts"
             - store_artifacts:
                   path: /tmp/artifacts
             {%- endif %}

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -447,7 +447,7 @@ jobs:
                 key: docker-deploy-env-v1-{{profile}}-{{'{{'}} .Revision {{'}}'}}
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
-                    - "home/opam/scripts"
+                    - "scripts"
             - store_artifacts:
                   path: /tmp/artifacts
             {%- endif %}

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -629,8 +629,8 @@ workflows:
             {%- if profile in medium_curve_profiles %}
             {%- for docker_image in ['coda-daemon', 'coda-demo'] %}
             - build-artifacts-docker--{{profile}}--{{docker_image}}:
-                - requires:
-                    - build-artifacts--{{profile}}
+                requires:
+                  - build-artifacts--{{profile}}
             {%- endfor %}
             {%- endif %}
             {%- endfor %}

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -483,7 +483,6 @@ jobs:
                               -v $CODA_GIT_TAG-$CODA_GIT_BRANCH-$CODA_GIT_HASH \
                               --extra-args "--build-arg coda_version=$CODA_DEB_VERSION --build-arg deb_repo=$CODA_DEB_REPO"
 
-                              echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
                         fi
                     fi
             - store_artifacts:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -628,7 +628,7 @@ workflows:
             {%- for profile in build_artifact_profiles %}
             {%- if profile in medium_curve_profiles %}
             {%- for docker_image in ['coda-daemon', 'coda-demo'] %}
-            - build-artifacts-docker--{{profile}}-{{docker_image}}:
+            - build-artifacts-docker--{{profile}}--{{docker_image}}:
                 - requires:
                     - build-artifacts--{{profile}}
             {%- endfor %}

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -448,6 +448,7 @@ jobs:
                 paths:
                     - "/tmp/DOCKER_DEPLOY_ENV"
                     - "scripts"
+                    - "dockerfiles"
             - store_artifacts:
                   path: /tmp/artifacts
             {%- endif %}


### PR DESCRIPTION
This PR moves docker builds out of the `build-artifacts` CI job into their own jobs. This
* allows the docker builds to run in parallel, speeding up CI
* the docker jobs are not required, so PRs that will not use the images may merge before the step is completed
* avoids CI failure for a PR when parallel PRs' CI jobs race to access the same dockerhub tag
* makes re-running a failed docker build much faster, since it doesn't require a whole re-run of `build-artifacts`

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
