### PR TITLE
Ppxlib.Deriving for register_event

### DIFF
--- a/src/lib/ppx_register_event/dune
+++ b/src/lib/ppx_register_event/dune
@@ -2,6 +2,6 @@
  (name ppx_register_event)
  (public_name ppx_register_event)
  (kind ppx_deriver)
- (libraries coda_digestif compiler-libs.common ppxlib ppx_deriving.api core_kernel ppx_deriving_yojson logproc_lib)
+ (libraries coda_digestif compiler-libs.common ppxlib core_kernel ppx_deriving_yojson logproc_lib)
  (preprocess (pps ppx_version ppxlib.metaquot))
  (ppx_runtime_libraries structured_log_events yojson))


### PR DESCRIPTION
We had had troubles mixing `Ppx_deriving` and `Ppxlib.Deriving`, and had changed most derivers to use the latter.

Change `ppx_register_event` to use `Ppxlib.Deriving`.