### PR TITLE
fixed leaderboard cron job error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
                 command: cd frontend/leaderboard/lib/js/src/ && mkdir blocks && gsutil -m rsync gs://points-data-hack-april20/v1/32b-joyous-occasion blocks
             - run:
                 name: Run the Leaderboard
-                run: node frontend/leaderboard/lib/js/src/Main.bs.js
+                command: node frontend/leaderboard/lib/js/src/Main.bs.js
 
     build-macos:
         macos:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -223,7 +223,7 @@ jobs:
                 command: cd frontend/leaderboard/lib/js/src/ && mkdir blocks && gsutil -m rsync gs://points-data-hack-april20/v1/32b-joyous-occasion blocks
             - run:
                 name: Run the Leaderboard
-                run: node frontend/leaderboard/lib/js/src/Main.bs.js
+                command: node frontend/leaderboard/lib/js/src/Main.bs.js
 
     build-macos:
         macos:


### PR DESCRIPTION
This PR:
Fixes an issue made with cron job for the leaderboard. 

The error reported by circleci is as the following:
![image](https://user-images.githubusercontent.com/9512405/85422898-f3b1ef80-b52a-11ea-9087-9e2054f9ad56.png)
