### PR TITLE
Buildkite CI: Better depends_on

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -30,6 +30,15 @@ let B/DependsOn =
           (List/map Text InnerUnion/Type (\(k: Text) -> InnerUnion/Type.DependsOn/Type { allow_failure = None Bool, step = Some k }) keys)
   }
 
+-- A type to make sure we don't accidentally forget the prefix on keys
+let TaggedKey = {
+  Type = {
+    name : Text,
+    key : Text
+  },
+  default = {=}
+}
+
 -- Everything here is taken directly from the buildkite Command documentation
 -- https://buildkite.com/docs/pipelines/command-step#command-step-attributes
 -- except "target" replaces "agents"
@@ -40,14 +49,14 @@ let B/DependsOn =
 let Config =
   { Type =
       { commands : List Cmd.Type
-      , depends_on : List Text
+      , depends_on : List TaggedKey.Type
       , label : Text
       , key : Text
       , target : Size
       , docker : Optional Docker.Type
       }
   , default =
-    { depends_on = [] : List Text
+    { depends_on = [] : List TaggedKey.Type
     , docker = None Docker.Type
     }
   }
@@ -65,15 +74,23 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
       if Prelude.List.null (Map.Entry Text Text) agents then None (Map.Type Text Text) else Some agents,
     commands =
       B.definitions/commandStep/properties/commands/Type.ListString (Decorate.decorateAll c.commands),
-    depends_on = if Prelude.List.null Text c.depends_on then
+    depends_on =
+      let flattened =
+        List/map
+          TaggedKey.Type
+          Text
+          (\(k : TaggedKey.Type) -> "_${k.name}-${k.key}")
+          c.depends_on
+      in
+      if Prelude.List.null Text flattened then
         None B/DependsOn.Type
       else
-        Some (B/DependsOn.depends c.depends_on),
+        Some (B/DependsOn.depends flattened),
     key = Some c.key,
     label = Some c.label,
     plugins =
       Optional/map Docker.Type B/Plugins (\(docker: Docker.Type) -> B/Plugins.Plugins/Type (toMap { `docker#v3.5.0` = docker })) c.docker
   }
 
-in {Config = Config, build = build, Type = B/Command.Type}
+in {Config = Config, build = build, Type = B/Command.Type, TaggedKey = TaggedKey}
 

--- a/buildkite/src/Jobs/Sample2.dhall
+++ b/buildkite/src/Jobs/Sample2.dhall
@@ -22,7 +22,10 @@ in
 Pipeline.build
   Pipeline.Config::{
     spec = JobSpec::{
-      dirtyWhen = [ S.contains "src/lib" ],
+      dirtyWhen = [
+        S.contains "src/lib",
+        S.contains "buildkite"
+      ],
       name = name
     },
     steps = [

--- a/buildkite/src/Jobs/Sample2.dhall
+++ b/buildkite/src/Jobs/Sample2.dhall
@@ -8,21 +8,32 @@ let Command = ../Command/Base.dhall
 let Docker = ../Command/Docker/Type.dhall
 let Size = ../Command/Size.dhall
 
+let c1 = Command.Config::{
+        commands = [ Cmd.run "echo \"hello2\"" ],
+        label = "Test Echo2", key = "hello2",
+        target = Size.Small,
+        docker = Some Docker::{ image = (../Constants/ContainerImages.dhall).toolchainBase }
+        }
+
+let name = "Sample2"
+
 in
 
 Pipeline.build
   Pipeline.Config::{
     spec = JobSpec::{
       dirtyWhen = [ S.contains "src/lib" ],
-      name = "Sample2"
+      name = name
     },
     steps = [
+    Command.build c1,
     Command.build
       Command.Config::{
-        commands = [ Cmd.run "echo \"hello2\"" ],
-        label = "Test Echo2", key = "hello2",
+        commands = [ Cmd.run "echo \"hello again\"" ],
+        label = "Test Echo2", key = "hello-again",
         target = Size.Small,
-        docker = Some Docker::{ image = (../Constants/ContainerImages.dhall).toolchainBase }
+        docker = Some Docker::{ image = (../Constants/ContainerImages.dhall).toolchainBase },
+        depends_on = [ { name = name, key = c1.key } ]
         }
     ]
   }


### PR DESCRIPTION
Since `key` must be globally unique in a composite running buildkite instance, but we're dynamically stitching together different pipelines, I thought it wise to compose the true `key` with the `name` from the spec of a pipeline when it is actually assembled together into yaml.

Since this is opaque from people actually building jobs, it's easy to not know or forget about this behavior and get blocked on steps not running in a pipeline.

To help mitigate this, I changed `depends_on` to take a `TaggedKey`, a key and a name. Now the compiler will help you remember to pass the spec name in. I also included a sample job with a dependency by changing Sample2 (and it works)