### PR TITLE
Readable event ids

### DIFF
--- a/src/lib/ppx_register_event/dune
+++ b/src/lib/ppx_register_event/dune
@@ -2,6 +2,6 @@
  (name ppx_register_event)
  (public_name ppx_register_event)
  (kind ppx_deriver)
- (libraries coda_digestif compiler-libs.common ppxlib core_kernel ppx_deriving_yojson logproc_lib)
+ (libraries compiler-libs.common ppxlib core_kernel ppx_deriving_yojson logproc_lib)
  (preprocess (pps ppx_version ppxlib.metaquot))
  (ppx_runtime_libraries structured_log_events yojson))

--- a/src/lib/ppx_register_event/register_event.ml
+++ b/src/lib/ppx_register_event/register_event.ml
@@ -3,11 +3,7 @@ open Ppxlib
 
 let deriver = "register_event"
 
-let hash name =
-  let open Digestif.SHA256 in
-  let ctx0 = init () in
-  let ctx1 = feed_string ctx0 name in
-  get ctx1 |> to_raw_string
+let digest s = Md5.digest_string s |> Md5.to_hex
 
 let check_interpolations ~loc msg label_names =
   match Ast_convenience.get_str msg with
@@ -134,7 +130,7 @@ let generate_loggers_and_parsers ~loc:_ ~path ty_ext msg_opt =
   [ [%stri
       let ([%p pvar (event_name ^ "_structured_events_id")] :
             Structured_log_events.id) =
-        Structured_log_events.id_of_string [%e estring (hash event_path)]]
+        Structured_log_events.id_of_string [%e estring (digest event_path)]]
   ; [%stri
       let ([%p pvar (event_name ^ "_structured_events_repr")] :
             Structured_log_events.repr) =


### PR DESCRIPTION
The event ids for registered events have been SHA-1 hashes containing arbitrary bytes. When examining a log, those hashes print out as unpleasant garbage. If the bytes happen to be control terminal control characters, reading a log can mess up your terminal.

This PR changes the event ids from SHA-1 hashes to MD5 digests converted to ASCII hex strings.

