### PR TITLE
Fixes typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The [Developer docs](https://codaprotocol.com/docs/developers/) contain all the 
 
 #### Quick Links:
 * [Developer readme](README-dev.md)
-* [Compiling from source and and running a node](docs/demo.md)
+* [Compiling from source and running a node](docs/demo.md)
 * [Directory structure](frontend/website/docs/developers/directory-structure.md)
 * [Lifecycle of a payment](frontend/website/docs/architecture/lifecycle-payment.md)
 


### PR DESCRIPTION
There appears to be a repeated word in the README.

No testing seems necessary for this.
