### PR TITLE
Fixes ocaml lint step

### DIFF
--- a/buildkite/scripts/lint-check-format.sh
+++ b/buildkite/scripts/lint-check-format.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+eval `opam config env` && make check-format

--- a/buildkite/src/Jobs/Lint/OCaml.dhall
+++ b/buildkite/src/Jobs/Lint/OCaml.dhall
@@ -6,18 +6,12 @@ let JobSpec = ../../Pipeline/JobSpec.dhall
 let Cmd = ../../Lib/Cmds.dhall
 
 let Pipeline = ../../Pipeline/Dsl.dhall
-let Command/Coda = ../../Command/Coda.dhall
+let OpamInit = ../../Command/OpamInit.dhall
+let Command = ../../Command/Base.dhall
 let Docker = ../../Command/Docker/Type.dhall
 let Size = ../../Command/Size.dhall
 
-let commands =
-  [
-    Cmd.run "./buildkite/scripts/lint-check-format.sh",
-    Cmd.run "./scripts/require-ppx-version.py"
-  ]
-in
-
-Pipeline.build
+in Pipeline.build
   Pipeline.Config::{
     spec =
       let dirtyDhallDir = S.strictlyStart (S.contains "buildkite/src/Jobs/Lint/OCaml")
@@ -32,11 +26,15 @@ Pipeline.build
         name = "OCaml"
       },
     steps = [
-      Command/Coda.build
-        Command/Coda.Config::{
-          commands = commands,
+      Command.build
+        Command.Config::{
+          commands = OpamInit.andThenRunInDocker (
+            "./buildkite/scripts/lint-check-format.sh && " ++
+            "./scripts/require-ppx-version.py"),
           label = "OCaml Lints; Check-format, Require-ppx-version",
-          key = "check"
+          key = "check",
+          target = Size.Large,
+          docker = None Docker.Type
         }
     ]
   }

--- a/buildkite/src/Jobs/Lint/OCaml.dhall
+++ b/buildkite/src/Jobs/Lint/OCaml.dhall
@@ -12,18 +12,16 @@ let Size = ../../Command/Size.dhall
 
 let commands =
   [
-    Cmd.run "eval $$(opam config env) && make check-format",
+    Cmd.run "./buildkite/scripts/lint-check-format.sh",
     Cmd.run "./scripts/require-ppx-version.py"
   ]
 in
 
 Pipeline.build
   Pipeline.Config::{
-    spec = 
-      let 
-          dirtyDhallDir = S.strictlyStart (S.contains "buildkite/src/Jobs/Lint/OCaml")
-      let 
-          dirtyDhallDirCompiles = assert : S.compile [dirtyDhallDir] === "^buildkite/src/Jobs/Lint/OCaml"
+    spec =
+      let dirtyDhallDir = S.strictlyStart (S.contains "buildkite/src/Jobs/Lint/OCaml")
+      let dirtyDhallDirCompiles = assert : S.compile [dirtyDhallDir] === "^buildkite/src/Jobs/Lint/OCaml"
       in
       JobSpec::{
         dirtyWhen = [


### PR DESCRIPTION
Regression caused from the update to the base toolchain container which no longer has any correct opam deps in it.

We need opam init on this step too (this is also reflected on circle)