### PR TITLE
Add `coda.exe internal dump-structured-events` command

### DIFF
--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -7,5 +7,5 @@
   (modes native)
   (libraries init tests child_processes memory_stats node_addrs_and_ports jemalloc genesis_ledger_helper)
   (preprocessor_deps ../../../config.mlh)
-  (preprocess (pps ppx_coda ppx_version ppx_let ppx_sexp_conv ppx_optcomp))
+  (preprocess (pps ppx_coda ppx_version ppx_let ppx_sexp_conv ppx_optcomp ppx_deriving_yojson))
   (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/lib/ppx_register_event/register_event.ml
+++ b/src/lib/ppx_register_event/register_event.ml
@@ -95,7 +95,7 @@ let generate_loggers_and_parsers ~loc:_ ~path ty_ext msg_opt =
   in
   check_interpolations ~loc:msg_loc msg label_names ;
   let event_name = String.lowercase ctor in
-  let event_path = path ^ "." ^ event_name in
+  let event_path = path ^ "." ^ ctor in
   let split_path = String.split path ~on:'.' in
   let to_yojson = Ppx_deriving_yojson.ser_expr_of_typ in
   let of_yojson = Ppx_deriving_yojson.desu_expr_of_typ in


### PR DESCRIPTION
Sample output:
```bash
$ _build/default/src/app/cli/src/coda.exe internal dump-structured-events -pretty
```
```json
[
  [
    "src/lib/coda_lib/coda_lib.ml.Rebroadcast_transition",
    "e81a9e94463d8fe61fa3f2ed4f5bfc6a",
    [ "state_hash" ]
  ],
  [
    "src/lib/coda_lib/coda_lib.ml.Synced",
    "34413e73c270eec4ce05ab1c93f6de94", []
  ],
  [
    "src/lib/coda_lib/coda_lib.ml.Ledger_catchup",
    "501599549a087a4ccd013187a461c363", []
  ],
  [
    "src/lib/coda_lib/coda_lib.ml.Bootstrapping",
    "e4389364f4c98c689c6556faf4a7ae93", []
  ],
  [
    "src/lib/coda_lib/coda_lib.ml.Listening",
    "be2b8f8a44380187992bd246e24bede0", []
  ],
  [
    "src/lib/coda_lib/coda_lib.ml.Connecting",
    "aa6017b1c3e4fd28f14e86e60750c72a", []
  ],
  [
    "src/lib/snark_worker/functor.ml.Base_snark_generated",
    "885328f9dca84fa1cfb99089080613d6",
    [ "time" ]
  ],
  [
    "src/lib/snark_worker/functor.ml.Merge_snark_generated",
    "bcc5cf56ab582a129736e0906dea7cfa",
    [ "time" ]
  ],
  [
    "src/lib/bootstrap_controller/bootstrap_controller.ml.Bootstrap_complete",
    "10211dce99574d1627cf3c577abeaef8", []
  ],
  [
    "src/lib/block_producer/block_producer.ml.Block_produced",
    "64e2d3e86c37c09b15efdaf7470ce879", []
  ],
  [
    "src/lib/coda_networking/coda_networking.ml.Gossip_snark_pool_diff",
    "7d34e7f7faf38aed17cb2e992d595238",
    [ "work" ]
  ],
  [
    "src/lib/coda_networking/coda_networking.ml.Gossip_transaction_pool_diff",
    "559600825965913542f76778e9aa2e99",
    [ "txns" ]
  ],
  [
    "src/lib/coda_networking/coda_networking.ml.Gossip_new_state",
    "1545437164f4a0cb00c4a91f08783290",
    [ "state_hash" ]
  ],
  [
    "src/lib/coda_networking/coda_networking.ml.Transactions_received",
    "5858c962c699b8a169d1457e8b59779b",
    [ "sender", "txns" ]
  ],
  [
    "src/lib/coda_networking/coda_networking.ml.Snark_work_received",
    "52bf201134af34b30739d57786df2b65",
    [ "sender", "work" ]
  ],
  [
    "src/lib/coda_networking/coda_networking.ml.Block_received",
    "586638300e6d186ec71e4cf1e1808a1b",
    [ "sender", "state_hash" ]
  ],
  [
    "src/lib/syncable_ledger/syncable_ledger.ml.Snarked_ledger_synced",
    "51975e9bb4d823183da96fe7e4d8437e", []
  ],
  [
    "src/lib/trust_system/peer_trust.ml.Make0.Peer_banned",
    "d96f07926929980a90b5f2700c638c63",
    [ "action", "expiration", "peer_id" ]
  ]
]
```

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
