### PR TITLE
Update benchmark build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ web:
 ## Benchmarks
 
 benchmarks:
-	dune build app/benchmarks/main.exe
+	dune build src/app/benchmarks/main.exe
 
 
 ########################################

--- a/src/app/benchmarks/main.ml
+++ b/src/app/benchmarks/main.ml
@@ -7,7 +7,7 @@
 
 open Core_kernel
 
-let available_libraries = ["snark_params"; "vrf_lib_tests"; "coda_base"]
+let available_libraries = ["vrf_lib_tests"; "coda_base"]
 
 let run_benchmarks_in_lib libname =
   Core.printf "Running inline tests in library \"%s\"\n%!" libname ;


### PR DESCRIPTION
Removed `snark_params` from list of benchmarked libraries. Fix `Makefile` so that `make benchmarks` works.