### PR TITLE
Fix error where genesis ledger 'named' file already exists

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -380,12 +380,14 @@ module Ledger = struct
                 }
               in
               let name =
-                match config.base with
-                | Named name ->
+                match (config.base, config.name) with
+                | Named name, _ ->
                     Some name
-                | Accounts accounts ->
+                | _, Some name ->
+                    Some name
+                | Accounts accounts, None ->
                     Some (accounts_name accounts)
-                | Hash _ ->
+                | Hash _, None ->
                     None
               in
               match (tar_path, name) with
@@ -794,7 +796,8 @@ let init_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
          ~default:
            { base= Named Coda_compile_config.genesis_ledger
            ; num_accounts= None
-           ; hash= None })
+           ; hash= None
+           ; name= None })
   in
   let config =
     {config with ledger= Option.map config.ledger ~f:(fun _ -> ledger_config)}

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -395,6 +395,11 @@ module Ledger = struct
                     ^/ named_filename ~constraint_constants
                          ~num_accounts:config.num_accounts name
                   in
+                  (* Delete the file if it already exists. *)
+                  let%bind () =
+                    Deferred.Or_error.try_with (fun () -> Sys.remove link_name)
+                    |> Deferred.ignore
+                  in
                   (* Add a symlink from the named path to the hash path. *)
                   let%map () = Unix.symlink ~target:tar_path ~link_name in
                   Logger.info ~module_:__MODULE__ ~location:__LOC__ logger

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -155,9 +155,9 @@ module Ledger = struct
     in
     "accounts_" ^ Blake2.to_hex hash
 
-  let find_tar ~logger ~constraint_constants (config : Runtime_config.Ledger.t)
-      =
-    let search_paths = Cache_dir.possible_paths "" in
+  let find_tar ~logger ~genesis_dir ~constraint_constants
+      (config : Runtime_config.Ledger.t) =
+    let search_paths = Cache_dir.possible_paths "" @ [genesis_dir] in
     let file_exists filename path =
       let filename = path ^/ filename in
       if%map file_exists ~follow_symlinks:true filename then (
@@ -331,7 +331,9 @@ module Ledger = struct
             accounts
         in
         let open Deferred.Let_syntax in
-        let%bind tar_path = find_tar ~logger ~constraint_constants config in
+        let%bind tar_path =
+          find_tar ~logger ~genesis_dir ~constraint_constants config
+        in
         match tar_path with
         | Some tar_path -> (
             match%map


### PR DESCRIPTION
This PR
* removes the existing ledger symlink before attempting to create a new one
  - this avoids an error where linking would fail if the file existed
* adds support for naming ledgers via the config file
  - now `name` may be used to set as well as retrieve ledgers
  - non-built-in names are supported: `"ledger": {"name": "my-release", "accounts": {...}}` can be retrieved with just `"ledger": {"name": "my-release"}` after the first run
* adds the genesis directory to the list of search paths for ledgers
  - this is probably the root-cause of the error @yourbuddyconner's was seeing, where the ledger existed in the genesis directory but wasn't being found.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: