### PR TITLE
Optional -proof-level flag for snark worker

### DIFF
--- a/src/lib/snark_worker/functor.ml
+++ b/src/lib/snark_worker/functor.ml
@@ -209,7 +209,7 @@ module Make (Inputs : Intf.Inputs_intf) :
           ~doc:"HOST-AND-PORT address daemon is listening on"
       and proof_level =
         flag "proof-level"
-          (required (Arg_type.create Genesis_constants.Proof_level.of_string))
+          (optional (Arg_type.create Genesis_constants.Proof_level.of_string))
           ~doc:"full|check|none"
       and shutdown_on_disconnect =
         flag "shutdown-on-disconnect" (optional bool)
@@ -225,6 +225,10 @@ module Make (Inputs : Intf.Inputs_intf) :
               !"Received signal to terminate. Aborting snark worker process"
               ~module_:__MODULE__ ~location:__LOC__ ;
             Core.exit 0 ) ;
+        let proof_level =
+          Option.value ~default:Genesis_constants.Proof_level.compiled
+            proof_level
+        in
         main
           (module Rpcs_versioned)
           ~logger ~proof_level


### PR DESCRIPTION
This PR makes the `-proof-level` flag optional, defaulting to the compiled proof level.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: