### PR TITLE
[Tokens] Simplify transaction pool

### DIFF
--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -43,7 +43,6 @@ val handle_committed_txn :
      t
   -> User_command.With_valid_signature.t
   -> fee_payer_balance:Currency.Amount.t
-  -> source_balance:Currency.Amount.t
   -> ( t * User_command.With_valid_signature.t Sequence.t
      , [ `Queued_txns_by_sender of
          string * User_command.With_valid_signature.t Sequence.t ] )

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -16,7 +16,7 @@ type t [@@deriving sexp_of]
 (* TODO sexp is debug only, remove *)
 
 (** Empty pool *)
-val empty : t
+val empty : constraint_constants:Genesis_constants.Constraint_constants.t -> t
 
 (** How many transactions are currently in the pool *)
 val size : t -> int

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -24,7 +24,8 @@ module type Resource_pool_base_intf = sig
     transition_frontier_diff -> t -> unit Deferred.t
 
   val create :
-       frontier_broadcast_pipe:transition_frontier Option.t
+       constraint_constants:Genesis_constants.Constraint_constants.t
+    -> frontier_broadcast_pipe:transition_frontier Option.t
                                Broadcast_pipe.Reader.t
     -> config:Config.t
     -> logger:Logger.t
@@ -53,8 +54,7 @@ module type Resource_pool_diff_intf = sig
   conincides with applying locally generated diffs or diffs from the network
   or diffs from transition frontier extensions.*)
   val unsafe_apply :
-       constraint_constants:Genesis_constants.Constraint_constants.t
-    -> pool
+       pool
     -> t Envelope.Incoming.t
     -> ( t * rejected
        , [`Locally_generated of t * rejected | `Other of Error.t] )

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -228,8 +228,6 @@ module type Transaction_pool_diff_intf = sig
       | Invalid_signature
       | Duplicate
       | Sender_account_does_not_exist
-      | Insufficient_amount_for_account_creation
-      | Delegate_not_found
       | Invalid_nonce
       | Insufficient_funds
       | Insufficient_fee

--- a/src/lib/network_pool/network_pool_base.ml
+++ b/src/lib/network_pool/network_pool_base.ml
@@ -41,10 +41,7 @@ end)
         valid_cb true ;
         Linear_pipe.write t.write_broadcasts diff' )
     in
-    match%bind
-      Resource_pool.Diff.unsafe_apply
-        ~constraint_constants:t.constraint_constants t.resource_pool pool_diff
-    with
+    match%bind Resource_pool.Diff.unsafe_apply t.resource_pool pool_diff with
     | Ok res ->
         rebroadcast res
     | Error (`Locally_generated res) ->
@@ -141,8 +138,8 @@ end)
     in
     let t =
       of_resource_pool_and_diffs
-        (Resource_pool.create ~config ~logger ~frontier_broadcast_pipe
-           ~tf_diff_writer)
+        (Resource_pool.create ~constraint_constants ~config ~logger
+           ~frontier_broadcast_pipe ~tf_diff_writer)
         ~constraint_constants ~incoming_diffs ~local_diffs ~logger
         ~tf_diffs:tf_diff_reader
     in

--- a/src/lib/network_pool/snark_pool.ml
+++ b/src/lib/network_pool/snark_pool.ml
@@ -276,7 +276,8 @@ module Make (Transition_frontier : Transition_frontier_intf) :
         in
         Deferred.don't_wait_for tf_deferred
 
-      let create ~frontier_broadcast_pipe ~config ~logger ~tf_diff_writer =
+      let create ~constraint_constants:_ ~frontier_broadcast_pipe ~config
+          ~logger ~tf_diff_writer =
         let t =
           { snark_tables=
               { all= Statement_table.create ()
@@ -516,8 +517,7 @@ let%test_module "random set test" =
         Mock_snark_pool.Resource_pool.Diff.Add_solved_work
           (work, {Priced_proof.Stable.Latest.proof= proof work; fee})
       in
-      Mock_snark_pool.Resource_pool.Diff.unsafe_apply ~constraint_constants
-        resource_pool
+      Mock_snark_pool.Resource_pool.Diff.unsafe_apply resource_pool
         {Envelope.Incoming.data= diff; sender}
 
     let config verifier =

--- a/src/lib/network_pool/snark_pool_diff.ml
+++ b/src/lib/network_pool/snark_pool_diff.ml
@@ -61,8 +61,7 @@ module Make
           ~f:Snark_work_lib.Work.Single.Spec.statement
       , {proof= res.proofs; fee= {fee= res.spec.fee; prover= res.prover}} )
 
-  let unsafe_apply ~constraint_constants:_ (pool : Pool.t)
-      (t : t Envelope.Incoming.t) =
+  let unsafe_apply (pool : Pool.t) (t : t Envelope.Incoming.t) =
     let {Envelope.Incoming.data= diff; sender} = t in
     let is_local = match sender with Local -> true | _ -> false in
     let to_or_error = function

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -454,9 +454,10 @@ struct
                   log_invalid () ) ;
       Deferred.unit
 
-    let create ~frontier_broadcast_pipe ~config ~logger ~tf_diff_writer =
+    let create ~constraint_constants ~frontier_broadcast_pipe ~config ~logger
+        ~tf_diff_writer =
       let t =
-        { pool= Indexed_pool.empty
+        { pool= Indexed_pool.empty ~constraint_constants
         ; locally_generated_uncommitted=
             Hashtbl.create (module User_command.With_valid_signature)
         ; locally_generated_committed=
@@ -598,9 +599,7 @@ struct
 
       let is_empty t = List.is_empty t
 
-      let apply
-          ~(constraint_constants : Genesis_constants.Constraint_constants.t) t
-          env =
+      let apply t env =
         let txs = Envelope.Incoming.data env in
         let sender = Envelope.Incoming.sender env in
         let is_sender_local = Envelope.Sender.(equal sender Local) in
@@ -859,12 +858,8 @@ struct
             in
             go txs t.pool ([], [])
 
-      let unsafe_apply ~constraint_constants t env =
-        match%map apply ~constraint_constants t env with
-        | Ok e ->
-            Ok e
-        | Error e ->
-            Error (`Other e)
+      let unsafe_apply t env =
+        match%map apply t env with Ok e -> Ok e | Error e -> Error (`Other e)
     end
 
     let get_rebroadcastable (t : t) ~is_expired =
@@ -1106,7 +1101,7 @@ let%test_module _ =
           in
           assert_pool_txs [] ;
           let%bind apply_res =
-            Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+            Test.Resource_pool.Diff.unsafe_apply pool
               (Envelope.Incoming.local independent_cmds)
           in
           [%test_eq: pool_apply]
@@ -1162,7 +1157,7 @@ let%test_module _ =
           in
           assert_pool_txs [] ;
           let%bind apply_res =
-            Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+            Test.Resource_pool.Diff.unsafe_apply pool
               ( Envelope.Incoming.local
               @@ (List.hd_exn independent_cmds :: List.drop independent_cmds 2)
               )
@@ -1198,7 +1193,7 @@ let%test_module _ =
               ; reorg_best_tip= false }
           in
           let%bind apply_res =
-            Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+            Test.Resource_pool.Diff.unsafe_apply pool
             @@ Envelope.Incoming.local independent_cmds
           in
           [%test_eq: pool_apply]
@@ -1250,7 +1245,7 @@ let%test_module _ =
                  ~max_fee:10_000_000_000 ())
           in
           let%bind apply_res =
-            Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+            Test.Resource_pool.Diff.unsafe_apply pool
             @@ Envelope.Incoming.local [cmd1]
           in
           [%test_eq: pool_apply] (accepted_user_commands apply_res) (Ok [cmd1]) ;
@@ -1304,7 +1299,7 @@ let%test_module _ =
             Broadcast_pipe.Writer.write frontier_pipe_w (Some frontier1)
           in
           let%bind _ =
-            Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+            Test.Resource_pool.Diff.unsafe_apply pool
               (Envelope.Incoming.local independent_cmds)
           in
           assert_pool_txs @@ independent_cmds ;
@@ -1359,7 +1354,7 @@ let%test_module _ =
       let txs3 = List.map ~f:(set_sender 3) txs0 in
       let txs_all = txs0 @ txs1 @ txs2 @ txs3 in
       let%bind apply_res =
-        Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+        Test.Resource_pool.Diff.unsafe_apply pool
           (Envelope.Incoming.local txs_all)
       in
       [%test_eq: pool_apply] (Ok txs_all) (accepted_user_commands apply_res) ;
@@ -1375,7 +1370,7 @@ let%test_module _ =
           mk_payment 3 10_000_000_000 1 4 927_000_000_000 ]
       in
       let%bind apply_res_2 =
-        Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+        Test.Resource_pool.Diff.unsafe_apply pool
           (Envelope.Incoming.local replace_txs)
       in
       [%test_eq: pool_apply]
@@ -1397,7 +1392,7 @@ let%test_module _ =
       in
       let committed_tx = mk_payment 0 5_000_000_000 0 2 25_000_000_000 in
       let%bind apply_res =
-        Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+        Test.Resource_pool.Diff.unsafe_apply pool
         @@ Envelope.Incoming.local txs
       in
       [%test_eq: pool_apply] (Ok txs) (accepted_user_commands apply_res) ;
@@ -1456,13 +1451,13 @@ let%test_module _ =
               in
               let cmds1, cmds2 = List.split_n cmds pool_max_size in
               let%bind apply_res1 =
-                Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+                Test.Resource_pool.Diff.unsafe_apply pool
                   (Envelope.Incoming.local cmds1)
               in
               assert (Result.is_ok apply_res1) ;
               [%test_eq: int] pool_max_size (Indexed_pool.size pool.pool) ;
               let%map _apply_res2 =
-                Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+                Test.Resource_pool.Diff.unsafe_apply pool
                   (Envelope.Incoming.local cmds2)
               in
               (* N.B. Adding a transaction when the pool is full may drop > 1
@@ -1499,7 +1494,7 @@ let%test_module _ =
           let remote_cmds = List.drop independent_cmds 5 in
           (* Locally generated transactions are rebroadcastable *)
           let%bind apply_res_1 =
-            Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+            Test.Resource_pool.Diff.unsafe_apply pool
               (Envelope.Incoming.local local_cmds)
           in
           [%test_eq: pool_apply]
@@ -1510,7 +1505,7 @@ let%test_module _ =
           (* Adding non-locally-generated transactions doesn't affect
              rebroadcastable pool *)
           let%bind apply_res_2 =
-            Test.Resource_pool.Diff.unsafe_apply ~constraint_constants pool
+            Test.Resource_pool.Diff.unsafe_apply pool
               (Envelope.Incoming.wrap ~data:remote_cmds ~sender:mock_sender)
           in
           [%test_eq: pool_apply]

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -199,7 +199,6 @@ struct
                    in the pool are always valid against the best tip, so
                    no need to check balances here *)
                 ~fee_payer_balance:Currency.Amount.max_int
-                ~source_balance:Currency.Amount.max_int
             with
             | Ok (t, _) ->
                 Some (cmd, t)
@@ -341,8 +340,6 @@ struct
             let fee_payer_balance =
               Currency.Balance.to_amount (balance fee_payer)
             in
-            let source = User_command.source cmd in
-            let source_balance = Currency.Balance.to_amount (balance source) in
             let cmd' =
               User_command.check cmd
               |> Option.value_exn ~message:"user command was invalid"
@@ -361,7 +358,6 @@ struct
             let p', dropped =
               match
                 Indexed_pool.handle_committed_txn p cmd' ~fee_payer_balance
-                  ~source_balance
               with
               | Ok res ->
                   res


### PR DESCRIPTION
This PR simplifies the transaction pool in preparation of the token commands. It
* removes the checks on source accounts
  - these are inherently racy, since they aren't tied to the fee-paying account
  - instead, the transaction logic (and transaction snark) enforce that fees are still charged but the transaction is not applied if it is invalid
* removes the checks on receiver accounts
  - these are also checked in the snark/txn logic, charing the fee on both failure and success
  - the `Create_token_account` command may result in later commands from a sender being valid even though the account doesn't yet exist
* stored the `constraints_constants` in the indexed pool
  - token creation and token account creation are charged to the fee payer, so we need access to the account creation fee there to calculate the amount consumed

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: