### PR TITLE
bazel support: initial minimal commit

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,32 @@
+## Sandboxed build fails; I don't know if this is a bug in OBazl or in Bazel.
+## In any case, until this resolved we must use a different spawn strategy:
+build --spawn_strategy=local
+
+# always enable platform-based toolchain resolution:
+build --incompatible_enable_cc_toolchain_resolution
+
+## for private control over bazel, use ./user.bazelrc
+## (which should be listed in .gitignore)
+
+try-import user.bazelrc
+
+## copy the following to user.bazelrc to get started:
+
+# build --color=yes
+# build --symlink_prefix=.bazel/   # use hidden dir instead of top-level symlinks
+# build --subcommands    # prints build cmd with space-separate args
+# build --subcommands=pretty_print  # same, but args are newline-separated
+# build --verbose_failures
+# build --explain bazel.log
+# build --verbose_explanations
+# build --sandbox_debug
+# build --toolchain_resolution_debug
+# build --show_timestamps
+# build --keep_going
+# build --jobs 600
+# build --toolchain_resolution_debug
+# build --nobuild  # run load and analysis phases only, do not run execution phase
+# query --keep_going
+
+## for development/debugging: use local obazl repo
+# build --override_repository=obazl=/path/to/obazl

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bazel
+user.bazelrc
 _build*
 *.pdf
 *.install

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,27 @@
+################################################################
+##  PLATFORMS (for cross-platform builds)
+
+platform(
+    name = "x86_64-unknown-linux-gnu",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "armv8-rpi3-linux-gnueabihf",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm",
+    ],
+)
+
+platform(
+    name = "x86_64-linux-musl",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+        "//tc:clib_musl",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_r
 git_repository(
     name = "obazl",
     remote = "https://github.com/mobileink/obazl",
-    # branch = "master",
-    commit = "feef897197b36b14b65ffdf00b9badcbdb8f42f4",
-    shallow_since = "1593623637 -0500"
+    branch = "master",
+    # commit = "feef897197b36b14b65ffdf00b9badcbdb8f42f4",
+    # shallow_since = "1593623637 -0500"
 )
 
 load("@obazl//ocaml:deps.bzl",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,40 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+
+################################################################
+#### OCAML ####
+git_repository(
+    name = "obazl",
+    remote = "https://github.com/mobileink/obazl",
+    # branch = "master",
+    commit = "feef897197b36b14b65ffdf00b9badcbdb8f42f4",
+    shallow_since = "1593623637 -0500"
+)
+
+load("@obazl//ocaml:deps.bzl",
+     "ocaml_configure_tooling",
+     # "ocaml_repositories",
+     # "ocaml_home_sdk",
+     "ocaml_register_toolchains")
+
+ocaml_configure_tooling()
+
+ocaml_register_toolchains(installation="host")
+
+git_repository(
+    name = "digestif",
+    branch = "bazel",
+    remote = "https://github.com/mobileink/digestif",
+)
+
+git_repository(
+    name = "ppx_optcomp",
+    branch = "bazel",
+    remote = "https://github.com/mobileink/ppx_optcomp"
+)
+
+git_repository(
+    name = "ppx_version",
+    branch = "bazel",
+    remote = "https://github.com/mobileink/ppx_version",
+)


### PR DESCRIPTION
Signed-off-by: Gregg Reynolds <601396+mobileink@users.noreply.github.com>

Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet.

This is the initial commit for Bazel support. I'm breaking it into small pieces, lots more on the way. It will take several days at least to add all changes.

The changes needed to support Bazel will not interfere with the current build system. so they can be ignored by those without the time for or interest in testing the Bazel code.  The rare exception is when something needs to be changed in order to conform to Bazel's rules; for example, use of ".." in an include path can cause trouble.  In such cases the changes should be very small and simple, and will be submitted as a separate PR.

There are places where Bazel suggests some code reorganization/refactoring.  For example, Bazel can handle conditional compilation, so src/lib/coda_digestif can be removed; the result would be simpler and clearer.  Such opportunities will be clearly identified and proposed as separate subprojects. 

To test, I maintain a Coda fork, plus forks of external repositories used by Coda. Since adding Bazel support involves only adding files, it's easy to keep it in sync with the main Coda repo.  I've tested by building the code and comparing build commands with Dune -verbose log messages.  Where tests are available I make build targets for those too.  Complete testing won't be possible until all the pieces are in place, of course.

One caveat is in order: I've only tested on MacOS Catalina.  I'll be testing on Linux over the next few days. 

I will add detailed documentation and instructions within the next day.

-Gregg

Checklist:

This checklist doesn't really apply at this point in time. No code changes are involved.

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

