### PR TITLE
Expose next_available_token in Blockchain_state.t, route it through to transaction snark

### DIFF
--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -192,6 +192,14 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
                   )
                 ~default:previous_ledger_hash
             in
+            let next_available_token =
+              match ledger_proof_opt with
+              | Some (proof, _) ->
+                  (Ledger_proof.statement proof).next_available_token_after
+              | None ->
+                  previous_protocol_state |> Protocol_state.blockchain_state
+                  |> Blockchain_state.next_available_token
+            in
             let supply_increase =
               Option.value_map ledger_proof_opt
                 ~f:(fun (proof, _) ->
@@ -208,7 +216,7 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
                  has a different slot from the [scheduled_time]
               *)
               Blockchain_state.create_value ~timestamp:scheduled_time
-                ~snarked_ledger_hash:next_ledger_hash
+                ~snarked_ledger_hash:next_ledger_hash ~next_available_token
                 ~staged_ledger_hash:next_staged_ledger_hash
             in
             let current_time =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -192,13 +192,13 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
                   )
                 ~default:previous_ledger_hash
             in
-            let next_available_token =
+            let snarked_next_available_token =
               match ledger_proof_opt with
               | Some (proof, _) ->
                   (Ledger_proof.statement proof).next_available_token_after
               | None ->
                   previous_protocol_state |> Protocol_state.blockchain_state
-                  |> Blockchain_state.next_available_token
+                  |> Blockchain_state.snarked_next_available_token
             in
             let supply_increase =
               Option.value_map ledger_proof_opt
@@ -216,7 +216,8 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
                  has a different slot from the [scheduled_time]
               *)
               Blockchain_state.create_value ~timestamp:scheduled_time
-                ~snarked_ledger_hash:next_ledger_hash ~next_available_token
+                ~snarked_ledger_hash:next_ledger_hash
+                ~snarked_next_available_token
                 ~staged_ledger_hash:next_staged_ledger_hash
             in
             let current_time =

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -130,9 +130,9 @@ module Make_update (T : Transaction_snark.Verification.S) = struct
                |> Blockchain_state.snarked_ledger_hash )
                pending_coinbase_source_stack deleted_stack supply_increase
                ( previous_state |> Protocol_state.blockchain_state
-               |> Blockchain_state.next_available_token )
+               |> Blockchain_state.snarked_next_available_token )
                ( transition |> Snark_transition.blockchain_state
-               |> Blockchain_state.next_available_token )
+               |> Blockchain_state.snarked_next_available_token )
                (As_prover.return
                   (Option.value ~default:Tock.Proof.dummy
                      (Snark_transition.ledger_proof transition))))

--- a/src/lib/blockchain_snark/blockchain_snark_state.ml
+++ b/src/lib/blockchain_snark/blockchain_snark_state.ml
@@ -47,7 +47,7 @@ module Make_update (T : Transaction_snark.Verification.S) = struct
       | Genesis_constants.Proof_level.Full ->
           T.verify_complete_merge
       | _ ->
-          fun _ _ _ _ _ _ _ -> Checked.return Boolean.true_
+          fun _ _ _ _ _ _ _ _ _ -> Checked.return Boolean.true_
 
     let%snarkydef update ~(logger : Logger.t) ~proof_level
         ~constraint_constants
@@ -129,6 +129,10 @@ module Make_update (T : Transaction_snark.Verification.S) = struct
                ( transition |> Snark_transition.blockchain_state
                |> Blockchain_state.snarked_ledger_hash )
                pending_coinbase_source_stack deleted_stack supply_increase
+               ( previous_state |> Protocol_state.blockchain_state
+               |> Blockchain_state.next_available_token )
+               ( transition |> Snark_transition.blockchain_state
+               |> Blockchain_state.next_available_token )
                (As_prover.return
                   (Option.value ~default:Tock.Proof.dummy
                      (Snark_transition.ledger_proof transition))))

--- a/src/lib/coda_base/account.ml
+++ b/src/lib/coda_base/account.ml
@@ -499,6 +499,8 @@ type t = Stable.Latest.t [@@deriving sexp, eq, hash, compare, yojson]
 [%%define_locally
 Stable.Latest.(public_key)]
 
+let token {Poly.token_id; _} = token_id
+
 let identifier ({public_key; token_id; _} : t) =
   Account_id.create public_key token_id
 

--- a/src/lib/coda_base/sparse_ledger.mli
+++ b/src/lib/coda_base/sparse_ledger.mli
@@ -1,6 +1,7 @@
 open Core
 open Snark_params.Tick
 
+[%%versioned:
 module Stable : sig
   module V1 : sig
     type t =
@@ -9,11 +10,9 @@ module Stable : sig
       , Account.Stable.V1.t
       , Token_id.Stable.V1.t )
       Sparse_ledger_lib.Sparse_ledger.T.Stable.V1.t
-    [@@deriving bin_io, sexp, to_yojson, version]
+    [@@deriving sexp, to_yojson]
   end
-
-  module Latest = V1
-end
+end]
 
 type t = Stable.Latest.t [@@deriving to_yojson, sexp]
 

--- a/src/lib/coda_base/sparse_ledger.mli
+++ b/src/lib/coda_base/sparse_ledger.mli
@@ -6,7 +6,8 @@ module Stable : sig
     type t =
       ( Ledger_hash.Stable.V1.t
       , Account_id.Stable.V1.t
-      , Account.Stable.V1.t )
+      , Account.Stable.V1.t
+      , Token_id.Stable.V1.t )
       Sparse_ledger_lib.Sparse_ledger.T.Stable.V1.t
     [@@deriving bin_io, sexp, to_yojson, version]
   end
@@ -18,6 +19,8 @@ type t = Stable.Latest.t [@@deriving to_yojson, sexp]
 
 val merkle_root : t -> Ledger_hash.t
 
+val next_available_token : t -> Token_id.t
+
 val get_exn : t -> int -> Account.t
 
 val path_exn :
@@ -25,7 +28,8 @@ val path_exn :
 
 val find_index_exn : t -> Account_id.t -> int
 
-val of_root : depth:int -> Ledger_hash.t -> t
+val of_root :
+  depth:int -> next_available_token:Token_id.t -> Ledger_hash.t -> t
 
 val apply_user_command_exn :
      constraint_constants:Genesis_constants.Constraint_constants.t

--- a/src/lib/coda_base/transaction_union.ml
+++ b/src/lib/coda_base/transaction_union.ml
@@ -97,3 +97,6 @@ let fee_excess (t : t) = Transaction_union_payload.fee_excess t.payload
 
 let supply_increase (t : t) =
   Transaction_union_payload.supply_increase t.payload
+
+let next_available_token (t : t) tid =
+  Transaction_union_payload.next_available_token t.payload tid

--- a/src/lib/coda_base/transaction_union_payload.ml
+++ b/src/lib/coda_base/transaction_union_payload.ml
@@ -231,3 +231,14 @@ let supply_increase (payload : payload) =
       payload.body.amount
   | Payment | Stake_delegation | Create_account | Fee_transfer ->
       Amount.zero
+
+let next_available_token (payload : payload) tid =
+  match payload.body.tag with
+  | Payment | Stake_delegation | Coinbase | Fee_transfer ->
+      tid
+  | Create_account when Token_id.(equal invalid) payload.body.token_id ->
+      (* Creating a new token. *)
+      Token_id.next tid
+  | Create_account ->
+      (* Creating an account for an existing token. *)
+      tid

--- a/src/lib/coda_state/blockchain_state.ml
+++ b/src/lib/coda_state/blockchain_state.ml
@@ -6,24 +6,30 @@ module Poly = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type ('staged_ledger_hash, 'snarked_ledger_hash, 'time) t =
+      type ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) t =
         { staged_ledger_hash: 'staged_ledger_hash
         ; snarked_ledger_hash: 'snarked_ledger_hash
+        ; next_available_token: 'token_id
         ; timestamp: 'time }
       [@@deriving bin_io, sexp, fields, eq, compare, hash, yojson, version]
     end
   end]
 
-  type ('staged_ledger_hash, 'snarked_ledger_hash, 'time) t =
-        ('staged_ledger_hash, 'snarked_ledger_hash, 'time) Stable.Latest.t =
+  type ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) t =
+        ( 'staged_ledger_hash
+        , 'snarked_ledger_hash
+        , 'token_id
+        , 'time )
+        Stable.Latest.t =
     { staged_ledger_hash: 'staged_ledger_hash
     ; snarked_ledger_hash: 'snarked_ledger_hash
+    ; next_available_token: 'token_id
     ; timestamp: 'time }
   [@@deriving sexp, fields, eq, compare, hash, yojson]
 end
 
 [%%define_locally
-Poly.(staged_ledger_hash, snarked_ledger_hash, timestamp)]
+Poly.(staged_ledger_hash, snarked_ledger_hash, next_available_token, timestamp)]
 
 module Value = struct
   [%%versioned
@@ -32,6 +38,7 @@ module Value = struct
       type t =
         ( Staged_ledger_hash.Stable.V1.t
         , Frozen_ledger_hash.Stable.V1.t
+        , Token_id.Stable.V1.t
         , Block_time.Stable.V1.t )
         Poly.Stable.V1.t
       [@@deriving sexp, eq, compare, hash, yojson]
@@ -46,69 +53,91 @@ end
 type var =
   ( Staged_ledger_hash.var
   , Frozen_ledger_hash.var
+  , Token_id.var
   , Block_time.Unpacked.var )
   Poly.t
 
-let create_value ~staged_ledger_hash ~snarked_ledger_hash ~timestamp =
-  {Poly.staged_ledger_hash; snarked_ledger_hash; timestamp}
+let create_value ~staged_ledger_hash ~snarked_ledger_hash ~next_available_token
+    ~timestamp =
+  { Poly.staged_ledger_hash
+  ; snarked_ledger_hash
+  ; next_available_token
+  ; timestamp }
 
-let to_hlist Poly.{staged_ledger_hash; snarked_ledger_hash; timestamp} =
-  H_list.[staged_ledger_hash; snarked_ledger_hash; timestamp]
+let to_hlist
+    Poly.
+      {staged_ledger_hash; snarked_ledger_hash; next_available_token; timestamp}
+    =
+  H_list.
+    [staged_ledger_hash; snarked_ledger_hash; next_available_token; timestamp]
 
-let of_hlist :
-    (unit, 'lbh -> 'lh -> 'ti -> unit) H_list.t -> ('lbh, 'lh, 'ti) Poly.t =
-  H_list.(
-    fun [staged_ledger_hash; snarked_ledger_hash; timestamp] ->
-      {staged_ledger_hash; snarked_ledger_hash; timestamp})
+let of_hlist : (unit, _) H_list.t -> _ Poly.t =
+ fun [staged_ledger_hash; snarked_ledger_hash; next_available_token; timestamp] ->
+  {staged_ledger_hash; snarked_ledger_hash; next_available_token; timestamp}
 
 let data_spec =
   let open Data_spec in
-  [Staged_ledger_hash.typ; Frozen_ledger_hash.typ; Block_time.Unpacked.typ]
+  [ Staged_ledger_hash.typ
+  ; Frozen_ledger_hash.typ
+  ; Token_id.typ
+  ; Block_time.Unpacked.typ ]
 
 let typ : (var, Value.t) Typ.t =
   Typ.of_hlistable data_spec ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist
     ~value_to_hlist:to_hlist ~value_of_hlist:of_hlist
 
-let var_to_input ({staged_ledger_hash; snarked_ledger_hash; timestamp} : var) =
+let var_to_input
+    ({staged_ledger_hash; snarked_ledger_hash; next_available_token; timestamp} :
+      var) =
   let open Random_oracle.Input in
+  let%map.Checked next_available_token =
+    Token_id.Checked.to_input next_available_token
+  in
   List.reduce_exn ~f:append
     [ Staged_ledger_hash.var_to_input staged_ledger_hash
     ; field (Frozen_ledger_hash.var_to_hash_packed snarked_ledger_hash)
+    ; next_available_token
     ; bitstring
         (Bitstring_lib.Bitstring.Lsb_first.to_list
            (Block_time.Unpacked.var_to_bits timestamp)) ]
 
-let to_input ({staged_ledger_hash; snarked_ledger_hash; timestamp} : Value.t) =
+let to_input
+    ({staged_ledger_hash; snarked_ledger_hash; next_available_token; timestamp} :
+      Value.t) =
   let open Random_oracle.Input in
   List.reduce_exn ~f:append
     [ Staged_ledger_hash.to_input staged_ledger_hash
     ; field (snarked_ledger_hash :> Field.t)
+    ; Token_id.to_input next_available_token
     ; bitstring (Block_time.Bits.to_bits timestamp) ]
 
 let set_timestamp t timestamp = {t with Poly.timestamp}
 
 let negative_one
     ~(constraint_constants : Genesis_constants.Constraint_constants.t)
-    ~genesis_ledger_hash =
-  Poly.
-    { staged_ledger_hash=
-        Staged_ledger_hash.genesis ~constraint_constants ~genesis_ledger_hash
-    ; snarked_ledger_hash=
-        Frozen_ledger_hash.of_ledger_hash genesis_ledger_hash
-    ; timestamp= Block_time.of_time Time.epoch }
+    ~genesis_ledger_hash ~next_available_token : Value.t =
+  { staged_ledger_hash=
+      Staged_ledger_hash.genesis ~constraint_constants ~genesis_ledger_hash
+  ; snarked_ledger_hash= Frozen_ledger_hash.of_ledger_hash genesis_ledger_hash
+  ; next_available_token
+  ; timestamp= Block_time.of_time Time.epoch }
 
 (* negative_one and genesis blockchain states are equivalent *)
 let genesis = negative_one
 
-type display = (string, string, string) Poly.t [@@deriving yojson]
+type display = (string, string, string, string) Poly.t [@@deriving yojson]
 
-let display Poly.{staged_ledger_hash; snarked_ledger_hash; timestamp} =
+let display
+    Poly.
+      {staged_ledger_hash; snarked_ledger_hash; next_available_token; timestamp}
+    =
   { Poly.staged_ledger_hash=
       Visualization.display_prefix_of_string @@ Ledger_hash.to_string
       @@ Staged_ledger_hash.ledger_hash staged_ledger_hash
   ; snarked_ledger_hash=
       Visualization.display_prefix_of_string
       @@ Frozen_ledger_hash.to_string snarked_ledger_hash
+  ; next_available_token= Token_id.to_string next_available_token
   ; timestamp=
       Time.to_string_trimmed ~zone:Time.Zone.utc (Block_time.to_time timestamp)
   }

--- a/src/lib/coda_state/blockchain_state.mli
+++ b/src/lib/coda_state/blockchain_state.mli
@@ -6,18 +6,24 @@ module Poly : sig
   [%%versioned:
   module Stable : sig
     module V1 : sig
-      type ('staged_ledger_hash, 'snarked_ledger_hash, 'time) t =
+      type ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) t =
         { staged_ledger_hash: 'staged_ledger_hash
         ; snarked_ledger_hash: 'snarked_ledger_hash
+        ; next_available_token: 'token_id
         ; timestamp: 'time }
       [@@deriving sexp, eq, compare, yojson]
     end
   end]
 
-  type ('staged_ledger_hash, 'snarked_ledger_hash, 'time) t =
-        ('staged_ledger_hash, 'snarked_ledger_hash, 'time) Stable.Latest.t =
+  type ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) t =
+        ( 'staged_ledger_hash
+        , 'snarked_ledger_hash
+        , 'token_id
+        , 'time )
+        Stable.Latest.t =
     { staged_ledger_hash: 'staged_ledger_hash
     ; snarked_ledger_hash: 'snarked_ledger_hash
+    ; next_available_token: 'token_id
     ; timestamp: 'time }
   [@@deriving sexp, eq, compare, fields, yojson]
 end
@@ -29,6 +35,7 @@ module Value : sig
       type t =
         ( Staged_ledger_hash.Stable.V1.t
         , Frozen_ledger_hash.Stable.V1.t
+        , Token_id.Stable.V1.t
         , Block_time.Stable.V1.t )
         Poly.Stable.V1.t
       [@@deriving sexp, eq, compare, hash, yojson]
@@ -43,40 +50,50 @@ include
   with type var =
               ( Staged_ledger_hash.var
               , Frozen_ledger_hash.var
+              , Token_id.var
               , Block_time.Unpacked.var )
               Poly.t
    and type value := Value.t
 
 val staged_ledger_hash :
-  ('staged_ledger_hash, _, _) Poly.t -> 'staged_ledger_hash
+  ('staged_ledger_hash, _, _, _) Poly.t -> 'staged_ledger_hash
 
 val snarked_ledger_hash :
-  (_, 'snarked_ledger_hash, _) Poly.t -> 'snarked_ledger_hash
+  (_, 'snarked_ledger_hash, _, _) Poly.t -> 'snarked_ledger_hash
 
-val timestamp : (_, _, 'time) Poly.t -> 'time
+val next_available_token : (_, _, 'token_id, _) Poly.t -> 'token_id
+
+val timestamp : (_, _, _, 'time) Poly.t -> 'time
 
 val create_value :
      staged_ledger_hash:Staged_ledger_hash.t
   -> snarked_ledger_hash:Frozen_ledger_hash.t
+  -> next_available_token:Token_id.t
   -> timestamp:Block_time.t
   -> Value.t
 
 val negative_one :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> genesis_ledger_hash:Ledger_hash.t
+  -> next_available_token:Token_id.t
   -> Value.t
 
 val genesis :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> genesis_ledger_hash:Ledger_hash.t
+  -> next_available_token:Token_id.t
   -> Value.t
 
-val set_timestamp : ('a, 'b, 'c) Poly.t -> 'c -> ('a, 'b, 'c) Poly.t
+val set_timestamp :
+     ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) Poly.t
+  -> 'time
+  -> ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) Poly.t
 
 val to_input : Value.t -> (Field.t, bool) Random_oracle.Input.t
 
-val var_to_input : var -> (Field.Var.t, Boolean.var) Random_oracle.Input.t
+val var_to_input :
+  var -> ((Field.Var.t, Boolean.var) Random_oracle.Input.t, _) Checked.t
 
-type display = (string, string, string) Poly.t [@@deriving yojson]
+type display = (string, string, string, string) Poly.t [@@deriving yojson]
 
 val display : Value.t -> display

--- a/src/lib/coda_state/blockchain_state.mli
+++ b/src/lib/coda_state/blockchain_state.mli
@@ -9,7 +9,7 @@ module Poly : sig
       type ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) t =
         { staged_ledger_hash: 'staged_ledger_hash
         ; snarked_ledger_hash: 'snarked_ledger_hash
-        ; next_available_token: 'token_id
+        ; snarked_next_available_token: 'token_id
         ; timestamp: 'time }
       [@@deriving sexp, eq, compare, yojson]
     end
@@ -23,7 +23,7 @@ module Poly : sig
         Stable.Latest.t =
     { staged_ledger_hash: 'staged_ledger_hash
     ; snarked_ledger_hash: 'snarked_ledger_hash
-    ; next_available_token: 'token_id
+    ; snarked_next_available_token: 'token_id
     ; timestamp: 'time }
   [@@deriving sexp, eq, compare, fields, yojson]
 end
@@ -61,27 +61,27 @@ val staged_ledger_hash :
 val snarked_ledger_hash :
   (_, 'snarked_ledger_hash, _, _) Poly.t -> 'snarked_ledger_hash
 
-val next_available_token : (_, _, 'token_id, _) Poly.t -> 'token_id
+val snarked_next_available_token : (_, _, 'token_id, _) Poly.t -> 'token_id
 
 val timestamp : (_, _, _, 'time) Poly.t -> 'time
 
 val create_value :
      staged_ledger_hash:Staged_ledger_hash.t
   -> snarked_ledger_hash:Frozen_ledger_hash.t
-  -> next_available_token:Token_id.t
+  -> snarked_next_available_token:Token_id.t
   -> timestamp:Block_time.t
   -> Value.t
 
 val negative_one :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> genesis_ledger_hash:Ledger_hash.t
-  -> next_available_token:Token_id.t
+  -> snarked_next_available_token:Token_id.t
   -> Value.t
 
 val genesis :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> genesis_ledger_hash:Ledger_hash.t
-  -> next_available_token:Token_id.t
+  -> snarked_next_available_token:Token_id.t
   -> Value.t
 
 val set_timestamp :

--- a/src/lib/coda_state/genesis_protocol_state.ml
+++ b/src/lib/coda_state/genesis_protocol_state.ml
@@ -3,7 +3,7 @@ open Coda_base
 
 let t ~genesis_ledger ~constraint_constants ~consensus_constants =
   let genesis_ledger_hash = Ledger.merkle_root (Lazy.force genesis_ledger) in
-  let next_available_token =
+  let snarked_next_available_token =
     Ledger.next_available_token (Lazy.force genesis_ledger)
   in
   let protocol_constants =
@@ -26,7 +26,7 @@ let t ~genesis_ledger ~constraint_constants ~consensus_constants =
       ~previous_state_hash:negative_one_protocol_state_hash
       ~blockchain_state:
         (Blockchain_state.genesis ~constraint_constants ~genesis_ledger_hash
-           ~next_available_token)
+           ~snarked_next_available_token)
       ~consensus_state:genesis_consensus_state ~constants:protocol_constants
   in
   With_hash.of_data ~hash_data:Protocol_state.hash state

--- a/src/lib/coda_state/genesis_protocol_state.ml
+++ b/src/lib/coda_state/genesis_protocol_state.ml
@@ -3,6 +3,9 @@ open Coda_base
 
 let t ~genesis_ledger ~constraint_constants ~consensus_constants =
   let genesis_ledger_hash = Ledger.merkle_root (Lazy.force genesis_ledger) in
+  let next_available_token =
+    Ledger.next_available_token (Lazy.force genesis_ledger)
+  in
   let protocol_constants =
     Consensus.Constants.to_protocol_constants consensus_constants
   in
@@ -22,7 +25,8 @@ let t ~genesis_ledger ~constraint_constants ~consensus_constants =
       ~genesis_state_hash:negative_one_protocol_state_hash
       ~previous_state_hash:negative_one_protocol_state_hash
       ~blockchain_state:
-        (Blockchain_state.genesis ~constraint_constants ~genesis_ledger_hash)
+        (Blockchain_state.genesis ~constraint_constants ~genesis_ledger_hash
+           ~next_available_token)
       ~consensus_state:genesis_consensus_state ~constants:protocol_constants
   in
   With_hash.of_data ~hash_data:Protocol_state.hash state

--- a/src/lib/coda_state/protocol_state.ml
+++ b/src/lib/coda_state/protocol_state.ml
@@ -293,7 +293,7 @@ let negative_one ~genesis_ledger ~constraint_constants ~consensus_constants =
           Blockchain_state.negative_one ~constraint_constants
             ~genesis_ledger_hash:
               (Coda_base.Ledger.merkle_root (Lazy.force genesis_ledger))
-            ~next_available_token:
+            ~snarked_next_available_token:
               (Coda_base.Ledger.next_available_token
                  (Lazy.force genesis_ledger))
       ; genesis_state_hash= State_hash.of_hash Outside_hash_image.t

--- a/src/lib/coda_state/protocol_state.ml
+++ b/src/lib/coda_state/protocol_state.ml
@@ -132,7 +132,9 @@ module Body = struct
 
   let var_to_input
       {Poly.genesis_state_hash; blockchain_state; consensus_state; constants} =
-    let blockchain_state = Blockchain_state.var_to_input blockchain_state in
+    let%bind blockchain_state =
+      Blockchain_state.var_to_input blockchain_state
+    in
     let%bind constants = Protocol_constants_checked.var_to_input constants in
     let%map consensus_state =
       Consensus.Data.Consensus_state.var_to_input consensus_state
@@ -291,6 +293,9 @@ let negative_one ~genesis_ledger ~constraint_constants ~consensus_constants =
           Blockchain_state.negative_one ~constraint_constants
             ~genesis_ledger_hash:
               (Coda_base.Ledger.merkle_root (Lazy.force genesis_ledger))
+            ~next_available_token:
+              (Coda_base.Ledger.next_available_token
+                 (Lazy.force genesis_ledger))
       ; genesis_state_hash= State_hash.of_hash Outside_hash_image.t
       ; consensus_state=
           Consensus.Data.Consensus_state.negative_one ~genesis_ledger

--- a/src/lib/coda_state/snark_transition.ml
+++ b/src/lib/coda_state/snark_transition.ml
@@ -109,7 +109,8 @@ let genesis ~constraint_constants ~genesis_ledger : value =
   { Poly.blockchain_state=
       Blockchain_state.genesis ~constraint_constants
         ~genesis_ledger_hash:(Ledger.merkle_root genesis_ledger)
-        ~next_available_token:(Ledger.next_available_token genesis_ledger)
+        ~snarked_next_available_token:
+          (Ledger.next_available_token genesis_ledger)
   ; consensus_transition= Consensus.Data.Consensus_transition.genesis
   ; supply_increase= Currency.Amount.zero
   ; sok_digest=

--- a/src/lib/coda_state/snark_transition.ml
+++ b/src/lib/coda_state/snark_transition.ml
@@ -109,6 +109,7 @@ let genesis ~constraint_constants ~genesis_ledger : value =
   { Poly.blockchain_state=
       Blockchain_state.genesis ~constraint_constants
         ~genesis_ledger_hash:(Ledger.merkle_root genesis_ledger)
+        ~next_available_token:(Ledger.next_available_token genesis_ledger)
   ; consensus_transition= Consensus.Data.Consensus_transition.genesis
   ; supply_increase= Currency.Amount.zero
   ; sok_digest=

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -31,13 +31,17 @@ module type Blockchain_state = sig
     [%%versioned:
     module Stable : sig
       module V1 : sig
-        type ('staged_ledger_hash, 'snarked_ledger_hash, 'time) t
+        type ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) t
         [@@deriving sexp]
       end
     end]
 
-    type ('staged_ledger_hash, 'snarked_ledger_hash, 'time) t =
-      ('staged_ledger_hash, 'snarked_ledger_hash, 'time) Stable.Latest.t
+    type ('staged_ledger_hash, 'snarked_ledger_hash, 'token_id, 'time) t =
+      ( 'staged_ledger_hash
+      , 'snarked_ledger_hash
+      , 'token_id
+      , 'time )
+      Stable.Latest.t
     [@@deriving sexp]
   end
 
@@ -46,7 +50,11 @@ module type Blockchain_state = sig
     module Stable : sig
       module V1 : sig
         type t =
-          (Staged_ledger_hash.t, Frozen_ledger_hash.t, Block_time.t) Poly.t
+          ( Staged_ledger_hash.t
+          , Frozen_ledger_hash.t
+          , Token_id.t
+          , Block_time.t )
+          Poly.t
         [@@deriving sexp]
       end
     end]
@@ -57,22 +65,26 @@ module type Blockchain_state = sig
   type var =
     ( Staged_ledger_hash.var
     , Frozen_ledger_hash.var
+    , Token_id.var
     , Block_time.Unpacked.var )
     Poly.t
 
   val create_value :
        staged_ledger_hash:Staged_ledger_hash.t
     -> snarked_ledger_hash:Frozen_ledger_hash.t
+    -> next_available_token:Token_id.t
     -> timestamp:Block_time.t
     -> Value.t
 
   val staged_ledger_hash :
-    ('staged_ledger_hash, _, _) Poly.t -> 'staged_ledger_hash
+    ('staged_ledger_hash, _, _, _) Poly.t -> 'staged_ledger_hash
 
   val snarked_ledger_hash :
-    (_, 'frozen_ledger_hash, _) Poly.t -> 'frozen_ledger_hash
+    (_, 'frozen_ledger_hash, _, _) Poly.t -> 'frozen_ledger_hash
 
-  val timestamp : (_, _, 'time) Poly.t -> 'time
+  val next_available_token : (_, _, 'token_id, _) Poly.t -> 'token_id
+
+  val timestamp : (_, _, _, 'time) Poly.t -> 'time
 end
 
 module type Protocol_state = sig

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -72,7 +72,7 @@ module type Blockchain_state = sig
   val create_value :
        staged_ledger_hash:Staged_ledger_hash.t
     -> snarked_ledger_hash:Frozen_ledger_hash.t
-    -> next_available_token:Token_id.t
+    -> snarked_next_available_token:Token_id.t
     -> timestamp:Block_time.t
     -> Value.t
 
@@ -82,7 +82,7 @@ module type Blockchain_state = sig
   val snarked_ledger_hash :
     (_, 'frozen_ledger_hash, _, _) Poly.t -> 'frozen_ledger_hash
 
-  val next_available_token : (_, _, 'token_id, _) Poly.t -> 'token_id
+  val snarked_next_available_token : (_, _, 'token_id, _) Poly.t -> 'token_id
 
   val timestamp : (_, _, _, 'time) Poly.t -> 'time
 end

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -34,11 +34,14 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
                  ; target
                  ; supply_increase
                  ; fee_excess
+                 ; next_available_token_before
+                 ; next_available_token_after
                  ; pending_coinbase_stack_state
                  ; proof_type
                  ; sok_digest= () } ~sok_digest ~proof =
     Transaction_snark.create ~source ~target ~pending_coinbase_stack_state
-      ~supply_increase ~fee_excess ~sok_digest ~proof ~proof_type
+      ~supply_increase ~fee_excess ~next_available_token_before
+      ~next_available_token_after ~sok_digest ~proof ~proof_type
 end
 
 module Debug :

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -441,17 +441,19 @@ module Make (Inputs : Inputs_intf.S) = struct
 
       let set_raw_account_batch t locations_and_accounts =
         let next_available_token = next_available_token t in
-        let new_next_available_token = ref next_available_token in
-        List.iter locations_and_accounts ~f:(fun (location, account) ->
-            let token = Account.token account in
-            new_next_available_token :=
-              Token_id.max !new_next_available_token (Token_id.next token) ;
-            if Account.token_owner account then
-              Token_id.Table.set t.token_owners ~key:token
-                ~data:(Account_id.public_key (Account.identifier account)) ;
-            self_set_account t location account ) ;
-        if Token_id.(next_available_token < !new_next_available_token) then
-          set_next_available_token t !new_next_available_token
+        let new_next_available_token =
+          List.fold ~init:next_available_token locations_and_accounts
+            ~f:(fun next_available_token (location, account) ->
+              let account_token = Account.token account in
+              if Account.token_owner account then
+                Token_id.Table.set t.token_owners ~key:account_token
+                  ~data:(Account_id.public_key (Account.identifier account)) ;
+              self_set_account t location account ;
+              Token_id.max next_available_token (Token_id.next account_token)
+          )
+        in
+        if Token_id.(next_available_token < new_next_available_token) then
+          set_next_available_token t new_next_available_token
     end)
 
     let set_batch_accounts t addresses_and_accounts =

--- a/src/lib/merkle_mask/masking_merkle_tree.ml
+++ b/src/lib/merkle_mask/masking_merkle_tree.ml
@@ -445,7 +445,7 @@ module Make (Inputs : Inputs_intf.S) = struct
         List.iter locations_and_accounts ~f:(fun (location, account) ->
             let token = Account.token account in
             new_next_available_token :=
-              Token_id.max token (Token_id.next !new_next_available_token) ;
+              Token_id.max !new_next_available_token (Token_id.next token) ;
             if Account.token_owner account then
               Token_id.Table.set t.token_owners ~key:token
                 ~data:(Account_id.public_key (Account.identifier account)) ;

--- a/src/lib/snark_worker/prod.ml
+++ b/src/lib/snark_worker/prod.ml
@@ -104,6 +104,8 @@ module Inputs = struct
                           { Transaction_protocol_state.Poly.transaction= t
                           ; block_data= w.protocol_state_body }
                           ~init_stack:w.init_stack
+                          ~next_available_token:
+                            input.next_available_token_before
                           ~pending_coinbase_stack_state:
                             input
                               .Transaction_snark.Statement
@@ -126,6 +128,8 @@ module Inputs = struct
                  ~proof_type ~supply_increase:stmt.supply_increase
                  ~pending_coinbase_stack_state:
                    stmt.pending_coinbase_stack_state
+                 ~next_available_token_before:stmt.next_available_token_before
+                 ~next_available_token_after:stmt.next_available_token_after
                  ~fee_excess:stmt.fee_excess ~sok_digest
                  ~proof:Precomputed_values.unit_test_base_proof
              , Time.Span.zero )

--- a/src/lib/sparse_ledger_lib/sparse_ledger.ml
+++ b/src/lib/sparse_ledger_lib/sparse_ledger.ml
@@ -23,29 +23,37 @@ module T = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type ('hash, 'key, 'account) t =
+      type ('hash, 'key, 'account, 'token_id) t =
         { indexes: ('key * int) list
         ; depth: int
-        ; tree: ('hash, 'account) Tree.Stable.V1.t }
+        ; tree: ('hash, 'account) Tree.Stable.V1.t
+        ; next_available_token: 'token_id }
       [@@deriving sexp, to_yojson]
     end
   end]
 
-  type ('hash, 'key, 'account) t = ('hash, 'key, 'account) Stable.Latest.t =
-    {indexes: ('key * int) list; depth: int; tree: ('hash, 'account) Tree.t}
+  type ('hash, 'key, 'account, 'token_id) t =
+        ('hash, 'key, 'account, 'token_id) Stable.Latest.t =
+    { indexes: ('key * int) list
+    ; depth: int
+    ; tree: ('hash, 'account) Tree.t
+    ; next_available_token: 'token_id }
   [@@deriving sexp, to_yojson]
 end
 
 module type S = sig
   type hash
 
+  type token_id
+
   type account_id
 
   type account
 
-  type t = (hash, account_id, account) T.t [@@deriving sexp, to_yojson]
+  type t = (hash, account_id, account, token_id) T.t
+  [@@deriving sexp, to_yojson]
 
-  val of_hash : depth:int -> hash -> t
+  val of_hash : depth:int -> next_available_token:token_id -> hash -> t
 
   val get_exn : t -> int -> account
 
@@ -61,34 +69,48 @@ module type S = sig
   val iteri : t -> f:(int -> account -> unit) -> unit
 
   val merkle_root : t -> hash
+
+  val next_available_token : t -> token_id
 end
 
 let tree {T.tree; _} = tree
 
-let of_hash ~depth h = {T.indexes= []; depth; tree= Hash h}
+let of_hash ~depth ~next_available_token h =
+  {T.indexes= []; depth; tree= Hash h; next_available_token}
 
 module Make (Hash : sig
   type t [@@deriving eq, sexp, to_yojson, compare]
 
   val merge : height:int -> t -> t -> t
+end) (Token_id : sig
+  type t [@@deriving sexp, to_yojson]
+
+  val next : t -> t
+
+  val max : t -> t -> t
 end) (Account_id : sig
   type t [@@deriving eq, sexp, to_yojson]
 end) (Account : sig
   type t [@@deriving eq, sexp, to_yojson]
 
   val data_hash : t -> Hash.t
+
+  val token : t -> Token_id.t
 end) : sig
   include
     S
     with type hash := Hash.t
+     and type token_id := Token_id.t
      and type account_id := Account_id.t
      and type account := Account.t
 
   val hash : (Hash.t, Account.t) Tree.t -> Hash.t
 end = struct
-  type t = (Hash.t, Account_id.t, Account.t) T.t [@@deriving sexp, to_yojson]
+  type t = (Hash.t, Account_id.t, Account.t, Token_id.t) T.t
+  [@@deriving sexp, to_yojson]
 
-  let of_hash ~depth (hash : Hash.t) = of_hash ~depth hash
+  let of_hash ~depth ~next_available_token (hash : Hash.t) =
+    of_hash ~depth ~next_available_token hash
 
   let hash : (Hash.t, Account.t) Tree.t -> Hash.t = function
     | Account a ->
@@ -101,6 +123,8 @@ end = struct
   type index = int [@@deriving sexp, to_yojson]
 
   let merkle_root {T.tree; _} = hash tree
+
+  let next_available_token {T.next_available_token; _} = next_available_token
 
   let add_path depth0 tree0 path0 account =
     let rec build_tree height p =
@@ -223,7 +247,11 @@ end = struct
              depth %i."
             idx expected_kind kind (t.depth - i) ()
     in
-    {t with tree= go (t.depth - 1) t.tree}
+    let acct_token = Account.token acct in
+    { t with
+      tree= go (t.depth - 1) t.tree
+    ; next_available_token=
+        Token_id.(max t.next_available_token (next acct_token)) }
 
   let path_exn {T.tree; depth; _} idx =
     let rec go acc i tree =
@@ -242,7 +270,8 @@ end = struct
     go [] (depth - 1) tree
 end
 
-type ('hash, 'key, 'account) t = ('hash, 'key, 'account) T.t
+type ('hash, 'key, 'account, 'token_id) t =
+  ('hash, 'key, 'account, 'token_id) T.t
 [@@deriving to_yojson]
 
 let%test_module "sparse-ledger-test" =
@@ -264,6 +293,14 @@ let%test_module "sparse-ledger-test" =
           ~f:Md5.digest_string
     end
 
+    module Token_id = struct
+      type t = unit [@@deriving sexp, to_yojson]
+
+      let max () () = ()
+
+      let next () = ()
+    end
+
     module Account = struct
       module T = struct
         type t = {name: string; favorite_number: int}
@@ -276,6 +313,8 @@ let%test_module "sparse-ledger-test" =
 
       let data_hash t = Md5.digest_string (Binable.to_string (module T) t)
 
+      let token _ = ()
+
       let gen =
         let open Quickcheck.Generator.Let_syntax in
         let%map name = String.quickcheck_generator
@@ -287,7 +326,7 @@ let%test_module "sparse-ledger-test" =
       type t = string [@@deriving sexp, eq, to_yojson]
     end
 
-    include Make (Hash) (Account_id) (Account)
+    include Make (Hash) (Token_id) (Account_id) (Account)
 
     let gen =
       let open Quickcheck.Generator in
@@ -328,7 +367,7 @@ let%test_module "sparse-ledger-test" =
       in
       let%bind depth = Int.gen_incl 0 16 in
       let%map tree = gen depth >>| prune_hash_branches in
-      {T.tree; depth; indexes= indexes depth tree}
+      {T.tree; depth; indexes= indexes depth tree; next_available_token= ()}
 
     let%test_unit "iteri consistent indices with t.indexes" =
       Quickcheck.test gen ~f:(fun t ->

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -87,6 +87,7 @@ val of_scan_state_and_ledger :
   -> constraint_constants:Genesis_constants.Constraint_constants.t
   -> verifier:Verifier.t
   -> snarked_ledger_hash:Frozen_ledger_hash.t
+  -> snarked_next_available_token:Token_id.t
   -> ledger:Ledger.t
   -> scan_state:Scan_state.t
   -> pending_coinbase_collection:Pending_coinbase.t
@@ -95,6 +96,7 @@ val of_scan_state_and_ledger :
 val of_scan_state_and_ledger_unchecked :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> snarked_ledger_hash:Frozen_ledger_hash.t
+  -> snarked_next_available_token:Token_id.t
   -> ledger:Ledger.t
   -> scan_state:Scan_state.t
   -> pending_coinbase_collection:Pending_coinbase.t

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -454,8 +454,14 @@ module Statement = struct
       else
         Or_error.errorf
           !"Next available token is inconsistent between transitions (%{sexp: \
-            Token_id.t} vs %{sexp: Token_id.t})"
+            Token_id.t} vs %{sexp: Token_id.t})\n\
+            Transitions are:\n\
+            %s\n\
+            vs\n\
+            %s\n"
           s1.next_available_token_after s2.next_available_token_before
+          (Yojson.Safe.pretty_to_string (to_yojson s1))
+          (Yojson.Safe.pretty_to_string (to_yojson s2))
     in
     ( { source= s1.source
       ; target= s2.target

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -481,19 +481,18 @@ module Statement = struct
     and supply_increase = Currency.Amount.gen
     and pending_coinbase_before = Pending_coinbase.Stack.gen
     and pending_coinbase_after = Pending_coinbase.Stack.gen
-    (*
     and next_available_token_before, next_available_token_after =
       let%map token1 = Token_id.gen_non_default
       and token2 = Token_id.gen_non_default in
-      (Token_id.min token1 token2, Token_id.max token1 token2)*)
+      (Token_id.min token1 token2, Token_id.max token1 token2)
     and proof_type =
       Bool.quickcheck_generator >>| fun b -> if b then `Merge else `Base
     in
     ( { source
       ; target
       ; fee_excess
-      ; next_available_token_before= Token_id.(next default)
-      ; next_available_token_after= Token_id.(next default)
+      ; next_available_token_before
+      ; next_available_token_after
       ; proof_type
       ; supply_increase
       ; pending_coinbase_stack_state=

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -129,6 +129,7 @@ module Statement = struct
              , 'amount
              , 'pending_coinbase
              , 'fee_excess
+             , 'token_id
              , 'proof_type
              , 'sok_digest )
              t =
@@ -137,17 +138,21 @@ module Statement = struct
           ; supply_increase: 'amount
           ; pending_coinbase_stack_state: 'pending_coinbase
           ; fee_excess: 'fee_excess
+          ; next_available_token_before: 'token_id
+          ; next_available_token_after: 'token_id
           ; proof_type: 'proof_type
           ; sok_digest: 'sok_digest }
         [@@deriving compare, equal, hash, sexp, yojson]
 
-        let to_latest ledger_hash amount pending_coinbase fee_excess'
+        let to_latest ledger_hash amount pending_coinbase fee_excess' token_id
             proof_type' sok_digest'
             { source
             ; target
             ; supply_increase
             ; pending_coinbase_stack_state
             ; fee_excess
+            ; next_available_token_before
+            ; next_available_token_after
             ; proof_type
             ; sok_digest } =
           { source= ledger_hash source
@@ -156,6 +161,8 @@ module Statement = struct
           ; pending_coinbase_stack_state=
               pending_coinbase pending_coinbase_stack_state
           ; fee_excess= fee_excess' fee_excess
+          ; next_available_token_before= token_id next_available_token_before
+          ; next_available_token_after= token_id next_available_token_after
           ; proof_type= proof_type' proof_type
           ; sok_digest= sok_digest' sok_digest }
       end
@@ -165,6 +172,7 @@ module Statement = struct
          , 'amount
          , 'pending_coinbase
          , 'fee_excess
+         , 'token_id
          , 'proof_type
          , 'sok_digest )
          t =
@@ -172,6 +180,7 @@ module Statement = struct
           , 'amount
           , 'pending_coinbase
           , 'fee_excess
+          , 'token_id
           , 'proof_type
           , 'sok_digest )
           Stable.Latest.t =
@@ -180,6 +189,8 @@ module Statement = struct
       ; supply_increase: 'amount
       ; pending_coinbase_stack_state: 'pending_coinbase
       ; fee_excess: 'fee_excess
+      ; next_available_token_before: 'token_id
+      ; next_available_token_after: 'token_id
       ; proof_type: 'proof_type
       ; sok_digest: 'sok_digest }
     [@@deriving compare, equal, hash, sexp, yojson]
@@ -190,6 +201,8 @@ module Statement = struct
         ; supply_increase
         ; pending_coinbase_stack_state
         ; fee_excess
+        ; next_available_token_before
+        ; next_available_token_after
         ; proof_type
         ; sok_digest } =
       H_list.
@@ -198,6 +211,8 @@ module Statement = struct
         ; supply_increase
         ; pending_coinbase_stack_state
         ; fee_excess
+        ; next_available_token_before
+        ; next_available_token_after
         ; proof_type
         ; sok_digest ]
 
@@ -207,6 +222,8 @@ module Statement = struct
          ; supply_increase
          ; pending_coinbase_stack_state
          ; fee_excess
+         ; next_available_token_before
+         ; next_available_token_after
          ; proof_type
          ; sok_digest ] :
           (unit, _) H_list.t) =
@@ -215,10 +232,12 @@ module Statement = struct
       ; supply_increase
       ; pending_coinbase_stack_state
       ; fee_excess
+      ; next_available_token_before
+      ; next_available_token_after
       ; proof_type
       ; sok_digest }
 
-    let typ ledger_hash amount pending_coinbase fee_excess proof_type
+    let typ ledger_hash amount pending_coinbase fee_excess token_id proof_type
         sok_digest =
       Tick.Typ.of_hlistable
         [ ledger_hash
@@ -226,6 +245,8 @@ module Statement = struct
         ; amount
         ; pending_coinbase
         ; fee_excess
+        ; token_id
+        ; token_id
         ; proof_type
         ; sok_digest ]
         ~var_to_hlist:to_hlist ~var_of_hlist:of_hlist ~value_to_hlist:to_hlist
@@ -236,6 +257,7 @@ module Statement = struct
        , 'amount
        , 'pending_coinbase
        , 'fee_excess
+       , 'token_id
        , 'proof_type
        , 'sok_digest )
        poly =
@@ -243,6 +265,7 @@ module Statement = struct
         , 'amount
         , 'pending_coinbase
         , 'fee_excess
+        , 'token_id
         , 'proof_type
         , 'sok_digest )
         Poly.t =
@@ -251,6 +274,8 @@ module Statement = struct
     ; supply_increase: 'amount
     ; pending_coinbase_stack_state: 'pending_coinbase
     ; fee_excess: 'fee_excess
+    ; next_available_token_before: 'token_id
+    ; next_available_token_after: 'token_id
     ; proof_type: 'proof_type
     ; sok_digest: 'sok_digest }
   [@@deriving compare, equal, hash, sexp, yojson]
@@ -263,6 +288,7 @@ module Statement = struct
         , Currency.Amount.Stable.V1.t
         , Pending_coinbase_stack_state.Stable.V1.t
         , Fee_excess.Stable.V1.t
+        , Token_id.Stable.V1.t
         , Proof_type.Stable.V1.t
         , unit )
         Poly.Stable.V1.t
@@ -277,6 +303,7 @@ module Statement = struct
     , Currency.Amount.t
     , Pending_coinbase_stack_state.t
     , Fee_excess.t
+    , Token_id.t
     , Proof_type.t
     , unit )
     Poly.t
@@ -291,6 +318,7 @@ module Statement = struct
           , Currency.Amount.Stable.V1.t
           , Pending_coinbase_stack_state.Stable.V1.t
           , Fee_excess.Stable.V1.t
+          , Token_id.Stable.V1.t
           , unit
           , Sok_message.Digest.Stable.V1.t )
           Poly.Stable.V1.t
@@ -307,14 +335,15 @@ module Statement = struct
       , Currency.Amount.var
       , Pending_coinbase_stack_state.var
       , Fee_excess.var
+      , Token_id.var
       , unit
       , Sok_message.Digest.Checked.t )
       Poly.t
 
     let typ : (var, t) Tick.Typ.t =
       Poly.typ Frozen_ledger_hash.typ Currency.Amount.typ
-        Pending_coinbase_stack_state.typ Fee_excess.typ Tick.Typ.unit
-        Sok_message.Digest.typ
+        Pending_coinbase_stack_state.typ Fee_excess.typ Token_id.typ
+        Tick.Typ.unit Sok_message.Digest.typ
 
     let to_input
         { source
@@ -322,6 +351,8 @@ module Statement = struct
         ; supply_increase
         ; pending_coinbase_stack_state
         ; fee_excess
+        ; next_available_token_before
+        ; next_available_token_after
         ; proof_type= _
         ; sok_digest } =
       let input =
@@ -331,7 +362,9 @@ module Statement = struct
            ; Frozen_ledger_hash.to_input target
            ; Pending_coinbase_stack_state.to_input pending_coinbase_stack_state
            ; Amount.to_input supply_increase
-           ; Fee_excess.to_input fee_excess |]
+           ; Fee_excess.to_input fee_excess
+           ; Token_id.to_input next_available_token_before
+           ; Token_id.to_input next_available_token_after |]
       in
       if !top_hash_logging_enabled then
         Format.eprintf
@@ -349,11 +382,19 @@ module Statement = struct
           ; supply_increase
           ; pending_coinbase_stack_state
           ; fee_excess
+          ; next_available_token_before
+          ; next_available_token_after
           ; proof_type= _
           ; sok_digest } =
         let open Tick in
         let open Checked.Let_syntax in
         let%bind fee_excess = Fee_excess.to_input_checked fee_excess in
+        let%bind next_available_token_before =
+          Token_id.Checked.to_input next_available_token_before
+        in
+        let%bind next_available_token_after =
+          Token_id.Checked.to_input next_available_token_after
+        in
         let input =
           Array.reduce_exn ~f:Random_oracle.Input.append
             [| Sok_message.Digest.Checked.to_input sok_digest
@@ -362,7 +403,9 @@ module Statement = struct
              ; Pending_coinbase_stack_state.var_to_input
                  pending_coinbase_stack_state
              ; Amount.var_to_input supply_increase
-             ; fee_excess |]
+             ; fee_excess
+             ; next_available_token_before
+             ; next_available_token_after |]
         in
         let%map () =
           as_prover
@@ -403,10 +446,20 @@ module Statement = struct
     and supply_increase =
       Currency.Amount.add s1.supply_increase s2.supply_increase
       |> option "Error adding supply_increase"
+    and () =
+      if
+        Token_id.equal s1.next_available_token_after
+          s2.next_available_token_before
+      then return ()
+      else
+        Or_error.errorf
+          "Next available token is inconsistent between transitions"
     in
     ( { source= s1.source
       ; target= s2.target
       ; fee_excess
+      ; next_available_token_before= s1.next_available_token_before
+      ; next_available_token_after= s2.next_available_token_after
       ; proof_type= `Merge
       ; supply_increase
       ; pending_coinbase_stack_state=
@@ -426,12 +479,18 @@ module Statement = struct
     and supply_increase = Currency.Amount.gen
     and pending_coinbase_before = Pending_coinbase.Stack.gen
     and pending_coinbase_after = Pending_coinbase.Stack.gen
+    and next_available_token_before, next_available_token_after =
+      let%map token1 = Token_id.gen_non_default
+      and token2 = Token_id.gen_non_default in
+      (Token_id.min token1 token2, Token_id.max token1 token2)
     and proof_type =
       Bool.quickcheck_generator >>| fun b -> if b then `Merge else `Base
     in
     ( { source
       ; target
       ; fee_excess
+      ; next_available_token_before
+      ; next_available_token_after
       ; proof_type
       ; supply_increase
       ; pending_coinbase_stack_state=
@@ -450,22 +509,13 @@ module Stable = struct
       ; supply_increase: Amount.Stable.V1.t
       ; pending_coinbase_stack_state: Pending_coinbase_stack_state.Stable.V1.t
       ; fee_excess: Fee_excess.Stable.V1.t
-      ; sok_digest: Sok_message.Digest.Stable.V1.t
+      ; next_available_token_before: Token_id.Stable.V1.t
+      ; next_available_token_after: Token_id.Stable.V1.t
+      ; sok_digest:
+          (Sok_message.Digest.Stable.V1.t[@to_yojson
+                                           fun _ -> `String "<opaque>"])
       ; proof: Proof.Stable.V1.t }
-    [@@deriving compare, fields, sexp, version]
-
-    let to_yojson t =
-      `Assoc
-        [ ("source", Frozen_ledger_hash.to_yojson t.source)
-        ; ("target", Frozen_ledger_hash.to_yojson t.target)
-        ; ("proof_type", Proof_type.to_yojson t.proof_type)
-        ; ("supply_increase", Amount.to_yojson t.supply_increase)
-        ; ( "pending_coinbase_stack_state"
-          , Pending_coinbase_stack_state.to_yojson
-              t.pending_coinbase_stack_state )
-        ; ("fee_excess", Fee_excess.to_yojson t.fee_excess)
-        ; ("sok_digest", `String "<opaque>")
-        ; ("proof", Proof.to_yojson t.proof) ]
+    [@@deriving compare, fields, sexp, version, to_yojson]
 
     let to_latest = Fn.id
   end
@@ -478,6 +528,8 @@ type t = Stable.Latest.t =
   ; supply_increase: Amount.t
   ; pending_coinbase_stack_state: Pending_coinbase_stack_state.t
   ; fee_excess: Fee_excess.t
+  ; next_available_token_before: Token_id.t
+  ; next_available_token_after: Token_id.t
   ; sok_digest: Sok_message.Digest.t
   ; proof: Proof.t }
 [@@deriving fields, sexp]
@@ -489,6 +541,8 @@ let statement
      ; target
      ; proof_type
      ; fee_excess
+     ; next_available_token_before
+     ; next_available_token_after
      ; supply_increase
      ; pending_coinbase_stack_state
      ; sok_digest= _
@@ -500,6 +554,8 @@ let statement
   ; supply_increase
   ; pending_coinbase_stack_state
   ; fee_excess
+  ; next_available_token_before
+  ; next_available_token_after
   ; sok_digest= () }
 
 let create = Fields.create
@@ -588,6 +644,7 @@ module Base = struct
     | Transaction : Transaction_union.t Snarky.Request.t
     | State_body : Coda_state.Protocol_state.Body.Value.t Snarky.Request.t
     | Init_stack : Pending_coinbase.Stack.t Snarky.Request.t
+    | Next_available_token : Token_id.t Snarky.Request.t
 
   module User_command_failure = struct
     (** The various ways that a user command may fail. These should be computed
@@ -1046,7 +1103,7 @@ module Base = struct
       (type shifted)
       (shifted : (module Inner_curve.Checked.Shifted.S with type t = shifted))
       root pending_coinbase_stack_init pending_coinbase_stack_before
-      pending_coinbase_after state_body
+      pending_coinbase_after next_available_token state_body
       ({signer; signature; payload} as txn : Transaction_union.var) =
     let tag = payload.body.tag in
     let is_user_command = Transaction_union.Tag.Unpacked.is_user_command tag in
@@ -1125,9 +1182,7 @@ module Base = struct
     let%bind creating_new_token =
       Boolean.(is_create_account && token_invalid)
     in
-    let%bind next_available_token, token =
-      (* TODO: Use next_available_token from the protocol state.  *)
-      let next_available_token = Token_id.(var_of_t (next default)) in
+    let%bind next_available_token_after, token =
       let%bind () =
         [%with_label "New token creation is disabled"]
           Boolean.(Assert.is_true (not creating_new_token))
@@ -1141,8 +1196,6 @@ module Base = struct
       in
       (next_available_token, token)
     in
-    (* TODO: Route this out back to the protocol state. *)
-    ignore next_available_token ;
     let fee = payload.common.fee in
     let receiver = Account_id.Checked.create payload.body.receiver_pk token in
     let source = Account_id.Checked.create payload.body.source_pk token in
@@ -1692,7 +1745,7 @@ module Base = struct
       Frozen_ledger_hash.if_ user_command_fails
         ~then_:root_after_fee_payer_update ~else_:root_after_source_update
     in
-    (final_root, fee_excess, supply_increase)
+    (final_root, fee_excess, supply_increase, next_available_token_after)
 
   (* Someday:
    write the following soundness tests:
@@ -1742,16 +1795,22 @@ module Base = struct
     let%bind pending_coinbase_init =
       exists Pending_coinbase.Stack.typ ~request:(As_prover.return Init_stack)
     in
+    let%bind next_available_token_before =
+      exists Token_id.typ ~request:(As_prover.return Next_available_token)
+    in
     let%bind state_body =
       exists
         (Coda_state.Protocol_state.Body.typ ~constraint_constants)
         ~request:(As_prover.return State_body)
     in
-    let%bind root_after, fee_excess, supply_increase =
+    let%bind ( root_after
+             , fee_excess
+             , supply_increase
+             , next_available_token_after ) =
       apply_tagged_transaction ~constraint_constants
         (module Shifted)
         root_before pending_coinbase_init pending_coinbase_before
-        pending_coinbase_after state_body t
+        pending_coinbase_after next_available_token_before state_body t
     in
     let%bind fee_excess =
       (* Use the default token for the fee excess if it is zero.
@@ -1783,6 +1842,8 @@ module Base = struct
              { source= root_before
              ; target= root_after
              ; fee_excess
+             ; next_available_token_before
+             ; next_available_token_after
              ; supply_increase
              ; pending_coinbase_stack_state=
                  { source= pending_coinbase_before
@@ -1800,7 +1861,8 @@ module Base = struct
 
   let transaction_union_handler handler (transaction : Transaction_union.t)
       (state_body : Coda_state.Protocol_state.Body.Value.t)
-      (init_stack : Pending_coinbase.Stack.t) : Snarky.Request.request -> _ =
+      (init_stack : Pending_coinbase.Stack.t)
+      (next_available_token : Token_id.t) : Snarky.Request.request -> _ =
    fun (With {request; respond} as r) ->
     match request with
     | Transaction ->
@@ -1809,6 +1871,8 @@ module Base = struct
         respond (Provide state_body)
     | Init_stack ->
         respond (Provide init_stack)
+    | Next_available_token ->
+        respond (Provide next_available_token)
     | _ ->
         handler r
 
@@ -1820,14 +1884,18 @@ module Base = struct
 
   let transaction_union_proof ?(preeval = false) ~constraint_constants
       ~proving_key sok_digest state1 state2 init_stack
-      pending_coinbase_stack_state (transaction : Transaction_union.t)
-      state_body handler =
+      pending_coinbase_stack_state next_available_token
+      (transaction : Transaction_union.t) state_body handler =
     if preeval then failwith "preeval currently disabled" ;
     let prover_state : Prover_state.t =
       {state1; state2; sok_digest; pending_coinbase_stack_state}
     in
     let handler =
       transaction_union_handler handler transaction state_body init_stack
+        next_available_token
+    in
+    let next_available_token_after =
+      Transaction_union.next_available_token transaction next_available_token
     in
     let main top_hash = handle (main ~constraint_constants top_hash) handler in
     let statement : Statement.With_sok.t =
@@ -1836,6 +1904,8 @@ module Base = struct
       ; supply_increase= Transaction_union.supply_increase transaction
       ; pending_coinbase_stack_state
       ; fee_excess= Transaction_union.fee_excess transaction
+      ; next_available_token_before= next_available_token
+      ; next_available_token_after
       ; proof_type= ()
       ; sok_digest }
     in
@@ -1894,6 +1964,9 @@ module Merge = struct
       ; transition12: Transition_data.t
       ; ledger_hash3: Frozen_ledger_hash.t
       ; transition23: Transition_data.t
+      ; next_available_token1: Token_id.t
+      ; next_available_token2: Token_id.t
+      ; next_available_token3: Token_id.t
       ; pending_coinbase_stack1: Pending_coinbase.Stack.t
       ; pending_coinbase_stack2: Pending_coinbase.Stack.t
       ; pending_coinbase_stack3: Pending_coinbase.Stack.t
@@ -1918,7 +1991,8 @@ module Merge = struct
      accept on one of [ H(s1, s2, excess); H(s1, s2, excess, tock_vk) ] *)
   let%snarkydef verify_transition tock_vk tock_vk_precomp wrap_vk_hash_state
       get_transition_data s1 s2 ~pending_coinbase_stack1
-      ~pending_coinbase_stack2 supply_increase ~fee_excess =
+      ~pending_coinbase_stack2 supply_increase ~fee_excess
+      ~next_available_token_before ~next_available_token_after =
     let%bind is_base =
       let get_type s = get_transition_data s |> Transition_data.proof |> fst in
       with_label __LOC__
@@ -1940,6 +2014,8 @@ module Merge = struct
           { source= s1
           ; target= s2
           ; fee_excess
+          ; next_available_token_before
+          ; next_available_token_after
           ; supply_increase
           ; pending_coinbase_stack_state=
               {source= pending_coinbase_stack1; target= pending_coinbase_stack2}
@@ -1989,6 +2065,12 @@ module Merge = struct
       exists' Amount.typ
         ~f:
           (Fn.compose Transition_data.supply_increase Prover_state.transition23)
+    and next_available_token1 =
+      exists' Token_id.typ ~f:Prover_state.next_available_token1
+    and next_available_token2 =
+      exists' Token_id.typ ~f:Prover_state.next_available_token2
+    and next_available_token3 =
+      exists' Token_id.typ ~f:Prover_state.next_available_token3
     and pending_coinbase1 =
       exists' Pending_coinbase.Stack.typ
         ~f:Prover_state.pending_coinbase_stack1
@@ -2039,6 +2121,8 @@ module Merge = struct
                { source= s1
                ; target= s3
                ; fee_excess
+               ; next_available_token_before= next_available_token1
+               ; next_available_token_after= next_available_token3
                ; supply_increase
                ; pending_coinbase_stack_state=
                    {source= pending_coinbase1; target= pending_coinbase4}
@@ -2056,14 +2140,18 @@ module Merge = struct
            Prover_state.transition12 s1 s2
            ~pending_coinbase_stack1:pending_coinbase1
            ~pending_coinbase_stack2:pending_coinbase2 supply_increase12
-           ~fee_excess:fee_excess12)
+           ~fee_excess:fee_excess12
+           ~next_available_token_before:next_available_token1
+           ~next_available_token_after:next_available_token2)
     and verify_23 =
       [%with_label "Verify right transition"]
         (verify_transition tock_vk tock_vk_precomp wrap_vk_hash_state
            Prover_state.transition23 s2 s3
            ~pending_coinbase_stack1:pending_coinbase3
            ~pending_coinbase_stack2:pending_coinbase4 supply_increase23
-           ~fee_excess:fee_excess23)
+           ~fee_excess:fee_excess23
+           ~next_available_token_before:next_available_token2
+           ~next_available_token_after:next_available_token3)
     in
     Boolean.Assert.all [verify_12; verify_23]
 
@@ -2108,6 +2196,8 @@ module Verification = struct
       -> Pending_coinbase.Stack.var
       -> Pending_coinbase.Stack.var
       -> Currency.Amount.var
+      -> Token_id.var
+      -> Token_id.var
       -> (Tock.Proof.t, 's) Tick.As_prover.t
       -> (Tick.Boolean.var, 's) Tick.Checked.t
   end
@@ -2137,6 +2227,8 @@ module Verification = struct
         ; proof
         ; proof_type
         ; fee_excess
+        ; next_available_token_before
+        ; next_available_token_after
         ; sok_digest
         ; supply_increase
         ; pending_coinbase_stack_state } =
@@ -2145,6 +2237,8 @@ module Verification = struct
         ; target
         ; proof_type= ()
         ; fee_excess
+        ; next_available_token_before
+        ; next_available_token_after
         ; sok_digest
         ; supply_increase
         ; pending_coinbase_stack_state }
@@ -2184,7 +2278,7 @@ module Verification = struct
     let verify_complete_merge sok_digest s1 s2
         (pending_coinbase_stack1 : Pending_coinbase.Stack.var)
         (pending_coinbase_stack2 : Pending_coinbase.Stack.var) supply_increase
-        get_proof =
+        next_available_token_before next_available_token_after get_proof =
       let open Tick in
       let%bind top_hash =
         let%bind input =
@@ -2192,6 +2286,8 @@ module Verification = struct
             { source= s1
             ; target= s2
             ; fee_excess= Fee_excess.(var_of_t empty)
+            ; next_available_token_before
+            ; next_available_token_after
             ; supply_increase
             ; pending_coinbase_stack_state=
                 { source= pending_coinbase_stack1
@@ -2321,6 +2417,7 @@ module type S = sig
     -> target:Frozen_ledger_hash.t
     -> init_stack:Pending_coinbase.Stack.t
     -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+    -> next_available_token:Token_id.t
     -> Transaction.t Transaction_protocol_state.t
     -> Tick.Handler.t
     -> t
@@ -2332,6 +2429,7 @@ module type S = sig
     -> target:Frozen_ledger_hash.t
     -> init_stack:Pending_coinbase.Stack.t
     -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+    -> next_available_token:Token_id.t
     -> User_command.With_valid_signature.t Transaction_protocol_state.t
     -> Tick.Handler.t
     -> t
@@ -2343,6 +2441,7 @@ module type S = sig
     -> target:Frozen_ledger_hash.t
     -> init_stack:Pending_coinbase.Stack.t
     -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+    -> next_available_token:Token_id.t
     -> Fee_transfer.t Transaction_protocol_state.t
     -> Tick.Handler.t
     -> t
@@ -2352,7 +2451,7 @@ end
 
 let check_transaction_union ?(preeval = false) ~constraint_constants
     sok_message source target init_stack pending_coinbase_stack_state
-    transaction state_body handler =
+    next_available_token transaction state_body handler =
   if preeval then failwith "preeval currently disabled" ;
   let sok_digest = Sok_message.digest sok_message in
   let prover_state : Base.Prover_state.t =
@@ -2360,6 +2459,10 @@ let check_transaction_union ?(preeval = false) ~constraint_constants
   in
   let handler =
     Base.transaction_union_handler handler transaction state_body init_stack
+      next_available_token
+  in
+  let next_available_token_after =
+    Transaction_union.next_available_token transaction next_available_token
   in
   let statement : Statement.With_sok.t =
     { source
@@ -2367,6 +2470,8 @@ let check_transaction_union ?(preeval = false) ~constraint_constants
     ; supply_increase= Transaction_union.supply_increase transaction
     ; pending_coinbase_stack_state
     ; fee_excess= Transaction_union.fee_excess transaction
+    ; next_available_token_before= next_available_token
+    ; next_available_token_after
     ; proof_type= ()
     ; sok_digest }
   in
@@ -2381,7 +2486,7 @@ let check_transaction_union ?(preeval = false) ~constraint_constants
   Or_error.ok_exn (run_and_check main prover_state) |> ignore
 
 let check_transaction ?preeval ~constraint_constants ~sok_message ~source
-    ~target ~init_stack ~pending_coinbase_stack_state
+    ~target ~init_stack ~pending_coinbase_stack_state ~next_available_token
     (transaction_in_block : Transaction.t Transaction_protocol_state.t) handler
     =
   let transaction =
@@ -2391,21 +2496,22 @@ let check_transaction ?preeval ~constraint_constants ~sok_message ~source
     Transaction_protocol_state.block_data transaction_in_block
   in
   check_transaction_union ?preeval ~constraint_constants sok_message source
-    target init_stack pending_coinbase_stack_state
+    target init_stack pending_coinbase_stack_state next_available_token
     (Transaction_union.of_transaction transaction)
     state_body handler
 
 let check_user_command ~constraint_constants ~sok_message ~source ~target
-    ~init_stack pending_coinbase_stack_state t_in_block handler =
+    ~init_stack ~pending_coinbase_stack_state ~next_available_token t_in_block
+    handler =
   let user_command = Transaction_protocol_state.transaction t_in_block in
   check_transaction ~constraint_constants ~sok_message ~source ~target
-    ~init_stack ~pending_coinbase_stack_state
+    ~init_stack ~pending_coinbase_stack_state ~next_available_token
     {t_in_block with transaction= User_command user_command}
     handler
 
 let generate_transaction_union_witness ?(preeval = false) ~constraint_constants
     sok_message source target transaction_in_block init_stack
-    pending_coinbase_stack_state handler =
+    next_available_token pending_coinbase_stack_state handler =
   if preeval then failwith "preeval currently disabled" ;
   let transaction =
     Transaction_protocol_state.transaction transaction_in_block
@@ -2419,6 +2525,10 @@ let generate_transaction_union_witness ?(preeval = false) ~constraint_constants
   in
   let handler =
     Base.transaction_union_handler handler transaction state_body init_stack
+      next_available_token
+  in
+  let next_available_token_after =
+    Transaction_union.next_available_token transaction next_available_token
   in
   let statement : Statement.With_sok.t =
     { source
@@ -2426,6 +2536,8 @@ let generate_transaction_union_witness ?(preeval = false) ~constraint_constants
     ; supply_increase= Transaction_union.supply_increase transaction
     ; pending_coinbase_stack_state
     ; fee_excess= Transaction_union.fee_excess transaction
+    ; next_available_token_before= next_available_token
+    ; next_available_token_after
     ; proof_type= ()
     ; sok_digest }
   in
@@ -2437,7 +2549,8 @@ let generate_transaction_union_witness ?(preeval = false) ~constraint_constants
   generate_auxiliary_input (tick_input ()) prover_state main top_hash
 
 let generate_transaction_witness ?preeval ~constraint_constants ~sok_message
-    ~source ~target ~init_stack pending_coinbase_stack_state
+    ~source ~target ~init_stack ~pending_coinbase_stack_state
+    ~next_available_token
     (transaction_in_block : Transaction.t Transaction_protocol_state.t) handler
     =
   let transaction =
@@ -2447,7 +2560,7 @@ let generate_transaction_witness ?preeval ~constraint_constants ~sok_message
     source target
     { transaction_in_block with
       transaction= Transaction_union.of_transaction transaction }
-    init_stack pending_coinbase_stack_state handler
+    init_stack next_available_token pending_coinbase_stack_state handler
 
 let verification_keys_of_keys {Keys0.verification; _} = verification
 
@@ -2473,6 +2586,7 @@ struct
       (Wrap_input.of_tick_field input)
 
   let merge_proof sok_digest ledger_hash1 ledger_hash2 ledger_hash3
+      next_available_token1 next_available_token2 next_available_token3
       transition12 transition23 =
     let fee_excess =
       Or_error.ok_exn
@@ -2491,6 +2605,8 @@ struct
           { source= transition12.pending_coinbase_stack_state.source
           ; target= transition23.pending_coinbase_stack_state.target }
       ; fee_excess
+      ; next_available_token_before= next_available_token1
+      ; next_available_token_after= next_available_token2
       ; proof_type= ()
       ; sok_digest }
     in
@@ -2500,6 +2616,9 @@ struct
       ; ledger_hash1
       ; ledger_hash2
       ; ledger_hash3
+      ; next_available_token1
+      ; next_available_token2
+      ; next_available_token3
       ; pending_coinbase_stack1=
           transition12.pending_coinbase_stack_state.source
       ; pending_coinbase_stack2=
@@ -2517,24 +2636,29 @@ struct
         top_hash )
 
   let of_transaction_union ?preeval ~constraint_constants sok_digest source
-      target ~init_stack ~pending_coinbase_stack_state transaction state_body
-      handler =
+      target ~init_stack ~pending_coinbase_stack_state ~next_available_token
+      transaction state_body handler =
     let top_hash, proof =
       Base.transaction_union_proof ?preeval ~constraint_constants sok_digest
         ~proving_key:keys.proving.base source target init_stack
-        pending_coinbase_stack_state transaction state_body handler
+        pending_coinbase_stack_state next_available_token transaction
+        state_body handler
     in
     { source
     ; sok_digest
     ; target
     ; proof_type= `Base
     ; fee_excess= Transaction_union.fee_excess transaction
+    ; next_available_token_before= next_available_token
+    ; next_available_token_after=
+        Transaction_union.next_available_token transaction next_available_token
     ; pending_coinbase_stack_state
     ; supply_increase= Transaction_union.supply_increase transaction
     ; proof= wrap `Base proof top_hash }
 
   let of_transaction ?preeval ~constraint_constants ~sok_digest ~source ~target
-      ~init_stack ~pending_coinbase_stack_state transaction_in_block handler =
+      ~init_stack ~pending_coinbase_stack_state ~next_available_token
+      transaction_in_block handler =
     let transaction =
       Transaction_protocol_state.transaction transaction_in_block
     in
@@ -2542,14 +2666,15 @@ struct
       Transaction_protocol_state.block_data transaction_in_block
     in
     of_transaction_union ?preeval ~constraint_constants sok_digest source
-      target ~init_stack ~pending_coinbase_stack_state
+      target ~init_stack ~pending_coinbase_stack_state ~next_available_token
       (Transaction_union.of_transaction transaction)
       state_body handler
 
   let of_user_command ~constraint_constants ~sok_digest ~source ~target
-      ~init_stack ~pending_coinbase_stack_state user_command_in_block handler =
+      ~init_stack ~pending_coinbase_stack_state ~next_available_token
+      user_command_in_block handler =
     of_transaction ~constraint_constants ~sok_digest ~source ~target
-      ~init_stack ~pending_coinbase_stack_state
+      ~init_stack ~pending_coinbase_stack_state ~next_available_token
       { user_command_in_block with
         transaction=
           User_command
@@ -2557,9 +2682,10 @@ struct
       handler
 
   let of_fee_transfer ~constraint_constants ~sok_digest ~source ~target
-      ~init_stack ~pending_coinbase_stack_state transfer_in_block handler =
+      ~init_stack ~pending_coinbase_stack_state ~next_available_token
+      transfer_in_block handler =
     of_transaction ~constraint_constants ~sok_digest ~source ~target
-      ~init_stack ~pending_coinbase_stack_state
+      ~init_stack ~pending_coinbase_stack_state ~next_available_token
       { transfer_in_block with
         transaction=
           Fee_transfer
@@ -2572,8 +2698,20 @@ struct
         !"Transaction_snark.merge: t1.target <> t2.source \
           (%{sexp:Frozen_ledger_hash.t} vs %{sexp:Frozen_ledger_hash.t})"
         t1.target t2.source () ;
+    if
+      not
+        (Token_id.( = ) t1.next_available_token_after
+           t2.next_available_token_before)
+    then
+      failwithf
+        !"Transaction_snark.merge: t1.next_available_token_befre <> \
+          t2.next_available_token_after (%{sexp:Token_id.t} vs \
+          %{sexp:Token_id.t})"
+        t1.next_available_token_after t2.next_available_token_before () ;
     let input, proof =
       merge_proof sok_digest t1.source t1.target t2.target
+        t1.next_available_token_before t1.next_available_token_after
+        t2.next_available_token_after
         { Transition_data.proof= (t1.proof_type, t1.proof)
         ; fee_excess= t1.fee_excess
         ; supply_increase= t1.supply_increase
@@ -2598,6 +2736,8 @@ struct
     ; target= t2.target
     ; sok_digest
     ; fee_excess
+    ; next_available_token_before= t1.next_available_token_before
+    ; next_available_token_after= t2.next_available_token_after
     ; supply_increase
     ; pending_coinbase_stack_state=
         { source= t1.pending_coinbase_stack_state.source
@@ -2896,12 +3036,14 @@ let%test_module "transaction_snark" =
         Ledger.merkle_root_after_user_command_exn ledger
           ~txn_global_slot:current_global_slot user_command
       in
+      let next_available_token = Ledger.next_available_token ledger in
       let user_command_in_block =
         { Transaction_protocol_state.Poly.transaction= user_command
         ; block_data= state_body }
       in
       of_user_command ~constraint_constants ~sok_digest ~source ~target
-        ~init_stack ~pending_coinbase_stack_state user_command_in_block handler
+        ~init_stack ~pending_coinbase_stack_state ~next_available_token
+        user_command_in_block handler
 
     (*
                 ~proposer:
@@ -2972,6 +3114,7 @@ let%test_module "transaction_snark" =
                 merkle_root
                   (apply_transaction_exn ~constraint_constants sparse_ledger
                      txn_in_block.transaction))
+            ~next_available_token:(Ledger.next_available_token ledger)
             ~init_stack:pending_coinbase_init
             ~pending_coinbase_stack_state:
               {source= source_stack; target= pending_coinbase_stack_target} )
@@ -3034,7 +3177,8 @@ let%test_module "transaction_snark" =
               check_user_command ~constraint_constants ~sok_message
                 ~source:(Ledger.merkle_root ledger)
                 ~target ~init_stack:pending_coinbase_stack
-                pending_coinbase_stack_state
+                ~pending_coinbase_stack_state
+                ~next_available_token:(Ledger.next_available_token ledger)
                 {transaction= t1; block_data= state_body}
                 (unstage @@ Sparse_ledger.handler sparse_ledger) ) )
 
@@ -3114,6 +3258,7 @@ let%test_module "transaction_snark" =
         ~pending_coinbase_stack_state:
           { Pending_coinbase_stack_state.source= pending_coinbase_stack
           ; target= pending_coinbase_stack_target }
+        ~next_available_token:(Ledger.next_available_token ledger)
         {transaction= txn; block_data= state_body}
         (unstage @@ Sparse_ledger.handler sparse_ledger)
 
@@ -3287,6 +3432,7 @@ let%test_module "transaction_snark" =
                 |> Sok_message.digest
               in
               let state1 = Ledger.merkle_root ledger in
+              let next_available_token1 = Ledger.next_available_token ledger in
               let sparse_ledger =
                 Sparse_ledger.of_ledger_subset_exn ledger
                   (List.concat_map
@@ -3399,6 +3545,7 @@ let%test_module "transaction_snark" =
                 Signed.create ~magnitude ~sgn:Sgn.Pos
               in
               let state3 = Sparse_ledger.merkle_root sparse_ledger in
+              let next_available_token3 = Ledger.next_available_token ledger in
               let proof13 =
                 merge ~sok_digest proof12 proof23 |> Or_error.ok_exn
               in
@@ -3410,6 +3557,8 @@ let%test_module "transaction_snark" =
                     pending_coinbase_stack_state_merge
                 ; fee_excess=
                     Fee_excess.of_single (Token_id.default, total_fees)
+                ; next_available_token_before= next_available_token1
+                ; next_available_token_after= next_available_token3
                 ; proof_type= ()
                 ; sok_digest }
               in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -453,7 +453,9 @@ module Statement = struct
       then return ()
       else
         Or_error.errorf
-          "Next available token is inconsistent between transitions"
+          !"Next available token is inconsistent between transitions (%{sexp: \
+            Token_id.t} vs %{sexp: Token_id.t})"
+          s1.next_available_token_after s2.next_available_token_before
     in
     ( { source= s1.source
       ; target= s2.target

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -454,14 +454,8 @@ module Statement = struct
       else
         Or_error.errorf
           !"Next available token is inconsistent between transitions (%{sexp: \
-            Token_id.t} vs %{sexp: Token_id.t})\n\
-            Transitions are:\n\
-            %s\n\
-            vs\n\
-            %s\n"
+            Token_id.t} vs %{sexp: Token_id.t})"
           s1.next_available_token_after s2.next_available_token_before
-          (Yojson.Safe.pretty_to_string (to_yojson s1))
-          (Yojson.Safe.pretty_to_string (to_yojson s2))
     in
     ( { source= s1.source
       ; target= s2.target

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -481,18 +481,19 @@ module Statement = struct
     and supply_increase = Currency.Amount.gen
     and pending_coinbase_before = Pending_coinbase.Stack.gen
     and pending_coinbase_after = Pending_coinbase.Stack.gen
+    (*
     and next_available_token_before, next_available_token_after =
       let%map token1 = Token_id.gen_non_default
       and token2 = Token_id.gen_non_default in
-      (Token_id.min token1 token2, Token_id.max token1 token2)
+      (Token_id.min token1 token2, Token_id.max token1 token2)*)
     and proof_type =
       Bool.quickcheck_generator >>| fun b -> if b then `Merge else `Base
     in
     ( { source
       ; target
       ; fee_excess
-      ; next_available_token_before
-      ; next_available_token_after
+      ; next_available_token_before= Token_id.(next default)
+      ; next_available_token_after= Token_id.(next default)
       ; proof_type
       ; supply_increase
       ; pending_coinbase_stack_state=

--- a/src/lib/transaction_snark/transaction_snark.mli
+++ b/src/lib/transaction_snark/transaction_snark.mli
@@ -89,6 +89,7 @@ module Statement : sig
              , 'amount
              , 'pending_coinbase
              , 'fee_excess
+             , 'token_id
              , 'proof_type
              , 'sok_digest )
              t =
@@ -97,6 +98,8 @@ module Statement : sig
           ; supply_increase: 'amount
           ; pending_coinbase_stack_state: 'pending_coinbase
           ; fee_excess: 'fee_excess
+          ; next_available_token_before: 'token_id
+          ; next_available_token_after: 'token_id
           ; proof_type: 'proof_type
           ; sok_digest: 'sok_digest }
         [@@deriving compare, equal, hash, sexp, yojson]
@@ -106,12 +109,14 @@ module Statement : sig
           -> ('amount -> 'amount')
           -> ('pending_coinbase -> 'pending_coinbase')
           -> ('fee_excess -> 'fee_excess')
+          -> ('token_id -> 'token_id')
           -> ('proof_type -> 'proof_type')
           -> ('sok_digest -> 'sok_digest')
           -> ( 'ledger_hash
              , 'amount
              , 'pending_coinbase
              , 'fee_excess
+             , 'token_id
              , 'proof_type
              , 'sok_digest )
              t
@@ -119,6 +124,7 @@ module Statement : sig
              , 'amount'
              , 'pending_coinbase'
              , 'fee_excess'
+             , 'token_id'
              , 'proof_type'
              , 'sok_digest' )
              t
@@ -129,6 +135,7 @@ module Statement : sig
          , 'amount
          , 'pending_coinbase
          , 'fee_excess
+         , 'token_id
          , 'proof_type
          , 'sok_digest )
          t =
@@ -136,6 +143,7 @@ module Statement : sig
           , 'amount
           , 'pending_coinbase
           , 'fee_excess
+          , 'token_id
           , 'proof_type
           , 'sok_digest )
           Stable.Latest.t =
@@ -144,6 +152,8 @@ module Statement : sig
       ; supply_increase: 'amount
       ; pending_coinbase_stack_state: 'pending_coinbase
       ; fee_excess: 'fee_excess
+      ; next_available_token_before: 'token_id
+      ; next_available_token_after: 'token_id
       ; proof_type: 'proof_type
       ; sok_digest: 'sok_digest }
     [@@deriving compare, equal, hash, sexp, yojson]
@@ -153,6 +163,7 @@ module Statement : sig
        , 'amount
        , 'pending_coinbase
        , 'fee_excess
+       , 'token_id
        , 'proof_type
        , 'sok_digest )
        poly =
@@ -160,6 +171,7 @@ module Statement : sig
         , 'amount
         , 'pending_coinbase
         , 'fee_excess
+        , 'token_id
         , 'proof_type
         , 'sok_digest )
         Poly.t =
@@ -168,6 +180,8 @@ module Statement : sig
     ; supply_increase: 'amount
     ; pending_coinbase_stack_state: 'pending_coinbase
     ; fee_excess: 'fee_excess
+    ; next_available_token_before: 'token_id
+    ; next_available_token_after: 'token_id
     ; proof_type: 'proof_type
     ; sok_digest: 'sok_digest }
   [@@deriving compare, equal, hash, sexp, yojson]
@@ -180,6 +194,7 @@ module Statement : sig
         , Currency.Amount.Stable.V1.t
         , Pending_coinbase_stack_state.Stable.V1.t
         , Fee_excess.Stable.V1.t
+        , Token_id.Stable.V1.t
         , Proof_type.Stable.V1.t
         , unit )
         Poly.Stable.V1.t
@@ -192,6 +207,7 @@ module Statement : sig
     , Currency.Amount.t
     , Pending_coinbase_stack_state.t
     , Fee_excess.t
+    , Token_id.t
     , Proof_type.t
     , unit )
     Poly.t
@@ -206,6 +222,7 @@ module Statement : sig
           , Currency.Amount.Stable.V1.t
           , Pending_coinbase_stack_state.Stable.V1.t
           , Fee_excess.Stable.V1.t
+          , Token_id.Stable.V1.t
           , unit
           , Sok_message.Digest.Stable.V1.t )
           Poly.Stable.V1.t
@@ -218,6 +235,7 @@ module Statement : sig
       , Currency.Amount.t
       , Pending_coinbase_stack_state.t
       , Fee_excess.t
+      , Token_id.t
       , unit
       , Sok_message.Digest.t )
       Poly.t
@@ -228,6 +246,7 @@ module Statement : sig
       , Currency.Amount.var
       , Pending_coinbase_stack_state.var
       , Fee_excess.var
+      , Token_id.var
       , unit
       , Sok_message.Digest.Checked.t )
       Poly.Stable.V1.t
@@ -273,6 +292,8 @@ val create :
   -> supply_increase:Currency.Amount.t
   -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
   -> fee_excess:Fee_excess.t
+  -> next_available_token_before:Token_id.t
+  -> next_available_token_after:Token_id.t
   -> sok_digest:Sok_message.Digest.t
   -> proof:Tock.Proof.t
   -> t
@@ -354,6 +375,8 @@ module Verification : sig
       -> Pending_coinbase.Stack.var
       -> Pending_coinbase.Stack.var
       -> Currency.Amount.var
+      -> Token_id.var
+      -> Token_id.var
       -> (Tock.Proof.t, 's) Tick.As_prover.t
       -> (Tick.Boolean.var, 's) Tick.Checked.t
   end
@@ -371,6 +394,7 @@ val check_transaction :
   -> target:Frozen_ledger_hash.t
   -> init_stack:Pending_coinbase.Stack.t
   -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+  -> next_available_token:Token_id.t
   -> Transaction.t Transaction_protocol_state.t
   -> Tick.Handler.t
   -> unit
@@ -381,7 +405,8 @@ val check_user_command :
   -> source:Frozen_ledger_hash.t
   -> target:Frozen_ledger_hash.t
   -> init_stack:Pending_coinbase.Stack.t
-  -> Pending_coinbase_stack_state.t
+  -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+  -> next_available_token:Token_id.t
   -> User_command.With_valid_signature.t Transaction_protocol_state.t
   -> Tick.Handler.t
   -> unit
@@ -393,7 +418,8 @@ val generate_transaction_witness :
   -> source:Frozen_ledger_hash.t
   -> target:Frozen_ledger_hash.t
   -> init_stack:Pending_coinbase.Stack.t
-  -> Pending_coinbase_stack_state.t
+  -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+  -> next_available_token:Token_id.t
   -> Transaction.t Transaction_protocol_state.t
   -> Tick.Handler.t
   -> unit
@@ -409,6 +435,7 @@ module type S = sig
     -> target:Frozen_ledger_hash.t
     -> init_stack:Pending_coinbase.Stack.t
     -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+    -> next_available_token:Token_id.t
     -> Transaction.t Transaction_protocol_state.t
     -> Tick.Handler.t
     -> t
@@ -420,6 +447,7 @@ module type S = sig
     -> target:Frozen_ledger_hash.t
     -> init_stack:Pending_coinbase.Stack.t
     -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+    -> next_available_token:Token_id.t
     -> User_command.With_valid_signature.t Transaction_protocol_state.t
     -> Tick.Handler.t
     -> t
@@ -431,6 +459,7 @@ module type S = sig
     -> target:Frozen_ledger_hash.t
     -> init_stack:Pending_coinbase.Stack.t
     -> pending_coinbase_stack_state:Pending_coinbase_stack_state.t
+    -> next_available_token:Token_id.t
     -> Fee_transfer.t Transaction_protocol_state.t
     -> Tick.Handler.t
     -> t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -186,6 +186,9 @@ let create_expected_statement ~constraint_constants
     Frozen_ledger_hash.of_ledger_hash
     @@ Sparse_ledger.merkle_root ledger_witness
   in
+  let next_available_token_before =
+    Sparse_ledger.next_available_token ledger_witness
+  in
   let%bind transaction = Ledger.Undo.transaction transaction_with_info in
   let%bind after =
     Or_error.try_with (fun () ->
@@ -195,6 +198,7 @@ let create_expected_statement ~constraint_constants
   let target =
     Frozen_ledger_hash.of_ledger_hash @@ Sparse_ledger.merkle_root after
   in
+  let next_available_token_after = Sparse_ledger.next_available_token after in
   let%bind pending_coinbase_before =
     match init_stack with
     | Base source ->
@@ -220,6 +224,8 @@ let create_expected_statement ~constraint_constants
   { Transaction_snark.Statement.source
   ; target
   ; fee_excess
+  ; next_available_token_before
+  ; next_available_token_after
   ; supply_increase
   ; pending_coinbase_stack_state=
       { statement.pending_coinbase_stack_state with
@@ -248,6 +254,14 @@ let completed_work_to_scanable_work (job : job) (fee, current_proof, prover) :
             s'.pending_coinbase_stack_state.source
         then Ok ()
         else Or_error.error_string "Invalid pending coinbase stack state"
+      and () =
+        if
+          Token_id.equal s.next_available_token_after
+            s'.next_available_token_before
+        then Ok ()
+        else
+          Or_error.error_string
+            "Statements have incompatible next_available_token state"
       in
       let statement : Transaction_snark.Statement.t =
         { source= s.source
@@ -257,6 +271,8 @@ let completed_work_to_scanable_work (job : job) (fee, current_proof, prover) :
             { source= s.pending_coinbase_stack_state.source
             ; target= s'.pending_coinbase_stack_state.target }
         ; fee_excess
+        ; next_available_token_before= s.next_available_token_before
+        ; next_available_token_after= s'.next_available_token_after
         ; proof_type= `Merge
         ; sok_digest= () }
       in
@@ -378,7 +394,9 @@ struct
 
   let check_invariants t ~constraint_constants ~verifier ~error_prefix
       ~ledger_hash_end:current_ledger_hash
-      ~ledger_hash_begin:snarked_ledger_hash =
+      ~ledger_hash_begin:snarked_ledger_hash
+      ~next_available_token_before:next_tkn1
+      ~next_available_token_after:next_tkn2 =
     let clarify_error cond err =
       if not cond then Or_error.errorf "%s : %s" error_prefix err else Ok ()
     in
@@ -396,6 +414,8 @@ struct
         { fee_excess= {fee_token_l; fee_excess_l; fee_token_r; fee_excess_r}
         ; source
         ; target
+        ; next_available_token_before
+        ; next_available_token_after
         ; supply_increase= _
         ; pending_coinbase_stack_state= _ (*TODO: check pending coinbases?*)
         ; proof_type= _
@@ -426,6 +446,14 @@ struct
           clarify_error
             (Token_id.equal Token_id.default fee_token_r)
             "nondefault fee token"
+        and () =
+          clarify_error
+            Token_id.(next_available_token_before = next_tkn1)
+            "next available token before does not match"
+        and () =
+          clarify_error
+            Token_id.(next_available_token_after = next_tkn2)
+            "next available token after does not match"
         in
         ()
 end
@@ -460,6 +488,11 @@ let statement_of_job : job -> Transaction_snark.Statement.t option = function
             None
       and supply_increase =
         Currency.Amount.add stmt1.supply_increase stmt2.supply_increase
+      and () =
+        Option.some_if
+          (Token_id.equal stmt1.next_available_token_after
+             stmt2.next_available_token_before)
+          ()
       in
       ( { source= stmt1.source
         ; target= stmt2.target
@@ -468,6 +501,8 @@ let statement_of_job : job -> Transaction_snark.Statement.t option = function
             { source= stmt1.pending_coinbase_stack_state.source
             ; target= stmt2.pending_coinbase_stack_state.target }
         ; fee_excess
+        ; next_available_token_before= stmt1.next_available_token_before
+        ; next_available_token_after= stmt2.next_available_token_after
         ; proof_type= `Merge
         ; sok_digest= () }
         : Transaction_snark.Statement.t )

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -71,6 +71,8 @@ module Make_statement_scanner
     -> error_prefix:string
     -> ledger_hash_end:Frozen_ledger_hash.t
     -> ledger_hash_begin:Frozen_ledger_hash.t option
+    -> next_available_token_before:Token_id.t
+    -> next_available_token_after:Token_id.t
     -> (unit, Error.t) result M.t
 end
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -322,18 +322,18 @@ module For_tests = struct
             Ledger_proof.statement proof |> Ledger_proof.statement_target )
           ~default:previous_ledger_hash
       in
-      let next_available_token =
+      let snarked_next_available_token =
         match ledger_proof_opt with
         | Some (proof, _) ->
             (Ledger_proof.statement proof).next_available_token_after
         | None ->
             previous_protocol_state |> Protocol_state.blockchain_state
-            |> Blockchain_state.next_available_token
+            |> Blockchain_state.snarked_next_available_token
       in
       let next_blockchain_state =
         Blockchain_state.create_value
           ~timestamp:(Block_time.now @@ Block_time.Controller.basic ~logger)
-          ~snarked_ledger_hash:next_ledger_hash ~next_available_token
+          ~snarked_ledger_hash:next_ledger_hash ~snarked_next_available_token
           ~staged_ledger_hash:next_staged_ledger_hash
       in
       let previous_state_hash = Protocol_state.hash previous_protocol_state in

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -322,10 +322,18 @@ module For_tests = struct
             Ledger_proof.statement proof |> Ledger_proof.statement_target )
           ~default:previous_ledger_hash
       in
+      let next_available_token =
+        match ledger_proof_opt with
+        | Some (proof, _) ->
+            (Ledger_proof.statement proof).next_available_token_after
+        | None ->
+            previous_protocol_state |> Protocol_state.blockchain_state
+            |> Blockchain_state.next_available_token
+      in
       let next_blockchain_state =
         Blockchain_state.create_value
           ~timestamp:(Block_time.now @@ Block_time.Controller.basic ~logger)
-          ~snarked_ledger_hash:next_ledger_hash
+          ~snarked_ledger_hash:next_ledger_hash ~next_available_token
           ~staged_ledger_hash:next_staged_ledger_hash
       in
       let previous_state_hash = Protocol_state.hash previous_protocol_state in

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -19,7 +19,7 @@ let construct_staged_ledger_at_root
   in
   let snarked_next_available_token =
     External_transition.Validated.blockchain_state root_transition
-    |> Blockchain_state.next_available_token
+    |> Blockchain_state.snarked_next_available_token
   in
   let scan_state = scan_state root in
   let pending_coinbase = pending_coinbase root in

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -17,6 +17,10 @@ let construct_staged_ledger_at_root
     External_transition.Validated.blockchain_state root_transition
     |> Blockchain_state.snarked_ledger_hash
   in
+  let snarked_next_available_token =
+    External_transition.Validated.blockchain_state root_transition
+    |> Blockchain_state.next_available_token
+  in
   let scan_state = scan_state root in
   let pending_coinbase = pending_coinbase root in
   let protocol_states_map =
@@ -65,7 +69,7 @@ let construct_staged_ledger_at_root
            () ))
   in
   Staged_ledger.of_scan_state_and_ledger_unchecked ~snarked_ledger_hash
-    ~ledger:mask ~scan_state
+    ~snarked_next_available_token ~ledger:mask ~scan_state
     ~constraint_constants:precomputed_values.constraint_constants
     ~pending_coinbase_collection:pending_coinbase
 


### PR DESCRIPTION
This PR
* adds support for `next_available_token` to `Sparse_ledger.t`
* adds `next_available_token_before` and `next_available_token_after` to `Transaction_snark.Statement.t`
* adds `next_available_token` to `Blockchain_state.t`
* routes the `next_available_token` data through the system as needed.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: