### PR TITLE
Add token permissions to token and account creation functions

### DIFF
--- a/src/lib/coda_base/new_account_payload.ml
+++ b/src/lib/coda_base/new_account_payload.ml
@@ -7,7 +7,8 @@ module Stable = struct
     type t =
       { token_id: Token_id.Stable.V1.t
       ; token_owner_pk: Public_key.Compressed.Stable.V1.t
-      ; receiver_pk: Public_key.Compressed.Stable.V1.t }
+      ; receiver_pk: Public_key.Compressed.Stable.V1.t
+      ; account_disabled: bool }
     [@@deriving compare, eq, sexp, hash, yojson]
 
     let to_latest = Fn.id
@@ -17,7 +18,8 @@ end]
 type t = Stable.Latest.t =
   { token_id: Token_id.t
   ; token_owner_pk: Public_key.Compressed.t
-  ; receiver_pk: Public_key.Compressed.t }
+  ; receiver_pk: Public_key.Compressed.t
+  ; account_disabled: bool }
 [@@deriving compare, eq, sexp, hash, yojson]
 
 let receiver_pk {receiver_pk; _} = receiver_pk
@@ -36,5 +38,6 @@ let gen =
   let open Quickcheck.Generator.Let_syntax in
   let%bind token_id = Token_id.gen_non_default in
   let%bind token_owner_pk = Public_key.Compressed.gen in
-  let%map receiver_pk = Public_key.Compressed.gen in
-  {token_id; token_owner_pk; receiver_pk}
+  let%bind receiver_pk = Public_key.Compressed.gen in
+  let%map account_disabled = Quickcheck.Generator.bool in
+  {token_id; token_owner_pk; receiver_pk; account_disabled}

--- a/src/lib/coda_base/new_token_payload.ml
+++ b/src/lib/coda_base/new_token_payload.ml
@@ -4,28 +4,33 @@ open Import
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type t = {token_owner_pk: Public_key.Compressed.Stable.V1.t}
+    type t =
+      { token_owner_pk: Public_key.Compressed.Stable.V1.t
+      ; disable_new_accounts: bool }
     [@@deriving compare, eq, sexp, hash, yojson]
 
     let to_latest = Fn.id
   end
 end]
 
-type t = Stable.Latest.t = {token_owner_pk: Public_key.Compressed.t}
+type t = Stable.Latest.t =
+  {token_owner_pk: Public_key.Compressed.t; disable_new_accounts: bool}
 [@@deriving compare, eq, sexp, hash, yojson]
 
-let receiver_pk {token_owner_pk} = token_owner_pk
+let receiver_pk {token_owner_pk; _} = token_owner_pk
 
-let receiver ~next_available_token {token_owner_pk} =
+let receiver ~next_available_token {token_owner_pk; _} =
   Account_id.create token_owner_pk next_available_token
 
-let source_pk {token_owner_pk} = token_owner_pk
+let source_pk {token_owner_pk; _} = token_owner_pk
 
-let source ~next_available_token {token_owner_pk} =
+let source ~next_available_token {token_owner_pk; _} =
   Account_id.create token_owner_pk next_available_token
 
 let token (_ : t) = Token_id.invalid
 
 let gen =
-  Quickcheck.Generator.map Public_key.Compressed.gen ~f:(fun pk ->
-      {token_owner_pk= pk} )
+  let open Quickcheck.Generator.Let_syntax in
+  let%bind token_owner_pk = Public_key.Compressed.gen in
+  let%map disable_new_accounts = Quickcheck.Generator.bool in
+  {token_owner_pk; disable_new_accounts}

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -342,6 +342,11 @@ let apply_user_command_exn
         in
         if action = `Existed then
           failwith "Attempted to create an account that already exists" ;
+        let receiver_account =
+          { receiver_account with
+            token_permissions= Token_permissions.Not_owned {account_disabled}
+          }
+        in
         let source_idx = find_index_exn t source in
         let source_account =
           if Account_id.equal source receiver then receiver_account

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -332,6 +332,13 @@ let apply_user_command_exn
         in
         [(fee_payer_idx, fee_payer_account); (receiver_idx, receiver_account)]
     | Create_token_account {account_disabled; _} ->
+        if
+          account_disabled
+          && not (Token_id.(equal default) (Account_id.token_id receiver))
+        then
+          raise
+            (Reject
+               (Failure "Cannot open a disabled account in the default token")) ;
         let fee_payer_account =
           try charge_account_creation_fee_exn fee_payer_account
           with exn -> raise (Reject exn)

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -334,7 +334,7 @@ let apply_user_command_exn
     | Create_token_account {account_disabled; _} ->
         if
           account_disabled
-          && not (Token_id.(equal default) (Account_id.token_id receiver))
+          && Token_id.(equal default) (Account_id.token_id receiver)
         then
           raise
             (Reject

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -681,7 +681,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       | Create_token_account {account_disabled; _} ->
           if
             account_disabled
-            && not (Token_id.(equal default) (Account_id.token_id receiver))
+            && Token_id.(equal default) (Account_id.token_id receiver)
           then
             raise
               (Reject

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -685,7 +685,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           then
             raise
               (Reject
-                 (Error.errorf
+                 (Error.createf
                     "Cannot open a disabled account in the default token")) ;
           let fee_payer_account =
             try charge_account_creation_fee_exn fee_payer_account

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -694,6 +694,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                 Or_error.errorf
                   "Attempted to create an account that already exists"
           in
+          let receiver_account =
+            { receiver_account with
+              token_permissions= Token_permissions.Not_owned {account_disabled}
+            }
+          in
           let%bind source_location, source_account =
             get_with_location ledger source
           in

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -679,6 +679,14 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           , Undo.User_command_undo.Body.Create_new_token
               {created_token= next_available_token} )
       | Create_token_account {account_disabled; _} ->
+          if
+            account_disabled
+            && not (Token_id.(equal default) (Account_id.token_id receiver))
+          then
+            raise
+              (Reject
+                 (Error.errorf
+                    "Cannot open a disabled account in the default token")) ;
           let fee_payer_account =
             try charge_account_creation_fee_exn fee_payer_account
             with exn -> raise (Reject (Error.of_exn exn))

--- a/src/lib/coda_base/transaction_union.ml
+++ b/src/lib/coda_base/transaction_union.ml
@@ -63,7 +63,8 @@ let of_transaction : Transaction.t -> t = function
               ; receiver_pk= receiver
               ; token_id= Token_id.default
               ; amount
-              ; tag= Tag.Coinbase } }
+              ; tag= Tag.Coinbase
+              ; token_locked= false } }
       ; signer= Public_key.decompress_exn other_pk
       ; signature= Signature.dummy }
   | Fee_transfer tr -> (
@@ -82,7 +83,8 @@ let of_transaction : Transaction.t -> t = function
                 ; receiver_pk= pk1
                 ; token_id
                 ; amount= Amount.of_fee fee1
-                ; tag= Tag.Fee_transfer } }
+                ; tag= Tag.Fee_transfer
+                ; token_locked= false } }
         ; signer= Public_key.decompress_exn pk2
         ; signature= Signature.dummy }
       in

--- a/src/lib/coda_base/transaction_union_payload.ml
+++ b/src/lib/coda_base/transaction_union_payload.ml
@@ -24,45 +24,57 @@ module Random_oracle = Random_oracle_nonconsensus.Random_oracle
 module Tag = Transaction_union_tag
 
 module Body = struct
-  type ('tag, 'public_key, 'token_id, 'amount) t_ =
+  type ('tag, 'public_key, 'token_id, 'amount, 'bool) t_ =
     { tag: 'tag
     ; source_pk: 'public_key
     ; receiver_pk: 'public_key
     ; token_id: 'token_id
-    ; amount: 'amount }
+    ; amount: 'amount
+    ; token_locked: 'bool }
   [@@deriving sexp]
 
-  type t = (Tag.t, Public_key.Compressed.t, Token_id.t, Currency.Amount.t) t_
+  type t =
+    (Tag.t, Public_key.Compressed.t, Token_id.t, Currency.Amount.t, bool) t_
   [@@deriving sexp]
 
   let of_user_command_payload_body = function
     | User_command_payload.Body.Payment
         {source_pk; receiver_pk; token_id; amount} ->
-        {tag= Tag.Payment; source_pk; receiver_pk; token_id; amount}
+        { tag= Tag.Payment
+        ; source_pk
+        ; receiver_pk
+        ; token_id
+        ; amount
+        ; token_locked= false }
     | Stake_delegation (Set_delegate {delegator; new_delegate}) ->
         { tag= Tag.Stake_delegation
         ; source_pk= delegator
         ; receiver_pk= new_delegate
         ; token_id= Token_id.default
-        ; amount= Currency.Amount.zero }
-    | Create_new_token {token_owner_pk} ->
+        ; amount= Currency.Amount.zero
+        ; token_locked= false }
+    | Create_new_token {token_owner_pk; disable_new_accounts} ->
         { tag= Tag.Create_account
         ; source_pk= token_owner_pk
         ; receiver_pk= token_owner_pk
         ; token_id= Token_id.invalid
-        ; amount= Currency.Amount.zero }
-    | Create_token_account {token_id; token_owner_pk; receiver_pk} ->
+        ; amount= Currency.Amount.zero
+        ; token_locked= disable_new_accounts }
+    | Create_token_account
+        {token_id; token_owner_pk; receiver_pk; account_disabled} ->
         { tag= Tag.Create_account
         ; source_pk= token_owner_pk
         ; receiver_pk
         ; token_id
-        ; amount= Currency.Amount.zero }
+        ; amount= Currency.Amount.zero
+        ; token_locked= account_disabled }
     | Mint_tokens {token_id; token_owner_pk; receiver_pk; amount} ->
         { tag= Tag.Mint_tokens
         ; source_pk= token_owner_pk
         ; receiver_pk
         ; token_id
-        ; amount }
+        ; amount
+        ; token_locked= false }
 
   let gen ~fee =
     let open Quickcheck.Generator.Let_syntax in
@@ -91,6 +103,20 @@ module Body = struct
             (Amount.zero, Amount.max_int)
       in
       Amount.gen_incl min max
+    and token_locked =
+      match tag with
+      | Payment ->
+          return false
+      | Stake_delegation ->
+          return false
+      | Create_account ->
+          Quickcheck.Generator.bool
+      | Fee_transfer ->
+          return false
+      | Coinbase ->
+          return false
+      | Mint_tokens ->
+          return false
     and source_pk = Public_key.Compressed.gen
     and receiver_pk = Public_key.Compressed.gen
     and token_id =
@@ -108,7 +134,7 @@ module Body = struct
       | Coinbase ->
           return Token_id.default
     in
-    {tag; source_pk; receiver_pk; token_id; amount}
+    {tag; source_pk; receiver_pk; token_id; amount; token_locked}
 
   [%%ifdef
   consensus_mechanism]
@@ -117,11 +143,12 @@ module Body = struct
     ( Tag.Unpacked.var
     , Public_key.Compressed.var
     , Token_id.var
-    , Currency.Amount.var )
+    , Currency.Amount.var
+    , Boolean.var )
     t_
 
-  let to_hlist {tag; source_pk; receiver_pk; token_id; amount} =
-    H_list.[tag; source_pk; receiver_pk; token_id; amount]
+  let to_hlist {tag; source_pk; receiver_pk; token_id; amount; token_locked} =
+    H_list.[tag; source_pk; receiver_pk; token_id; amount; token_locked]
 
   let spec =
     Data_spec.
@@ -129,44 +156,53 @@ module Body = struct
       ; Public_key.Compressed.typ
       ; Public_key.Compressed.typ
       ; Token_id.typ
-      ; Currency.Amount.typ ]
+      ; Currency.Amount.typ
+      ; Boolean.typ ]
 
   let typ =
     Typ.of_hlistable spec ~var_to_hlist:to_hlist ~value_to_hlist:to_hlist
       ~var_of_hlist:
-        (fun H_list.[tag; source_pk; receiver_pk; token_id; amount] ->
-        {tag; source_pk; receiver_pk; token_id; amount} )
+        (fun H_list.
+               [tag; source_pk; receiver_pk; token_id; amount; token_locked] ->
+        {tag; source_pk; receiver_pk; token_id; amount; token_locked} )
       ~value_of_hlist:
-        (fun H_list.[tag; source_pk; receiver_pk; token_id; amount] ->
-        {tag; source_pk; receiver_pk; token_id; amount} )
+        (fun H_list.
+               [tag; source_pk; receiver_pk; token_id; amount; token_locked] ->
+        {tag; source_pk; receiver_pk; token_id; amount; token_locked} )
 
   module Checked = struct
-    let constant ({tag; source_pk; receiver_pk; token_id; amount} : t) : var =
+    let constant
+        ({tag; source_pk; receiver_pk; token_id; amount; token_locked} : t) :
+        var =
       { tag= Tag.unpacked_of_t tag
       ; source_pk= Public_key.Compressed.var_of_t source_pk
       ; receiver_pk= Public_key.Compressed.var_of_t receiver_pk
       ; token_id= Token_id.var_of_t token_id
-      ; amount= Currency.Amount.var_of_t amount }
+      ; amount= Currency.Amount.var_of_t amount
+      ; token_locked= Boolean.var_of_value token_locked }
 
-    let to_input {tag; source_pk; receiver_pk; token_id; amount} =
+    let to_input {tag; source_pk; receiver_pk; token_id; amount; token_locked}
+        =
       let%map token_id = Token_id.Checked.to_input token_id in
       Array.reduce_exn ~f:Random_oracle.Input.append
         [| Tag.Unpacked.to_input tag
          ; Public_key.Compressed.Checked.to_input source_pk
          ; Public_key.Compressed.Checked.to_input receiver_pk
          ; token_id
-         ; Currency.Amount.var_to_input amount |]
+         ; Currency.Amount.var_to_input amount
+         ; Random_oracle.Input.bitstring [token_locked] |]
   end
 
   [%%endif]
 
-  let to_input {tag; source_pk; receiver_pk; token_id; amount} =
+  let to_input {tag; source_pk; receiver_pk; token_id; amount; token_locked} =
     Array.reduce_exn ~f:Random_oracle.Input.append
       [| Tag.to_input tag
        ; Public_key.Compressed.to_input source_pk
        ; Public_key.Compressed.to_input receiver_pk
        ; Token_id.to_input token_id
-       ; Currency.Amount.to_input amount |]
+       ; Currency.Amount.to_input amount
+       ; Random_oracle.Input.bitstring [token_locked] |]
 end
 
 type t = (User_command_payload.Common.t, Body.t) User_command_payload.Poly.t

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -128,8 +128,11 @@ let check_tokens ({payload= {common= {fee_token; _}; body}; _} : t) =
       not (Token_id.(equal invalid) token_id)
   | Stake_delegation _ ->
       true
-  | Create_new_token _ | Create_token_account _ ->
+  | Create_new_token _ ->
       Token_id.(equal default) fee_token
+  | Create_token_account {token_id; account_disabled; _} ->
+      Token_id.(equal default) fee_token
+      && not (Token_id.(equal default) token_id && account_disabled)
   | Mint_tokens {token_id; _} ->
       (not (Token_id.(equal invalid) token_id))
       && not (Token_id.(equal default) token_id)

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -217,7 +217,8 @@ module Body = struct
     let new_token_gen =
       match source_pk with
       | Some token_owner_pk ->
-          return {New_token_payload.token_owner_pk}
+          map New_token_payload.gen ~f:(fun payload ->
+              {payload with token_owner_pk} )
       | None ->
           New_token_payload.gen
     in

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -1243,10 +1243,15 @@ module Base = struct
       Token_id.(Checked.equal token (var_of_t default))
     in
     let%bind () =
-      [%with_label
-        "Token_locked value is compatible with the transaction kind"]
-        (Boolean.Assert.any
-           [Boolean.not payload.body.token_locked; is_create_account])
+      Checked.all_unit
+        [ [%with_label
+            "Token_locked value is compatible with the transaction kind"]
+            (Boolean.Assert.any
+               [Boolean.not payload.body.token_locked; is_create_account])
+        ; [%with_label "Token_locked cannot be used with the default token"]
+            (Boolean.Assert.any
+               [ Boolean.not payload.body.token_locked
+               ; Boolean.not token_default ]) ]
     in
     let%bind () =
       [%with_label "Validate tokens"]


### PR DESCRIPTION
This PR augments the `Create_token_account` and `Create_new_token` with booleans for disabling or enabling token accounts. 

```ocaml
Create_token_account
  { token_owner_pk
  ; token_id
  ; receiver_pk
  ; account_disabled (* Newly added in this PR *) }
Create_new_token
  { token_owner_pk
  ; disable_new_accounts (* Newly added in this PR *) }
```

Disabling an account currently has no effect. An upcoming PR will add commands to toggle this state (by token owners) and disable all other commands running against that account.

The `Create_token_account` will succeed iff
* `account_disabled` matches the `disable_new_accounts` field in the token owner's token permissions field; or
* the fee payer (ie. issuer/signer) was the token owner.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: