### PR TITLE
Use base58-check encoding for private keys (s-expressions and json)

### DIFF
--- a/src/lib/coda_transition/internal_transition.ml
+++ b/src/lib/coda_transition/internal_transition.ml
@@ -34,7 +34,6 @@ module Stable = struct
       { snark_transition: Snark_transition.Value.Stable.V1.t
       ; prover_state: Consensus.Data.Prover_state.Stable.V1.t
       ; staged_ledger_diff: Staged_ledger_diff.Stable.V1.t }
-    [@@deriving sexp, to_yojson, fields]
 
     let to_latest = Fn.id
   end

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -373,7 +373,7 @@ module type S = sig
       [%%versioned:
       module Stable : sig
         module V1 : sig
-          type t [@@deriving sexp, to_yojson]
+          type t
         end
       end]
 

--- a/src/lib/consensus/stake_proof.ml
+++ b/src/lib/consensus/stake_proof.ml
@@ -9,7 +9,6 @@ module Stable = struct
       ; ledger: Sparse_ledger.Stable.V1.t
       ; private_key: Signature_lib.Private_key.Stable.V1.t
       ; public_key: Signature_lib.Public_key.Stable.V1.t }
-    [@@deriving sexp, to_yojson]
 
     let to_latest = Fn.id
   end

--- a/src/lib/prover/prover.ml
+++ b/src/lib/prover/prover.ml
@@ -17,7 +17,6 @@ module Extend_blockchain_input = struct
         ; block: Snark_transition.Value.Stable.V1.t
         ; prover_state: Consensus.Data.Prover_state.Stable.V1.t
         ; pending_coinbase: Pending_coinbase_witness.Stable.V1.t }
-      [@@deriving sexp]
 
       let to_latest = Fn.id
     end

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -18,17 +18,9 @@ open Snark_params_nonconsensus
 [%%versioned_asserted
 module Stable = struct
   module V1 = struct
-    type t = Inner_curve.Scalar.t [@@deriving sexp]
+    type t = Inner_curve.Scalar.t
 
     let to_latest = Fn.id
-
-    let to_yojson t = `String (Inner_curve.Scalar.to_string t)
-
-    let of_yojson = function
-      | `String s ->
-          Ok (Inner_curve.Scalar.of_string s)
-      | _ ->
-          Error "Private_key.of_yojson expected `String"
 
     [%%ifdef
     consensus_mechanism]
@@ -86,7 +78,7 @@ module Stable = struct
   end
 end]
 
-type t = Stable.Latest.t [@@deriving yojson, sexp]
+type t = Stable.Latest.t
 
 [%%define_locally
 Stable.Latest.(gen)]
@@ -120,3 +112,19 @@ let to_base58_check t =
 let of_base58_check_exn s =
   let decoded = Base58_check.decode_exn s in
   decoded |> Bigstring.of_string |> of_bigstring_exn
+
+let sexp_of_t t = to_base58_check t |> Sexp.of_string
+
+let t_of_sexp sexp = Sexp.to_string sexp |> of_base58_check_exn
+
+let to_yojson t = `String (to_base58_check t)
+
+let of_yojson = function
+  | `String x -> (
+    try Ok (of_base58_check_exn x) with
+    | Failure str ->
+        Error str
+    | exn ->
+        Error ("Signature_lib.Private_key.of_yojson: " ^ Exn.to_string exn) )
+  | _ ->
+      Error "Signature_lib.Private_key.of_yojson: Expected a string"


### PR DESCRIPTION
This PR switches from encoding private keys using the raw `Inner_curve.Scalar.to_string` to `base58_check`.

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: