### PR TITLE
Fix coda-demo docker image

### DIFF
--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -16,7 +16,7 @@
 [%%define delta 3]
 
 [%%define record_async_backtraces false]
-[%%define time_offsets false]
+[%%define time_offsets true]
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 


### PR DESCRIPTION
This PR sets `time_offsets=true` in the `testnet_postake_medium_curves` compile-time config file.

The `coda-demo` docker image needs to set a time offset to avoid generating a new genesis proof each startup. Without this enabled, it fails at the first block with an 'empty epoch' error (previously an equivalent constraint failure in the block producer pre-#5329).

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: