### PR TITLE
Expose all transactions directly from the pool for GraphQL

### DIFF
--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1844,10 +1844,7 @@ module Queries = struct
         in
         ( match opt_pk with
         | None ->
-            Network_pool.Transaction_pool.Resource_pool.transactions
-              ~logger:(Coda_lib.top_level_logger coda)
-              resource_pool
-            |> Sequence.to_list
+            Network_pool.Transaction_pool.Resource_pool.get_all resource_pool
         | Some pk ->
             let account_id = Account_id.create pk Token_id.default in
             Network_pool.Transaction_pool.Resource_pool.all_from_account

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -215,6 +215,10 @@ let all_from_account :
     ~f:(fun (user_commands, _) ->
       Sequence.to_list @@ F_sequence.to_seq user_commands )
 
+let get_all {all_by_fee; _} : User_command.With_valid_signature.t list =
+  Map.fold_right all_by_fee ~init:[] ~f:(fun ~key:_ ~data acc ->
+      Set.fold_right data ~init:acc ~f:(fun txn acc -> txn :: acc) )
+
 (* Remove a command from the applicable_by_fee field. This may break an
    invariant. *)
 let remove_applicable_exn : t -> User_command.With_valid_signature.t -> t =

--- a/src/lib/network_pool/indexed_pool.ml
+++ b/src/lib/network_pool/indexed_pool.ml
@@ -216,8 +216,9 @@ let all_from_account :
       Sequence.to_list @@ F_sequence.to_seq user_commands )
 
 let get_all {all_by_fee; _} : User_command.With_valid_signature.t list =
-  Map.fold_right all_by_fee ~init:[] ~f:(fun ~key:_ ~data acc ->
-      Set.fold_right data ~init:acc ~f:(fun txn acc -> txn :: acc) )
+  Map.fold_right all_by_fee ~init:[] ~f:(fun ~key:_ ~data acc_txns ->
+      Set.fold_right data ~init:acc_txns ~f:(fun txn acc_txns ->
+          txn :: acc_txns ) )
 
 (* Remove a command from the applicable_by_fee field. This may break an
    invariant. *)

--- a/src/lib/network_pool/indexed_pool.mli
+++ b/src/lib/network_pool/indexed_pool.mli
@@ -85,9 +85,12 @@ val add_from_backtrack : t -> User_command.With_valid_signature.t -> t
 (** Check whether a command is in the pool *)
 val member : t -> User_command.With_valid_signature.t -> bool
 
-(* Get all the user commands sent by a user with a particular account *)
+(** Get all the user commands sent by a user with a particular account *)
 val all_from_account :
   t -> Account_id.t -> User_command.With_valid_signature.t list
+
+(** Get all user commands in the pool. *)
+val get_all : t -> User_command.With_valid_signature.t list
 
 (** Check the contents of the pool are valid against the current ledger. Call
     this whenever the transition frontier is (re)created.

--- a/src/lib/network_pool/intf.ml
+++ b/src/lib/network_pool/intf.ml
@@ -263,4 +263,6 @@ module type Transaction_resource_pool_intf = sig
 
   val all_from_account :
     t -> Account_id.t -> User_command.With_valid_signature.t list
+
+  val get_all : t -> User_command.With_valid_signature.t list
 end

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -221,6 +221,8 @@ struct
 
     let all_from_account {pool; _} = Indexed_pool.all_from_account pool
 
+    let get_all {pool; _} = Indexed_pool.get_all pool
+
     (** Get the best tip ledger*)
     let get_best_tip_ledger frontier =
       Transition_frontier.best_tip frontier


### PR DESCRIPTION
Previously, this used the `transactions` command, which runs the pool
checks and reconstructs a pool after removing each command. We don't
want to do this, for (currently) up to 3000 commands, on each txnpool
GraphQL query

Checklist:

- [ ] Tests were added for the new behavior
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: