### PR TITLE
Make compile-time-constants fail less, disable logging

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1269,11 +1269,12 @@ let compile_time_constants =
          let open Async in
          let%map ({consensus_constants; _} as precomputed_values), _ =
            config_file |> Genesis_ledger_helper.load_config_json
-           >>| Or_error.ok_exn >>| Runtime_config.of_yojson
-           >>| Result.ok_or_failwith
+           >>| Or_error.ok
+           >>| Option.value ~default:(`Assoc [])
+           >>| Runtime_config.of_yojson >>| Result.ok
+           >>| Option.value ~default:Runtime_config.default
            >>= Genesis_ledger_helper.init_from_config_file ~genesis_dir
-                 ~logger:(Logger.create ()) ~may_generate:false
-                 ~proof_level:None
+                 ~logger:(Logger.null ()) ~may_generate:false ~proof_level:None
                  ~genesis_constants:Genesis_constants.compiled
            >>| Or_error.ok_exn
          in


### PR DESCRIPTION
This PR changes the `compile-time-constants` command so that
* use a default value if `load_json_config` doesn't find a file
* use the default runtime config if it cannot parse the json config file
* disables the logging for initialisation
  - this is unfortunate, but apprently we log to stdout, and so we clobber any actual output

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: