### PR TITLE
Add logging for validation errors

### DIFF
--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -46,7 +46,7 @@ let handle_validation_error ~logger ~trust_system ~sender ~state_hash ~delta
     | `Invalid_proof ->
         [("reason", `String "invalid proof")]
     | `Invalid_delta_transition_chain_proof ->
-        [("reason", `String "invalid_delta_transition_chain_proof")]
+        [("reason", `String "invalid delta transition chain proof")]
     | `Verifier_error err ->
         [ ("reason", `String "verifier error")
         ; ("error", `String (Error.to_string_hum err)) ]

--- a/src/lib/transition_router/initial_validator.ml
+++ b/src/lib/transition_router/initial_validator.ml
@@ -32,6 +32,33 @@ let handle_validation_error ~logger ~trust_system ~sender ~state_hash ~delta
     Trust_system.record_envelope_sender trust_system logger sender
       (action, Some (message', metadata))
   in
+  let metadata =
+    match error with
+    | `Invalid_time_received `Too_early ->
+        [ ("reason", `String "invalid time")
+        ; ("time_error", `String "too early") ]
+    | `Invalid_time_received (`Too_late slot_diff) ->
+        [ ("reason", `String "invalid time")
+        ; ("time_error", `String "too late")
+        ; ("slot_diff", `String (Int64.to_string slot_diff)) ]
+    | `Invalid_genesis_protocol_state ->
+        [("reason", `String "invalid genesis state")]
+    | `Invalid_proof ->
+        [("reason", `String "invalid proof")]
+    | `Invalid_delta_transition_chain_proof ->
+        [("reason", `String "invalid_delta_transition_chain_proof")]
+    | `Verifier_error err ->
+        [ ("reason", `String "verifier error")
+        ; ("error", `String (Error.to_string_hum err)) ]
+    | `Mismatched_protocol_version ->
+        [("reason", `String "protocol version mismatch")]
+    | `Invalid_protocol_version ->
+        [("reason", `String "invalid protocol version")]
+  in
+  Logger.error logger ~module_:__MODULE__ ~location:__LOC__
+    ~metadata:(("state_hash", State_hash.to_yojson state_hash) :: metadata)
+    "Validation error: external transition with state hash $state_hash was \
+     rejected for reason $reason" ;
   match error with
   | `Verifier_error err ->
       let error_metadata = [("error", `String (Error.to_string_hum err))] in


### PR DESCRIPTION
We don't appear to log the reason for validation failures anywhere, which makes debugging forks etc. harder. This PR adds log messages for those validation failures.

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: