### PR TITLE
WORKSPACE: add local_repository for each submodule in src/external

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,20 +21,10 @@ ocaml_configure_tooling()
 
 ocaml_register_toolchains(installation="host")
 
-git_repository(
-    name = "digestif",
-    branch = "bazel",
-    remote = "https://github.com/mobileink/digestif",
-)
-
-git_repository(
-    name = "ppx_optcomp",
-    branch = "bazel",
-    remote = "https://github.com/mobileink/ppx_optcomp"
-)
-
-git_repository(
-    name = "ppx_version",
-    branch = "bazel",
-    remote = "https://github.com/mobileink/ppx_version",
-)
+local_repository( name = "async_kernel" , path = "src/external/async_kernel")
+local_repository( name = "digestif"     , path = "src/external/digestif")
+local_repository( name = "graphql_ppx"  , path = "src/external/graphql_ppx")
+local_repository( name = "ocaml_extlib" , path = "src/external/ocaml_extlib")
+local_repository( name = "ppx_optcomp"  , path = "src/external/ppx_optcomp")
+local_repository( name = "ppx_version"  , path = "src/external/ppx_version")
+local_repository( name = "rpc_parallel" , path = "src/external/rpc_parallel")


### PR DESCRIPTION
In preparation for when bazel support for the externals is merged
upstream and pulled into the submodules.

When the time comes to remove the git submodules from the source tree, all we will need to do is change these local_repository rules to http_archive rules.

Signed-off-by: Gregg Reynolds <601396+mobileink@users.noreply.github.com>

