### PR TITLE
Add ppx_representatives

### DIFF
--- a/src/lib/ppx_coda/dune
+++ b/src/lib/ppx_coda/dune
@@ -2,6 +2,6 @@
  (name ppx_coda)
  (public_name ppx_coda)
  (kind ppx_deriver)
- (libraries compiler-libs.common ppxlib ppx_deriving.api ppx_bin_prot ppx_register_event core_kernel)
+ (libraries compiler-libs.common ppxlib ppx_deriving.api ppx_bin_prot ppx_register_event core_kernel ppx_representatives)
  (preprocessor_deps ../../config.mlh)
  (preprocess (pps ppx_version ppxlib.metaquot ppx_optcomp)))

--- a/src/lib/ppx_coda/ppx_representatives/dune
+++ b/src/lib/ppx_coda/ppx_representatives/dune
@@ -1,0 +1,7 @@
+(library
+ (name ppx_representatives)
+ (public_name ppx_representatives)
+ (kind ppx_deriver)
+ (libraries compiler-libs.common ppxlib)
+ (preprocess (pps ppxlib.metaquot))
+ (ppx_runtime_libraries ppx_representatives.runtime))

--- a/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
+++ b/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
@@ -51,7 +51,8 @@ let rec core_type ~loc (typ : core_type) : expression =
   let open Ast_builder.Default in
   match typ.ptyp_desc with
   | Ptyp_any ->
-      [%expr Stdlib.Lazy.from_fun (fun () -> failwith "Unknown type")]
+      Location.raise_errorf ~loc:typ.ptyp_loc
+        "Cannot derive %s for anonymous type variables" deriver_name
   | Ptyp_var name ->
       (* Names for type variables should be placed in context at the type
         declaration level.

--- a/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
+++ b/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
@@ -61,10 +61,10 @@ let rec core_type ~loc (typ : core_type) : expression =
   | Ptyp_arrow (label, _, _) ->
       [%expr
         lazy
-          [%e
-            pexp_fun ~loc label None
-              [%pat? _]
-              [%expr failwith "Functional type"]]]
+          [ [%e
+              pexp_fun ~loc label None
+                [%pat? _]
+                [%expr failwith "Functional type"]] ]]
   | Ptyp_tuple typs ->
       let exprs = List.map ~f:(core_type ~loc) typs in
       let mk_name i =

--- a/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
+++ b/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
@@ -64,7 +64,15 @@ let rec core_type ~loc (typ : core_type) : expression =
           [ [%e
               pexp_fun ~loc label None
                 [%pat? _]
-                [%expr failwith "Functional type"]] ]]
+                [%expr
+                  Stdlib.failwith
+                    [%e
+                      estring ~loc
+                        (Stdlib.Format.asprintf
+                           "%s: Illegal call to dummy functional value \
+                            defined by %a"
+                           deriver_name Ocaml_common.Location.print_loc
+                           typ.ptyp_loc)]]] ]]
   | Ptyp_tuple typs ->
       let exprs = List.map ~f:(core_type ~loc) typs in
       let mk_name i =

--- a/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
+++ b/src/lib/ppx_coda/ppx_representatives/ppx_representatives.ml
@@ -1,0 +1,273 @@
+open Base
+open Ppxlib
+
+let deriver_name = "to_representatives"
+
+let mangle ~suffix name =
+  if String.equal name "t" then suffix else name ^ "_" ^ suffix
+
+let mangle_lid ~suffix lid =
+  match lid with
+  | Lident name ->
+      Lident (mangle ~suffix name)
+  | Ldot (lid, name) ->
+      Ldot (lid, mangle ~suffix name)
+  | Lapply _ ->
+      assert false
+
+let mk_lid name = Loc.make ~loc:name.loc (Longident.Lident name.txt)
+
+let constr_of_decl ~loc decl =
+  Ast_builder.Default.ptyp_constr ~loc (mk_lid decl.ptype_name)
+    (List.map ~f:fst decl.ptype_params)
+
+let is_builtin = function
+  | "unit" | "bool" | "int" | "string" | "char" ->
+      true
+  | _ ->
+      false
+
+(* The way that we expand representatives below makes it extremely easy to blow
+   the stack if we're not tail-recursive. All generated list iterators should
+   use the [rev_*] versions of functions when their non-reversed alternatives
+   are not tail recursive.
+*)
+let rec core_type ~loc (typ : core_type) : expression =
+  let open Ast_builder.Default in
+  match typ.ptyp_desc with
+  | Ptyp_any ->
+      [%expr Stdlib.Lazy.from_fun (fun () -> failwith "Unknown type")]
+  | Ptyp_var name ->
+      (* Names for type variables should be placed in context at the type
+        declaration level.
+     *)
+      evar ~loc name
+  | Ptyp_arrow (label, _, _) ->
+      [%expr
+        lazy
+          [%e
+            pexp_fun ~loc label None
+              [%pat? _]
+              [%expr failwith "Functional type"]]]
+  | Ptyp_tuple typs ->
+      let exprs = List.map ~f:(core_type ~loc) typs in
+      let mk_name i =
+        "__" ^ deriver_name ^ "__internal_name_" ^ Int.to_string i
+      in
+      let result =
+        [%expr
+          [ [%e
+              pexp_tuple ~loc
+                (List.mapi exprs ~f:(fun i _ -> evar ~loc (mk_name i)))] ]]
+      in
+      (* We map over each alternative in the tuple to get every possible
+         combination.
+      *)
+      [%expr
+        lazy
+          [%e
+            List.foldi ~init:result exprs ~f:(fun i expr arg ->
+                [%expr
+                  Ppx_representatives_runtime.Util.rev_concat
+                    (Stdlib.List.rev_map
+                       (fun [%p pvar ~loc (mk_name i)] -> [%e expr])
+                       (Stdlib.Lazy.force [%e arg]))] )]]
+  | Ptyp_constr ({txt= Lident name; _}, []) when is_builtin name -> (
+    match name with
+    | "unit" ->
+        [%expr Ppx_representatives_runtime.unit_to_representatives]
+    | "bool" ->
+        [%expr Ppx_representatives_runtime.bool_to_representatives]
+    | "int" ->
+        [%expr Ppx_representatives_runtime.int_to_representatives]
+    | "string" ->
+        [%expr Ppx_representatives_runtime.string_to_representatives]
+    | "char" ->
+        [%expr Ppx_representatives_runtime.char_to_representatives]
+    | _ ->
+        assert false )
+  | Ptyp_constr ({txt= Lident "list"; _}, [_]) ->
+      [%expr Ppx_representatives_runtime.list_to_representatives ()]
+  | Ptyp_constr ({txt= Lident "option"; _}, [_]) ->
+      [%expr Ppx_representatives_runtime.option_to_representatives ()]
+  | Ptyp_constr (lid, typs) ->
+      let exprs = List.map ~f:(core_type ~loc) typs in
+      pexp_apply ~loc
+        (pexp_ident ~loc (Located.map (mangle_lid ~suffix:deriver_name) lid))
+        (List.map exprs ~f:(fun e -> (Nolabel, e)))
+  | Ptyp_object _ ->
+      Location.raise_errorf ~loc:typ.ptyp_loc
+        "Cannot derive %s for object types" deriver_name
+  | Ptyp_class _ ->
+      Location.raise_errorf ~loc:typ.ptyp_loc
+        "Cannot derive %s for class types" deriver_name
+  | Ptyp_alias _ ->
+      (* Really we should bubble a let definition for the alias out to the
+         type, but we don't need this currently, so it's not worth the
+         complexity.
+      *)
+      Location.raise_errorf ~loc:typ.ptyp_loc
+        "Cannot derive %s for type aliases" deriver_name
+  | Ptyp_variant (rows, _, _) ->
+      (* Could throw an error if it is open, but the alias failure above
+         prevents this from happening in type definitions anyway.
+      *)
+      [%expr
+        lazy
+          (Ppx_representatives_runtime.Util.rev_concat
+             [%e
+               elist ~loc
+                 (List.rev_map rows ~f:(function
+                   | Rtag (name, _, _, []) ->
+                       [%expr [[%e pexp_variant ~loc name.txt None]]]
+                   | Rtag (name, _, _, [typ]) ->
+                       [%expr
+                         Stdlib.List.rev_map
+                           (fun e ->
+                             [%e pexp_variant ~loc name.txt (Some [%expr e])]
+                             )
+                           (Stdlib.Lazy.force [%e core_type ~loc typ])]
+                   | Rtag _ ->
+                       Location.raise_errorf ~loc:typ.ptyp_loc
+                         "Cannot derive %s for variant constructors with \
+                          different type arguments for the same constructor"
+                         deriver_name
+                   | Rinherit typ' ->
+                       [%expr
+                         Stdlib.List.rev
+                           (Stdlib.Lazy.force
+                              (* Coerce here, because the inherited type may be a
+                                 strict subtype.
+                              *)
+                              ([%e core_type ~loc typ'] :> [%t typ] list lazy_t))] ))])]
+  | Ptyp_poly (vars, typ) ->
+      (* Inject dummy representatives into the environment so that they can
+         resolve.
+      *)
+      [%expr
+        lazy
+          [%e
+            List.fold ~init:(core_type ~loc typ) vars ~f:(fun expr var ->
+                [%expr
+                  let [%p pvar ~loc var.txt] =
+                    Stdlib.Lazy.from_fun (fun () -> failwith "Unknown type")
+                  in
+                  [%e expr]] )]]
+  | Ptyp_package _ ->
+      Location.raise_errorf ~loc:typ.ptyp_loc
+        "Cannot derive %s for packaged modules" deriver_name
+  | Ptyp_extension _ ->
+      Location.raise_errorf ~loc:typ.ptyp_loc
+        "Cannot derive %s for un-expanded extensions" deriver_name
+
+let record_decl ~loc (fields : label_declaration list) : expression =
+  let open Ast_builder.Default in
+  [%expr
+    lazy
+      [%e
+        List.fold fields
+          ~f:(fun expr field ->
+            [%expr
+              Ppx_representatives_runtime.Util.rev_concat
+                (Stdlib.List.rev_map
+                   (fun [%p pvar ~loc field.pld_name.txt] -> [%e expr])
+                   (Lazy.force [%e core_type ~loc field.pld_type]))] )
+          ~init:
+            [%expr
+              [ [%e
+                  pexp_record ~loc
+                    (List.map fields ~f:(fun field ->
+                         (mk_lid field.pld_name, evar ~loc field.pld_name.txt)
+                     ))
+                    None] ]]]]
+
+let str_decl ~loc (decl : type_declaration) : structure_item =
+  let open Ast_builder.Default in
+  let binding expr =
+    [%stri
+      let ([%p pvar ~loc (mangle ~suffix:deriver_name decl.ptype_name.txt)] :
+            [%t
+              List.fold_right decl.ptype_params
+                ~f:(fun (param, _) typ ->
+                  [%type: [%t param] list lazy_t -> [%t typ]] )
+                ~init:[%type: [%t constr_of_decl ~loc decl] list lazy_t]]) =
+        [%e
+          List.fold_right decl.ptype_params ~init:expr
+            ~f:(fun (param, _) expr ->
+              let pat =
+                match param.ptyp_desc with
+                | Ptyp_any ->
+                    [%pat? _]
+                | Ptyp_var name ->
+                    pvar ~loc name
+                | _ ->
+                    Location.raise_errorf ~loc:param.ptyp_loc
+                      "Expected a type variable or _"
+              in
+              [%expr fun [%p pat] -> [%e expr]] )]]
+  in
+  match decl with
+  | {ptype_kind= Ptype_variant constrs; _} ->
+      binding
+        [%expr
+          lazy
+            (Ppx_representatives_runtime.Util.rev_concat
+               [%e
+                 elist ~loc
+                   (List.rev_map constrs ~f:(fun constr ->
+                        let args =
+                          match constr.pcd_args with
+                          | Pcstr_tuple [] ->
+                              None
+                          | Pcstr_tuple [typ] ->
+                              Some (core_type ~loc typ)
+                          | Pcstr_tuple typs ->
+                              Some (core_type ~loc (ptyp_tuple ~loc typs))
+                          | Pcstr_record fields ->
+                              Some (record_decl ~loc fields)
+                        in
+                        match args with
+                        | None ->
+                            [%expr
+                              [ [%e
+                                  pexp_construct ~loc (mk_lid constr.pcd_name)
+                                    None] ]]
+                        | Some arg ->
+                            [%expr
+                              Stdlib.List.rev_map
+                                (fun x ->
+                                  [%e
+                                    pexp_construct ~loc
+                                      (mk_lid constr.pcd_name)
+                                      (Some [%expr x])] )
+                                (Stdlib.Lazy.force [%e arg])] ))])]
+  | {ptype_kind= Ptype_abstract; ptype_manifest= Some typ; _} ->
+      binding (core_type ~loc typ)
+  | {ptype_kind= Ptype_record fields; _} ->
+      binding (record_decl ~loc fields)
+  | _ ->
+      Location.raise_errorf ~loc "Cannot derive %s for this type" deriver_name
+
+let sig_decl ~loc (decl : type_declaration) : signature_item =
+  let open Ast_builder.Default in
+  psig_value ~loc
+  @@ value_description ~loc ~prim:[]
+       ~name:
+         (Located.mk ~loc (mangle ~suffix:deriver_name decl.ptype_name.txt))
+       ~type_:
+         (List.fold_right decl.ptype_params
+            ~f:(fun (param, _) typ ->
+              [%type: [%t param] list lazy_t -> [%t typ]] )
+            ~init:[%type: [%t constr_of_decl ~loc decl] list lazy_t])
+
+let str_type_decl ~loc ~path:_ (_rec_flag, decls) : structure =
+  List.map ~f:(str_decl ~loc) decls
+
+let sig_type_decl ~loc ~path:_ (_rec_flag, decls) : signature =
+  List.map ~f:(sig_decl ~loc) decls
+
+let deriver =
+  Deriving.add
+    ~str_type_decl:(Deriving.Generator.make_noarg str_type_decl)
+    ~sig_type_decl:(Deriving.Generator.make_noarg sig_type_decl)
+    deriver_name

--- a/src/lib/ppx_coda/ppx_representatives/runtime/dune
+++ b/src/lib/ppx_coda/ppx_representatives/runtime/dune
@@ -1,0 +1,3 @@
+(library
+ (name ppx_representatives_runtime)
+ (public_name ppx_representatives.runtime))

--- a/src/lib/ppx_coda/ppx_representatives/runtime/ppx_representatives_runtime.ml
+++ b/src/lib/ppx_coda/ppx_representatives/runtime/ppx_representatives_runtime.ml
@@ -22,6 +22,16 @@ let string_to_representatives = lazy [""]
 
 let char_to_representatives = lazy [' ']
 
+let bytes_to_representatives = lazy [Bytes.empty]
+
+let int32_to_representatives = lazy [0l]
+
+let int64_to_representatives = lazy [0L]
+
+let nativeint_to_representatives = lazy [0n]
+
 let list_to_representatives _ = lazy [[]]
 
 let option_to_representatives _ = lazy [None]
+
+let array_to_representatives _ = lazy [[||]]

--- a/src/lib/ppx_coda/ppx_representatives/runtime/ppx_representatives_runtime.ml
+++ b/src/lib/ppx_coda/ppx_representatives/runtime/ppx_representatives_runtime.ml
@@ -1,0 +1,27 @@
+module Util = struct
+  let rev_concat l =
+    let rec rev_concat acc l =
+      match l with
+      | [] ->
+          acc
+      | [] :: l ->
+          rev_concat acc l
+      | (x :: xs) :: l ->
+          rev_concat (x :: acc) (xs :: l)
+    in
+    rev_concat [] l
+end
+
+let unit_to_representatives = lazy [()]
+
+let bool_to_representatives = lazy [false]
+
+let int_to_representatives = lazy [0]
+
+let string_to_representatives = lazy [""]
+
+let char_to_representatives = lazy [' ']
+
+let list_to_representatives _ = lazy [[]]
+
+let option_to_representatives _ = lazy [None]

--- a/src/lib/ppx_coda/ppx_representatives/runtime/ppx_representatives_runtime.ml
+++ b/src/lib/ppx_coda/ppx_representatives/runtime/ppx_representatives_runtime.ml
@@ -1,15 +1,15 @@
 module Util = struct
   let rev_concat l =
-    let rec rev_concat acc l =
+    let rec go acc l =
       match l with
       | [] ->
           acc
       | [] :: l ->
-          rev_concat acc l
+          go acc l
       | (x :: xs) :: l ->
-          rev_concat (x :: acc) (xs :: l)
+          go (x :: acc) (xs :: l)
     in
-    rev_concat [] l
+    go [] l
 end
 
 let unit_to_representatives = lazy [()]

--- a/src/ppx_representatives.opam
+++ b/src/ppx_representatives.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+


### PR DESCRIPTION
This PR adds the ppx `[@@deriving to_representatives]`, which computes a list of the representative values for a type. The built-in types use dummy values (e.g. `string` uses `""`, `bool` uses `false`), but the various forms of user-generated types are exposed in full. The list of representatives is held lazily in a value named after the type, `val to_representatives : t list Lazy.t` for a type `t`, or `val type_name_to_representatives : t list Lazy.t` for a type `type_name`.

@bkase requested this to expose the different cases that should be handled for the rosetta API.

This is implemented recursively, so user-defined types that refer to other user-defined types will also receive their expansions inline. For example,

```ocaml
$ dune utop src/lib/ppx_coda/ppx_representatives/
───────────────┬─────────────────────────────────────────────────────────────┬────────────────
               │ Welcome to utop version 2.3.0 (using OCaml version 4.07.1)! │
               └─────────────────────────────────────────────────────────────┘
Findlib has been successfully loaded. Additional directives:
  #require "package";;      to load a package
  #list;;                   to list the available packages
  #camlp4o;;                to load camlp4 (standard syntax)
  #camlp4r;;                to load camlp4 (revised syntax)
  #predicates "p,q,...";;   to set these predicates
  Topfind.reset();;         to force that packages will be reloaded
  #thread;;                 to enable threads


Type #utop_help for help about using utop.

─( 21:44:47 )─< command 0 >────────────────────────────────────────────────────{ counter: 0 }─
utop # type t = [`A of int | `B of string] [@@deriving to_representatives];;
type t = [ `A of int | `B of string ]
val to_representatives : t list lazy_t = <lazy>
─( 21:44:48 )─< command 1 >────────────────────────────────────────────────────{ counter: 0 }─
utop # type u = [`X of t | `Y of string] [@@deriving to_representatives];;
type u = [ `X of t | `Y of string ]
val u_to_representatives : u list lazy_t = <lazy>
─( 21:44:53 )─< command 2 >────────────────────────────────────────────────────{ counter: 0 }─
utop # type v = t * u [@@deriving to_representatives];;
type v = t * u
val v_to_representatives : v list lazy_t = <lazy>
─( 21:44:57 )─< command 3 >────────────────────────────────────────────────────{ counter: 0 }─
utop # type 'a a = {a: 'a; b: int; c: v} [@@deriving to_representatives];;
type 'a a = { a : 'a; b : int; c : v; }
val a_to_representatives : 'a list lazy_t -> 'a a list lazy_t = <fun>
─( 21:45:01 )─< command 4 >────────────────────────────────────────────────────{ counter: 0 }─
utop # type b = A of bool | B of string [@@deriving to_representatives];;
type b = A of bool | B of string
val b_to_representatives : b list lazy_t = <lazy>
─( 21:45:05 )─< command 5 >────────────────────────────────────────────────────{ counter: 0 }─
utop # type c = b a [@@deriving to_representatives];;
type c = b a
val c_to_representatives : c list lazy_t = <lazy>
─( 21:45:12 )─< command 6 >────────────────────────────────────────────────────{ counter: 0 }─
utop # Lazy.force c_to_representatives;;
- : c list =
[{a = A false; b = 0; c = (`B "", `X (`A 0))};
 {a = B ""; b = 0; c = (`B "", `X (`A 0))};
 {a = A false; b = 0; c = (`A 0, `X (`A 0))};
 {a = B ""; b = 0; c = (`A 0, `X (`A 0))};
 {a = A false; b = 0; c = (`B "", `X (`B ""))};
 {a = B ""; b = 0; c = (`B "", `X (`B ""))};
 {a = A false; b = 0; c = (`A 0, `X (`B ""))};
 {a = B ""; b = 0; c = (`A 0, `X (`B ""))};
 {a = A false; b = 0; c = (`B "", `Y "")};
 {a = B ""; b = 0; c = (`B "", `Y "")};
 {a = A false; b = 0; c = (`A 0, `Y "")}; {a = B ""; b = 0; c = (`A 0, `Y "")}]
```

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
