### PR TITLE
Use CircleCIs pipeline.git.base_revision instead of a JSON query

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,7 @@ jobs:
             - run:
                 name: Decode Apple Certificates
                 context: org-global
-                command: bash -c '[ -z $APPLE_CERTIFICATES ] || base64 -D -o frontend/wallet/Certificates.p12 <<< $APPLE_CERTIFICATES'
+                command: bash -c '[ -z $APPLE_CERTIFICATES ] || base64 -D -o frontend/wallet/Certificates.p12 \<<< $APPLE_CERTIFICATES'
             - run:
                 name: Fastlane
                 context: org-global

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@
 
 
 
-version: 3
+version: 2.1
 jobs:
     tracetool:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,8 +241,6 @@ jobs:
     lint-opt:
         docker:
             - image: codaprotocol/coda:toolchain-9924f4c56a40d65d36440e8f70b93720f29ba171
-        environment:
-          BASE_BRANCH_NAME: << pipeline.git.base_revision >>
         steps:
             
             - run:
@@ -275,9 +273,13 @@ jobs:
 
             - run:
                   name: Compare versioned types in PR
+                  environment:
+                    BASE_BRANCH_NAME: << pipeline.git.base_revision >>
                   command: ./scripts/compare_ci_diff_types.sh
             - run:
                   name: Compare binable functors in PR
+                  environment:
+                    BASE_BRANCH_NAME: << pipeline.git.base_revision >>
                   command: ./scripts/compare_ci_diff_binables.sh
     compare-test-signatures:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,6 +241,8 @@ jobs:
     lint-opt:
         docker:
             - image: codaprotocol/coda:toolchain-9924f4c56a40d65d36440e8f70b93720f29ba171
+        environment:
+          BASE_BRANCH_NAME: << pipeline.git.base_revision >>
         steps:
             
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -186,6 +186,8 @@ jobs:
     lint-opt:
         docker:
             - image: codaprotocol/coda:toolchain-9924f4c56a40d65d36440e8f70b93720f29ba171
+        environment:
+          BASE_BRANCH_NAME: << pipeline.git.base_revision >>
         steps:
             {{ checkout_no_lfs }}
             - run:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -186,8 +186,6 @@ jobs:
     lint-opt:
         docker:
             - image: codaprotocol/coda:toolchain-9924f4c56a40d65d36440e8f70b93720f29ba171
-        environment:
-          BASE_BRANCH_NAME: << pipeline.git.base_revision >>
         steps:
             {{ checkout_no_lfs }}
             - run:
@@ -196,9 +194,13 @@ jobs:
             {{ opam_init_linux }}
             - run:
                   name: Compare versioned types in PR
+                  environment:
+                    BASE_BRANCH_NAME: << pipeline.git.base_revision >>
                   command: ./scripts/compare_ci_diff_types.sh
             - run:
                   name: Compare binable functors in PR
+                  environment:
+                    BASE_BRANCH_NAME: << pipeline.git.base_revision >>
                   command: ./scripts/compare_ci_diff_binables.sh
     compare-test-signatures:
         docker:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -33,7 +33,7 @@
             - checkout
 {%endset%}
 
-version: 3
+version: 2.1
 jobs:
     tracetool:
         docker:

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -363,7 +363,7 @@ jobs:
             - run:
                 name: Decode Apple Certificates
                 context: org-global
-                command: bash -c '[ -z $APPLE_CERTIFICATES ] || base64 -D -o frontend/wallet/Certificates.p12 <<< $APPLE_CERTIFICATES'
+                command: bash -c '[ -z $APPLE_CERTIFICATES ] || base64 -D -o frontend/wallet/Certificates.p12 \<<< $APPLE_CERTIFICATES'
             - run:
                 name: Fastlane
                 context: org-global

--- a/scripts/compare_ci_diff_binables.sh
+++ b/scripts/compare_ci_diff_binables.sh
@@ -15,4 +15,4 @@ rm -rf base
 # build print_binable_functors, then run Python script to compare binable functors in a pull request
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/src/print_binable_functors.exe) && \
-    ./scripts/compare_pr_diff_binables.py ${CIRCLE_PULL_REQUEST}
+    ./scripts/compare_pr_diff_binables.py ${BASE_BRANCH_NAME}

--- a/scripts/compare_ci_diff_types.sh
+++ b/scripts/compare_ci_diff_types.sh
@@ -16,4 +16,4 @@ rm -rf base
 
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/src/print_versioned_types.exe) && \
-    ./scripts/compare_pr_diff_types.py ${CIRCLE_PULL_REQUEST}
+    ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME}

--- a/scripts/compare_pr_diff_binables.py
+++ b/scripts/compare_pr_diff_binables.py
@@ -10,7 +10,7 @@ from compare_pr_diff_items import run_comparison
 
 if __name__ == "__main__":
     if len(sys.argv) != 2 :
-        print("Usage: %s Github-PR-URL" % sys.argv[0], file=sys.stderr)
+        print("Usage: %s base-branch" % sys.argv[0], file=sys.stderr)
         sys.exit(1)
 
     run_comparison(sys.argv[1],'compare_binables.py')

--- a/scripts/compare_pr_diff_items.py
+++ b/scripts/compare_pr_diff_items.py
@@ -11,7 +11,6 @@ import json
 exit_code = 0
 
 
-# pr_url is of form https://github.com/CodaProtocol/coda/pull/n
 def run_comparison(base, compare_script):
     cwd = os.getcwd()
     # create a copy of the repo at base branch

--- a/scripts/compare_pr_diff_items.py
+++ b/scripts/compare_pr_diff_items.py
@@ -6,7 +6,6 @@ import os
 import sys
 import shutil
 import subprocess
-import json
 
 exit_code = 0
 

--- a/scripts/compare_pr_diff_items.py
+++ b/scripts/compare_pr_diff_items.py
@@ -12,19 +12,7 @@ exit_code = 0
 
 
 # pr_url is of form https://github.com/CodaProtocol/coda/pull/n
-def run_comparison(pr_url, compare_script):
-    pr_number = os.path.basename(pr_url)
-    api_url = 'https://api.github.com/repos/CodaProtocol/coda/pulls/' + pr_number
-    pr_json = 'pr.json'
-    if os.path.exists(pr_json):
-        os.remove(pr_json)
-    subprocess.run([
-        'curl', api_url, '-H', 'Accept: application/vnd.github.v3.json', '-o',
-        pr_json
-    ])
-    with open(pr_json, 'r') as fp:
-        json_obj = json.load(fp, encoding='utf-8')
-    base = json_obj['base']['ref']
+def run_comparison(base, compare_script):
     cwd = os.getcwd()
     # create a copy of the repo at base branch
     if os.path.exists('base'):

--- a/scripts/compare_pr_diff_items.py
+++ b/scripts/compare_pr_diff_items.py
@@ -11,7 +11,7 @@ import json
 exit_code = 0
 
 
-def run_comparison(base, compare_script):
+def run_comparison(base_commit, compare_script):
     cwd = os.getcwd()
     # create a copy of the repo at base branch
     if os.path.exists('base'):
@@ -20,10 +20,11 @@ def run_comparison(base, compare_script):
     os.chdir('base')
     # it would be faster to do a clone of the local repo, but there's "smudge error" (?)
     subprocess.run(['git', 'clone', 'git@github.com:CodaProtocol/coda.git'])
+    subprocess.run(['git', 'checkout', base_commit])
     os.chdir(cwd)
     # changed files in the PR
     diffs_raw = subprocess.check_output(
-        ['git', 'diff', '--name-only', 'origin/' + base])
+        ['git', 'diff', '--name-only', base_commit])
     diffs_decoded = diffs_raw.decode('UTF-8')
     diffs = diffs_decoded.split('\n')
     for diff in diffs:

--- a/scripts/compare_pr_diff_types.py
+++ b/scripts/compare_pr_diff_types.py
@@ -10,7 +10,7 @@ from compare_pr_diff_items import run_comparison
 
 if __name__ == "__main__":
     if len(sys.argv) != 2 :
-        print("Usage: %s Github-PR-URL" % sys.argv[0], file=sys.stderr)
+        print("Usage: %s base-branch" % sys.argv[0], file=sys.stderr)
         sys.exit(1)
 
     run_comparison(sys.argv[1],'compare_versioned_types.py')


### PR DESCRIPTION
This should circumvent the error we were seeing [here](https://app.circleci.com/pipelines/github/CodaProtocol/coda/23847/workflows/ba15bfa1-1e1a-4d39-b76f-8e669a3a6a6e/jobs/454163/parallel-runs/0/steps/0-109).

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: