### PR TITLE
[Trivial] Log the runtime configuration on startup

### DIFF
--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -753,6 +753,9 @@ let load_config_file filename =
 
 let init_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
     ~may_generate ~proof_level ~genesis_constants (config : Runtime_config.t) =
+  Logger.info logger ~module_:__MODULE__ ~location:__LOC__
+    "Initialising with runtime configuration $config"
+    ~metadata:[("config", Runtime_config.to_yojson config)] ;
   let open Deferred.Or_error.Let_syntax in
   let proof_level =
     List.find_map_exn ~f:Fn.id

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -754,7 +754,7 @@ let load_config_file filename =
 let init_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
     ~may_generate ~proof_level ~genesis_constants (config : Runtime_config.t) =
   Logger.info logger ~module_:__MODULE__ ~location:__LOC__
-    "Initialising with runtime configuration $config"
+    "Initializing with runtime configuration $config"
     ~metadata:[("config", Runtime_config.to_yojson config)] ;
   let open Deferred.Or_error.Let_syntax in
   let proof_level =


### PR DESCRIPTION
This is a sanity check log, so that we can make sure we're starting all nodes with the right runtime config.

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: