### PR TITLE
Uses new goodies that @mrmr1993 has created

### DIFF
--- a/src/app/rosetta/dune
+++ b/src/app/rosetta/dune
@@ -5,6 +5,7 @@
   (modes native)
   (libraries
     async
+    async_ssl
     caqti
     caqti-async
     caqti-driver-postgresql

--- a/src/app/rosetta/lib/dune
+++ b/src/app/rosetta/lib/dune
@@ -4,6 +4,7 @@
   (inline_tests)
   (libraries
      async
+     async_ssl
     caqti
     caqti-async
     caqti-driver-postgresql


### PR DESCRIPTION
* Endpoints support `https` (in theory)
  * On macOS I get `LibreSSL SSL_connect: SSL_ERROR_SYSCALL` at
  runtime but I suspect that it will work on linux
* Use `to_enum` for errors' `code` function
* Use `to_representatives` for getting all variants (not hooked up yet)