### PR TITLE
Leaderboard - Case Insensitive Search and In-Order Member Profile Tables

### DIFF
--- a/frontend/website/src/components/Leaderboard.re
+++ b/frontend/website/src/components/Leaderboard.re
@@ -275,7 +275,12 @@ let make =
       state.members,
     )
     |> Js.Array.filter(member =>
-         search === "" ? true : Js.String.includes(search, member.name)
+         search === ""
+           ? true
+           : Js.String.includes(
+               String.lowercase_ascii(search),
+               String.lowercase_ascii(member.name),
+             )
        )
     |> Js.Array.filter(member => sortRank(member) !== 0);
 

--- a/frontend/website/src/pages/MemberProfilePage.re
+++ b/frontend/website/src/pages/MemberProfilePage.re
@@ -119,7 +119,12 @@ let fetchReleases = name => {
     ("Release 3.2a", "3.2a!B3:Z", 2), /* offset for challenge titles in 3.2a starts on the 2nd column */
     ("Release 3.2b", "3.2b!B3:Z", 2) /* offset for challenge titles in 3.2b starts on the 2nd column */
   |]
-  |> Array.map(release => fetchRelease(name, release));
+  |> Array.map(release => fetchRelease(name, release))
+  |> Js.Promise.all
+  |> Js.Promise.then_(releaseValues => {
+       Belt.Array.keepMap(releaseValues, release => release)
+       |> Js.Promise.resolve
+     });
 };
 
 let parseMember = map => {
@@ -179,16 +184,22 @@ let initialState = {
 type actions =
   | UpdateReleaseInfo(array(ChallengePointsTable.release))
   | UpdateCurrentUser(Leaderboard.member)
+  | UpdateCurrentReleaseAndUser(
+      array(ChallengePointsTable.release),
+      Leaderboard.member,
+    )
   | UpdateError(bool);
 
 let reducer = (prevState, action) => {
   switch (action) {
-  | UpdateReleaseInfo(releases) => {
-      ...prevState,
-      loading: false,
-      releases: Belt.Array.concat(prevState.releases, releases),
-    }
+  | UpdateReleaseInfo(releases) => {...prevState, loading: false, releases}
   | UpdateCurrentUser(member) => {...prevState, currentMember: Some(member)}
+  | UpdateCurrentReleaseAndUser(releases, member) => {
+      loading: false,
+      error: false,
+      currentMember: Some(member),
+      releases,
+    }
   | UpdateError(error) => {...prevState, error}
   };
 };
@@ -249,17 +260,9 @@ let make = () => {
       switch (parseMember(router.query)) {
       | Some(member) =>
         fetchReleases(member.name)
-        |> Array.iter(e => {
-             e
-             |> Promise.iter(releaseInfo => {
-                  switch (releaseInfo) {
-                  | Some(releaseInfo) =>
-                    dispatch(UpdateCurrentUser(member));
-                    dispatch(UpdateReleaseInfo([|releaseInfo|]));
-                  | None => ()
-                  }
-                })
-           })
+        |> Promise.iter(releases =>
+             dispatch(UpdateCurrentReleaseAndUser(releases, member))
+           )
       | None => dispatch(UpdateError(true))
       };
       None;


### PR DESCRIPTION
This PR includes the following functionality:

1. It makes the leaderboard user participant search case insensitive.
2. Orders the challenge points tables in /memberProfile to be ordered by the proper releases. 

This solves the following issues:
https://github.com/CodaProtocol/coda/issues/5341
https://github.com/CodaProtocol/coda/issues/5343

This was all tested manually. 