### PR TITLE
Carry the status of user commands with them once applied

### DIFF
--- a/src/app/archive/archive_lib/diff.ml
+++ b/src/app/archive/archive_lib/diff.ml
@@ -75,9 +75,10 @@ module Builder = struct
       External_transition.Validated.user_commands validated_block
     in
     let sender_receipt_chains_from_parent_ledger =
-      let user_commands = User_command.Set.of_list user_commands in
       let senders =
-        Account_id.Set.map user_commands ~f:User_command.fee_payer
+        user_commands
+        |> List.map ~f:(fun {data; _} -> User_command.fee_payer data)
+        |> Account_id.Set.of_list
       in
       let ledger =
         Staged_ledger.ledger @@ Breadcrumb.staged_ledger breadcrumb

--- a/src/app/archive/archive_lib/dune
+++ b/src/app/archive/archive_lib/dune
@@ -4,5 +4,5 @@
   (libraries core async coda_base coda_transition one_or_two transition_frontier caqti-async caqti caqti-driver-postgresql)
   (inline_tests)
   (modes native)
-  (preprocess (pps ppx_version ppx_jane ppx_custom_printf)))
+  (preprocess (pps ppx_version ppx_jane ppx_custom_printf h_list.ppx)))
   

--- a/src/app/archive/archive_lib/processor.ml
+++ b/src/app/archive/archive_lib/processor.ml
@@ -424,11 +424,11 @@ module Block = struct
           Core.List.fold transactions ~init:([], [], [])
             ~f:(fun (acc_user_commands, acc_fee_transfers, acc_coinbases) ->
             function
-            | { Coda_base.User_command_status.With_status.status
+            | { Coda_base.With_status.status
               ; data= Coda_base.Transaction.User_command user_command_checked
               } ->
                 let user_command =
-                  { Coda_base.User_command_status.With_status.status
+                  { Coda_base.With_status.status
                   ; data=
                       Coda_base.User_command.forget_check user_command_checked
                   }

--- a/src/app/archive/archive_lib/test.ml
+++ b/src/app/archive/archive_lib/test.ml
@@ -257,7 +257,7 @@ let%test_module "Archive node unit tests" =
                             match%map.Async
                               Processor.User_command.find conn
                                 ~transaction_hash:
-                                  (Transaction_hash.hash_user_command cmd)
+                                  (Transaction_hash.hash_user_command cmd.data)
                             with
                             | Ok (Some _) ->
                                 ()
@@ -267,7 +267,7 @@ let%test_module "Archive node unit tests" =
                                      !"The user command %{sexp: \
                                        User_command.t} was pruned when it \
                                        should not have been"
-                                     cmd)
+                                     cmd.data)
                             | Error e ->
                                 failwith @@ Caqti_error.show e )
                       in
@@ -292,7 +292,7 @@ let%test_module "Archive node unit tests" =
                             match%map.Async
                               Processor.User_command.find conn
                                 ~transaction_hash:
-                                  (Transaction_hash.hash_user_command cmd)
+                                  (Transaction_hash.hash_user_command cmd.data)
                             with
                             | Ok None ->
                                 ()
@@ -302,7 +302,7 @@ let%test_module "Archive node unit tests" =
                                      !"The user command %{sexp: \
                                        User_command.t} was not pruned when it \
                                        should have been"
-                                     cmd)
+                                     cmd.data)
                             | Error e ->
                                 failwith @@ Caqti_error.show e )
                       in

--- a/src/app/archive/create_schema.sql
+++ b/src/app/archive/create_schema.sql
@@ -14,19 +14,23 @@ CREATE INDEX idx_snarked_ledger_hashes_value ON snarked_ledger_hashes(value);
 
 CREATE TYPE user_command_type AS ENUM ('payment', 'delegation', 'create_token', 'create_account', 'mint_tokens');
 
+CREATE TYPE user_command_status AS ENUM ('applied', 'failed');
+
 CREATE TABLE user_commands
-( id           serial            PRIMARY KEY
-, type         user_command_type NOT NULL
-, fee_payer_id int               NOT NULL REFERENCES public_keys(id)
-, source_id    int               NOT NULL REFERENCES public_keys(id)
-, receiver_id  int               NOT NULL REFERENCES public_keys(id)
-, fee_token    text              NOT NULL
-, token        text              NOT NULL
-, nonce        bigint            NOT NULL
-, amount       bigint
-, fee          bigint            NOT NULL
-, memo         text              NOT NULL
-, hash         text              NOT NULL UNIQUE
+( id             serial              PRIMARY KEY
+, type           user_command_type   NOT NULL
+, fee_payer_id   int                 NOT NULL REFERENCES public_keys(id)
+, source_id      int                 NOT NULL REFERENCES public_keys(id)
+, receiver_id    int                 NOT NULL REFERENCES public_keys(id)
+, fee_token      text                NOT NULL
+, token          text                NOT NULL
+, nonce          bigint              NOT NULL
+, amount         bigint
+, fee            bigint              NOT NULL
+, memo           text                NOT NULL
+, hash           text                NOT NULL UNIQUE
+, status         user_command_status
+, failure_reason text
 );
 
 CREATE TYPE internal_command_type AS ENUM ('fee_transfer', 'coinbase');

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -396,13 +396,13 @@ let start_payment_check logger root_pipe (testnet : Api.t) =
                      expected_deadline root_length ;
                    exit 9 |> ignore ) ) ;
              List.iter user_commands ~f:(fun user_cmd ->
-                 Hashtbl.change user_cmds_under_inspection user_cmd
+                 Hashtbl.change user_cmds_under_inspection user_cmd.data
                    ~f:(function
                    | Some {passed_root; _} ->
                        Ivar.fill passed_root () ;
                        Logger.info logger ~module_:__MODULE__ ~location:__LOC__
                          ~metadata:
-                           [ ("user_cmd", User_command.to_yojson user_cmd)
+                           [ ("user_cmd", User_command.to_yojson user_cmd.data)
                            ; ("worker_id", `Int worker_id)
                            ; ("length", `Int root_length) ]
                          "Transaction $user_cmd finally gets into the root of \

--- a/src/lib/auxiliary_database/filtered_external_transition.ml
+++ b/src/lib/auxiliary_database/filtered_external_transition.ml
@@ -110,7 +110,8 @@ let validate_transactions external_transition =
   Staged_ledger.Pre_diff_info.get_transactions staged_ledger_diff
 
 let of_transition external_transition tracked_participants
-    (calculated_transactions : Transaction.t list) =
+    (calculated_transactions :
+      Transaction.t User_command_status.With_status.t list) =
   let open External_transition.Validated in
   let creator = block_producer external_transition in
   let protocol_state =
@@ -132,7 +133,7 @@ let of_transition external_transition tracked_participants
           ; coinbase_receiver= None }
         , next_available_token )
       ~f:(fun (acc_transactions, next_available_token) -> function
-        | User_command checked_user_command -> (
+        | {data= User_command checked_user_command; _} -> (
             let user_command =
               User_command.forget_check checked_user_command
             in
@@ -157,7 +158,8 @@ let of_transition external_transition tracked_participants
                     user_commands=
                       user_command :: acc_transactions.user_commands }
                 , User_command.next_available_token user_command
-                    next_available_token ) ) | Fee_transfer fee_transfer ->
+                    next_available_token ) )
+        | {data= Fee_transfer fee_transfer; _} ->
             let fee_transfer_list =
               Coda_base.Fee_transfer.to_list fee_transfer
             in
@@ -176,7 +178,7 @@ let of_transition external_transition tracked_participants
                 fee_transfers= fee_transfers @ acc_transactions.fee_transfers
               }
             , next_available_token )
-        | Coinbase {Coinbase.amount; fee_transfer; receiver} ->
+        | {data= Coinbase {Coinbase.amount; fee_transfer; receiver}; _} ->
             let fee_transfer =
               Option.map ~f:Coinbase_fee_transfer.to_fee_transfer fee_transfer
             in

--- a/src/lib/auxiliary_database/filtered_external_transition.ml
+++ b/src/lib/auxiliary_database/filtered_external_transition.ml
@@ -110,8 +110,7 @@ let validate_transactions external_transition =
   Staged_ledger.Pre_diff_info.get_transactions staged_ledger_diff
 
 let of_transition external_transition tracked_participants
-    (calculated_transactions :
-      Transaction.t User_command_status.With_status.t list) =
+    (calculated_transactions : Transaction.t With_status.t list) =
   let open External_transition.Validated in
   let creator = block_producer external_transition in
   let protocol_state =

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -227,13 +227,8 @@ let generate_next_state ~constraint_constants ~previous_protocol_state
             measure "consensus generate_transition" (fun () ->
                 Consensus_state_hooks.generate_transition
                   ~previous_protocol_state ~blockchain_state ~current_time
-                  ~block_data
-                  ~transactions:
-                    ( Staged_ledger_diff.With_valid_signatures_and_proofs
-                      .user_commands diff
-                      :> User_command.t list )
-                  ~snarked_ledger_hash:previous_ledger_hash ~supply_increase
-                  ~logger ~constraint_constants ) )
+                  ~block_data ~snarked_ledger_hash:previous_ledger_hash
+                  ~supply_increase ~logger ~constraint_constants ) )
       in
       lift_sync (fun () ->
           measure "making Snark and Internal transitions" (fun () ->

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -106,7 +106,7 @@ module Undo : sig
   module User_command_undo : sig
     module Common : sig
       type t = Undo.User_command_undo.Common.t =
-        { user_command: User_command.t User_command_status.With_status.t
+        { user_command: User_command.t With_status.t
         ; previous_receipt_chain_hash: Receipt.Chain_hash.t
         ; fee_payer_timing: Account.Timing.t
         ; source_timing: Account.Timing.t option }
@@ -151,8 +151,7 @@ module Undo : sig
   type t = Undo.t = {previous_hash: Ledger_hash.t; varying: Varying.t}
   [@@deriving sexp]
 
-  val transaction :
-    t -> Transaction.t User_command_status.With_status.t Or_error.t
+  val transaction : t -> Transaction.t With_status.t Or_error.t
 
   val user_command_status : t -> User_command_status.t
 end

--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -106,7 +106,7 @@ module Undo : sig
   module User_command_undo : sig
     module Common : sig
       type t = Undo.User_command_undo.Common.t =
-        { user_command: User_command.t
+        { user_command: User_command.t User_command_status.With_status.t
         ; previous_receipt_chain_hash: Receipt.Chain_hash.t
         ; fee_payer_timing: Account.Timing.t
         ; source_timing: Account.Timing.t option }
@@ -151,7 +151,10 @@ module Undo : sig
   type t = Undo.t = {previous_hash: Ledger_hash.t; varying: Varying.t}
   [@@deriving sexp]
 
-  val transaction : t -> Transaction.t Or_error.t
+  val transaction :
+    t -> Transaction.t User_command_status.With_status.t Or_error.t
+
+  val user_command_status : t -> User_command_status.t
 end
 
 val create_new_account_exn : t -> Account_id.t -> Account.t -> unit

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -40,9 +40,7 @@ module Undo = struct
       module Stable = struct
         module V1 = struct
           type t =
-            { user_command:
-                User_command.Stable.V1.t
-                User_command_status.With_status.Stable.V1.t
+            { user_command: User_command.Stable.V1.t With_status.Stable.V1.t
             ; previous_receipt_chain_hash: Receipt.Chain_hash.Stable.V1.t
             ; fee_payer_timing: Account.Timing.Stable.V1.t
             ; source_timing: Account.Timing.Stable.V1.t option }
@@ -53,7 +51,7 @@ module Undo = struct
       end]
 
       type t = Stable.Latest.t =
-        { user_command: User_command.t User_command_status.With_status.t
+        { user_command: User_command.t With_status.t
         ; previous_receipt_chain_hash: Receipt.Chain_hash.t
         ; fee_payer_timing: Account.Timing.t
         ; source_timing: Account.Timing.t option }
@@ -185,7 +183,7 @@ module type S = sig
     module User_command_undo : sig
       module Common : sig
         type t = Undo.User_command_undo.Common.t =
-          { user_command: User_command.t User_command_status.With_status.t
+          { user_command: User_command.t With_status.t
           ; previous_receipt_chain_hash: Receipt.Chain_hash.t
           ; fee_payer_timing: Account.Timing.t
           ; source_timing: Account.Timing.t option }
@@ -231,8 +229,7 @@ module type S = sig
     type t = Undo.t = {previous_hash: Ledger_hash.t; varying: Varying.t}
     [@@deriving sexp]
 
-    val transaction :
-      t -> Transaction.t User_command_status.With_status.t Or_error.t
+    val transaction : t -> Transaction.t With_status.t Or_error.t
 
     val user_command_status : t -> User_command_status.t
   end
@@ -418,13 +415,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
   module Undo = struct
     include Undo
 
-    let transaction :
-        t -> Transaction.t User_command_status.With_status.t Or_error.t =
+    let transaction : t -> Transaction.t With_status.t Or_error.t =
      fun {varying; _} ->
       match varying with
       | User_command uc ->
-          User_command_status.With_status.map_result uc.common.user_command
-            ~f:(fun cmd ->
+          With_status.map_result uc.common.user_command ~f:(fun cmd ->
               Option.value_map ~default:(Or_error.error_string "Bad signature")
                 (UC.check cmd) ~f:(fun cmd -> Ok (Transaction.User_command cmd))
           )

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -506,6 +506,12 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
     let source = User_command.source ~next_available_token user_command in
     let receiver = User_command.receiver ~next_available_token user_command in
     let exception Reject of Error.t in
+    let ok_or_reject = function
+      | Ok x ->
+          x
+      | Error err ->
+          raise (Reject err)
+    in
     let charge_account_creation_fee_exn (account : Account.t) =
       let balance =
         Option.value_exn
@@ -521,6 +527,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       {account with timing}
     in
     let compute_updates () =
+      let open Result.Let_syntax in
       (* Compute the necessary changes to apply the command, failing if any of
          the conditions are not met.
       *)
@@ -548,27 +555,25 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               return predicate_result
           | Payment _ | Stake_delegation _ | Mint_tokens _ ->
               (* TODO(#4554): Hook predicate evaluation in here once implemented. *)
-              Or_error.errorf
-                "The fee-payer is not authorised to issue commands for the \
-                 source account"
+              Result.fail User_command_status.Failure.Predicate
       in
       match payload.body with
       | Stake_delegation _ ->
-          let%bind receiver_location, _receiver_account =
+          let receiver_location, _receiver_account =
             (* Check that receiver account exists. *)
-            get_with_location ledger receiver
+            get_with_location ledger receiver |> ok_or_reject
           in
-          let%bind source_location, source_account =
-            get_with_location ledger source
+          let source_location, source_account =
+            get_with_location ledger source |> ok_or_reject
           in
           let%bind () =
             match (source_location, receiver_location) with
             | `Existing _, `Existing _ ->
                 return ()
             | `New, _ ->
-                Or_error.errorf "The delegating account does not exist"
+                Result.fail User_command_status.Failure.Source_not_present
             | _, `New ->
-                Or_error.errorf "The delegated-to account does not exist"
+                Result.fail User_command_status.Failure.Receiver_not_present
           in
           let previous_delegate = source_account.delegate in
           let source_timing = source_account.timing in
@@ -578,6 +583,8 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           let%map timing =
             validate_timing ~txn_amount:Amount.zero
               ~txn_global_slot:current_global_slot ~account:source_account
+            |> Result.map_error ~f:(fun _ ->
+                   User_command_status.Failure.Source_insufficient_balance )
           in
           let source_account =
             { source_account with
@@ -588,8 +595,8 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           , `Source_timing source_timing
           , Undo.User_command_undo.Body.Stake_delegation {previous_delegate} )
       | Payment {amount; token_id= token; _} ->
-          let%bind receiver_location, receiver_account =
-            get_with_location ledger receiver
+          let receiver_location, receiver_account =
+            get_with_location ledger receiver |> ok_or_reject
           in
           (* Charge the account creation fee. *)
           let%bind receiver_amount =
@@ -600,15 +607,19 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                 if Token_id.(equal default) token then
                   (* Subtract the creation fee from the transaction amount. *)
                   sub_account_creation_fee ~constraint_constants `Added amount
+                  |> Result.map_error ~f:(fun _ ->
+                         User_command_status.Failure
+                         .Amount_insufficient_to_create_account )
                 else
-                  Or_error.errorf
-                    !"The receiving account does not exist, and the \
-                      transferred token %{sexp: Token_id.t} is not the default"
-                    token
+                  Result.fail
+                    User_command_status.Failure
+                    .Cannot_pay_creation_fee_in_token
           in
           let%bind receiver_account =
             let%map balance =
               add_amount receiver_account.balance receiver_amount
+              |> Result.map_error ~f:(fun _ ->
+                     User_command_status.Failure.Overflow )
             in
             {receiver_account with balance}
           in
@@ -620,29 +631,44 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                   | `Existing _ ->
                       return (receiver_location, receiver_account)
                   | `New ->
-                      Or_error.errorf "The source account does not exist"
-                else get_with_location ledger source
+                      Result.fail
+                        User_command_status.Failure.Source_not_present
+                else return (get_with_location ledger source |> ok_or_reject)
               in
               let%bind () =
                 match location with
                 | `Existing _ ->
                     return ()
                 | `New ->
-                    Or_error.errorf "The source account does not exist"
+                    Result.fail User_command_status.Failure.Source_not_present
               in
               let source_timing = account.timing in
               let%bind timing =
                 validate_timing ~txn_amount:amount
                   ~txn_global_slot:current_global_slot ~account
+                |> Result.map_error ~f:(fun _ ->
+                       User_command_status.Failure.Source_insufficient_balance
+                   )
               in
-              let%map balance = sub_amount account.balance amount in
+              let%map balance =
+                Result.map_error (sub_amount account.balance amount)
+                  ~f:(fun _ ->
+                    User_command_status.Failure.Source_insufficient_balance )
+              in
               (location, source_timing, {account with timing; balance})
             in
             if Account_id.equal fee_payer source then
               (* Don't process transactions with insufficient balance from the
                  fee-payer.
               *)
-              match ret with Ok _ -> ret | Error err -> raise (Reject err)
+              match ret with
+              | Ok x ->
+                  Ok x
+              | Error failure ->
+                  raise
+                    (Reject
+                       (Error.createf "%s"
+                          (User_command_status.Failure.describe failure)))
             else ret
           in
           let previous_empty_accounts =
@@ -659,11 +685,12 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       | Create_new_token {disable_new_accounts; _} ->
           (* NOTE: source and receiver are definitionally equal here. *)
           let fee_payer_account =
-            try charge_account_creation_fee_exn fee_payer_account
-            with exn -> raise (Reject (Error.of_exn exn))
+            Or_error.try_with (fun () ->
+                charge_account_creation_fee_exn fee_payer_account )
+            |> ok_or_reject
           in
-          let%map receiver_location, receiver_account =
-            get_with_location ledger receiver
+          let receiver_location, receiver_account =
+            get_with_location ledger receiver |> ok_or_reject
           in
           if not (receiver_location = `New) then
             failwith
@@ -673,11 +700,12 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               token_permissions=
                 Token_permissions.Token_owned {disable_new_accounts} }
           in
-          ( [ (fee_payer_location, fee_payer_account)
-            ; (receiver_location, receiver_account) ]
-          , `Source_timing receiver_account.timing
-          , Undo.User_command_undo.Body.Create_new_token
-              {created_token= next_available_token} )
+          return
+            ( [ (fee_payer_location, fee_payer_account)
+              ; (receiver_location, receiver_account) ]
+            , `Source_timing receiver_account.timing
+            , Undo.User_command_undo.Body.Create_new_token
+                {created_token= next_available_token} )
       | Create_token_account {account_disabled; _} ->
           if
             account_disabled
@@ -688,27 +716,27 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                  (Error.createf
                     "Cannot open a disabled account in the default token")) ;
           let fee_payer_account =
-            try charge_account_creation_fee_exn fee_payer_account
-            with exn -> raise (Reject (Error.of_exn exn))
+            Or_error.try_with (fun () ->
+                charge_account_creation_fee_exn fee_payer_account )
+            |> ok_or_reject
           in
-          let%bind receiver_location, receiver_account =
-            get_with_location ledger receiver
+          let receiver_location, receiver_account =
+            get_with_location ledger receiver |> ok_or_reject
           in
           let%bind () =
             match receiver_location with
             | `New ->
                 return ()
             | `Existing _ ->
-                Or_error.errorf
-                  "Attempted to create an account that already exists"
+                Result.fail User_command_status.Failure.Receiver_already_exists
           in
           let receiver_account =
             { receiver_account with
               token_permissions= Token_permissions.Not_owned {account_disabled}
             }
           in
-          let%bind source_location, source_account =
-            get_with_location ledger source
+          let source_location, source_account =
+            get_with_location ledger source |> ok_or_reject
           in
           let%bind source_account =
             if Account_id.equal source receiver then return receiver_account
@@ -717,7 +745,7 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
             else
               match source_location with
               | `New ->
-                  Or_error.errorf "Token owner account does not exist"
+                  Result.fail User_command_status.Failure.Source_not_present
               | `Existing _ ->
                   return source_account
           in
@@ -729,21 +757,21 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                     ( Bool.equal account_disabled disable_new_accounts
                     || predicate_passed )
                 then
-                  Or_error.errorf
-                    "The fee-payer is not authorised to create token accounts \
-                     for this token"
+                  Result.fail
+                    User_command_status.Failure.Mismatched_token_permissions
                 else return ()
             | Not_owned _ ->
                 if Token_id.(equal default) (Account_id.token_id receiver) then
                   return ()
-                else
-                  Or_error.errorf "Token owner account does not own the token"
+                else Result.fail User_command_status.Failure.Not_token_owner
           in
           let source_timing = source_account.timing in
           let%map source_account =
             let%map timing =
               validate_timing ~txn_amount:Amount.zero
                 ~txn_global_slot:current_global_slot ~account:source_account
+              |> Result.map_error ~f:(fun _ ->
+                     User_command_status.Failure.Source_insufficient_balance )
             in
             {source_account with timing}
           in
@@ -763,50 +791,52 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       | Mint_tokens {token_id= token; amount; _} ->
           let%bind () =
             if Token_id.(equal default) token then
-              Or_error.errorf "Cannot mint more of the default token"
+              Result.fail User_command_status.Failure.Not_token_owner
             else return ()
           in
-          let%bind receiver_location, receiver_account =
-            get_with_location ledger receiver
+          let receiver_location, receiver_account =
+            get_with_location ledger receiver |> ok_or_reject
           in
           let%bind () =
             match receiver_location with
             | `Existing _ ->
                 return ()
             | `New ->
-                Or_error.errorf "The receiving account does not exist"
+                Result.fail User_command_status.Failure.Receiver_not_present
           in
           let%bind receiver_account =
-            let%map balance = add_amount receiver_account.balance amount in
+            let%map balance =
+              Result.map_error (add_amount receiver_account.balance amount)
+                ~f:(fun _ -> User_command_status.Failure.Overflow)
+            in
             {receiver_account with balance}
           in
           let%map source_location, source_timing, source_account =
-            let%bind location, account =
+            let location, account =
               if Account_id.equal source receiver then
-                return (receiver_location, receiver_account)
-              else get_with_location ledger source
+                (receiver_location, receiver_account)
+              else get_with_location ledger source |> ok_or_reject
             in
             let%bind () =
               match location with
               | `Existing _ ->
                   return ()
               | `New ->
-                  Or_error.errorf "The token owner account does not exist"
+                  Result.fail User_command_status.Failure.Source_not_present
             in
             let%bind () =
               match account.token_permissions with
               | Token_owned _ ->
                   return ()
               | Not_owned _ ->
-                  Or_error.errorf
-                    !"The claimed token owner %{sexp: Account_id.t} does not \
-                      own the token %{sexp: Token_id.t}"
-                    source token
+                  Result.fail User_command_status.Failure.Not_token_owner
             in
             let source_timing = account.timing in
             let%map timing =
               validate_timing ~txn_amount:Amount.zero
                 ~txn_global_slot:current_global_slot ~account
+              |> Result.map_error ~f:(fun _ ->
+                     User_command_status.Failure.Source_insufficient_balance )
             in
             (location, source_timing, {account with timing})
           in

--- a/src/lib/coda_base/transaction_validator.ml
+++ b/src/lib/coda_base/transaction_validator.ml
@@ -88,9 +88,10 @@ include Transaction_logic.Make (Hashless_ledger)
 let create = Hashless_ledger.create
 
 let apply_user_command ~constraint_constants ~txn_global_slot l uc =
-  Result.map ~f:(Fn.const ())
+  Result.map
+    ~f:(fun undo -> undo.Undo.User_command_undo.common.user_command.status)
     (apply_user_command l ~constraint_constants ~txn_global_slot uc)
 
 let apply_transaction ~constraint_constants ~txn_global_slot l txn =
-  Result.map ~f:(Fn.const ())
+  Result.map ~f:Undo.user_command_status
     (apply_transaction l ~constraint_constants ~txn_global_slot txn)

--- a/src/lib/coda_base/transaction_validator.mli
+++ b/src/lib/coda_base/transaction_validator.mli
@@ -9,14 +9,14 @@ val apply_user_command :
   -> txn_global_slot:Coda_numbers.Global_slot.t
   -> Hashless_ledger.t
   -> User_command.With_valid_signature.t
-  -> unit Or_error.t
+  -> User_command_status.t Or_error.t
 
 val apply_transaction :
      constraint_constants:Genesis_constants.Constraint_constants.t
   -> txn_global_slot:Coda_numbers.Global_slot.t
   -> Hashless_ledger.t
   -> Transaction.t
-  -> unit Or_error.t
+  -> User_command_status.t Or_error.t
 
 module For_tests : sig
   open Currency

--- a/src/lib/coda_base/user_command_status.ml
+++ b/src/lib/coda_base/user_command_status.ml
@@ -120,26 +120,3 @@ end]
 
 type t = Stable.Latest.t = Applied | Failed of Failure.t
 [@@deriving sexp, yojson, eq, compare]
-
-type status = t [@@deriving sexp, yojson, eq, compare]
-
-module With_status = struct
-  [%%versioned
-  module Stable = struct
-    module V1 = struct
-      type 'a t = {data: 'a; status: Stable.V1.t}
-      [@@deriving sexp, yojson, eq, compare]
-    end
-  end]
-
-  type 'a t = 'a Stable.Latest.t = {data: 'a; status: status}
-  [@@deriving sexp, yojson, eq, compare]
-
-  let map ~f {data; status} = {data= f data; status}
-
-  let map_opt ~f {data; status} =
-    Option.map (f data) ~f:(fun data -> {data; status})
-
-  let map_result ~f {data; status} =
-    Result.map (f data) ~f:(fun data -> {data; status})
-end

--- a/src/lib/coda_base/user_command_status.ml
+++ b/src/lib/coda_base/user_command_status.ml
@@ -15,7 +15,7 @@ module Failure = struct
         | Not_token_owner
         | Mismatched_token_permissions
         | Overflow
-      [@@deriving sexp, yojson, eq]
+      [@@deriving sexp, yojson, eq, compare]
 
       let to_latest = Fn.id
     end
@@ -32,7 +32,7 @@ module Failure = struct
     | Not_token_owner
     | Mismatched_token_permissions
     | Overflow
-  [@@deriving sexp, yojson, eq]
+  [@@deriving sexp, yojson, eq, compare]
 
   let to_latest = Fn.id
 
@@ -112,27 +112,28 @@ end
 module Stable = struct
   module V1 = struct
     type t = Applied | Failed of Failure.Stable.V1.t
-    [@@deriving sexp, yojson, eq]
+    [@@deriving sexp, yojson, eq, compare]
 
     let to_latest = Fn.id
   end
 end]
 
 type t = Stable.Latest.t = Applied | Failed of Failure.t
-[@@deriving sexp, yojson, eq]
+[@@deriving sexp, yojson, eq, compare]
 
-type status = t [@@deriving sexp, yojson, eq]
+type status = t [@@deriving sexp, yojson, eq, compare]
 
 module With_status = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type 'a t = {data: 'a; status: Stable.V1.t} [@@deriving sexp, eq]
+      type 'a t = {data: 'a; status: Stable.V1.t}
+      [@@deriving sexp, yojson, eq, compare]
     end
   end]
 
   type 'a t = 'a Stable.Latest.t = {data: 'a; status: status}
-  [@@deriving sexp, eq]
+  [@@deriving sexp, yojson, eq, compare]
 
   let map ~f {data; status} = {data= f data; status}
 

--- a/src/lib/coda_base/user_command_status.ml
+++ b/src/lib/coda_base/user_command_status.ml
@@ -1,0 +1,122 @@
+open Core_kernel
+
+module Failure = struct
+  [%%versioned
+  module Stable = struct
+    module V1 = struct
+      type t =
+        | Predicate
+        | Source_not_present
+        | Receiver_not_present
+        | Amount_insufficient_to_create_account
+        | Cannot_pay_creation_fee_in_token
+        | Source_insufficient_balance
+        | Receiver_already_exists
+        | Not_token_owner
+        | Mismatched_token_permissions
+        | Overflow
+
+      (* TODO: Handle this in txn snark *)
+
+      let to_latest = Fn.id
+    end
+  end]
+
+  type t = Stable.Latest.t =
+    | Predicate
+    | Source_not_present
+    | Receiver_not_present
+    | Amount_insufficient_to_create_account
+    | Cannot_pay_creation_fee_in_token
+    | Source_insufficient_balance
+    | Receiver_already_exists
+    | Not_token_owner
+    | Mismatched_token_permissions
+    | Overflow
+
+  (* TODO: Handle this in txn snark *)
+
+  let to_latest = Fn.id
+
+  let to_string = function
+    | Predicate ->
+        "Predicate"
+    | Source_not_present ->
+        "Source_not_present"
+    | Receiver_not_present ->
+        "Receiver_not_present"
+    | Amount_insufficient_to_create_account ->
+        "Amount_insufficient_to_create_account"
+    | Cannot_pay_creation_fee_in_token ->
+        "Cannot_pay_creation_fee_in_token"
+    | Source_insufficient_balance ->
+        "Source_insufficient_balance"
+    | Receiver_already_exists ->
+        "Receiver_already_exists"
+    | Not_token_owner ->
+        "Not_token_owner"
+    | Mismatched_token_permissions ->
+        "Mismatched_token_permissions"
+    | Overflow ->
+        "Overflow"
+
+  let of_string = function
+    | "Predicate" ->
+        Ok Predicate
+    | "Source_not_present" ->
+        Ok Source_not_present
+    | "Receiver_not_present" ->
+        Ok Receiver_not_present
+    | "Amount_insufficient_to_create_account" ->
+        Ok Amount_insufficient_to_create_account
+    | "Cannot_pay_creation_fee_in_token" ->
+        Ok Cannot_pay_creation_fee_in_token
+    | "Source_insufficient_balance" ->
+        Ok Source_insufficient_balance
+    | "Receiver_already_exists" ->
+        Ok Receiver_already_exists
+    | "Not_token_owner" ->
+        Ok Not_token_owner
+    | "Mismatched_token_permissions" ->
+        Ok Mismatched_token_permissions
+    | "Overflow" ->
+        Ok Overflow
+    | _ ->
+        Error "User_command_status.Failure.of_string: Unknown value"
+
+  let describe = function
+    | Predicate ->
+        "The fee-payer is not authorised to issue this command for the source \
+         account"
+    | Source_not_present ->
+        "The source account does not exist"
+    | Receiver_not_present ->
+        "The receiver account does not exist"
+    | Amount_insufficient_to_create_account ->
+        "Cannot create account: transaction amount is smaller than the \
+         account creation fee"
+    | Cannot_pay_creation_fee_in_token ->
+        "Cannot create account: account creation fees cannot be paid in \
+         non-default tokens"
+    | Source_insufficient_balance ->
+        "The source account has an insufficient balance"
+    | Receiver_already_exists ->
+        "Attempted to create an account that already exists"
+    | Not_token_owner ->
+        "The source account does not own the token"
+    | Mismatched_token_permissions ->
+        "The permissions for this token do not match those in the command"
+    | Overflow ->
+        "The resulting balance is too large to store"
+end
+
+[%%versioned
+module Stable = struct
+  module V1 = struct
+    type t = Applied | Failed of Failure.Stable.V1.t
+
+    let to_latest = Fn.id
+  end
+end]
+
+type t = Stable.Latest.t = Applied | Failed of Failure.t

--- a/src/lib/coda_base/with_status.ml
+++ b/src/lib/coda_base/with_status.ml
@@ -1,0 +1,20 @@
+open Core_kernel
+
+[%%versioned
+module Stable = struct
+  module V1 = struct
+    type 'a t = {data: 'a; status: User_command_status.Stable.V1.t}
+    [@@deriving sexp, yojson, eq, compare]
+  end
+end]
+
+type 'a t = 'a Stable.Latest.t = {data: 'a; status: User_command_status.t}
+[@@deriving sexp, yojson, eq, compare]
+
+let map ~f {data; status} = {data= f data; status}
+
+let map_opt ~f {data; status} =
+  Option.map (f data) ~f:(fun data -> {data; status})
+
+let map_result ~f {data; status} =
+  Result.map (f data) ~f:(fun data -> {data; status})

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -551,14 +551,20 @@ module Root_diff = struct
   [%%versioned
   module Stable = struct
     module V1 = struct
-      type t = {user_commands: User_command.Stable.V1.t list; root_length: int}
+      type t =
+        { user_commands:
+            User_command.Stable.V1.t
+            User_command_status.With_status.Stable.V1.t
+            list
+        ; root_length: int }
 
       let to_latest = Fn.id
     end
   end]
 
   type t = Stable.Latest.t =
-    {user_commands: User_command.t list; root_length: int}
+    { user_commands: User_command.t User_command_status.With_status.t list
+    ; root_length: int }
 end
 
 let initialization_finish_signal t = t.initialization_finish_signal

--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -552,10 +552,7 @@ module Root_diff = struct
   module Stable = struct
     module V1 = struct
       type t =
-        { user_commands:
-            User_command.Stable.V1.t
-            User_command_status.With_status.Stable.V1.t
-            list
+        { user_commands: User_command.Stable.V1.t With_status.Stable.V1.t list
         ; root_length: int }
 
       let to_latest = Fn.id
@@ -563,8 +560,7 @@ module Root_diff = struct
   end]
 
   type t = Stable.Latest.t =
-    { user_commands: User_command.t User_command_status.With_status.t list
-    ; root_length: int }
+    {user_commands: User_command.t With_status.t list; root_length: int}
 end
 
 let initialization_finish_signal t = t.initialization_finish_signal

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -99,10 +99,7 @@ module Root_diff : sig
   module Stable : sig
     module V1 : sig
       type t =
-        { user_commands:
-            User_command.Stable.V1.t
-            User_command_status.With_status.Stable.V1.t
-            list
+        { user_commands: User_command.Stable.V1.t With_status.Stable.V1.t list
         ; root_length: int }
     end
   end]

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -98,7 +98,12 @@ module Root_diff : sig
   [%%versioned:
   module Stable : sig
     module V1 : sig
-      type t = {user_commands: User_command.Stable.V1.t list; root_length: int}
+      type t =
+        { user_commands:
+            User_command.Stable.V1.t
+            User_command_status.With_status.Stable.V1.t
+            list
+        ; root_length: int }
     end
   end]
 

--- a/src/lib/coda_transition/external_transition.ml
+++ b/src/lib/coda_transition/external_transition.ml
@@ -101,7 +101,7 @@ module Stable = struct
 
     let payments external_transition =
       List.filter (user_commands external_transition) ~f:(function
-        | {payload= {body= Payment _; _}; _} ->
+        | {data= {payload= {body= Payment _; _}; _}; _} ->
             true
         | _ ->
             false )

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -35,11 +35,12 @@ module type External_transition_common_intf = sig
   val transactions :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> t
-    -> Transaction.t list
+    -> Transaction.t User_command_status.With_status.t list
 
-  val user_commands : t -> User_command.t list
+  val user_commands :
+    t -> User_command.t User_command_status.With_status.t list
 
-  val payments : t -> User_command.t list
+  val payments : t -> User_command.t User_command_status.With_status.t list
 
   val delta_transition_chain_proof : t -> State_hash.t * State_body_hash.t list
 

--- a/src/lib/coda_transition/external_transition_intf.ml
+++ b/src/lib/coda_transition/external_transition_intf.ml
@@ -35,12 +35,11 @@ module type External_transition_common_intf = sig
   val transactions :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> t
-    -> Transaction.t User_command_status.With_status.t list
+    -> Transaction.t With_status.t list
 
-  val user_commands :
-    t -> User_command.t User_command_status.With_status.t list
+  val user_commands : t -> User_command.t With_status.t list
 
-  val payments : t -> User_command.t User_command_status.With_status.t list
+  val payments : t -> User_command.t With_status.t list
 
   val delta_transition_chain_proof : t -> State_hash.t * State_body_hash.t list
 

--- a/src/lib/consensus/intf.ml
+++ b/src/lib/consensus/intf.ml
@@ -251,7 +251,6 @@ module type State_hooks = sig
     -> blockchain_state:blockchain_state
     -> current_time:Unix_timestamp.t
     -> block_data:block_data
-    -> transactions:Coda_base.User_command.t list
     -> snarked_ledger_hash:Coda_base.Frozen_ledger_hash.t
     -> supply_increase:Currency.Amount.t
     -> logger:Logger.t

--- a/src/lib/consensus/proof_of_stake.ml
+++ b/src/lib/consensus/proof_of_stake.ml
@@ -3067,8 +3067,7 @@ module Hooks = struct
 
     let generate_transition ~(previous_protocol_state : Protocol_state.Value.t)
         ~blockchain_state ~current_time ~(block_data : Block_data.t)
-        ~transactions:_ ~snarked_ledger_hash ~supply_increase ~logger
-        ~constraint_constants =
+        ~snarked_ledger_hash ~supply_increase ~logger ~constraint_constants =
       let previous_consensus_state =
         Protocol_state.consensus_state previous_protocol_state
       in

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -23,8 +23,9 @@ module type Transition_frontier_intf = sig
   end
 
   type best_tip_diff =
-    { new_user_commands: User_command.t list
-    ; removed_user_commands: User_command.t list
+    { new_user_commands: User_command.t User_command_status.With_status.t list
+    ; removed_user_commands:
+        User_command.t User_command_status.With_status.t list
     ; reorg_best_tip: bool }
 
   val best_tip : t -> Breadcrumb.t
@@ -274,10 +275,17 @@ struct
       Logger.trace t.logger ~module_:__MODULE__ ~location:__LOC__
         ~metadata:
           [ ( "removed"
-            , `List (List.map removed_user_commands ~f:User_command.to_yojson)
-            )
+            , `List
+                (List.map removed_user_commands
+                   ~f:
+                     (User_command_status.With_status.to_yojson
+                        User_command.to_yojson)) )
           ; ( "added"
-            , `List (List.map new_user_commands ~f:User_command.to_yojson) ) ]
+            , `List
+                (List.map new_user_commands
+                   ~f:
+                     (User_command_status.With_status.to_yojson
+                        User_command.to_yojson)) ) ]
         "Diff: removed: $removed added: $added from best tip" ;
       let pool', dropped_backtrack =
         Sequence.fold
@@ -287,7 +295,7 @@ struct
                    ~message:
                      "somehow user command from the frontier has an invalid \
                       signature!"
-                   (User_command.check unchecked) ) )
+                   (User_command.check unchecked.data) ) )
           ~init:(t.pool, Sequence.empty)
           ~f:(fun (pool, dropped_so_far) cmd ->
             ( match
@@ -338,12 +346,12 @@ struct
                   in
                   acc.balance
             in
-            let fee_payer = User_command.fee_payer cmd in
+            let fee_payer = User_command.fee_payer cmd.data in
             let fee_payer_balance =
               Currency.Balance.to_amount (balance fee_payer)
             in
             let cmd' =
-              User_command.check cmd
+              User_command.check cmd.data
               |> Option.value_exn ~message:"user command was invalid"
             in
             ( match
@@ -354,7 +362,10 @@ struct
             | Some time_added ->
                 Logger.info t.logger ~module_:__MODULE__ ~location:__LOC__
                   "Locally generated command $cmd committed in a block!"
-                  ~metadata:[("cmd", User_command.to_yojson cmd)] ;
+                  ~metadata:
+                    [ ( "cmd"
+                      , User_command_status.With_status.to_yojson
+                          User_command.to_yojson cmd ) ] ;
                 Hashtbl.add_exn t.locally_generated_committed ~key:cmd'
                   ~data:time_added ) ;
             let p', dropped =
@@ -367,7 +378,9 @@ struct
                   Logger.error t.logger ~module_:__MODULE__ ~location:__LOC__
                     "Error handling committed transaction $cmd: $error "
                     ~metadata:
-                      [ ("cmd", User_command.to_yojson cmd)
+                      [ ( "cmd"
+                        , User_command_status.With_status.to_yojson
+                            User_command.to_yojson cmd )
                       ; ("error", `String error_str)
                       ; ( "queue"
                         , `List
@@ -964,8 +977,10 @@ include Make
             include Transition_frontier
 
             type best_tip_diff = Extensions.Best_tip_diff.view =
-              { new_user_commands: User_command.t list
-              ; removed_user_commands: User_command.t list
+              { new_user_commands:
+                  User_command.t User_command_status.With_status.t list
+              ; removed_user_commands:
+                  User_command.t User_command_status.With_status.t list
               ; reorg_best_tip: bool }
 
             let best_tip_diff_pipe t =
@@ -1005,8 +1020,10 @@ let%test_module _ =
       end
 
       type best_tip_diff =
-        { new_user_commands: User_command.t list
-        ; removed_user_commands: User_command.t list
+        { new_user_commands:
+            User_command.t User_command_status.With_status.t list
+        ; removed_user_commands:
+            User_command.t User_command_status.With_status.t list
         ; reorg_best_tip: bool }
 
       type t = best_tip_diff Broadcast_pipe.Reader.t * Breadcrumb.t ref
@@ -1134,6 +1151,9 @@ let%test_module _ =
 
     let accepted_user_commands = Result.map ~f:fst
 
+    let mk_with_status cmd =
+      {User_command_status.With_status.data= cmd; status= Applied}
+
     let%test_unit "transactions are removed in linear case" =
       Thread_safe.block_on_async_exn (fun () ->
           let%bind assert_pool_txs, pool, best_tip_diff_w, _frontier =
@@ -1150,7 +1170,8 @@ let%test_module _ =
           assert_pool_txs independent_cmds ;
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
-              { new_user_commands= [List.hd_exn independent_cmds]
+              { new_user_commands=
+                  [mk_with_status (List.hd_exn independent_cmds)]
               ; removed_user_commands= []
               ; reorg_best_tip= false }
           in
@@ -1158,7 +1179,9 @@ let%test_module _ =
           assert_pool_txs (List.tl_exn independent_cmds) ;
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
-              { new_user_commands= List.take (List.tl_exn independent_cmds) 2
+              { new_user_commands=
+                  List.map ~f:mk_with_status
+                    (List.take (List.tl_exn independent_cmds) 2)
               ; removed_user_commands= []
               ; reorg_best_tip= false }
           in
@@ -1210,8 +1233,11 @@ let%test_module _ =
             map_set_multi !best_tip_ref [mk_account 1 1_000_000_000_000 1] ;
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
-              { new_user_commands= List.take independent_cmds 1
-              ; removed_user_commands= [List.nth_exn independent_cmds 1]
+              { new_user_commands=
+                  List.map ~f:mk_with_status @@ List.take independent_cmds 1
+              ; removed_user_commands=
+                  List.map ~f:mk_with_status
+                  @@ [List.nth_exn independent_cmds 1]
               ; reorg_best_tip= true }
           in
           assert_pool_txs (List.tl_exn independent_cmds) ;
@@ -1270,7 +1296,8 @@ let%test_module _ =
             map_set_multi !best_tip_ref [mk_account 0 1_000_000_000_000 1] ;
           let%bind _ =
             Broadcast_pipe.Writer.write best_tip_diff_w
-              { new_user_commands= List.take independent_cmds 2
+              { new_user_commands=
+                  List.map ~f:mk_with_status @@ List.take independent_cmds 2
               ; removed_user_commands= []
               ; reorg_best_tip= false }
           in
@@ -1295,8 +1322,11 @@ let%test_module _ =
           best_tip_ref := map_set_multi !best_tip_ref [mk_account 0 0 1] ;
           let%bind _ =
             Broadcast_pipe.Writer.write best_tip_diff_w
-              { new_user_commands= cmd2 :: List.drop independent_cmds 2
-              ; removed_user_commands= List.take independent_cmds 2
+              { new_user_commands=
+                  List.map ~f:mk_with_status
+                  @@ (cmd2 :: List.drop independent_cmds 2)
+              ; removed_user_commands=
+                  List.map ~f:mk_with_status @@ List.take independent_cmds 2
               ; reorg_best_tip= true }
           in
           assert_pool_txs [List.nth_exn independent_cmds 1] ;
@@ -1447,7 +1477,7 @@ let%test_module _ =
         map_set_multi !best_tip_ref [mk_account 0 970_000_000_000 1] ;
       let%bind () =
         Broadcast_pipe.Writer.write best_tip_diff_w
-          { new_user_commands= [committed_tx]
+          { new_user_commands= List.map ~f:mk_with_status @@ [committed_tx]
           ; removed_user_commands= []
           ; reorg_best_tip= false }
       in
@@ -1564,7 +1594,8 @@ let%test_module _ =
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
               { new_user_commands=
-                  List.take local_cmds 2 @ List.take remote_cmds 3
+                  List.map ~f:mk_with_status @@ List.take local_cmds 2
+                  @ List.take remote_cmds 3
               ; removed_user_commands= []
               ; reorg_best_tip= false }
           in
@@ -1574,8 +1605,10 @@ let%test_module _ =
              rebroadcastable pool, if they were removed and not re-added *)
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
-              { new_user_commands= List.take local_cmds 1
-              ; removed_user_commands= List.take local_cmds 2
+              { new_user_commands=
+                  List.map ~f:mk_with_status @@ List.take local_cmds 1
+              ; removed_user_commands=
+                  List.map ~f:mk_with_status @@ List.take local_cmds 2
               ; reorg_best_tip= true }
           in
           assert_pool_txs (List.tl_exn local_cmds @ List.drop remote_cmds 3) ;
@@ -1584,7 +1617,8 @@ let%test_module _ =
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
               { new_user_commands=
-                  List.tl_exn local_cmds @ List.drop remote_cmds 3
+                  List.map ~f:mk_with_status @@ List.tl_exn local_cmds
+                  @ List.drop remote_cmds 3
               ; removed_user_commands= []
               ; reorg_best_tip= false }
           in
@@ -1595,7 +1629,9 @@ let%test_module _ =
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
               { new_user_commands= []
-              ; removed_user_commands= List.drop local_cmds 3 @ remote_cmds
+              ; removed_user_commands=
+                  List.map ~f:mk_with_status @@ List.drop local_cmds 3
+                  @ remote_cmds
               ; reorg_best_tip= true }
           in
           assert_pool_txs (List.drop local_cmds 3 @ remote_cmds) ;
@@ -1604,7 +1640,8 @@ let%test_module _ =
              two step reorg processes) *)
           let%bind () =
             Broadcast_pipe.Writer.write best_tip_diff_w
-              { new_user_commands= [List.nth_exn local_cmds 3]
+              { new_user_commands=
+                  List.map ~f:mk_with_status @@ [List.nth_exn local_cmds 3]
               ; removed_user_commands= []
               ; reorg_best_tip= false }
           in

--- a/src/lib/staged_ledger/diff_creation_log.ml
+++ b/src/lib/staged_ledger/diff_creation_log.ml
@@ -56,8 +56,7 @@ module Summary = struct
   let init_resources
       ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(user_commands :
-         User_command.With_valid_signature.t User_command_status.With_status.t
-         Sequence.t)
+         User_command.With_valid_signature.t With_status.t Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
     let completed_work =
       ( Sequence.length completed_work
@@ -77,8 +76,7 @@ module Summary = struct
 
   let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(user_commands :
-         User_command.With_valid_signature.t User_command_status.With_status.t
-         Sequence.t)
+         User_command.With_valid_signature.t With_status.t Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t)
       ~partition ~available_slots ~required_work_count =
     let start_resources =
@@ -103,8 +101,7 @@ module Summary = struct
 
   let end_log t ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(user_commands :
-         User_command.With_valid_signature.t User_command_status.With_status.t
-         Sequence.t)
+         User_command.With_valid_signature.t With_status.t Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
     end_resources.set
       (init_resources ~completed_work ~user_commands ~coinbase)
@@ -149,8 +146,7 @@ module Detail = struct
 
   let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
       ~(user_commands :
-         User_command.With_valid_signature.t User_command_status.With_status.t
-         Sequence.t)
+         User_command.With_valid_signature.t With_status.t Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
     let init =
       Summary.init_resources ~completed_work ~user_commands ~coinbase
@@ -211,8 +207,7 @@ type detail_list = Detail.t list [@@deriving sexp, to_yojson]
 
 let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
     ~(user_commands :
-       User_command.With_valid_signature.t User_command_status.With_status.t
-       Sequence.t)
+       User_command.With_valid_signature.t With_status.t Sequence.t)
     ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t)
     ~partition ~available_slots ~required_work_count =
   let summary =
@@ -234,8 +229,7 @@ let discard_completed_work why completed_work t =
 
 let end_log ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
     ~(user_commands :
-       User_command.With_valid_signature.t User_command_status.With_status.t
-       Sequence.t)
+       User_command.With_valid_signature.t With_status.t Sequence.t)
     ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) t =
   let summary =
     Summary.end_log (fst t) ~completed_work ~user_commands ~coinbase

--- a/src/lib/staged_ledger/diff_creation_log.ml
+++ b/src/lib/staged_ledger/diff_creation_log.ml
@@ -55,7 +55,9 @@ module Summary = struct
 
   let init_resources
       ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
-      ~(user_commands : User_command.With_valid_signature.t Sequence.t)
+      ~(user_commands :
+         User_command.With_valid_signature.t User_command_status.With_status.t
+         Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
     let completed_work =
       ( Sequence.length completed_work
@@ -68,13 +70,15 @@ module Summary = struct
       , Sequence.sum
           (module Fee_Summable)
           user_commands
-          ~f:(Fn.compose User_command.fee User_command.forget_check) )
+          ~f:(fun cmd -> User_command.fee (cmd.data :> User_command.t)) )
     in
     let coinbase_work_fees = coinbase_fees coinbase in
     {completed_work; user_commands; coinbase_work_fees}
 
   let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
-      ~(user_commands : User_command.With_valid_signature.t Sequence.t)
+      ~(user_commands :
+         User_command.With_valid_signature.t User_command_status.With_status.t
+         Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t)
       ~partition ~available_slots ~required_work_count =
     let start_resources =
@@ -98,7 +102,9 @@ module Summary = struct
     ; end_resources }
 
   let end_log t ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
-      ~(user_commands : User_command.With_valid_signature.t Sequence.t)
+      ~(user_commands :
+         User_command.With_valid_signature.t User_command_status.With_status.t
+         Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
     end_resources.set
       (init_resources ~completed_work ~user_commands ~coinbase)
@@ -142,7 +148,9 @@ module Detail = struct
   type t = line list [@@deriving sexp, to_yojson]
 
   let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
-      ~(user_commands : User_command.With_valid_signature.t Sequence.t)
+      ~(user_commands :
+         User_command.With_valid_signature.t User_command_status.With_status.t
+         Sequence.t)
       ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) =
     let init =
       Summary.init_resources ~completed_work ~user_commands ~coinbase
@@ -202,7 +210,9 @@ type summary_list = Summary.t list [@@deriving sexp, to_yojson]
 type detail_list = Detail.t list [@@deriving sexp, to_yojson]
 
 let init ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
-    ~(user_commands : User_command.With_valid_signature.t Sequence.t)
+    ~(user_commands :
+       User_command.With_valid_signature.t User_command_status.With_status.t
+       Sequence.t)
     ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t)
     ~partition ~available_slots ~required_work_count =
   let summary =
@@ -223,7 +233,9 @@ let discard_completed_work why completed_work t =
   (summary, detailed)
 
 let end_log ~(completed_work : Transaction_snark_work.Checked.t Sequence.t)
-    ~(user_commands : User_command.With_valid_signature.t Sequence.t)
+    ~(user_commands :
+       User_command.With_valid_signature.t User_command_status.With_status.t
+       Sequence.t)
     ~(coinbase : Coinbase.Fee_transfer.t Staged_ledger_diff.At_most_two.t) t =
   let summary =
     Summary.end_log (fst t) ~completed_work ~user_commands ~coinbase

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -19,7 +19,7 @@ module type S = sig
   val get :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> Staged_ledger_diff.t
-    -> ( Transaction.t list
+    -> ( Transaction.t User_command_status.With_status.t list
          * Transaction_snark_work.t list
          * int
          * Currency.Amount.t list
@@ -29,7 +29,7 @@ module type S = sig
   val get_unchecked :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> Staged_ledger_diff.With_valid_signatures_and_proofs.t
-    -> ( Transaction.t list
+    -> ( Transaction.t User_command_status.With_status.t list
          * Transaction_snark_work.t list
          * int
          * Currency.Amount.t list
@@ -39,7 +39,7 @@ module type S = sig
   val get_transactions :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> Staged_ledger_diff.t
-    -> (Transaction.t list, Error.t) result
+    -> (Transaction.t User_command_status.With_status.t list, Error.t) result
 end
 
 module Error = struct
@@ -69,7 +69,7 @@ module Error = struct
 end
 
 type t =
-  { transactions: Transaction.t list
+  { transactions: Transaction.t User_command_status.With_status.t list
   ; work: Transaction_snark_work.t list
   ; user_commands_count: int
   ; coinbases: Currency.Amount.t list }
@@ -179,11 +179,14 @@ let sum_fees xs ~f =
 let to_staged_ledger_or_error =
   Result.map_error ~f:(fun error -> Error.Unexpected error)
 
-let fee_remainder (user_commands : User_command.With_valid_signature.t list)
-    completed_works coinbase_fee =
+let fee_remainder
+    (user_commands :
+      User_command.With_valid_signature.t User_command_status.With_status.t
+      list) completed_works coinbase_fee =
   let open Result.Let_syntax in
   let%bind budget =
-    sum_fees user_commands ~f:(fun t -> User_command.fee (t :> User_command.t))
+    sum_fees user_commands ~f:(fun {data= t; _} ->
+        User_command.fee (t :> User_command.t) )
     |> to_staged_ledger_or_error
   in
   let%bind work_fee =
@@ -261,9 +264,16 @@ let get_individual_info ~constraint_constants coinbase_parts ~receiver
     create_fee_transfers txn_works_others delta receiver coinbase_fts
   in
   let transactions =
-    List.map user_commands ~f:(fun t -> Transaction.User_command t)
-    @ List.map coinbase_parts ~f:(fun t -> Transaction.Coinbase t)
-    @ List.map fee_transfers ~f:(fun t -> Transaction.Fee_transfer t)
+    List.map user_commands
+      ~f:
+        (User_command_status.With_status.map ~f:(fun t ->
+             Transaction.User_command t ))
+    @ List.map coinbase_parts ~f:(fun t ->
+          { User_command_status.With_status.data= Transaction.Coinbase t
+          ; status= Applied } )
+    @ List.map fee_transfers ~f:(fun t ->
+          { User_command_status.With_status.data= Transaction.Fee_transfer t
+          ; status= Applied } )
   in
   { transactions
   ; work= completed_works
@@ -335,7 +345,7 @@ let get ~constraint_constants t =
   | Ok diff ->
       get' ~constraint_constants diff
   | Error uc ->
-      Error (Error.Bad_signature uc)
+      Error (Error.Bad_signature uc.data)
 
 let get_unchecked ~constraint_constants
     (t : With_valid_signatures_and_proofs.t) =

--- a/src/lib/staged_ledger/pre_diff_info.ml
+++ b/src/lib/staged_ledger/pre_diff_info.ml
@@ -19,7 +19,7 @@ module type S = sig
   val get :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> Staged_ledger_diff.t
-    -> ( Transaction.t User_command_status.With_status.t list
+    -> ( Transaction.t With_status.t list
          * Transaction_snark_work.t list
          * int
          * Currency.Amount.t list
@@ -29,7 +29,7 @@ module type S = sig
   val get_unchecked :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> Staged_ledger_diff.With_valid_signatures_and_proofs.t
-    -> ( Transaction.t User_command_status.With_status.t list
+    -> ( Transaction.t With_status.t list
          * Transaction_snark_work.t list
          * int
          * Currency.Amount.t list
@@ -39,7 +39,7 @@ module type S = sig
   val get_transactions :
        constraint_constants:Genesis_constants.Constraint_constants.t
     -> Staged_ledger_diff.t
-    -> (Transaction.t User_command_status.With_status.t list, Error.t) result
+    -> (Transaction.t With_status.t list, Error.t) result
 end
 
 module Error = struct
@@ -69,7 +69,7 @@ module Error = struct
 end
 
 type t =
-  { transactions: Transaction.t User_command_status.With_status.t list
+  { transactions: Transaction.t With_status.t list
   ; work: Transaction_snark_work.t list
   ; user_commands_count: int
   ; coinbases: Currency.Amount.t list }
@@ -180,9 +180,8 @@ let to_staged_ledger_or_error =
   Result.map_error ~f:(fun error -> Error.Unexpected error)
 
 let fee_remainder
-    (user_commands :
-      User_command.With_valid_signature.t User_command_status.With_status.t
-      list) completed_works coinbase_fee =
+    (user_commands : User_command.With_valid_signature.t With_status.t list)
+    completed_works coinbase_fee =
   let open Result.Let_syntax in
   let%bind budget =
     sum_fees user_commands ~f:(fun {data= t; _} ->
@@ -265,15 +264,11 @@ let get_individual_info ~constraint_constants coinbase_parts ~receiver
   in
   let transactions =
     List.map user_commands
-      ~f:
-        (User_command_status.With_status.map ~f:(fun t ->
-             Transaction.User_command t ))
+      ~f:(With_status.map ~f:(fun t -> Transaction.User_command t))
     @ List.map coinbase_parts ~f:(fun t ->
-          { User_command_status.With_status.data= Transaction.Coinbase t
-          ; status= Applied } )
+          {With_status.data= Transaction.Coinbase t; status= Applied} )
     @ List.map fee_transfers ~f:(fun t ->
-          { User_command_status.With_status.data= Transaction.Fee_transfer t
-          ; status= Applied } )
+          {With_status.data= Transaction.Fee_transfer t; status= Applied} )
   in
   { transactions
   ; work= completed_works

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -32,15 +32,12 @@ module Scan_state : sig
 
   val snark_job_list_json : t -> string
 
-  val staged_transactions :
-    t -> Transaction.t User_command_status.With_status.t list Or_error.t
+  val staged_transactions : t -> Transaction.t With_status.t list Or_error.t
 
   val staged_transactions_with_protocol_states :
        t
     -> get_state:(State_hash.t -> Coda_state.Protocol_state.value Or_error.t)
-    -> ( Transaction.t User_command_status.With_status.t
-       * Coda_state.Protocol_state.value )
-       list
+    -> (Transaction.t With_status.t * Coda_state.Protocol_state.value) list
        Or_error.t
 
   val all_work_statements_exn : t -> Transaction_snark_work.Statement.t list
@@ -60,8 +57,7 @@ module Pre_diff_info : Pre_diff_info.S
 module Staged_ledger_error : sig
   type t =
     | Non_zero_fee_excess of
-        Scan_state.Space_partition.t
-        * Transaction.t User_command_status.With_status.t list
+        Scan_state.Space_partition.t * Transaction.t With_status.t list
     | Invalid_proofs of
         ( Ledger_proof.t
         * Transaction_snark.Statement.t
@@ -111,10 +107,7 @@ val of_scan_state_and_ledger_unchecked :
 val replace_ledger_exn : t -> Ledger.t -> t
 
 val proof_txns_with_state_hashes :
-     t
-  -> (Transaction.t User_command_status.With_status.t * State_hash.t)
-     Non_empty_list.t
-     option
+  t -> (Transaction.t With_status.t * State_hash.t) Non_empty_list.t option
 
 val copy : t -> t
 
@@ -130,9 +123,7 @@ val apply :
   -> state_and_body_hash:State_hash.t * State_body_hash.t
   -> ( [`Hash_after_applying of Staged_ledger_hash.t]
        * [ `Ledger_proof of
-           ( Ledger_proof.t
-           * (Transaction.t User_command_status.With_status.t * State_hash.t)
-             list )
+           (Ledger_proof.t * (Transaction.t With_status.t * State_hash.t) list)
            option ]
        * [`Staged_ledger of t]
        * [ `Pending_coinbase_data of
@@ -149,9 +140,7 @@ val apply_diff_unchecked :
   -> state_and_body_hash:State_hash.t * State_body_hash.t
   -> ( [`Hash_after_applying of Staged_ledger_hash.t]
        * [ `Ledger_proof of
-           ( Ledger_proof.t
-           * (Transaction.t User_command_status.With_status.t * State_hash.t)
-             list )
+           (Ledger_proof.t * (Transaction.t With_status.t * State_hash.t) list)
            option ]
        * [`Staged_ledger of t]
        * [ `Pending_coinbase_data of

--- a/src/lib/staged_ledger/staged_ledger.mli
+++ b/src/lib/staged_ledger/staged_ledger.mli
@@ -32,12 +32,16 @@ module Scan_state : sig
 
   val snark_job_list_json : t -> string
 
-  val staged_transactions : t -> Transaction.t list Or_error.t
+  val staged_transactions :
+    t -> Transaction.t User_command_status.With_status.t list Or_error.t
 
   val staged_transactions_with_protocol_states :
        t
     -> get_state:(State_hash.t -> Coda_state.Protocol_state.value Or_error.t)
-    -> (Transaction.t * Coda_state.Protocol_state.value) list Or_error.t
+    -> ( Transaction.t User_command_status.With_status.t
+       * Coda_state.Protocol_state.value )
+       list
+       Or_error.t
 
   val all_work_statements_exn : t -> Transaction_snark_work.Statement.t list
 
@@ -55,7 +59,9 @@ module Pre_diff_info : Pre_diff_info.S
 
 module Staged_ledger_error : sig
   type t =
-    | Non_zero_fee_excess of Scan_state.Space_partition.t * Transaction.t list
+    | Non_zero_fee_excess of
+        Scan_state.Space_partition.t
+        * Transaction.t User_command_status.With_status.t list
     | Invalid_proofs of
         ( Ledger_proof.t
         * Transaction_snark.Statement.t
@@ -105,7 +111,10 @@ val of_scan_state_and_ledger_unchecked :
 val replace_ledger_exn : t -> Ledger.t -> t
 
 val proof_txns_with_state_hashes :
-  t -> (Transaction.t * State_hash.t) Non_empty_list.t option
+     t
+  -> (Transaction.t User_command_status.With_status.t * State_hash.t)
+     Non_empty_list.t
+     option
 
 val copy : t -> t
 
@@ -121,7 +130,10 @@ val apply :
   -> state_and_body_hash:State_hash.t * State_body_hash.t
   -> ( [`Hash_after_applying of Staged_ledger_hash.t]
        * [ `Ledger_proof of
-           (Ledger_proof.t * (Transaction.t * State_hash.t) list) option ]
+           ( Ledger_proof.t
+           * (Transaction.t User_command_status.With_status.t * State_hash.t)
+             list )
+           option ]
        * [`Staged_ledger of t]
        * [ `Pending_coinbase_data of
            bool * Currency.Amount.t * Pending_coinbase.Update.Action.t ]
@@ -137,7 +149,10 @@ val apply_diff_unchecked :
   -> state_and_body_hash:State_hash.t * State_body_hash.t
   -> ( [`Hash_after_applying of Staged_ledger_hash.t]
        * [ `Ledger_proof of
-           (Ledger_proof.t * (Transaction.t * State_hash.t) list) option ]
+           ( Ledger_proof.t
+           * (Transaction.t User_command_status.With_status.t * State_hash.t)
+             list )
+           option ]
        * [`Staged_ledger of t]
        * [ `Pending_coinbase_data of
            bool * Currency.Amount.t * Pending_coinbase.Update.Action.t ]

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -111,7 +111,8 @@ module Pre_diff_with_at_most_two_coinbase = struct
     module V1 = struct
       type t =
         ( Transaction_snark_work.Stable.V1.t
-        , User_command.Stable.V1.t )
+        , User_command.Stable.V1.t User_command_status.With_status.Stable.V1.t
+        )
         Pre_diff_two.Stable.V1.t
       [@@deriving sexp, to_yojson]
 
@@ -128,7 +129,8 @@ module Pre_diff_with_at_most_one_coinbase = struct
     module V1 = struct
       type t =
         ( Transaction_snark_work.Stable.V1.t
-        , User_command.Stable.V1.t )
+        , User_command.Stable.V1.t User_command_status.With_status.Stable.V1.t
+        )
         Pre_diff_one.Stable.V1.t
       [@@deriving sexp, to_yojson]
 
@@ -177,13 +179,13 @@ type t = Stable.Latest.t =
 module With_valid_signatures_and_proofs = struct
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -208,13 +210,13 @@ let forget_cw cw_list = List.map ~f:Transaction_snark_work.forget cw_list
 module With_valid_signatures = struct
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -232,13 +234,15 @@ end
 
 let validate_user_commands (t : t)
     ~(check : User_command.t -> User_command.With_valid_signature.t option) :
-    (With_valid_signatures.t, User_command.t) result =
+    ( With_valid_signatures.t
+    , User_command.t User_command_status.With_status.t )
+    result =
   let open Result.Let_syntax in
   let validate user_commands =
     let%map user_commands' =
       List.fold_until user_commands ~init:[]
         ~f:(fun acc t ->
-          match check t with
+          match User_command_status.With_status.map_opt ~f:check t with
           | Some t ->
               Continue (t :: acc)
           | None ->
@@ -288,14 +292,18 @@ let forget_pre_diff_with_at_most_two
       With_valid_signatures_and_proofs.pre_diff_with_at_most_two_coinbase) :
     Pre_diff_with_at_most_two_coinbase.t =
   { completed_works= forget_cw pre_diff.completed_works
-  ; user_commands= (pre_diff.user_commands :> User_command.t list)
+  ; user_commands=
+      ( pre_diff.user_commands
+        :> User_command.t User_command_status.With_status.t list )
   ; coinbase= pre_diff.coinbase }
 
 let forget_pre_diff_with_at_most_one
     (pre_diff :
       With_valid_signatures_and_proofs.pre_diff_with_at_most_one_coinbase) =
   { Pre_diff_one.completed_works= forget_cw pre_diff.completed_works
-  ; user_commands= (pre_diff.user_commands :> User_command.t list)
+  ; user_commands=
+      ( pre_diff.user_commands
+        :> User_command.t User_command_status.With_status.t list )
   ; coinbase= pre_diff.coinbase }
 
 let forget (t : With_valid_signatures_and_proofs.t) =

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.ml
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.ml
@@ -111,8 +111,7 @@ module Pre_diff_with_at_most_two_coinbase = struct
     module V1 = struct
       type t =
         ( Transaction_snark_work.Stable.V1.t
-        , User_command.Stable.V1.t User_command_status.With_status.Stable.V1.t
-        )
+        , User_command.Stable.V1.t With_status.Stable.V1.t )
         Pre_diff_two.Stable.V1.t
       [@@deriving sexp, to_yojson]
 
@@ -129,8 +128,7 @@ module Pre_diff_with_at_most_one_coinbase = struct
     module V1 = struct
       type t =
         ( Transaction_snark_work.Stable.V1.t
-        , User_command.Stable.V1.t User_command_status.With_status.Stable.V1.t
-        )
+        , User_command.Stable.V1.t With_status.Stable.V1.t )
         Pre_diff_one.Stable.V1.t
       [@@deriving sexp, to_yojson]
 
@@ -179,13 +177,13 @@ type t = Stable.Latest.t =
 module With_valid_signatures_and_proofs = struct
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -210,13 +208,13 @@ let forget_cw cw_list = List.map ~f:Transaction_snark_work.forget cw_list
 module With_valid_signatures = struct
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -234,15 +232,13 @@ end
 
 let validate_user_commands (t : t)
     ~(check : User_command.t -> User_command.With_valid_signature.t option) :
-    ( With_valid_signatures.t
-    , User_command.t User_command_status.With_status.t )
-    result =
+    (With_valid_signatures.t, User_command.t With_status.t) result =
   let open Result.Let_syntax in
   let validate user_commands =
     let%map user_commands' =
       List.fold_until user_commands ~init:[]
         ~f:(fun acc t ->
-          match User_command_status.With_status.map_opt ~f:check t with
+          match With_status.map_opt ~f:check t with
           | Some t ->
               Continue (t :: acc)
           | None ->
@@ -292,18 +288,14 @@ let forget_pre_diff_with_at_most_two
       With_valid_signatures_and_proofs.pre_diff_with_at_most_two_coinbase) :
     Pre_diff_with_at_most_two_coinbase.t =
   { completed_works= forget_cw pre_diff.completed_works
-  ; user_commands=
-      ( pre_diff.user_commands
-        :> User_command.t User_command_status.With_status.t list )
+  ; user_commands= (pre_diff.user_commands :> User_command.t With_status.t list)
   ; coinbase= pre_diff.coinbase }
 
 let forget_pre_diff_with_at_most_one
     (pre_diff :
       With_valid_signatures_and_proofs.pre_diff_with_at_most_one_coinbase) =
   { Pre_diff_one.completed_works= forget_cw pre_diff.completed_works
-  ; user_commands=
-      ( pre_diff.user_commands
-        :> User_command.t User_command_status.With_status.t list )
+  ; user_commands= (pre_diff.user_commands :> User_command.t With_status.t list)
   ; coinbase= pre_diff.coinbase }
 
 let forget (t : With_valid_signatures_and_proofs.t) =

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.mli
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.mli
@@ -65,9 +65,7 @@ end
 
 module Pre_diff_with_at_most_two_coinbase : sig
   type t =
-    ( Transaction_snark_work.t
-    , User_command.t User_command_status.With_status.t )
-    Pre_diff_two.t
+    (Transaction_snark_work.t, User_command.t With_status.t) Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   module Stable :
@@ -81,9 +79,7 @@ end
 
 module Pre_diff_with_at_most_one_coinbase : sig
   type t =
-    ( Transaction_snark_work.t
-    , User_command.t User_command_status.With_status.t )
-    Pre_diff_one.t
+    (Transaction_snark_work.t, User_command.t With_status.t) Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
   module Stable :
@@ -133,13 +129,13 @@ module Stable :
 module With_valid_signatures_and_proofs : sig
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -155,21 +151,19 @@ module With_valid_signatures_and_proofs : sig
   [@@deriving sexp, to_yojson]
 
   val user_commands :
-       t
-    -> User_command.With_valid_signature.t User_command_status.With_status.t
-       list
+    t -> User_command.With_valid_signature.t With_status.t list
 end
 
 module With_valid_signatures : sig
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t User_command_status.With_status.t )
+    , User_command.With_valid_signature.t With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -191,13 +185,11 @@ val forget_proof_checks :
 val validate_user_commands :
      t
   -> check:(User_command.t -> User_command.With_valid_signature.t option)
-  -> ( With_valid_signatures.t
-     , User_command.t User_command_status.With_status.t )
-     result
+  -> (With_valid_signatures.t, User_command.t With_status.t) result
 
 val forget : With_valid_signatures_and_proofs.t -> t
 
-val user_commands : t -> User_command.t User_command_status.With_status.t list
+val user_commands : t -> User_command.t With_status.t list
 
 val completed_works : t -> Transaction_snark_work.t list
 

--- a/src/lib/staged_ledger_diff/staged_ledger_diff.mli
+++ b/src/lib/staged_ledger_diff/staged_ledger_diff.mli
@@ -64,7 +64,10 @@ module Pre_diff_one : sig
 end
 
 module Pre_diff_with_at_most_two_coinbase : sig
-  type t = (Transaction_snark_work.t, User_command.t) Pre_diff_two.t
+  type t =
+    ( Transaction_snark_work.t
+    , User_command.t User_command_status.With_status.t )
+    Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   module Stable :
@@ -77,7 +80,10 @@ module Pre_diff_with_at_most_two_coinbase : sig
 end
 
 module Pre_diff_with_at_most_one_coinbase : sig
-  type t = (Transaction_snark_work.t, User_command.t) Pre_diff_one.t
+  type t =
+    ( Transaction_snark_work.t
+    , User_command.t User_command_status.With_status.t )
+    Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
   module Stable :
@@ -127,13 +133,13 @@ module Stable :
 module With_valid_signatures_and_proofs : sig
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.Checked.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -148,19 +154,22 @@ module With_valid_signatures_and_proofs : sig
     ; coinbase_receiver: Public_key.Compressed.t }
   [@@deriving sexp, to_yojson]
 
-  val user_commands : t -> User_command.With_valid_signature.t list
+  val user_commands :
+       t
+    -> User_command.With_valid_signature.t User_command_status.With_status.t
+       list
 end
 
 module With_valid_signatures : sig
   type pre_diff_with_at_most_two_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_two.t
   [@@deriving sexp, to_yojson]
 
   type pre_diff_with_at_most_one_coinbase =
     ( Transaction_snark_work.t
-    , User_command.With_valid_signature.t )
+    , User_command.With_valid_signature.t User_command_status.With_status.t )
     Pre_diff_one.t
   [@@deriving sexp, to_yojson]
 
@@ -182,11 +191,13 @@ val forget_proof_checks :
 val validate_user_commands :
      t
   -> check:(User_command.t -> User_command.With_valid_signature.t option)
-  -> (With_valid_signatures.t, User_command.t) result
+  -> ( With_valid_signatures.t
+     , User_command.t User_command_status.With_status.t )
+     result
 
 val forget : With_valid_signatures_and_proofs.t -> t
 
-val user_commands : t -> User_command.t list
+val user_commands : t -> User_command.t User_command_status.With_status.t list
 
 val completed_works : t -> Transaction_snark_work.t list
 

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.ml
@@ -189,7 +189,9 @@ let create_expected_statement ~constraint_constants
   let next_available_token_before =
     Sparse_ledger.next_available_token ledger_witness
   in
-  let%bind transaction = Ledger.Undo.transaction transaction_with_info in
+  let%bind {data= transaction; status= _} =
+    Ledger.Undo.transaction transaction_with_info
+  in
   let txn_global_slot =
     (* TODO: Get from protocol state. *)
     Coda_numbers.Global_slot.zero
@@ -663,7 +665,9 @@ let all_work_pairs t
         , state_hash
         , ledger_witness
         , init_stack ) ->
-        let%bind transaction = Ledger.Undo.transaction transaction_with_info in
+        let%bind {data= transaction; status} =
+          Ledger.Undo.transaction transaction_with_info
+        in
         let%bind protocol_state_body =
           let%map state = get_state (fst state_hash) in
           Coda_state.Protocol_state.body state
@@ -680,7 +684,8 @@ let all_work_pairs t
           , transaction
           , { Transaction_witness.ledger= ledger_witness
             ; protocol_state_body
-            ; init_stack } )
+            ; init_stack
+            ; status } )
     | Second (p1, p2) ->
         let%map merged =
           Transaction_snark.Statement.merge

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -96,12 +96,17 @@ val fill_work_and_enqueue_transactions :
      t
   -> Transaction_with_witness.t list
   -> Transaction_snark_work.t list
-  -> ((Ledger_proof.t * (Transaction.t * State_hash.t) list) option * t)
+  -> ( ( Ledger_proof.t
+       * (Transaction.t User_command_status.With_status.t * State_hash.t) list
+       )
+       option
+     * t )
      Or_error.t
 
 val latest_ledger_proof :
      t
-  -> (Ledger_proof_with_sok_message.t * (Transaction.t * State_hash.t) list)
+  -> ( Ledger_proof_with_sok_message.t
+     * (Transaction.t User_command_status.With_status.t * State_hash.t) list )
      option
 
 val free_space : t -> int
@@ -113,13 +118,17 @@ val hash : t -> Staged_ledger_hash.Aux_hash.t
 val target_merkle_root : t -> Frozen_ledger_hash.t option
 
 (** All the transactions in the order in which they were applied*)
-val staged_transactions : t -> Transaction.t list Or_error.t
+val staged_transactions :
+  t -> Transaction.t User_command_status.With_status.t list Or_error.t
 
 (** All the transactions with parent protocol state of the block in which they were included in the order in which they were applied*)
 val staged_transactions_with_protocol_states :
      t
   -> get_state:(State_hash.t -> Coda_state.Protocol_state.value Or_error.t)
-  -> (Transaction.t * Coda_state.Protocol_state.value) list Or_error.t
+  -> ( Transaction.t User_command_status.With_status.t
+     * Coda_state.Protocol_state.value )
+     list
+     Or_error.t
 
 (** Available space and the corresponding required work-count in one and/or two trees (if the slots to be occupied are in two different trees)*)
 val partition_if_overflowing : t -> Space_partition.t

--- a/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
+++ b/src/lib/transaction_snark_scan_state/transaction_snark_scan_state.mli
@@ -96,9 +96,7 @@ val fill_work_and_enqueue_transactions :
      t
   -> Transaction_with_witness.t list
   -> Transaction_snark_work.t list
-  -> ( ( Ledger_proof.t
-       * (Transaction.t User_command_status.With_status.t * State_hash.t) list
-       )
+  -> ( (Ledger_proof.t * (Transaction.t With_status.t * State_hash.t) list)
        option
      * t )
      Or_error.t
@@ -106,7 +104,7 @@ val fill_work_and_enqueue_transactions :
 val latest_ledger_proof :
      t
   -> ( Ledger_proof_with_sok_message.t
-     * (Transaction.t User_command_status.With_status.t * State_hash.t) list )
+     * (Transaction.t With_status.t * State_hash.t) list )
      option
 
 val free_space : t -> int
@@ -118,16 +116,13 @@ val hash : t -> Staged_ledger_hash.Aux_hash.t
 val target_merkle_root : t -> Frozen_ledger_hash.t option
 
 (** All the transactions in the order in which they were applied*)
-val staged_transactions :
-  t -> Transaction.t User_command_status.With_status.t list Or_error.t
+val staged_transactions : t -> Transaction.t With_status.t list Or_error.t
 
 (** All the transactions with parent protocol state of the block in which they were included in the order in which they were applied*)
 val staged_transactions_with_protocol_states :
      t
   -> get_state:(State_hash.t -> Coda_state.Protocol_state.value Or_error.t)
-  -> ( Transaction.t User_command_status.With_status.t
-     * Coda_state.Protocol_state.value )
-     list
+  -> (Transaction.t With_status.t * Coda_state.Protocol_state.value) list
      Or_error.t
 
 (** Available space and the corresponding required work-count in one and/or two trees (if the slots to be occupied are in two different trees)*)

--- a/src/lib/transaction_status/transaction_status.ml
+++ b/src/lib/transaction_status/transaction_status.ml
@@ -41,21 +41,17 @@ let get_status ~frontier_broadcast_pipe ~transaction_pool cmd =
           let best_tip_path =
             Transition_frontier.best_tip_path transition_frontier
           in
-          let best_tip_user_commands =
-            Sequence.fold (Sequence.of_list best_tip_path)
-              ~init:User_command.Set.empty ~f:(fun acc_set breadcrumb ->
-                let user_commands =
-                  Transition_frontier.Breadcrumb.user_commands breadcrumb
-                in
-                List.fold user_commands ~init:acc_set ~f:Set.add )
+          let in_breadcrumb breadcrumb =
+            List.exists
+              (Transition_frontier.Breadcrumb.user_commands breadcrumb)
+              ~f:(fun {data= cmd'; _} -> User_command.equal cmd cmd')
           in
-          if Set.mem best_tip_user_commands cmd then return State.Included ;
-          let all_transactions =
-            Transition_frontier.(
-              Breadcrumb.all_user_commands
-                (Transition_frontier.all_breadcrumbs transition_frontier))
-          in
-          if Set.mem all_transactions cmd then return State.Pending ;
+          if List.exists ~f:in_breadcrumb best_tip_path then
+            return State.Included ;
+          if
+            List.exists ~f:in_breadcrumb
+              (Transition_frontier.all_breadcrumbs transition_frontier)
+          then return State.Pending ;
           if Transaction_pool.Resource_pool.member resource_pool check_cmd then
             return State.Pending ;
           State.Unknown )

--- a/src/lib/transaction_witness/transaction_witness.ml
+++ b/src/lib/transaction_witness/transaction_witness.ml
@@ -6,7 +6,8 @@ module Stable = struct
     type t =
       { ledger: Coda_base.Sparse_ledger.Stable.V1.t
       ; protocol_state_body: Coda_state.Protocol_state.Body.Value.Stable.V1.t
-      ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.Stable.V1.t }
+      ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.Stable.V1.t
+      ; status: Coda_base.User_command_status.Stable.V1.t }
     [@@deriving sexp, to_yojson]
 
     let to_latest = Fn.id
@@ -16,5 +17,6 @@ end]
 type t = Stable.Latest.t =
   { ledger: Coda_base.Sparse_ledger.t
   ; protocol_state_body: Coda_state.Protocol_state.Body.Value.t
-  ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.t }
+  ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.t
+  ; status: Coda_base.User_command_status.t }
 [@@deriving sexp, to_yojson]

--- a/src/lib/transaction_witness/transaction_witness.mli
+++ b/src/lib/transaction_witness/transaction_witness.mli
@@ -6,7 +6,8 @@ module Stable : sig
     type t =
       { ledger: Coda_base.Sparse_ledger.Stable.V1.t
       ; protocol_state_body: Coda_state.Protocol_state.Body.Value.Stable.V1.t
-      ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.Stable.V1.t }
+      ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.Stable.V1.t
+      ; status: Coda_base.User_command_status.Stable.V1.t }
     [@@deriving sexp, to_yojson]
   end
 end]
@@ -14,5 +15,6 @@ end]
 type t = Stable.Latest.t =
   { ledger: Coda_base.Sparse_ledger.t
   ; protocol_state_body: Coda_state.Protocol_state.Body.Value.t
-  ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.t }
+  ; init_stack: Coda_base.Pending_coinbase.Stack_versioned.t
+  ; status: Coda_base.User_command_status.t }
 [@@deriving sexp, to_yojson]

--- a/src/lib/transition_frontier/extensions/best_tip_diff.ml
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.ml
@@ -6,8 +6,9 @@ module T = struct
   type t = {logger: Logger.t}
 
   type view =
-    { new_user_commands: User_command.t list
-    ; removed_user_commands: User_command.t list
+    { new_user_commands: User_command.t User_command_status.With_status.t list
+    ; removed_user_commands:
+        User_command.t User_command_status.With_status.t list
     ; reorg_best_tip: bool }
 
   let create ~logger frontier =

--- a/src/lib/transition_frontier/extensions/best_tip_diff.ml
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.ml
@@ -6,9 +6,8 @@ module T = struct
   type t = {logger: Logger.t}
 
   type view =
-    { new_user_commands: User_command.t User_command_status.With_status.t list
-    ; removed_user_commands:
-        User_command.t User_command_status.With_status.t list
+    { new_user_commands: User_command.t With_status.t list
+    ; removed_user_commands: User_command.t With_status.t list
     ; reorg_best_tip: bool }
 
   let create ~logger frontier =

--- a/src/lib/transition_frontier/extensions/best_tip_diff.mli
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.mli
@@ -1,9 +1,8 @@
 open Coda_base
 
 type view =
-  { new_user_commands: User_command.t User_command_status.With_status.t list
-  ; removed_user_commands:
-      User_command.t User_command_status.With_status.t list
+  { new_user_commands: User_command.t With_status.t list
+  ; removed_user_commands: User_command.t With_status.t list
   ; reorg_best_tip: bool }
 
 include Intf.Extension_intf with type view := view

--- a/src/lib/transition_frontier/extensions/best_tip_diff.mli
+++ b/src/lib/transition_frontier/extensions/best_tip_diff.mli
@@ -1,8 +1,9 @@
 open Coda_base
 
 type view =
-  { new_user_commands: User_command.t list
-  ; removed_user_commands: User_command.t list
+  { new_user_commands: User_command.t User_command_status.With_status.t list
+  ; removed_user_commands:
+      User_command.t User_command_status.With_status.t list
   ; reorg_best_tip: bool }
 
 include Intf.Extension_intf with type view := view

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -164,8 +164,9 @@ let display t =
 let all_user_commands breadcrumbs =
   Sequence.fold (Sequence.of_list breadcrumbs) ~init:User_command.Set.empty
     ~f:(fun acc_set breadcrumb ->
-      let user_commands = user_commands breadcrumb in
-      Set.union acc_set (User_command.Set.of_list user_commands) )
+      breadcrumb |> user_commands
+      |> List.map ~f:(fun {data; _} -> data)
+      |> User_command.Set.of_list |> Set.union acc_set )
 
 module For_tests = struct
   open Currency

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -59,9 +59,9 @@ val parent_hash : t -> State_hash.t
 
 val block_producer : t -> Signature_lib.Public_key.Compressed.t
 
-val user_commands : t -> User_command.t list
+val user_commands : t -> User_command.t User_command_status.With_status.t list
 
-val payments : t -> User_command.t list
+val payments : t -> User_command.t User_command_status.With_status.t list
 
 val mask : t -> Ledger.Mask.Attached.t
 

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.mli
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.mli
@@ -59,9 +59,9 @@ val parent_hash : t -> State_hash.t
 
 val block_producer : t -> Signature_lib.Public_key.Compressed.t
 
-val user_commands : t -> User_command.t User_command_status.With_status.t list
+val user_commands : t -> User_command.t With_status.t list
 
-val payments : t -> User_command.t User_command_status.With_status.t list
+val payments : t -> User_command.t With_status.t list
 
 val mask : t -> Ledger.Mask.Attached.t
 

--- a/src/lib/transition_frontier/full_frontier/full_frontier.ml
+++ b/src/lib/transition_frontier/full_frontier/full_frontier.ml
@@ -426,7 +426,7 @@ let move_root t ~new_root_hash ~new_root_protocol_states ~garbage
                (Ledger.apply_transaction
                   ~constraint_constants:
                     t.precomputed_values.constraint_constants ~txn_global_slot
-                  mt txn)) ) ;
+                  mt txn.data)) ) ;
       (* STEP 6 *)
       Ledger.commit mt ;
       (* STEP 7 *)

--- a/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
+++ b/src/lib/transition_frontier/persistent_frontier/persistent_frontier.ml
@@ -52,21 +52,28 @@ let construct_staged_ledger_at_root
   in
   let mask = Ledger.of_database root_ledger in
   let%bind () =
-    Deferred.return
-      (List.fold transactions_with_protocol_state ~init:(Or_error.return ())
-         ~f:(fun acc (txn, protocol_state) ->
-           let open Or_error.Let_syntax in
-           let%bind () = acc in
-           let%map _ =
+    Deferred.Or_error.List.iter transactions_with_protocol_state
+      ~f:(fun (txn, protocol_state) ->
+        Deferred.return
+        @@ let%bind.Or_error.Let_syntax txn_with_info =
              Ledger.apply_transaction
                ~constraint_constants:precomputed_values.constraint_constants
                mask
                ~txn_global_slot:
                  ( Protocol_state.consensus_state protocol_state
                  |> Consensus.Data.Consensus_state.curr_global_slot )
-               txn
+               txn.data
            in
-           () ))
+           let computed_status =
+             Ledger.Undo.user_command_status txn_with_info
+           in
+           if User_command_status.equal txn.status computed_status then
+             Or_error.return ()
+           else
+             Or_error.errorf
+               !"Mismatched user command status. Expected: %{sexp: \
+                 User_command_status.t} Got: %{sexp: User_command_status.t}"
+               txn.status computed_status )
   in
   Staged_ledger.of_scan_state_and_ledger_unchecked ~snarked_ledger_hash
     ~snarked_next_available_token ~ledger:mask ~scan_state


### PR DESCRIPTION
This PR
* adds `User_command_status.t` and `User_command_status.Failure.t`
* generates the correct status and failure when applying user commands to the ledger
* carries the status with the commands in blocks, checks it when applying external transitions
* makes it available to the archive node database

This PR doesn't expose this as part of the GraphQL API yet, nor does it integrate this with `Transaction_snark.User_command_failure.t`; these will be done in later PRs.

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: