### PR TITLE
fix for qa-net forking

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -869,6 +869,11 @@ let daemon logger =
          coda_initialization_deferred ()
        in
        coda_ref := Some coda ;
+       (*This pipe is consumed only by integration tests*)
+       don't_wait_for
+         (Pipe_lib.Strict_pipe.Reader.iter_without_pushback
+            (Coda_lib.validated_transitions coda)
+            ~f:ignore) ;
        let%bind () = maybe_sleep 3. in
        Coda_run.setup_local_server ?client_trustlist ~rest_server_port
          ~insecure_rest_server coda ;

--- a/src/lib/block_producer/block_producer.ml
+++ b/src/lib/block_producer/block_producer.ml
@@ -537,7 +537,8 @@ let run ~logger ~prover ~verifier ~trust_system ~get_completed_work
                                 Logger.Str.trace logger ~module_:__MODULE__
                                   ~location:__LOC__
                                   ~metadata:
-                                    [("breadcrumb", Breadcrumb.to_yojson crumb)]
+                                    [ ( "breadcrumb"
+                                      , Breadcrumb.to_yojson breadcrumb ) ]
                                   Block_produced ;
                                 let metadata =
                                   [ ( "state_hash"


### PR DESCRIPTION
1. Drain `validated_transitions` pipe that is no longer used by daemon (only used in integration tests)
2. correct `Block_produced` metadata

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
