### PR TITLE
Website Leaderboard - Style fixes and added last manually updated to sheets and frontend

### DIFF
--- a/frontend/website/src/components/ChallengePointsTable.re
+++ b/frontend/website/src/components/ChallengePointsTable.re
@@ -77,22 +77,11 @@ module Styles = {
       padding2(~v=`zero, ~h=`rem(1.)),
       padding(`px(8)),
       display(`grid),
-      gridTemplateColumns([
-        `percent(6.),
-        `percent(6.),
-        `auto,
-        `percent(15.),
-      ]),
+      gridTemplateColumns([`percent(12.), `auto, `percent(15.)]),
+      gridColumnGap(`rem(1.5)),
       media(
         Theme.MediaQuery.notMobile,
-        [
-          gridTemplateColumns([
-            `percent(8.),
-            `percent(5.),
-            `auto,
-            `percent(20.),
-          ]),
-        ],
+        [gridTemplateColumns([`percent(10.), `auto, `percent(20.)])],
       ),
     ]);
   };
@@ -110,12 +99,7 @@ module Styles = {
           Theme.MediaQuery.notMobile,
           [
             display(`grid),
-            gridTemplateColumns([
-              `percent(12.5),
-              `percent(5.),
-              `auto,
-              `percent(23.5),
-            ]),
+            gridTemplateColumns([`percent(11.), `auto, `percent(23.)]),
           ],
         ),
       ]),
@@ -129,12 +113,8 @@ module Styles = {
     ]);
   };
 
-  let star = {
-    style([justifySelf(`flexEnd)]);
-  };
-
   let rank = {
-    style([fontWeight(`normal), justifySelf(`center)]);
+    style([fontWeight(`normal), justifySelf(`flexEnd)]);
   };
 
   let points = {
@@ -158,14 +138,8 @@ module Styles = {
 
 module Row = {
   [@react.component]
-  let make = (~star, ~rank, ~name, ~points) => {
+  let make = (~rank, ~name, ~points) => {
     <div className=Styles.tableRow>
-      <span className=Styles.star>
-        {switch (star) {
-         | Some(star) => React.string(star)
-         | None => React.null
-         }}
-      </span>
       <span className=Styles.rank>
         {React.string(string_of_int(rank))}
       </span>
@@ -208,13 +182,7 @@ let make = (~releaseTitle, ~challenges) => {
     challenges
     |> Array.mapi((index, challenge) => {
          let {name, points} = challenge;
-         <Row
-           key={string_of_int(index)}
-           star={Some("")} /* TODO: not sure what these are. Follow up with Chris on this. */
-           rank={index + 1}
-           name
-           points
-         />;
+         <Row key={string_of_int(index)} rank={index + 1} name points />;
        })
     |> React.array;
   };
@@ -223,10 +191,10 @@ let make = (~releaseTitle, ~challenges) => {
     <div className=Styles.releaseTitle> {React.string(releaseTitle)} </div>
     <div className=Styles.tableContainer>
       <div className=Styles.topRow>
-        <span className=Css.(style([gridColumn(3, 4)]))>
+        <span className=Css.(style([gridColumn(2, 3)]))>
           {React.string("Challenge Name")}
         </span>
-        <span className=Css.(style([gridColumn(4, 5)]))>
+        <span className=Css.(style([gridColumn(3, 4)]))>
           {React.string("* Points")}
         </span>
       </div>
@@ -234,10 +202,10 @@ let make = (~releaseTitle, ~challenges) => {
         {renderChallengePointsTable()}
       </div>
       <div className=Styles.bottomRow>
-        <span className=Css.(style([gridColumn(3, 4)]))>
+        <span className=Css.(style([gridColumn(2, 3)]))>
           {React.string("Total Points *")}
         </span>
-        <span className=Css.(style([gridColumn(4, 5)]))>
+        <span className=Styles.points>
           {React.string(calculateTotalPoints())}
         </span>
       </div>

--- a/frontend/website/src/components/Leaderboard.re
+++ b/frontend/website/src/components/Leaderboard.re
@@ -140,8 +140,9 @@ module Styles = {
     style([
       cursor(`pointer),
       padding2(~v=`rem(1.), ~h=`rem(1.)),
-      height(`rem(3.5)),
+      height(`rem(4.)),
       display(`grid),
+      alignItems(`center),
       gridColumnGap(rem(1.5)),
       width(`percent(100.)),
       gridTemplateColumns([`rem(3.5), `rem(6.), `auto, `rem(9.)]),
@@ -219,17 +220,31 @@ module Styles = {
   let cell =
     style([height(`rem(2.)), whiteSpace(`nowrap), overflowX(`hidden)]);
   let flexEnd = style([justifySelf(`flexEnd)]);
-  let rank = merge([cell, flexEnd, style([gridColumn(0, 1)])]);
+  let flexAlignItems = style([display(`flex), alignItems(`center)]);
+  let rank =
+    merge([cell, flexEnd, flexAlignItems, style([gridColumn(0, 1)])]);
   let username =
-    merge([cell, style([textOverflow(`ellipsis), fontWeight(`semiBold)])]);
-  let pointsCell = merge([cell, style([justifySelf(`flexEnd)])]);
+    merge([
+      cell,
+      flexAlignItems,
+      style([textOverflow(`ellipsis), fontWeight(`semiBold)]),
+    ]);
+  let pointsCell =
+    merge([cell, flexAlignItems, style([justifySelf(`flexEnd)])]);
   let activePointsCell =
-    merge([cell, style([justifySelf(`flexEnd), fontWeight(`semiBold)])]);
+    merge([
+      cell,
+      flexAlignItems,
+      style([justifySelf(`flexEnd), fontWeight(`semiBold)]),
+    ]);
   let inactivePointsCell =
     merge([
       pointsCell,
       style([
-        media(Theme.MediaQuery.tablet, [display(`inline)]),
+        media(
+          Theme.MediaQuery.tablet,
+          [display(`flex), alignItems(`center)],
+        ),
         display(`none),
         opacity(0.5),
       ]),
@@ -242,9 +257,10 @@ module Styles = {
       textAlign(`center),
     ]);
 
-  let badges = style([display(`flex), justifyContent(`flexEnd)]);
+  let badges =
+    style([display(`flex), justifyContent(`flexEnd), alignItems(`center)]);
   let mobileBadges =
-    style([display(`flex), marginLeft(`rem(0.5)), paddingBottom(px(5))]);
+    merge([flexAlignItems, style([marginLeft(`rem(0.3))])]);
 
   let desktopLayout =
     style([
@@ -265,6 +281,7 @@ module Styles = {
     style([
       display(`flex),
       justifyContent(`flexStart),
+      alignItems(`center),
       flexDirection(`row),
       textAlign(`left),
     ]);

--- a/frontend/website/src/components/ProfileHero.re
+++ b/frontend/website/src/components/ProfileHero.re
@@ -112,7 +112,16 @@ module Styles = {
       ]),
     ]);
 
-  let nameContainer = style([display(`flex), alignItems(`center)]);
+  let nameContainer =
+    style([
+      display(`flex),
+      flexDirection(`column),
+      alignItems(`flexStart),
+      media(
+        Theme.MediaQuery.notMobile,
+        [flexDirection(`row), alignItems(`center)],
+      ),
+    ]);
 
   let username = merge([header, style([marginRight(`rem(1.5))])]);
 };
@@ -306,7 +315,9 @@ let make = (~member: Leaderboard.member) => {
     </span>
     <div className=Styles.nameContainer>
       <p className=Styles.username> {React.string(member.name)} </p>
-      {Leaderboard.LeaderboardRow.renderBadges(member, 2., 2.)}
+      <span className=Css.(style([display(`flex), paddingTop(`rem(0.5))]))>
+        {Leaderboard.LeaderboardRow.renderBadges(member, 2., 2.)}
+      </span>
     </div>
     <div className=Styles.middleRow> <Points member /> <Links /> </div>
   </div>;


### PR DESCRIPTION
This PR addresses the following issues caught in the latest Leaderboard QA:

https://github.com/CodaProtocol/coda/issues/5426 (not included)
https://github.com/CodaProtocol/coda/issues/5427
https://github.com/CodaProtocol/coda/issues/5437
https://github.com/CodaProtocol/coda/issues/5436

Desktop Member Profile - Badge Alignment:
![image](https://user-images.githubusercontent.com/9512405/87836148-fced5e00-c843-11ea-8a07-f5bf9e425121.png)

Mobile Member Profile - Badge Alignment:

Desktop - Member Profile Challenge Table - Points Alignment:
![image](https://user-images.githubusercontent.com/9512405/87836229-4047cc80-c844-11ea-9c86-9e6b983dacdd.png)

Mobile Member Profile Challenge Table - Points Alignment:
![image](https://user-images.githubusercontent.com/9512405/87836260-50f84280-c844-11ea-874d-1747e5d310af.png)

Desktop - Leaderboard Row - Badge Alignment
![image](https://user-images.githubusercontent.com/9512405/87836304-72f1c500-c844-11ea-8dfb-9db3b05e7f00.png)

Mobile - Leaderboard Row - Badge Alignment: