### PR TITLE
ensure agent-dind shared volume is auto-mounted during job `docker run...`s

### DIFF
--- a/buildkite/src/Lib/Cmds.dhall
+++ b/buildkite/src/Lib/Cmds.dhall
@@ -106,7 +106,7 @@ let tests =
 
   let dockerExample = assert :
   { line =
-"docker run -it --rm --init --volume /var/buildkite/builds/\\\$BUILDKITE_AGENT_NAME/\\\$BUILDKITE_ORGANIZATION_SLUG/\\\$BUILDKITE_PIPELINE_SLUG:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello'"
+"docker run -it --rm --init --volume /var/buildkite:/var/buildkite/shared --volume /var/buildkite/builds/\\\$BUILDKITE_AGENT_NAME/\\\$BUILDKITE_ORGANIZATION_SLUG/\\\$BUILDKITE_PIPELINE_SLUG:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello'"
   , readable =
     Some "Docker@foo/bar:tag ( echo hello )"
   }
@@ -120,7 +120,7 @@ let tests =
 
   let cacheExample = assert :
 ''
-  ./buildkite/scripts/cache-through.sh data.tar "docker run -it --rm --init --volume /var/buildkite/builds/\$BUILDKITE_AGENT_NAME/\$BUILDKITE_ORGANIZATION_SLUG/\$BUILDKITE_PIPELINE_SLUG:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello > /tmp/data/foo.txt && tar cvf data.tar /tmp/data'"''
+  ./buildkite/scripts/cache-through.sh data.tar "docker run -it --rm --init --volume /var/buildkite:/var/buildkite/shared --volume /var/buildkite/builds/\$BUILDKITE_AGENT_NAME/\$BUILDKITE_ORGANIZATION_SLUG/\$BUILDKITE_PIPELINE_SLUG:/workdir --workdir /workdir --env ENV1 --env ENV2 --env TEST foo/bar:tag /bin/sh -c 'echo hello > /tmp/data/foo.txt && tar cvf data.tar /tmp/data'"''
   ===
   M.format (
     M.cacheThrough

--- a/buildkite/src/Lib/Cmds.dhall
+++ b/buildkite/src/Lib/Cmds.dhall
@@ -43,8 +43,9 @@ let module = \(environment : List Text) ->
         (docker.extraEnv # environment)
     let outerDir : Text =
       "/var/buildkite/builds/\\\$BUILDKITE_AGENT_NAME/\\\$BUILDKITE_ORGANIZATION_SLUG/\\\$BUILDKITE_PIPELINE_SLUG"
+    let sharedDir : Text = "/var/buildkite/shared"
     in
-    { line = "docker run -it --rm --init --volume ${outerDir}:/workdir --workdir /workdir${envVars} ${docker.image} /bin/sh -c '${inner.line}'"
+    { line = "docker run -it --rm --init --volume /var/buildkite:${sharedDir} --volume ${outerDir}:/workdir --workdir /workdir${envVars} ${docker.image} /bin/sh -c '${inner.line}'"
     , readable = Optional/map Text Text (\(readable : Text) -> "Docker@${docker.image} ( ${readable} )") inner.readable
     }
 


### PR DESCRIPTION
When executing Buildkite pipeline job commands in Docker containers with the expectation of producing an artifact to be acted on by an agent post-production, it is necessary to ensure that the `dind` pod's shared-volume DIR is auto-mounted for all `docker run...` commands so that writes to it are persisted.

Checklist:
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Does this close issues? List them:
