### PR TITLE
Separate runtime lib, ppx_version

### DIFF
--- a/src/app/archive/dune
+++ b/src/app/archive/dune
@@ -3,6 +3,6 @@
   (name archive)
   (public_name archive)
   (modes native)
-  (libraries core async archive_lib cli_lib ppx_version caqti caqti-async caqti-driver-postgresql)
+  (libraries core async archive_lib cli_lib caqti caqti-async caqti-driver-postgresql)
   (preprocess (pps ppx_version ppx_jane))
   )

--- a/src/lib/blake2/blake2.ml
+++ b/src/lib/blake2/blake2.ml
@@ -82,7 +82,7 @@ include Make ()
 let%test "serialization test V1" =
   let blake2s = T0.digest_string "serialization test V1" in
   let known_good_digest = "162e120bf889f4e2bccf8017ed93d845" in
-  Ppx_version.Serialization.check_serialization
+  Ppx_version_runtime.Serialization.check_serialization
     (module Stable.V1)
     blake2s known_good_digest
 

--- a/src/lib/blake2/dune
+++ b/src/lib/blake2/dune
@@ -6,5 +6,5 @@
   (libraries
     core_kernel
     coda_digestif
-    ppx_version
+    ppx_version.runtime
   ))

--- a/src/lib/coda_base/data_hash.ml
+++ b/src/lib/coda_base/data_hash.ml
@@ -170,7 +170,7 @@ module T0 = struct
 
     let%test "Binable from stringable V1" =
       let known_good_digest = "66e2f2648cf3d2c39465ddbe4f05202a" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module Stable.V1)
         field known_good_digest
 
@@ -179,7 +179,7 @@ module T0 = struct
 
     let%test "Binable from stringable V1" =
       let known_good_digest = "0e586911e7deaf7e5b49c801bf248c92" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module Stable.V1)
         field known_good_digest
 

--- a/src/lib/coda_base/dune
+++ b/src/lib/coda_base/dune
@@ -27,7 +27,7 @@
     one_or_two
     o1trace
     outside_hash_image
-    ppx_version
+    ppx_version.runtime
     quickcheck_lib
     random_oracle
     rocksdb

--- a/src/lib/coda_base/proof.ml
+++ b/src/lib/coda_base/proof.ml
@@ -68,7 +68,7 @@ let%test_module "proof-tests" =
     let%test "proof serialization v1" =
       let proof = Tock_backend.Proof.get_dummy () in
       let known_good_digest = "7b2f3495a9b190a72e134bc5a5c7d53f" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module Stable.V1)
         proof known_good_digest
 
@@ -78,7 +78,7 @@ let%test_module "proof-tests" =
     let%test "proof serialization v1" =
       let proof = Tock_backend.Proof.get_dummy () in
       let known_good_digest = "4e54b20026fe9e66fcb432ff6772bd7c" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module Stable.V1)
         proof known_good_digest
 

--- a/src/lib/coda_base/signature.ml
+++ b/src/lib/coda_base/signature.ml
@@ -48,7 +48,7 @@ module Stable = struct
           ~seed:(`Deterministic "signature serialization") V1.gen
       in
       let known_good_digest = "5581d593702a09f4418fe46bde1ca116" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module V1)
         signature known_good_digest
 
@@ -61,7 +61,7 @@ module Stable = struct
           ~seed:(`Deterministic "signature serialization") V1.gen
       in
       let known_good_digest = "7cc56fd93cef313e1eef9fc83f55aedb" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module V1)
         signature known_good_digest
 

--- a/src/lib/genesis_constants/dune
+++ b/src/lib/genesis_constants/dune
@@ -3,7 +3,7 @@
  (public_name genesis_constants)
  (library_flags -linkall)
  (inline_tests)
- (libraries core blake2 coda_compile_config currency ppx_version)
+ (libraries core blake2 coda_compile_config currency ppx_version.runtime)
  (preprocessor_deps ../../config.mlh)
  (preprocess (pps
   ppx_version ppx_optcomp ppx_bin_prot ppx_compare ppx_hash

--- a/src/lib/genesis_constants/genesis_constants.ml
+++ b/src/lib/genesis_constants/genesis_constants.ml
@@ -268,7 +268,7 @@ module Protocol = struct
         in
         (*from the print statement in Serialization.check_serialization*)
         let known_good_digest = "2b1a964e0fea8c31fdf76e7f5bebcdd6" in
-        Ppx_version.Serialization.check_serialization
+        Ppx_version_runtime.Serialization.check_serialization
           (module V1)
           t known_good_digest
     end

--- a/src/lib/merkle_address/dune
+++ b/src/lib/merkle_address/dune
@@ -3,7 +3,7 @@
  (public_name merkle_address)
  (library_flags -linkall)
  (inline_tests)
- (libraries core bitstring direction ppx_version)
+ (libraries core bitstring direction ppx_version.runtime)
  (preprocess
   (pps ppx_coda ppx_version ppx_jane ppx_hash ppx_deriving.eq ppx_deriving_yojson bitstring.ppx bisect_ppx --
     -conditional))

--- a/src/lib/merkle_address/merkle_address.ml
+++ b/src/lib/merkle_address/merkle_address.ml
@@ -268,7 +268,7 @@ let%test "Bitstring bin_io serialization does not change" =
   in
   let bitstring = Bitstring.bitstring_of_string text in
   let known_good_digest = "c4c7ade09ba305b69ffac494a6eab60e" in
-  Ppx_version.Serialization.check_serialization
+  Ppx_version_runtime.Serialization.check_serialization
     (module Stable.V1)
     bitstring known_good_digest
 

--- a/src/lib/non_zero_curve_point/dune
+++ b/src/lib/non_zero_curve_point/dune
@@ -4,7 +4,7 @@
  (flags :standard -short-paths)
  (inline_tests)
  (library_flags -linkall)
- (libraries core_kernel snark_params fold_lib codable ppx_version)
+ (libraries core_kernel snark_params fold_lib codable ppx_version.runtime)
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_snarky ppx_coda ppx_version ppx_optcomp ppx_let ppx_hash ppx_compare ppx_sexp_conv ppx_bin_prot ppx_inline_test ppx_deriving_yojson ppx_deriving.eq h_list.ppx)))

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -105,7 +105,7 @@ module Compressed = struct
             ~seed:(`Deterministic "nonzero_curve_point_compressed-seed") V1.gen
         in
         let known_good_digest = "067f8be67e5cc31f5c5ac4be91d5f6db" in
-        Ppx_version.Serialization.check_serialization
+        Ppx_version_runtime.Serialization.check_serialization
           (module V1)
           point known_good_digest
 

--- a/src/lib/non_zero_curve_point/non_zero_curve_point.ml
+++ b/src/lib/non_zero_curve_point/non_zero_curve_point.ml
@@ -92,7 +92,7 @@ module Compressed = struct
             ~seed:(`Deterministic "nonzero_curve_point_compressed-seed") V1.gen
         in
         let known_good_digest = "437f5bc6710b6a8fda8f9e8cf697fc2c" in
-        Ppx_version.Serialization.check_serialization
+        Ppx_version_runtime.Serialization.check_serialization
           (module V1)
           point known_good_digest
 

--- a/src/lib/signature_lib/dune
+++ b/src/lib/signature_lib/dune
@@ -8,7 +8,7 @@
    core
    hash_prefix_states
    non_zero_curve_point
-   ppx_version
+   ppx_version.runtime
    random_oracle
    snark_params
    snarky

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -52,7 +52,7 @@ module Stable = struct
           V1.gen
       in
       let known_good_digest = "4bbc6cd7832cfc67f0fe3abcd7f765df" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module V1)
         pk known_good_digest
 

--- a/src/lib/signature_lib/private_key.ml
+++ b/src/lib/signature_lib/private_key.ml
@@ -65,7 +65,7 @@ module Stable = struct
           V1.gen
       in
       let known_good_digest = "65c75a7d10b6ce193f0c0e296611a935" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module V1)
         pk known_good_digest
 

--- a/src/lib/transaction_snark/dune
+++ b/src/lib/transaction_snark/dune
@@ -3,7 +3,7 @@
  (public_name transaction_snark)
  (library_flags -linkall)
  (inline_tests)
- (libraries core cache_dir cached snarky coda_base sgn bignum ppx_version transaction_protocol_state coda_state)
+ (libraries core cache_dir cached snarky coda_base sgn bignum ppx_version.runtime transaction_protocol_state coda_state)
  (preprocess
   (pps ppx_snarky ppx_version ppx_jane ppx_deriving.std ppx_deriving_yojson h_list.ppx bisect_ppx -- -conditional))
  (synopsis "Transaction state transition snarking library"))

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -543,7 +543,7 @@ module Verification_keys = struct
         let merge = Tick.Verification_key.of_string "merge key" in
         let keys = V1.{base; wrap; merge} in
         let known_good_digest = "1cade6287d659338ae1f2c3971ee8d06" in
-        Ppx_version.Serialization.check_serialization
+        Ppx_version_runtime.Serialization.check_serialization
           (module V1)
           keys known_good_digest
     end
@@ -1311,7 +1311,7 @@ module Base = struct
 
     (* These are all the possible cases:
 
-       Init_stack     Source                 Target 
+       Init_stack     Source                 Target
       --------------------------------------------------------------
         i               i                       i + state
         i               i                       i + state + coinbase

--- a/src/lib/trust_system/banned_status.ml
+++ b/src/lib/trust_system/banned_status.ml
@@ -30,7 +30,7 @@ module Stable = struct
       let tm = Time.of_string "2019-10-08 17:51:23.050849Z" in
       let status = V1.Banned_until tm in
       let known_good_digest = "99a12fdb97c62ceba0c4d4f5879b0cdc" in
-      Ppx_version.Serialization.check_serialization
+      Ppx_version_runtime.Serialization.check_serialization
         (module V1)
         status known_good_digest
   end

--- a/src/lib/trust_system/dune
+++ b/src/lib/trust_system/dune
@@ -2,7 +2,7 @@
  (name trust_system)
  (public_name trust_system)
  (library_flags (-linkall))
- (libraries core async network_peer key_value_database logger pipe_lib rocksdb coda_metrics ppx_version)
+ (libraries core async network_peer key_value_database logger pipe_lib rocksdb coda_metrics ppx_version.runtime)
  (inline_tests)
  (preprocess (pps ppx_base ppx_coda ppx_version ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson
                   ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv ppx_register_event bisect_ppx -conditional))

--- a/src/lib/unsigned_extended/dune
+++ b/src/lib/unsigned_extended/dune
@@ -3,7 +3,7 @@
  (public_name unsigned_extended)
  (library_flags -linkall)
  (inline_tests)
- (libraries core integers snark_params ppx_version)
+ (libraries core integers snark_params ppx_version.runtime)
  (preprocessor_deps ../../config.mlh)
  (preprocess
   (pps ppx_coda ppx_version ppx_optcomp ppx_bin_prot ppx_sexp_conv ppx_compare ppx_hash ppx_inline_test ppx_deriving.std ppx_deriving_yojson bisect_ppx -- -conditional))

--- a/src/lib/unsigned_extended/unsigned_extended.ml
+++ b/src/lib/unsigned_extended/unsigned_extended.ml
@@ -169,7 +169,7 @@ end
 (* check that serializations don't change *)
 let%test_module "Unsigned serializations" =
   ( module struct
-    open Ppx_version.Serialization
+    open Ppx_version_runtime.Serialization
 
     let%test "UInt32 V1 serialization" =
       let uint32 = UInt32.of_int 9775 in


### PR DESCRIPTION
Bump `ppx_version` to use separate runtime library. Use that runtime library in Coda.