### PR TITLE
Use the given runtime config instead of inferring one

### DIFF
--- a/src/app/cli/src/tests/coda_peers_test.ml
+++ b/src/app/cli/src/tests/coda_peers_test.ml
@@ -36,8 +36,7 @@ let main () =
       ~block_production_keys:(Fn.const None) ~work_selection_method
       ~trace_dir:(Unix.getenv "CODA_TRACING")
       ~max_concurrent_connections:None
-      ~runtime_config:
-        (Genesis_ledger_helper.extract_runtime_config precomputed_values)
+      ~runtime_config:precomputed_values.runtime_config
   in
   let%bind workers = Coda_processes.spawn_local_processes_exn configs in
   let _, expected_peers = (List.hd_exn configs).net_configs in

--- a/src/app/cli/src/tests/coda_receipt_chain_test.ml
+++ b/src/app/cli/src/tests/coda_receipt_chain_test.ml
@@ -51,8 +51,7 @@ let main () =
       ~block_production_keys:(Fn.const None) ~work_selection_method
       ~trace_dir:(Unix.getenv "CODA_TRACING")
       ~max_concurrent_connections:None
-      ~runtime_config:
-        (Genesis_ledger_helper.extract_runtime_config precomputed_values)
+      ~runtime_config:precomputed_values.runtime_config
   in
   let%bind workers = Coda_processes.spawn_local_processes_exn configs in
   let worker = List.hd_exn workers in

--- a/src/app/cli/src/tests/coda_transitive_peers_test.ml
+++ b/src/app/cli/src/tests/coda_transitive_peers_test.ml
@@ -37,8 +37,7 @@ let main () =
       ~acceptable_delay ~chain_id:name ~snark_worker_public_keys:None
       ~block_production_keys:(Fn.const None) ~work_selection_method ~trace_dir
       ~max_concurrent_connections
-      ~runtime_config:
-        (Genesis_ledger_helper.extract_runtime_config precomputed_values)
+      ~runtime_config:precomputed_values.runtime_config
   in
   let%bind workers = Coda_processes.spawn_local_processes_exn configs in
   let%bind net_configs = Coda_processes.net_configs (n + 1) in
@@ -63,8 +62,7 @@ let main () =
       ~work_selection_method ~trace_dir ~offset:Time.Span.zero ()
       ~max_concurrent_connections ~is_archive_rocksdb:false
       ~archive_process_location:None
-      ~runtime_config:
-        (Genesis_ledger_helper.extract_runtime_config precomputed_values)
+      ~runtime_config:precomputed_values.runtime_config
   in
   let%bind worker = Coda_process.spawn_exn config in
   let%bind _ = after (Time.Span.of_sec 10.) in

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -486,9 +486,7 @@ let test ?archive_process_location ?is_archive_rocksdb ~name logger n
   in
   let%bind program_dir = Unix.getcwd () in
   Coda_processes.init () ;
-  let runtime_config =
-    Genesis_ledger_helper.extract_runtime_config precomputed_values
-  in
+  let runtime_config = precomputed_values.runtime_config in
   let%bind configs =
     Coda_processes.local_configs n ~block_production_interval ~program_dir
       ~block_production_keys ~acceptable_delay ~chain_id:name

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -494,8 +494,8 @@ module Genesis_proof = struct
                 ; ("error", `String (Error.to_string_hum e)) ] ;
             return None )
 
-  let generate_inputs ~proof_level ~ledger ~constraint_constants
-      ~(genesis_constants : Genesis_constants.t) =
+  let generate_inputs ~runtime_config ~proof_level ~ledger
+      ~constraint_constants ~(genesis_constants : Genesis_constants.t) =
     let consensus_constants =
       Consensus.Constants.create ~constraint_constants
         ~protocol_constants:genesis_constants.protocol
@@ -512,7 +512,8 @@ module Genesis_proof = struct
       | _ ->
           return Snark_params.Tick.Field.zero
     in
-    { Genesis_proof.Inputs.constraint_constants
+    { Genesis_proof.Inputs.runtime_config
+    ; constraint_constants
     ; proof_level
     ; genesis_ledger= ledger
     ; consensus_constants
@@ -527,7 +528,8 @@ module Genesis_proof = struct
         Genesis_proof.create_values ~keys inputs
     | _ ->
         return
-          { Genesis_proof.constraint_constants= inputs.constraint_constants
+          { Genesis_proof.runtime_config= inputs.runtime_config
+          ; constraint_constants= inputs.constraint_constants
           ; proof_level= inputs.proof_level
           ; genesis_constants= inputs.genesis_constants
           ; genesis_ledger= inputs.genesis_ledger
@@ -557,8 +559,8 @@ module Genesis_proof = struct
         match%map load file with
         | Ok genesis_proof ->
             Ok
-              ( { Genesis_proof.constraint_constants=
-                    inputs.constraint_constants
+              ( { Genesis_proof.runtime_config= inputs.runtime_config
+                ; constraint_constants= inputs.constraint_constants
                 ; proof_level= inputs.proof_level
                 ; genesis_constants= inputs.genesis_constants
                 ; genesis_ledger= inputs.genesis_ledger
@@ -586,7 +588,8 @@ module Genesis_proof = struct
             ; ("compiled_hash", Ledger_hash.to_yojson compiled.base_hash) ] ;
         let filename = genesis_dir ^/ filename ~base_hash:inputs.base_hash in
         let values =
-          { Genesis_proof.constraint_constants= inputs.constraint_constants
+          { Genesis_proof.runtime_config= inputs.runtime_config
+          ; constraint_constants= inputs.constraint_constants
           ; proof_level= inputs.proof_level
           ; genesis_constants= inputs.genesis_constants
           ; genesis_ledger= inputs.genesis_ledger
@@ -840,8 +843,8 @@ let init_from_config_file ?(genesis_dir = Cache_dir.autogen_path) ~logger
   in
   let open Deferred.Let_syntax in
   let%bind proof_inputs =
-    Genesis_proof.generate_inputs ~proof_level ~ledger:genesis_ledger
-      ~constraint_constants ~genesis_constants
+    Genesis_proof.generate_inputs ~runtime_config:config ~proof_level
+      ~ledger:genesis_ledger ~constraint_constants ~genesis_constants
   in
   let open Deferred.Or_error.Let_syntax in
   let%map values, proof_file =

--- a/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
+++ b/src/lib/genesis_ledger_helper/genesis_ledger_helper.ml
@@ -919,7 +919,7 @@ let upgrade_old_config ~logger filename json =
       (* This error will get handled properly elsewhere, do nothing here. *)
       return json
 
-let extract_runtime_config (precomputed_values : Precomputed_values.t) :
+let inferred_runtime_config (precomputed_values : Precomputed_values.t) :
     Runtime_config.t =
   let genesis_constants = precomputed_values.genesis_constants in
   let constraint_constants = precomputed_values.constraint_constants in

--- a/src/lib/genesis_proof/dune
+++ b/src/lib/genesis_proof/dune
@@ -7,5 +7,6 @@
    consensus
    keys_lib
    genesis_constants
+   runtime_config
    with_hash)
  (preprocess (pps ppx_version)))

--- a/src/lib/genesis_proof/genesis_proof.ml
+++ b/src/lib/genesis_proof/genesis_proof.ml
@@ -3,7 +3,8 @@ open Coda_state
 
 module Inputs = struct
   type t =
-    { constraint_constants: Genesis_constants.Constraint_constants.t
+    { runtime_config: Runtime_config.t
+    ; constraint_constants: Genesis_constants.Constraint_constants.t
     ; proof_level: Genesis_constants.Proof_level.t
     ; genesis_constants: Genesis_constants.t
     ; genesis_ledger: Genesis_ledger.Packed.t
@@ -15,7 +16,8 @@ end
 
 module T = struct
   type t =
-    { constraint_constants: Genesis_constants.Constraint_constants.t
+    { runtime_config: Runtime_config.t
+    ; constraint_constants: Genesis_constants.Constraint_constants.t
     ; genesis_constants: Genesis_constants.t
     ; proof_level: Genesis_constants.Proof_level.t
     ; genesis_ledger: Genesis_ledger.Packed.t
@@ -24,6 +26,8 @@ module T = struct
         (Protocol_state.value, State_hash.t) With_hash.t
     ; base_hash: State_hash.t
     ; genesis_proof: Proof.t }
+
+  let runtime_config {runtime_config; _} = runtime_config
 
   let constraint_constants {constraint_constants; _} = constraint_constants
 
@@ -120,7 +124,8 @@ let base_proof ?(logger = Logger.create ())
   wrap ~keys t.base_hash tick
 
 let create_values ?logger ~keys (t : Inputs.t) =
-  { constraint_constants= t.constraint_constants
+  { runtime_config= t.runtime_config
+  ; constraint_constants= t.constraint_constants
   ; proof_level= t.proof_level
   ; genesis_constants= t.genesis_constants
   ; genesis_ledger= t.genesis_ledger

--- a/src/lib/precomputed_values/gen_values/gen_values.ml
+++ b/src/lib/precomputed_values/gen_values/gen_values.ml
@@ -54,7 +54,8 @@ module Make_real (Keys : Keys_lib.Keys.S) = struct
   let compiled_values =
     Genesis_proof.create_values
       ~keys:(module Keys : Keys_lib.Keys.S)
-      { constraint_constants
+      { runtime_config= Runtime_config.default
+      ; constraint_constants
       ; proof_level= Full
       ; genesis_constants
       ; genesis_ledger= (module Test_genesis_ledger)
@@ -108,7 +109,8 @@ let main () =
                ~consensus_constants:
                  (Lazy.force Consensus.Constants.for_unit_tests)
            in
-           { constraint_constants=
+           { runtime_config= Runtime_config.default
+           ; constraint_constants=
                Genesis_constants.Constraint_constants.for_unit_tests
            ; proof_level= Genesis_constants.Proof_level.for_unit_tests
            ; genesis_constants= Genesis_constants.for_unit_tests
@@ -137,7 +139,8 @@ let main () =
                ~genesis_ledger:Test_genesis_ledger.t ~constraint_constants
                ~consensus_constants
            in
-           { constraint_constants
+           { runtime_config= Runtime_config.default
+           ; constraint_constants
            ; proof_level= Genesis_constants.Proof_level.compiled
            ; genesis_constants
            ; genesis_ledger= (module Test_genesis_ledger)


### PR DESCRIPTION
This PR
* carries the runtime config in `Precomputed_values.t`
* uses the given runtime config when spawning child processes instead of inferring one from the precomputed values

This removes some spurious warnings about setting constraint constants from the inferred config, and makes the initialisation from these configs more efficient. This will also make it far easier to output the config to the GraphQL API.

Checklist:

- [ ] Document code purpose, how to use it
  + Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  + Document test purpose, significance of failures
  + Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:
