### PR TITLE
Leaderboard Website - Remove Challenge #s

### DIFF
--- a/frontend/leaderboard/src/Challenges.re
+++ b/frontend/leaderboard/src/Challenges.re
@@ -212,23 +212,12 @@ let zkSnarksChallenge = metricsMap => {
 };
 
 let calculatePoints = (challengeID, metricsMap) => {
-  // Regex grabs last string after a "Challenge #"
-  switch (
-    Js.String.match(
-      [%re "/\s*([a-zA-z\s-*]+)\s*(?!.*\s*([a-zA-z\s-*]+)\s*)/"],
-      challengeID,
-    )
-  ) {
-  | Some(res) =>
-    switch (String.lowercase_ascii(res[1])) {
-    | "stake your coda and produce blocks" =>
-      Some(blocksChallenge(metricsMap))
-    | "create and sell zk-snarks on coda" =>
-      Some(zkSnarksChallenge(metricsMap))
-    | "connect to testnet and send coda" =>
-      Some(echoServiceChallenge(metricsMap))
-    | _ => None
-    }
-  | None => None
+  switch (String.lowercase_ascii(challengeID)) {
+  | "stake your coda and produce blocks" => Some(blocksChallenge(metricsMap))
+  | "create and sell zk-snarks on coda" =>
+    Some(zkSnarksChallenge(metricsMap))
+  | "connect to testnet and send coda" =>
+    Some(echoServiceChallenge(metricsMap))
+  | _ => None
   };
 };

--- a/frontend/leaderboard/src/Sheets.re
+++ b/frontend/leaderboard/src/Sheets.re
@@ -49,7 +49,7 @@ module Core = {
 
     let getSheet = sheet => {
       switch (sheet) {
-      | Main => {name: "main", range: "main!A6:I"}
+      | Main => {name: "main", range: "main!A5:I"}
       | AllTimeLeaderboard => {
           name: "All-Time Leaderboard",
           range: "All-Time Leaderboard!C4:H",
@@ -58,7 +58,7 @@ module Core = {
           name: "Phase 3 Leaderboard",
           range: "Phase 3 Leaderboard!B4:E",
         }
-      | CurrentReleaseLeaderboard => {name: "3.2b", range: "3.2b!A4:C"}
+      | CurrentReleaseLeaderboard => {name: "3.2b", range: "3.2b!A5:C"}
       | MemberProfileData => {
           name: "Member_Profile_Data",
           range: "Member_Profile_Data!A2:Z",

--- a/frontend/leaderboard/src/UploadLeaderboardPoints.re
+++ b/frontend/leaderboard/src/UploadLeaderboardPoints.re
@@ -160,7 +160,7 @@ let uploadChallengePoints = (spreadsheetId, metricsMap) => {
       updateChallengeSheet(
         client,
         spreadsheetId,
-        Sheets.getSheet(Sheets.CurrentReleaseLeaderboard).name ++ "!A3:M",
+        Sheets.getSheet(Sheets.CurrentReleaseLeaderboard).name ++ "!A4:M",
         userMap,
         metricsMap,
       );

--- a/frontend/website/src/components/ChallengePointsTable.re
+++ b/frontend/website/src/components/ChallengePointsTable.re
@@ -121,7 +121,7 @@ module Styles = {
     style([
       textAlign(`right),
       paddingRight(`rem(1.5)),
-      media(Theme.MediaQuery.notMobile, [paddingRight(`rem(5.))]),
+      media(Theme.MediaQuery.notMobile, [paddingRight(`rem(3.))]),
     ]);
   };
 

--- a/frontend/website/src/pages/MemberProfilePage.re
+++ b/frontend/website/src/pages/MemberProfilePage.re
@@ -115,9 +115,9 @@ let fetchRelease = (username, release) => {
 
 let fetchReleases = name => {
   [|
-    ("Release 3.1", "3.1!B3:Z", 4), /* offset for challenge titles in 3.1 starts on the 4th column */
-    ("Release 3.2a", "3.2a!B3:Z", 2), /* offset for challenge titles in 3.2a starts on the 2nd column */
-    ("Release 3.2b", "3.2b!B3:Z", 2) /* offset for challenge titles in 3.2b starts on the 2nd column */
+    ("Release 3.1", "3.1!B4:Z", 4), /* offset for challenge titles in 3.1 starts on the 4th column */
+    ("Release 3.2a", "3.2a!B4:Z", 2), /* offset for challenge titles in 3.2a starts on the 2nd column */
+    ("Release 3.2b", "3.2b!B4:Z", 2) /* offset for challenge titles in 3.2b starts on the 2nd column */
   |]
   |> Array.map(release => fetchRelease(name, release))
   |> Js.Promise.all


### PR DESCRIPTION
This PR implements the following:

1. An update to the ranges used by the Google Sheets API to reflect the changes made on the actual Google Sheets. We have removed the "Challenge #" from the Challenge titles and instead added a row above the challenge titles that contain the number. See the image below:

![image](https://user-images.githubusercontent.com/9512405/88215348-5cff4e00-cc10-11ea-8921-7d4b858987a6.png)

2. Small fix to the Challenge Points Table with the alignment of the points. Large numbers were being spaced out by the padding, so padding was reduced. 

Manual Testing was done to verify the correct behavior.

Closes https://github.com/CodaProtocol/coda/issues/5453
Closes https://github.com/CodaProtocol/coda/issues/5383
