### PR TITLE
changed community badge icon

### DIFF
--- a/frontend/website/public/static/img/LeaderboardAwardCommunityMVP.png
+++ b/frontend/website/public/static/img/LeaderboardAwardCommunityMVP.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8c9f78901f5ecbb50e947e5aa1d2aecc2a16ff9ede8812603c938d7222701844
-size 1510
+oid sha256:b0412c80d2420d18f9926390401847e70fa41a5dfa70a99f7989966965ed4ac4
+size 1398


### PR DESCRIPTION
This PR:

Changes the Community Badge Icon. 

NEW:
![image](https://user-images.githubusercontent.com/9512405/88228754-7b6f4480-cc24-11ea-84f5-1d403a70e9fc.png)
