### PR TITLE
Website - points right align fix

### DIFF
--- a/frontend/website/src/components/ChallengePointsTable.re
+++ b/frontend/website/src/components/ChallengePointsTable.re
@@ -99,7 +99,7 @@ module Styles = {
           Theme.MediaQuery.notMobile,
           [
             display(`grid),
-            gridTemplateColumns([`percent(11.), `auto, `percent(25.)]),
+            gridTemplateColumns([`percent(11.), `auto, `percent(38.)]),
           ],
         ),
       ]),
@@ -195,7 +195,14 @@ let make = (~releaseTitle, ~challenges) => {
         <span className=Css.(style([gridColumn(2, 3)]))>
           {React.string("Challenge Name")}
         </span>
-        <span className=Css.(style([gridColumn(3, 4)]))>
+        <span
+          className=Css.(
+            style([
+              textAlign(`right),
+              gridColumn(3, 4),
+              paddingRight(`rem(2.5)),
+            ])
+          )>
           {React.string("Points *")}
         </span>
       </div>

--- a/frontend/website/src/components/ChallengePointsTable.re
+++ b/frontend/website/src/components/ChallengePointsTable.re
@@ -200,7 +200,7 @@ let make = (~releaseTitle, ~challenges) => {
             style([
               textAlign(`right),
               gridColumn(3, 4),
-              paddingRight(`rem(2.5)),
+              paddingRight(`rem(3.5)),
             ])
           )>
           {React.string("Points *")}


### PR DESCRIPTION
Adds the correct amount of padding to the "Points *" column header in the Member Profile Page.


![image](https://user-images.githubusercontent.com/9512405/88239767-263e2d80-cc3a-11ea-85a5-e224185b1087.png)


Closes https://github.com/CodaProtocol/coda/issues/5486
