### PR TITLE
Circle ci build me

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1570,7 +1570,10 @@ workflows:
     version: 2
     coda_parallel:
         when:
-            - << pipeline.parameters.run-ci >>
+            # We do seem to need a useless `or true` here
+            or:
+              - true
+              - << pipeline.parameters.run-ci >>
         jobs:
             - lint
             - lint-opt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1570,8 +1570,8 @@ workflows:
     version: 2
     coda_parallel:
         when:
-            # We do seem to need a useless `or true` here
-            or:
+            # We do seem to need a useless `and true` here
+            and:
               - true
               - << pipeline.parameters.run-ci >>
         jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@
 
 
 version: 2.1
+parameters:
+  run-ci:
+    type: boolean
+    default: false
 jobs:
     tracetool:
         docker:
@@ -1565,6 +1569,9 @@ jobs:
 workflows:
     version: 2
     coda_parallel:
+        when:
+            condition:
+                - << pipeline.parameters.run-ci >>
         jobs:
             - lint
             - lint-opt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1570,8 +1570,7 @@ workflows:
     version: 2
     coda_parallel:
         when:
-            condition:
-                - << pipeline.parameters.run-ci >>
+            - << pipeline.parameters.run-ci >>
         jobs:
             - lint
             - lint-opt

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -34,6 +34,10 @@
 {%endset%}
 
 version: 2.1
+parameters:
+  run-ci:
+    type: boolean
+    default: false
 jobs:
     tracetool:
         docker:
@@ -711,6 +715,9 @@ jobs:
 workflows:
     version: 2
     coda_parallel:
+        when:
+            condition:
+                - << pipeline.parameters.run-ci >>
         jobs:
             - lint
             - lint-opt

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -716,8 +716,7 @@ workflows:
     version: 2
     coda_parallel:
         when:
-            condition:
-                - << pipeline.parameters.run-ci >>
+            - << pipeline.parameters.run-ci >>
         jobs:
             - lint
             - lint-opt

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -716,7 +716,10 @@ workflows:
     version: 2
     coda_parallel:
         when:
-            - << pipeline.parameters.run-ci >>
+            # We do seem to need a useless `or true` here
+            or:
+              - true
+              - << pipeline.parameters.run-ci >>
         jobs:
             - lint
             - lint-opt

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -716,8 +716,8 @@ workflows:
     version: 2
     coda_parallel:
         when:
-            # We do seem to need a useless `or true` here
-            or:
+            # We do seem to need a useless `and true` here
+            and:
               - true
               - << pipeline.parameters.run-ci >>
         jobs:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
-yet.
+yet. In that doc, there are more details around how to start our CI.
 
 Explain your changes here.
 
@@ -8,10 +8,10 @@ Explain how you tested your changes here.
 Checklist:
 
 - [ ] Document code purpose, how to use it
-  + Mention expected invariants, implicit constraints
+  - Mention expected invariants, implicit constraints
 - [ ] Tests were added for the new behavior
-  + Document test purpose, significance of failures
-  + Test names should reflect their purpose
+  - Document test purpose, significance of failures
+  - Test names should reflect their purpose
 - [ ] All tests pass (CI will check this if you didn't)
 - [ ] Serialized types are in stable-versioned modules
 - [ ] Does this close issues? List them:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ team on github.
 Maintainers should assign reviewers to pull requests, and tag them with any
 relevant labels.
 
+If you are PRing from the main remote, add `ci-build-me` label when you want to run CI. If you are PRing from a fork, ask a core contributor to `!ci-build-me` when you're ready for CI to run. Note: You will need the `!ci-build-me` comment for each and every run of CI.
+
 Once a PR has been reviewed and approved, and all CI tests have passed, tag the PR with the `ready-to-merge` label to trigger Mergify and automatically merge the code.
 
 ## Documentation

--- a/frontend/ci-build-me/README.md
+++ b/frontend/ci-build-me/README.md
@@ -17,12 +17,12 @@ We currently dispatch a build the moment the `ci-build-me` label is added and an
 
 ## Deploy
 
-Acquire `$GITHUB_SECRET` and `$BUILDKITE_API_ACCESS_TOKEN` from our AWS secret store on us-west-2.
+Acquire `$GITHUB_SECRET` and `$BUILDKITE_API_ACCESS_TOKEN` and `$CIRCLECI_API_ACCESS_TOKEN` from our AWS secret store on us-west-2.
 
 ```
 gcloud functions deploy githubWebhookHandler \
   --trigger-http --runtime nodejs10 --memory 128MB \
-  --set-env-vars GITHUB_SECRET=$GITHUB_SECRET,BUILDKITE_API_ACCESS_TOKEN=$BUILDKITE_API_ACCESS_TOKEN \
+  --set-env-vars GITHUB_SECRET=$GITHUB_SECRET,BUILDKITE_API_ACCESS_TOKEN=$BUILDKITE_API_ACCESS_TOKEN,CIRCLECI_API_ACCESS_TOKEN=$CIRCLECI_API_ACCESS_TOKEN \
   --project o1labs-192920
 ```
 

--- a/frontend/ci-build-me/src/index.js
+++ b/frontend/ci-build-me/src/index.js
@@ -10,6 +10,9 @@ const circleApiKey = process.env.CIRCLECI_API_ACCESS_TOKEN;
 const runCircleBuild = async (github) => {
   const postData = JSON.stringify({
     branch: github.pull_request.head.ref,
+    parameters: {
+      "run-ci": true,
+    },
   });
 
   const options = {


### PR DESCRIPTION
In an effort to curb CI spending, we wish to change circle builds to opt-in.

You must either:
    
a) Add the `ci-build-me` label to your PR (this only works if you are PRing _not_ from a fork for security reasons). A build will trigger the moment you add the label and every time commits are pushed to that branch.
    
b) Add the comment `!ci-build-me` to your PR. This will trigger one and only one build at that moment.

Tested in production (I temporarily deployed with these changes, tested, and have subsequently reverted to the bot @ develop until this PR is ready to land)