### PR TITLE
Add basic plugin support

### DIFF
--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -46,6 +46,21 @@ let chain_id ~genesis_state_hash ~genesis_constants =
 [%%inject
 "compile_time_current_protocol_version", current_protocol_version]
 
+[%%if
+plugins]
+
+let plugin_flag =
+  let open Command.Param in
+  flag "load-plugin" (listed string)
+    ~doc:
+      "PATH The path to load a .cmxs plugin from. May be passed multiple times"
+
+[%%else]
+
+let plugin_flag = Command.Param.return []
+
+[%%endif]
+
 let daemon logger =
   let open Command.Let_syntax in
   let open Cli_lib.Arg_type in
@@ -241,12 +256,7 @@ let daemon logger =
        flag "proof-level"
          (optional (Arg_type.create Genesis_constants.Proof_level.of_string))
          ~doc:"full|check|none"
-     and plugins =
-       flag "load-plugin" (listed string)
-         ~doc:
-           "PATH The path to load a .cmxs plugin from. May be passed multiple \
-            times"
-     in
+     and plugins = plugin_flag in
      fun () ->
        let open Deferred.Let_syntax in
        let compute_conf_dir home =

--- a/src/app/cli/src/coda.ml
+++ b/src/app/cli/src/coda.ml
@@ -241,6 +241,11 @@ let daemon logger =
        flag "proof-level"
          (optional (Arg_type.create Genesis_constants.Proof_level.of_string))
          ~doc:"full|check|none"
+     and plugins =
+       flag "load-plugin" (listed string)
+         ~doc:
+           "PATH The path to load a .cmxs plugin from. May be passed multiple \
+            times"
      in
      fun () ->
        let open Deferred.Let_syntax in
@@ -882,6 +887,7 @@ let daemon logger =
              Coda_metrics.server ~port ~logger >>| ignore )
          |> Option.value ~default:Deferred.unit
        in
+       let () = Coda_plugins.init_plugins ~logger coda plugins in
        Logger.info logger ~module_:__MODULE__ ~location:__LOC__
          "Daemon ready. Clients can now connect" ;
        Async.never ())

--- a/src/app/cli/src/dune
+++ b/src/app/cli/src/dune
@@ -5,7 +5,7 @@
   (name coda)
   (public_name coda)
   (modes native)
-  (libraries init tests child_processes memory_stats node_addrs_and_ports jemalloc genesis_ledger_helper)
+  (libraries init tests child_processes memory_stats node_addrs_and_ports jemalloc genesis_ledger_helper coda_plugins)
   (preprocessor_deps ../../../config.mlh)
   (preprocess (pps ppx_coda ppx_version ppx_let ppx_sexp_conv ppx_optcomp ppx_deriving_yojson))
   (flags -short-paths -g -w @a-4-29-40-41-42-44-45-48-58-59-60))

--- a/src/coda_plugins.opam
+++ b/src/coda_plugins.opam
@@ -1,0 +1,6 @@
+opam-version: "1.2"
+version: "0.1"
+build: [
+  ["dune" "build" "--only" "src" "--root" "." "-j" jobs "@install"]
+]
+

--- a/src/config/debug.mlh
+++ b/src/config/debug.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets false]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 2000]

--- a/src/config/dev.mlh
+++ b/src/config/dev.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins true]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 2000]

--- a/src/config/dev_frontend.mlh
+++ b/src/config/dev_frontend.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets false]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 2000]

--- a/src/config/dev_medium_curves.mlh
+++ b/src/config/dev_medium_curves.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets false]
 [%%define fake_hash false]
 
+[%%define plugins true]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 30000]

--- a/src/config/dev_snark.mlh
+++ b/src/config/dev_snark.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets false]
 [%%define fake_hash false]
 
+[%%define plugins true]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 20000]

--- a/src/config/fake_hash.mlh
+++ b/src/config/fake_hash.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash true]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 600]

--- a/src/config/fuzz_medium.mlh
+++ b/src/config/fuzz_medium.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "fuzz"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 1000]

--- a/src/config/fuzz_small.mlh
+++ b/src/config/fuzz_small.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "fuzz"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 1000]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -12,6 +12,7 @@
 
 [%%define time_offsets false]
 [%%define fake_hash false]
+
 [%%define plugins false]
 
 [%%define genesis_ledger "test"]

--- a/src/config/print_versioned_types.mlh
+++ b/src/config/print_versioned_types.mlh
@@ -12,6 +12,7 @@
 
 [%%define time_offsets false]
 [%%define fake_hash false]
+[%%define plugins false]
 
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -12,6 +12,7 @@
 
 [%%define time_offsets true]
 [%%define fake_hash true]
+
 [%%define plugins false]
 
 [%%define genesis_ledger "test"]

--- a/src/config/test_archive_processor.mlh
+++ b/src/config/test_archive_processor.mlh
@@ -12,6 +12,7 @@
 
 [%%define time_offsets true]
 [%%define fake_hash true]
+[%%define plugins false]
 
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]

--- a/src/config/test_postake.mlh
+++ b/src/config/test_postake.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 30000]

--- a/src/config/test_postake_catchup.mlh
+++ b/src/config/test_postake_catchup.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash true]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 2000]

--- a/src/config/test_postake_five_even_txns.mlh
+++ b/src/config/test_postake_five_even_txns.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test_five_even_stakes"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 10000]

--- a/src/config/test_postake_full_epoch.mlh
+++ b/src/config/test_postake_full_epoch.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 15000]

--- a/src/config/test_postake_holy_grail.mlh
+++ b/src/config/test_postake_holy_grail.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash true]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test_five_even_stakes"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 2000]

--- a/src/config/test_postake_medium_curves.mlh
+++ b/src/config/test_postake_medium_curves.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 360000]

--- a/src/config/test_postake_snarkless.mlh
+++ b/src/config/test_postake_snarkless.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 10000]

--- a/src/config/test_postake_snarkless_medium_curves.mlh
+++ b/src/config/test_postake_snarkless_medium_curves.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 30000]

--- a/src/config/test_postake_split.mlh
+++ b/src/config/test_postake_split.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test_split_two_stakers"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 10000]

--- a/src/config/test_postake_split_medium_curves.mlh
+++ b/src/config/test_postake_split_medium_curves.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test_split_two_stakers"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 30000]

--- a/src/config/test_postake_three_producers.mlh
+++ b/src/config/test_postake_three_producers.mlh
@@ -13,6 +13,8 @@
 [%%define time_offsets true]
 [%%define fake_hash true]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "test_three_even_stakes"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 4000]

--- a/src/config/testnet_postake.mlh
+++ b/src/config/testnet_postake.mlh
@@ -14,6 +14,8 @@
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "testnet_postake"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 15000]

--- a/src/config/testnet_postake_many_producers.mlh
+++ b/src/config/testnet_postake_many_producers.mlh
@@ -12,6 +12,7 @@
 
 [%%define time_offsets false]
 [%%define cache_exceptions false]
+
 [%%define fake_hash false]
 
 [%%define genesis_ledger "testnet_postake_many_producers"]

--- a/src/config/testnet_postake_many_producers_medium_curves.mlh
+++ b/src/config/testnet_postake_many_producers_medium_curves.mlh
@@ -14,6 +14,8 @@
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "testnet_postake_many_producers"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 300000]

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -20,6 +20,8 @@
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "testnet_postake"]
 
 [%%define genesis_state_timestamp "2020-05-12 10:00:00-07:00"]

--- a/src/config/testnet_postake_snarkless.mlh
+++ b/src/config/testnet_postake_snarkless.mlh
@@ -14,6 +14,8 @@
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "testnet_postake"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 6000]

--- a/src/config/testnet_postake_snarkless_fake_hash.mlh
+++ b/src/config/testnet_postake_snarkless_fake_hash.mlh
@@ -15,6 +15,8 @@
 [%%define cache_exceptions false]
 [%%define fake_hash true]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "testnet_postake"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 5000]

--- a/src/config/testnet_public.mlh
+++ b/src/config/testnet_public.mlh
@@ -14,6 +14,8 @@
 [%%define cache_exceptions false]
 [%%define fake_hash false]
 
+[%%define plugins false]
+
 [%%define genesis_ledger "testnet_postake"]
 [%%define genesis_state_timestamp "2019-01-30 12:00:00-08:00"]
 [%%define block_window_duration 20000]

--- a/src/lib/coda_plugins/coda_plugins.ml
+++ b/src/lib/coda_plugins/coda_plugins.ml
@@ -1,0 +1,29 @@
+open Core_kernel
+
+let coda_lib' : Coda_lib.t option ref = ref None
+
+exception Not_initializing
+
+let get_coda_lib () =
+  match !coda_lib' with Some coda -> coda | None -> raise Not_initializing
+
+let init_plugins ~logger coda plugin_paths =
+  Logger.info logger "Initializing plugins" ~module_:__MODULE__
+    ~location:__LOC__ ;
+  coda_lib' := Some coda ;
+  List.iter plugin_paths ~f:(fun path ->
+      Logger.info logger "Initializing plugin from $path" ~module_:__MODULE__
+        ~location:__LOC__
+        ~metadata:[("path", `String path)] ;
+      try
+        Dynlink.loadfile path ;
+        Logger.info logger "Plugin successfully loaded from $path"
+          ~module_:__MODULE__ ~location:__LOC__
+          ~metadata:[("path", `String path)]
+      with Dynlink.Error err ->
+        Logger.error logger "Failed to load plugin from $path: $error"
+          ~module_:__MODULE__ ~location:__LOC__
+          ~metadata:
+            [ ("path", `String path)
+            ; ("error", `String (Dynlink.error_message err)) ] ) ;
+  coda_lib' := None

--- a/src/lib/coda_plugins/coda_plugins.ml
+++ b/src/lib/coda_plugins/coda_plugins.ml
@@ -20,10 +20,11 @@ let init_plugins ~logger coda plugin_paths =
         Logger.info logger "Plugin successfully loaded from $path"
           ~module_:__MODULE__ ~location:__LOC__
           ~metadata:[("path", `String path)]
-      with Dynlink.Error err ->
+      with Dynlink.Error err as exn ->
         Logger.error logger "Failed to load plugin from $path: $error"
           ~module_:__MODULE__ ~location:__LOC__
           ~metadata:
             [ ("path", `String path)
-            ; ("error", `String (Dynlink.error_message err)) ] ) ;
+            ; ("error", `String (Dynlink.error_message err)) ] ;
+        raise exn ) ;
   coda_lib' := None

--- a/src/lib/coda_plugins/coda_plugins.mli
+++ b/src/lib/coda_plugins/coda_plugins.mli
@@ -1,0 +1,17 @@
+exception Not_initializing
+
+(** Get the current instance of [Coda_lib] that plugins are being loaded for.
+
+    This should be called during plugin initialization and stored in the plugin
+    state. Calling this at any other time will raise a [Not_initializing]
+    exception.
+*)
+val get_coda_lib : unit -> Coda_lib.t
+
+(** Initialize plugins from the list of paths given.
+
+    Plugin paths should normally end in [.cmxs].
+    The [Coda_lib.t] argument is returned by [get_coda_lib] while
+    initialization is in progress.
+*)
+val init_plugins : logger:Logger.t -> Coda_lib.t -> string list -> unit

--- a/src/lib/coda_plugins/dune
+++ b/src/lib/coda_plugins/dune
@@ -1,0 +1,5 @@
+(library
+ (public_name coda_plugins)
+ (name coda_plugins)
+ (libraries core_kernel dynlink coda_lib)
+ (preprocess (pps ppx_version)))

--- a/src/lib/coda_plugins/examples/do_nothing/dune
+++ b/src/lib/coda_plugins/examples/do_nothing/dune
@@ -1,0 +1,4 @@
+(library
+ (name plugin_do_nothing)
+ (libraries coda_plugins)
+ (preprocess (pps ppx_version)))

--- a/src/lib/coda_plugins/examples/do_nothing/plugin_do_nothing.ml
+++ b/src/lib/coda_plugins/examples/do_nothing/plugin_do_nothing.ml
@@ -3,4 +3,5 @@ let coda = Coda_plugins.get_coda_lib ()
 let () =
   let config = Coda_lib.config coda in
   Logger.info config.logger "Hi from do-nothing plugin!" ~module_:__MODULE__
-    ~location:__LOC__
+    ~location:__LOC__ ;
+  if true then assert false

--- a/src/lib/coda_plugins/examples/do_nothing/plugin_do_nothing.ml
+++ b/src/lib/coda_plugins/examples/do_nothing/plugin_do_nothing.ml
@@ -1,0 +1,6 @@
+let coda = Coda_plugins.get_coda_lib ()
+
+let () =
+  let config = Coda_lib.config coda in
+  Logger.info config.logger "Hi from do-nothing plugin!" ~module_:__MODULE__
+    ~location:__LOC__


### PR DESCRIPTION
This PR adds basic plugin support, using the `Dynlink` module to dynamically load modules passed on the command line. Currently, the interface only exposes a reference to `Coda_lib.t`, and this PR adds no hooks that a plugin could attach to.

We want this to allow node operators to manage exchange rates, without our prescribing a specific system. This will allow us to expose simple hooks that operators can use to manage rates in any way that they see fit.

It may also make sense to move some other things to be plugins, or expose plugin interfaces for them. For example,
* prometheus metrics
  - many (/most?) operators will not use these
* trust system
  - nodes may want stricter/less strict rules than the default, or special-casing for some nodes
* SNARK proving
  - this would allow swapping in a custom/GPU implementation without needing to recompile a custom coda binary

To test:
```bash
dune build src/lib/coda_plugins/examples/do_nothing/plugin_do_nothing.cmxs
make build
_build/default/src/app/cli/src/coda.exe daemon -seed -demo -load-plugin _build/default/src/lib/coda_plugins/examples/do_nothing/plugin_do_nothing.cmxs
```

Lines similar to these should appear in the log:
```
2020-07-27 15:19:25 UTC [Info] Initializing plugins
2020-07-27 15:19:25 UTC [Info] Initializing plugin from $path
        path: "_build/default/src/lib/coda_plugins/examples/do_nothing/plugin_do_nothing.cmxs"
2020-07-27 15:19:25 UTC [Info] Hi from do-nothing plugin!
2020-07-27 15:19:25 UTC [Info] Plugin successfully loaded from $path
```

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: