### PR TITLE
Integer_js_stubs owned by protocol

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,7 +34,6 @@
 /src/lib/crypto_params/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/dummy_values/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/hash_prefixes/ @CodaProtocol/crypto-eng-reviewers
-/src/lib/integers_stubs_js @CodaProtocol/crypto-eng-reviewers
 /src/lib/keys_lib/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/non_zero_curve_point/ @CodaProtocol/crypto-eng-reviewers
 /src/lib/outside_hash_image/ @CodaProtocol/crypto-eng-reviewers


### PR DESCRIPTION
This shouldn't be owned by crypto. I wrote these originally, @emberian reviewed.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: