### PR TITLE
Fix major memory leaks in pickles

### DIFF
--- a/src/lib/pickles/cache.ml
+++ b/src/lib/pickles/cache.ml
@@ -13,7 +13,7 @@ module Step = struct
     end
 
     module Verification = struct
-      type t = Type_equal.Id.Uid.t * int * Md5.t
+      type t = Type_equal.Id.Uid.t * int * Md5.t [@@deriving sexp]
 
       let to_string : t -> _ = function
         | _id, _n, h ->
@@ -24,11 +24,15 @@ module Step = struct
   let storable =
     Key_cache.Sync.Disk_storable.simple Key.Proving.to_string
       (fun (_, _, t) ~path ->
-        Snarky_bn382.Tweedle.Dum.Field_index.read
-          (Backend.Tick.Keypair.load_urs ())
-          t.m.a t.m.b t.m.c
-          (Unsigned.Size_t.of_int (1 + t.public_input_size))
-          path )
+        let t =
+          Snarky_bn382.Tweedle.Dum.Field_index.read
+            (Backend.Tick.Keypair.load_urs ())
+            t.m.a t.m.b t.m.c
+            (Unsigned.Size_t.of_int (1 + t.public_input_size))
+            path
+        in
+        Caml.Gc.finalise Snarky_bn382.Tweedle.Dum.Field_index.delete t ;
+        t )
       Snarky_bn382.Tweedle.Dum.Field_index.write
 
   let vk_storable =
@@ -87,7 +91,9 @@ end
 module Wrap = struct
   module Key = struct
     module Verification = struct
-      type t = Type_equal.Id.Uid.t * Md5.t [@@deriving sexp, eq]
+      type t = Type_equal.Id.Uid.t * Md5.t [@@deriving sexp]
+
+      let equal (_, x1) (_, x2) = Md5.equal x1 x2
 
       let to_string : t -> _ = function
         | _id, h ->
@@ -107,11 +113,15 @@ module Wrap = struct
   let storable =
     Key_cache.Sync.Disk_storable.simple Key.Proving.to_string
       (fun (_, t) ~path ->
-        Snarky_bn382.Tweedle.Dee.Field_index.read
-          (Backend.Tock.Keypair.load_urs ())
-          t.m.a t.m.b t.m.c
-          (Unsigned.Size_t.of_int (1 + t.public_input_size))
-          path )
+        let t =
+          Snarky_bn382.Tweedle.Dee.Field_index.read
+            (Backend.Tock.Keypair.load_urs ())
+            t.m.a t.m.b t.m.c
+            (Unsigned.Size_t.of_int (1 + t.public_input_size))
+            path
+        in
+        Caml.Gc.finalise Snarky_bn382.Tweedle.Dee.Field_index.delete t ;
+        t )
       Snarky_bn382.Tweedle.Dee.Field_index.write
 
   let vk_storable =

--- a/src/lib/pickles/pickles.mli
+++ b/src/lib/pickles/pickles.mli
@@ -30,6 +30,8 @@ module Verification_key : sig
     type t [@@deriving sexp, eq]
 
     val dummy : unit -> t
+
+    val to_string : t -> string
   end
 
   val load :

--- a/src/lib/pickles_types/matrix_evals.ml
+++ b/src/lib/pickles_types/matrix_evals.ml
@@ -4,7 +4,7 @@ module H_list = Snarky.H_list
 [%%versioned
 module Stable = struct
   module V1 = struct
-    type 'a t = {row: 'a; col: 'a; value: 'a; rc: 'a} [@@deriving sexp]
+    type 'a t = {row: 'a; col: 'a; value: 'a; rc: 'a} [@@deriving sexp, fields]
   end
 end]
 

--- a/src/lib/zexe_backend/bn382/dlog_based.ml
+++ b/src/lib/zexe_backend/bn382/dlog_based.ml
@@ -14,8 +14,15 @@ end
 
 let field_size : Bigint.R.t = Field.size
 
-module R1CS_constraint_system =
-  R1cs_constraint_system.Make (Field) (Snarky_bn382.Fq.Constraint_matrix)
+module Mat = struct
+  include Snarky_bn382.Fq.Constraint_matrix
+
+  let create () =
+    let t = create () in
+    Caml.Gc.finalise delete t ; t
+end
+
+module R1CS_constraint_system = R1cs_constraint_system.Make (Field) (Mat)
 module Var = Var
 
 module Verification_key = struct
@@ -70,7 +77,7 @@ module Keypair = Dlog_based_keypair.Make (struct
   module Curve = G
   module Poly_comm = Fq_poly_comm
   module Verifier_index = Snarky_bn382.Fq_verifier_index
-  module Constraint_matrix = Snarky_bn382.Fq.Constraint_matrix
+  module Constraint_matrix = Mat
 end)
 
 module Oracles = Dlog_based_oracles.Make (struct

--- a/src/lib/zexe_backend/bn382/pairing_based.ml
+++ b/src/lib/zexe_backend/bn382/pairing_based.ml
@@ -51,10 +51,16 @@ module Verification_key = struct
   let of_string _ = failwith "TODO"
 end
 
+module Mat = struct
+  include Snarky_bn382.Fp.Constraint_matrix
+
+  let create () =
+    let t = create () in
+    Caml.Gc.finalise delete t ; t
+end
+
 module R1CS_constraint_system =
-  Zexe_backend_common.R1cs_constraint_system.Make
-    (Fp)
-    (Snarky_bn382.Fp.Constraint_matrix)
+  Zexe_backend_common.R1cs_constraint_system.Make (Fp) (Mat)
 module Var = Zexe_backend_common.Var
 
 module Oracles = struct

--- a/src/lib/zexe_backend/tweedle/dee_based.ml
+++ b/src/lib/zexe_backend/tweedle/dee_based.ml
@@ -17,8 +17,15 @@ end
 
 let field_size : Bigint.R.t = Field.size
 
-module R1CS_constraint_system =
-  R1cs_constraint_system.Make (Field) (T.Fp.Constraint_matrix)
+module Mat = struct
+  include T.Fp.Constraint_matrix
+
+  let create () =
+    let t = create () in
+    Caml.Gc.finalise delete t ; t
+end
+
+module R1CS_constraint_system = R1cs_constraint_system.Make (Field) (Mat)
 module Var = Var
 
 module Verification_key = struct
@@ -73,7 +80,7 @@ module Keypair = Dlog_based_keypair.Make (struct
   module Curve = Curve
   module Poly_comm = Fp_poly_comm
   module Verifier_index = B.Field_verifier_index
-  module Constraint_matrix = T.Fp.Constraint_matrix
+  module Constraint_matrix = Mat
 end)
 
 module Oracles = Dlog_based_oracles.Make (struct

--- a/src/lib/zexe_backend/tweedle/dum_based.ml
+++ b/src/lib/zexe_backend/tweedle/dum_based.ml
@@ -17,8 +17,15 @@ end
 
 let field_size : Bigint.R.t = Field.size
 
-module R1CS_constraint_system =
-  R1cs_constraint_system.Make (Field) (T.Fq.Constraint_matrix)
+module Mat = struct
+  include T.Fq.Constraint_matrix
+
+  let create () =
+    let t = create () in
+    Caml.Gc.finalise delete t ; t
+end
+
+module R1CS_constraint_system = R1cs_constraint_system.Make (Field) (Mat)
 module Var = Var
 
 module Verification_key = struct
@@ -73,7 +80,7 @@ module Keypair = Dlog_based_keypair.Make (struct
   module Curve = Curve
   module Poly_comm = Fq_poly_comm
   module Verifier_index = B.Field_verifier_index
-  module Constraint_matrix = T.Fq.Constraint_matrix
+  module Constraint_matrix = Mat
 end)
 
 module Oracles = Dlog_based_oracles.Make (struct

--- a/src/lib/zexe_backend/zexe_backend_common/dlog_based_keypair.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/dlog_based_keypair.ml
@@ -20,6 +20,8 @@ module type Inputs_intf = sig
   module Index : sig
     type t
 
+    val delete : t -> unit
+
     val create :
          Constraint_matrix.t
       -> Constraint_matrix.t
@@ -137,10 +139,14 @@ module Make (Inputs : Inputs_intf) = struct
       ; m= {a; b; c}
       ; weight } =
     let vars = 1 + public_input_size + auxiliary_input_size in
-    Index.create a b c
-      (Unsigned.Size_t.of_int vars)
-      (Unsigned.Size_t.of_int (public_input_size + 1))
-      (load_urs ())
+    let t =
+      Index.create a b c
+        (Unsigned.Size_t.of_int vars)
+        (Unsigned.Size_t.of_int (public_input_size + 1))
+        (load_urs ())
+    in
+    Caml.Gc.finalise Index.delete t ;
+    t
 
   let vk t = Verifier_index.create t
 

--- a/src/lib/zexe_backend/zexe_backend_common/r1cs_constraint_system.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/r1cs_constraint_system.ml
@@ -215,7 +215,9 @@ struct
           Snarky_bn382.Usize_vector.emplace_back indices
             (Unsigned.Size_t.of_int i) ;
           Fp.Vector.emplace_back coeffs x ) ;
-      Mat.append_row m indices coeffs
+      Mat.append_row m indices coeffs ;
+      Snarky_bn382.Usize_vector.delete indices ;
+      Fp.Vector.delete coeffs
     in
     t.constraints <- t.constraints + 1 ;
     append t.m.a a ;


### PR DESCRIPTION
This PR

- fixes a few major memory leaks in the new snark
- fixes how "verification ids" were checked for equality