### PR TITLE
Website - Leaderboard QA fixes with Dropdown and Release Ordering

### DIFF
--- a/frontend/website/src/components/Dropdown.re
+++ b/frontend/website/src/components/Dropdown.re
@@ -58,7 +58,7 @@ module Styles = {
         borderRadius(`px(4)),
         pointerEvents(`auto),
         opacity(1.),
-        zIndex(1),
+        zIndex(100),
         selector(
           "li",
           [

--- a/frontend/website/src/pages/MemberProfilePage.re
+++ b/frontend/website/src/pages/MemberProfilePage.re
@@ -115,9 +115,9 @@ let fetchRelease = (username, release) => {
 
 let fetchReleases = name => {
   [|
-    ("Release 3.1", "3.1!B4:Z", 4), /* offset for challenge titles in 3.1 starts on the 4th column */
+    ("Release 3.2b", "3.2b!B4:Z", 2), /* offset for challenge titles in 3.2b starts on the 2nd column */
     ("Release 3.2a", "3.2a!B4:Z", 2), /* offset for challenge titles in 3.2a starts on the 2nd column */
-    ("Release 3.2b", "3.2b!B4:Z", 2) /* offset for challenge titles in 3.2b starts on the 2nd column */
+    ("Release 3.1", "3.1!B4:Z", 4) /* offset for challenge titles in 3.1 starts on the 4th column */
   |]
   |> Array.map(release => fetchRelease(name, release))
   |> Js.Promise.all


### PR DESCRIPTION
This PR includes:
1. A fix to the dropdown menu in the tablet view of the leaderboard.
2. A fix to the order of the releases on the member profile page. They were released as oldest to newest but the order has now switched to newest to oldest releases.

![image](https://user-images.githubusercontent.com/9512405/88698144-81e53c80-d0ba-11ea-9492-98bea071a436.png)

![image](https://user-images.githubusercontent.com/9512405/88698220-a3debf00-d0ba-11ea-81fd-6973f0e4c833.png)


Closes https://github.com/CodaProtocol/coda/issues/5511
