### PR TITLE
Sane logging when no keys are on

### DIFF
--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -2256,6 +2256,16 @@ module Mutations = struct
               | None ->
                   `Snd pk )
         in
+        Logger.info
+          (Coda_lib.top_level_logger coda)
+          ~module_:__MODULE__ ~location:__LOC__
+          ~metadata:
+            [ ( "old"
+              , [%to_yojson: Public_key.Compressed.t list]
+                  (Public_key.Compressed.Set.to_list old_block_production_keys)
+              )
+            ; ("new", [%to_yojson: Public_key.Compressed.t list] pks) ]
+          !"Block production key replacement; old: $old, new: $new" ;
         ignore
         @@ Coda_lib.replace_block_production_keypairs coda
              (Keypair.And_compressed_pk.Set.of_list unlocked) ;

--- a/src/lib/coda_graphql/dune
+++ b/src/lib/coda_graphql/dune
@@ -5,5 +5,6 @@
     ; opam deps
     async node_addrs_and_ports network_peer core cohttp graphql-async graphql-cohttp
     ; libs
+    ppx_deriving_yojson.runtime
     auxiliary_database coda_base coda_commands user_command_input coda_lib)
-  (preprocess (pps ppx_version ppx_jane)))
+  (preprocess (pps ppx_version ppx_jane ppx_deriving_yojson)))


### PR DESCRIPTION
One level of protection against someone falling into the same trap as I
did (thinking block production was broken)

Tested by disabling via the GraphQL API and observing the better logging behavior, and made sure production still works when it's enabled.