### PR TITLE
[WIP] add retry property to Job config spec and define automatic/manual retry defaults

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -52,6 +52,8 @@ let TaggedKey = {
   default = {=}
 }
 
+let B/Retry = B.definitions/commandStep/properties/retry/Type
+
 -- Everything here is taken directly from the buildkite Command documentation
 -- https://buildkite.com/docs/pipelines/command-step#command-step-attributes
 -- except "target" replaces "agents"
@@ -67,6 +69,7 @@ let Config =
       , label : Text
       , key : Text
       , target : Size
+      , retry : B/Retry.Type
       , docker : Optional Docker.Type
       , docker_login : Optional DockerLogin.Type
       , summon : Optional Summon.Type
@@ -77,6 +80,10 @@ let Config =
     , docker_login = None DockerLogin.Type
     , summon = None Summon.Type
     , artifact_paths = [] : List SelectFiles.Type
+    , retry =
+        { automatic = None ((B.definitions/commandStep/properties/retry/properties/automatic/Type ))
+        , manual = None ((B.definitions/commandStep/properties/retry/properties/manual/Type ))
+        }
     }
   }
 


### PR DESCRIPTION
Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

Ensures all jobs are retried to a certain extent when infrastructure failures (-1 job exit status) is encountered.

Testing: Buildkite CI: <TBD>

Checklist:
- [ ] All tests pass (CI will check this if you didn't)

Closes #5561
