### PR TITLE
[Trivial] Deduplicate ppx entries in dune files

### DIFF
--- a/src/lib/base58_check/dune
+++ b/src/lib/base58_check/dune
@@ -4,5 +4,15 @@
  (inline_tests)
  (libraries digestif core_kernel base58)
  (library_flags (-linkall))
- (preprocess (pps ppx_base ppx_version ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_inline_test ppx_deriving_yojson bisect_ppx -conditional))
+ (preprocess
+  (pps
+   bisect_ppx -conditional
+   ppx_assert
+   ppx_base
+   ppx_deriving.std
+   ppx_deriving_yojson
+   ppx_inline_test
+   ppx_let
+   ppx_sexp_conv
+   ppx_version))
  (synopsis "Base58Check implementation"))

--- a/src/lib/consensus/dune
+++ b/src/lib/consensus/dune
@@ -1,32 +1,49 @@
 (library
-  (name consensus)
-  (public_name consensus)
-  (inline_tests)
-  (modules (:standard \ proof_of_stake_fuzzer))
-  (flags (-w -37))
-  (library_flags (-linkall))
-  (libraries
-    snarky_taylor
-    core_kernel
-    coda_base
-    block_time
-    with_hash
-    test_genesis_ledger
-    snark_params
-    perf_histograms
-    rc_pool
-    test_util
-    vrf_lib
-    unix_timestamp
-    global_signer_private_key
-    non_zero_curve_point
-    yojson
-    staged_ledger_hash
-    coda_metrics
-    graphql_lib)
-   (preprocessor_deps "../../config.mlh")
-   (preprocess (pps ppx_base ppx_coda ppx_version ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv h_list.ppx bisect_ppx -conditional))
-   (synopsis "Consensus mechanisms"))
+ (name consensus)
+ (public_name consensus)
+ (inline_tests)
+ (modules (:standard \ proof_of_stake_fuzzer))
+ (flags (-w -37))
+ (library_flags (-linkall))
+ (libraries
+   snarky_taylor
+   core_kernel
+   coda_base
+   block_time
+   with_hash
+   test_genesis_ledger
+   snark_params
+   perf_histograms
+   rc_pool
+   test_util
+   vrf_lib
+   unix_timestamp
+   global_signer_private_key
+   non_zero_curve_point
+   yojson
+   staged_ledger_hash
+   coda_metrics
+   graphql_lib)
+ (preprocessor_deps "../../config.mlh")
+ (preprocess
+  (pps
+   bisect_ppx -conditional
+   h_list.ppx
+   ppx_assert
+   ppx_base
+   ppx_bin_prot
+   ppx_coda
+   ppx_custom_printf
+   ppx_deriving.std
+   ppx_deriving_yojson
+   ppx_fields_conv
+   ppx_inline_test
+   ppx_let
+   ppx_optcomp
+   ppx_sexp_conv
+   ppx_snarky
+   ppx_version))
+  (synopsis "Consensus mechanisms"))
 
 (executable
   (name proof_of_stake_fuzzer)

--- a/src/lib/merkle_mask/dune
+++ b/src/lib/merkle_mask/dune
@@ -5,5 +5,10 @@
  (libraries core debug_assert bitstring integers immutable_array
    dyn_array merkle_ledger merkle_address yojson visualization)
  (preprocess
-  (pps ppx_version ppx_jane ppx_deriving_yojson ppx_jane ppx_deriving.eq ppx_deriving.show))
+  (pps
+   ppx_deriving.eq
+   ppx_deriving.show
+   ppx_deriving_yojson
+   ppx_jane
+   ppx_version))
  (synopsis "Implementation of Merkle tree masks"))

--- a/src/lib/snark_worker/dune
+++ b/src/lib/snark_worker/dune
@@ -6,10 +6,18 @@
  (libraries core async cli_lib currency snark_work_lib coda_base
    blockchain_snark transaction_snark keys_lib perf_histograms
    core_kernel.hash_heap sparse_ledger_lib ledger_proof transaction_witness)
- (preprocess (pps
-   ppx_coda ppx_version ppx_sexp_conv ppx_optcomp
-   ppx_sexp_conv ppx_bin_prot ppx_let ppx_custom_printf
-   ppx_inline_test bisect_ppx ppx_register_event
-   ppx_deriving_yojson -- -conditional))
+ (preprocess
+  (pps
+   bisect_ppx -conditional
+   ppx_bin_prot
+   ppx_coda
+   ppx_custom_printf
+   ppx_deriving_yojson
+   ppx_inline_test
+   ppx_let
+   ppx_optcomp
+   ppx_register_event
+   ppx_sexp_conv
+   ppx_version))
  (preprocessor_deps "../../config.mlh")
  (synopsis "Lib powering the snark_worker interactions with the daemon"))

--- a/src/lib/trust_system/dune
+++ b/src/lib/trust_system/dune
@@ -4,6 +4,22 @@
  (library_flags (-linkall))
  (libraries core async network_peer key_value_database logger pipe_lib rocksdb coda_metrics ppx_version.runtime)
  (inline_tests)
- (preprocess (pps ppx_base ppx_coda ppx_version ppx_let ppx_assert ppx_deriving.std ppx_deriving_yojson
-                  ppx_sexp_conv ppx_bin_prot ppx_custom_printf ppx_inline_test ppx_optcomp ppx_snarky ppx_deriving_yojson ppx_fields_conv ppx_register_event bisect_ppx -conditional))
+ (preprocess
+  (pps
+   bisect_ppx -conditional
+   ppx_assert
+   ppx_base
+   ppx_bin_prot
+   ppx_coda
+   ppx_custom_printf
+   ppx_deriving.std
+   ppx_deriving_yojson
+   ppx_fields_conv
+   ppx_inline_test
+   ppx_let
+   ppx_optcomp
+   ppx_register_event
+   ppx_sexp_conv
+   ppx_snarky
+   ppx_version))
  (synopsis "Track how much we trust peers"))

--- a/src/lib/vrf_lib/dune
+++ b/src/lib/vrf_lib/dune
@@ -5,7 +5,13 @@
  (library_flags -linkall)
  (libraries core genesis_constants snarky snarky_curves test_util)
  (preprocess
-  (pps ppx_version ppx_jane ppx_bench ppx_deriving.eq h_list.ppx bisect_ppx -- -conditional))
+  (pps
+   bisect_ppx -conditional
+   h_list.ppx
+   ppx_bench
+   ppx_deriving.eq
+   ppx_jane
+   ppx_version))
  (modules integrated standalone)
  (synopsis "VRF instantiation"))
 
@@ -17,5 +23,11 @@
  (libraries core snarky snarky_curves test_util signature_lib snark_params
    vrf_lib coda_base random_oracle fold_lib)
  (preprocess
-  (pps ppx_version ppx_version ppx_jane ppx_bench h_list.ppx ppx_deriving.eq bisect_ppx -- -conditional))
+  (pps
+   bisect_ppx -conditional
+   h_list.ppx
+   ppx_bench
+   ppx_deriving.eq
+   ppx_jane
+   ppx_version))
  (modules integrated_test))


### PR DESCRIPTION
This PR alphabetises and deduplicates ppx entries in dune files; thanks to @mobileink for the list.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: