### PR TITLE
Fixes compare test signatures job

### DIFF
--- a/buildkite/scripts/compare_test_signatures.sh
+++ b/buildkite/scripts/compare_test_signatures.sh
@@ -2,5 +2,5 @@
 
 set -eou pipefail
 
-eval $(opam config env) && ./scripts/compare_test_signatures.sh
+eval $(opam config env) && export PATH=$HOME/.cargo/bin:$PATH && ./scripts/compare_test_signatures.sh
 

--- a/buildkite/scripts/compare_test_signatures.sh
+++ b/buildkite/scripts/compare_test_signatures.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eou pipefail
+
+eval $(opam config env) && ./scripts/compare_test_signatures.sh
+

--- a/buildkite/src/Command/OpamInit.dhall
+++ b/buildkite/src/Command/OpamInit.dhall
@@ -10,8 +10,6 @@ let file =
 
 let unpackageScript : Text = "tar xfz ${file} --strip-components=2 -C /home/opam"
 
-let exposeOpamEnv : Text = "eval '\$(opam config env)'"
-
 let commands : List Text -> List Cmd.Type = \(environment : List Text) ->
   [
     r ("cat scripts/setup-opam.sh src/opam.export <(date +%Y-%m)" ++
@@ -34,7 +32,7 @@ let andThenRunInDocker : List Text -> Text -> List Cmd.Type =
     [ Coda.fixPermissionsCommand ] # (commands environment) # [
       Cmd.runInDocker
         (Cmd.Docker::{ image = (../Constants/ContainerImages.dhall).codaToolchain, extraEnv = environment })
-        (unpackageScript ++ " && " ++ exposeOpamEnv ++ " && " ++ innerScript)
+        (unpackageScript ++ " && " ++ innerScript)
     ]
 
 in

--- a/buildkite/src/Command/OpamInit.dhall
+++ b/buildkite/src/Command/OpamInit.dhall
@@ -10,7 +10,7 @@ let file =
 
 let unpackageScript : Text = "tar xfz ${file} --strip-components=2 -C /home/opam"
 
-let exposeOpamEnv : Text = "eval \\\"\\\\\$(opam config env)\\\""
+let exposeOpamEnv : Text = "eval '\$(opam config env)'"
 
 let commands : List Text -> List Cmd.Type = \(environment : List Text) ->
   [

--- a/buildkite/src/Command/OpamInit.dhall
+++ b/buildkite/src/Command/OpamInit.dhall
@@ -10,7 +10,7 @@ let file =
 
 let unpackageScript : Text = "tar xfz ${file} --strip-components=2 -C /home/opam"
 
-let exposeOpamEnv : Text = "eval \\\\\$(opam config env)"
+let exposeOpamEnv : Text = "eval \\\\\\\$(opam config env)"
 
 let commands : List Text -> List Cmd.Type = \(environment : List Text) ->
   [

--- a/buildkite/src/Command/OpamInit.dhall
+++ b/buildkite/src/Command/OpamInit.dhall
@@ -10,7 +10,7 @@ let file =
 
 let unpackageScript : Text = "tar xfz ${file} --strip-components=2 -C /home/opam"
 
-let exposeOpamEnv : Text = "eval `opam config env`"
+let exposeOpamEnv : Text = "eval \\\\\$(opam config env)"
 
 let commands : List Text -> List Cmd.Type = \(environment : List Text) ->
   [

--- a/buildkite/src/Command/OpamInit.dhall
+++ b/buildkite/src/Command/OpamInit.dhall
@@ -10,7 +10,7 @@ let file =
 
 let unpackageScript : Text = "tar xfz ${file} --strip-components=2 -C /home/opam"
 
-let exposeOpamEnv : Text = "eval \"\\\\\$(opam config env)\""
+let exposeOpamEnv : Text = "eval \\\"\\\\\$(opam config env)\\\""
 
 let commands : List Text -> List Cmd.Type = \(environment : List Text) ->
   [

--- a/buildkite/src/Command/OpamInit.dhall
+++ b/buildkite/src/Command/OpamInit.dhall
@@ -10,7 +10,7 @@ let file =
 
 let unpackageScript : Text = "tar xfz ${file} --strip-components=2 -C /home/opam"
 
-let exposeOpamEnv : Text = "eval \\\\\\\$(opam config env)"
+let exposeOpamEnv : Text = "eval \"\\\\\$(opam config env)\""
 
 let commands : List Text -> List Cmd.Type = \(environment : List Text) ->
   [

--- a/buildkite/src/Jobs/CompareSignatures.dhall
+++ b/buildkite/src/Jobs/CompareSignatures.dhall
@@ -23,7 +23,7 @@ Pipeline.build
     , steps =
       [ Command.build
           Command.Config::
-            { commands = OpamInit.andThenRunInDocker ([] : List Text) (WithCargo.withCargo "./buildkite/scripts/compare_test_signatures.sh")
+            { commands = OpamInit.andThenRunInDocker ([] : List Text) "./buildkite/scripts/compare_test_signatures.sh"
             , label = "Compare test signatures"
             , key = "compare-test-signatures"
             , target = Size.Large

--- a/buildkite/src/Jobs/CompareSignatures.dhall
+++ b/buildkite/src/Jobs/CompareSignatures.dhall
@@ -23,7 +23,7 @@ Pipeline.build
     , steps =
       [ Command.build
           Command.Config::
-            { commands = OpamInit.andThenRunInDocker ([] : List Text) (WithCargo.withCargo "./scripts/compare_test_signatures.sh")
+            { commands = OpamInit.andThenRunInDocker ([] : List Text) (WithCargo.withCargo "./buildkite/scripts/compare_test_signatures.sh")
             , label = "Compare test signatures"
             , key = "compare-test-signatures"
             , target = Size.Large


### PR DESCRIPTION
Attempts to fix compare test signatures. I noticed the failure was occurring because the eval wasn't escaped enough.

Compare test sigs test passes now.