### PR TITLE
Fail faster + cargo properly on build-artifacts

### DIFF
--- a/buildkite/scripts/build-artifact.sh
+++ b/buildkite/scripts/build-artifact.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-set -o pipefail
+set -eo pipefail
 
 eval `opam config env`
+export PATH=$HOME/.cargo/bin:$PATH
 
 echo "--- Explicitly generate PV-keys and upload before building"
 LIBP2P_NIXLESS=1 make build_pv_keys 2>&1 | tee /tmp/artifacts/buildocaml.log


### PR DESCRIPTION
Build-artifacts job was erroneously succeeding even though it was actually failing. This is due to a missing `set -e` at the top of the build-artifacts.sh script. There is also an export PATH after the opam eval that should fix the missing cargo binary error.