### PR TITLE
ensure docker-artifact build/release script shares pass/fail fate of embedded commands

### DIFF
--- a/buildkite/scripts/docker-artifact.sh
+++ b/buildkite/scripts/docker-artifact.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 source DOCKER_DEPLOY_ENV
 

--- a/buildkite/scripts/docker-artifact.sh
+++ b/buildkite/scripts/docker-artifact.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -o pipefail
+set -euo pipefail
 
 source DOCKER_DEPLOY_ENV
 


### PR DESCRIPTION
Fast-fail docker-artifact.sh on embedded command failures in addition to unset expected EnvVars (expectation is that all environment variables should be set by DOCKER_DEPLOY_ENV).

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
