### PR TITLE
Attempt to fix mac build

### DIFF
--- a/scripts/macos-setup-brew.sh
+++ b/scripts/macos-setup-brew.sh
@@ -3,9 +3,6 @@ set -eu
 
 export HOMEBREW_NO_AUTO_UPDATE=1
 
-# re-reads /usr/local/Homebrew if a cache has been put in place
-brew update-reset
-
 brew uninstall python@2 || true
 
 brew bundle install --file=scripts/Brewfile


### PR DESCRIPTION
CircleCI already comes with brew installed; we probably don't need to chase master, which is what keeps breaking us.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: