### PR TITLE
[Website] Added empty message for leaderboard

### DIFF
--- a/frontend/website/public/static/img/LeaderboardEmpty.png
+++ b/frontend/website/public/static/img/LeaderboardEmpty.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b9d5847fb27a455e74e93f9b59b65e4ac180db5df737357427dab5331d5591a
+size 1464

--- a/frontend/website/src/components/Leaderboard.re
+++ b/frontend/website/src/components/Leaderboard.re
@@ -690,7 +690,10 @@ let make =
               <span> {React.string("release will be added shortly.")} </span>
             | Phase =>
               <span> {React.string("phase will be added shortly.")} </span>
-            | _ => React.null
+            | AllTime =>
+              <span>
+                {React.string("leaderboard will be added shortly.")}
+              </span>
             }}
          </div>;
        } else {

--- a/frontend/website/src/components/Leaderboard.re
+++ b/frontend/website/src/components/Leaderboard.re
@@ -34,23 +34,36 @@ let fetchLeaderboard = () => {
   )
   |> Promise.map(res => {
        Array.map(parseEntry, res)
-       |> Array.map(entry => {
-            {
-              name: entry |> safeArrayGet(0),
-              allTimePoints: entry |> safeArrayGet(1) |> safeParseInt,
-              phasePoints: entry |> safeArrayGet(2) |> safeParseInt,
-              releasePoints: entry |> safeArrayGet(3) |> safeParseInt,
-              allTimeRank: entry |> safeArrayGet(4) |> safeParseInt,
-              phaseRank: entry |> safeArrayGet(5) |> safeParseInt,
-              releaseRank: entry |> safeArrayGet(6) |> safeParseInt,
-              genesisMember:
-                entry |> safeArrayGet(7) |> String.length == 0 ? false : true,
-              technicalMVP:
-                entry |> safeArrayGet(8) |> String.length == 0 ? false : true,
-              communityMVP:
-                entry |> safeArrayGet(9) |> String.length == 0 ? false : true,
-            }
-          })
+       |> Array.map(entry
+            /* check if the member has a username */
+            =>
+              if (entry |> safeArrayGet(0) != "") {
+                {
+                  name: entry |> safeArrayGet(0),
+                  allTimePoints: entry |> safeArrayGet(1) |> safeParseInt,
+                  phasePoints: entry |> safeArrayGet(2) |> safeParseInt,
+                  releasePoints: entry |> safeArrayGet(3) |> safeParseInt,
+                  allTimeRank: entry |> safeArrayGet(4) |> safeParseInt,
+                  phaseRank: entry |> safeArrayGet(5) |> safeParseInt,
+                  releaseRank: entry |> safeArrayGet(6) |> safeParseInt,
+                  genesisMember:
+                    entry |> safeArrayGet(7) |> String.length == 0
+                      ? false : true,
+                  technicalMVP:
+                    entry |> safeArrayGet(8) |> String.length == 0
+                      ? false : true,
+                  communityMVP:
+                    entry |> safeArrayGet(9) |> String.length == 0
+                      ? false : true,
+                }
+                ->Some;
+              } else {
+                None;
+              }
+            )
+     })
+  |> Js.Promise.then_(members => {
+       Belt.Array.keepMap(members, release => release) |> Js.Promise.resolve
      })
   |> Js.Promise.catch(_ => Promise.return([||]));
 };
@@ -341,6 +354,16 @@ module Styles = {
         ]),
       ]),
     ]);
+
+  let emptyMessage =
+    style([
+      important(backgroundColor(Theme.Colors.white)),
+      height(`rem(20.)),
+      display(`flex),
+      flexDirection(`column),
+      justifyContent(`center),
+      alignItems(`center),
+    ]);
 };
 
 module LeaderboardRow = {
@@ -569,7 +592,7 @@ let reducer = (_, action) => {
 [@react.component]
 let make =
     (
-      ~filter: Filter.t=Release,
+      ~filter: Filter.t=Phase,
       ~toggle: Toggle.t=All,
       ~search: string="",
       ~interactive: bool=true,
@@ -644,35 +667,61 @@ let make =
         </span>
         {Array.map(renderColumnHeader, Filter.filters) |> React.array}
       </div>
-      {state.loading
-         ? <div className=Styles.loading> {React.string("Loading...")} </div>
-         : Array.concat([
-             Array.length(topTen) > 0
-               ? [|
-                 <div className=Styles.topTen>
-                   <img src="/static/img/star.svg" alt="Star icon" />
-                   <p> {React.string("Top 10")} </p>
-                 </div>,
-               |]
-               : [||],
-             Array.map(renderRow, topTen),
-             Array.length(topFifty) > 0 && Array.length(topTen) > 0
-               ? [|<hr />|] : [||],
-             Array.length(topFifty) > 0
-               ? [|
-                 <div className=Styles.topTen>
-                   <img src="/static/img/star.svg" alt="Star icon" />
-                   <p> {React.string("Top 50")} </p>
-                 </div>,
-               |]
-               : [||],
-             Array.map(renderRow, topFifty),
-             Array.length(theRest) > 0
-             && max(Array.length(topFifty), Array.length(topTen)) > 0
-               ? [|<hr />|] : [||],
-             Array.map(renderRow, theRest),
-           ])
-           |> React.array}
+      {if (state.loading) {
+         <div className=Styles.loading> {React.string("Loading...")} </div>;
+       } else if (Array.length(filteredMembers) == 0) {
+         <div className=Styles.emptyMessage>
+           <Badge
+             src="/static/img/LeaderboardEmpty.png"
+             title="Empty Leaderboard"
+             alt="Empty Leaderboard"
+           />
+           <span
+             className=Css.(
+               style([fontWeight(`num(500)), marginTop(`rem(1.5))])
+             )>
+             {React.string("Please Be Patient")}
+           </span>
+           <span className=Css.(style([marginTop(`rem(1.))]))>
+             {React.string("Participant data for this")}
+           </span>
+           {switch (filter) {
+            | Release =>
+              <span> {React.string("release will be added shortly.")} </span>
+            | Phase =>
+              <span> {React.string("phase will be added shortly.")} </span>
+            | _ => React.null
+            }}
+         </div>;
+       } else {
+         Array.concat([
+           Array.length(topTen) > 0
+             ? [|
+               <div className=Styles.topTen>
+                 <img src="/static/img/star.svg" alt="Star icon" />
+                 <p> {React.string("Top 10")} </p>
+               </div>,
+             |]
+             : [||],
+           Array.map(renderRow, topTen),
+           Array.length(topFifty) > 0 && Array.length(topTen) > 0
+             ? [|<hr />|] : [||],
+           Array.length(topFifty) > 0
+             ? [|
+               <div className=Styles.topTen>
+                 <img src="/static/img/star.svg" alt="Star icon" />
+                 <p> {React.string("Top 50")} </p>
+               </div>,
+             |]
+             : [||],
+           Array.map(renderRow, topFifty),
+           Array.length(theRest) > 0
+           && max(Array.length(topFifty), Array.length(topTen)) > 0
+             ? [|<hr />|] : [||],
+           Array.map(renderRow, theRest),
+         ])
+         |> React.array;
+       }}
     </div>
   </div>;
 };

--- a/frontend/website/src/pages/LeaderboardPage.re
+++ b/frontend/website/src/pages/LeaderboardPage.re
@@ -181,7 +181,7 @@ type state = {
   username: string,
 };
 
-let initialState = {currentToggle: All, currentFilter: Release, username: ""};
+let initialState = {currentToggle: All, currentFilter: Phase, username: ""};
 
 type action =
   | Toggled(Leaderboard.Toggle.t)


### PR DESCRIPTION
This PR implements the following functionality:

- Adds an error message when the leaderboard has empty members to show. This error message is present for sorting both by `Release` and `Phase`. 
- Changes the default sort method to be `Phase` instead of `Release`

Closes https://github.com/CodaProtocol/coda/issues/5629

These changes were tested manually. See below for mocks of changes.

**Desktop - Empty Release**
![image](https://user-images.githubusercontent.com/9512405/90059896-b5b68980-dc98-11ea-8d3c-5fd39f1b1d7f.png)

**Mobile - Empty Release**
![image](https://user-images.githubusercontent.com/9512405/90059935-c666ff80-dc98-11ea-95ef-dba14ec6d7d1.png)

**Desktop - Empty Phase**
![image](https://user-images.githubusercontent.com/9512405/90059982-d848a280-dc98-11ea-8482-5dd8bc785b60.png)

**Desktop - Empty All-Time**
![image](https://user-images.githubusercontent.com/9512405/90060917-45106c80-dc9a-11ea-8de1-3ddc6ab1c4f0.png)

