### PR TITLE
rosetta/add-docker-demo-start

### DIFF
--- a/src/app/rosetta/docker-demo-start.sh
+++ b/src/app/rosetta/docker-demo-start.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -eou pipefail
+
+function cleanup
+{
+  CODE=${1:-0}
+  echo "Killing archive.exe"
+  kill $(ps aux | egrep '_build/default/src/app/.*archive.exe' | grep -v grep | awk '{ print $2 }') || true
+  echo "Killing coda.exe"
+  kill $(ps aux | egrep '_build/default/src/app/.*coda.exe'    | grep -v grep | awk '{ print $2 }') || true
+  echo "Killing rosetta.exe"
+  kill $(ps aux | egrep '_build/default/src/app/rosetta'       | grep -v grep | awk '{ print $2 }') || true
+  exit $CODE
+}
+
+trap cleanup TERM
+trap cleanup INT
+
+PG_CONN=postgres://$USER:$USER@localhost:5432/archiver
+
+# Start postgres
+echo "========================= STARTING POSTGRESQL ==========================="
+pg_ctlcluster 11 main start
+
+# wait for it to settle
+sleep 2
+
+# archive
+echo "========================= STARTING ARCHIVE PROCESS ==========================="
+/coda-bin/archive/archive.exe run \
+  -postgres-uri $PG_CONN \
+  -server-port 3086 \
+  -log-level fatal &
+
+# wait for it to settle
+sleep 2
+
+# Setup and run demo-node
+PK=${PK:-B62qrPN5Y5yq8kGE3FbVKbGTdTAJNdtNtB5sNVpxyRwWGcDEhpMzc8g}
+genesis_time=$(date -d '2019-01-30 20:00:00.000000Z' '+%s')
+now_time=$(date +%s)
+export CODA_TIME_OFFSET=$(( $now_time - $genesis_time ))
+export CODA_PRIVKEY_PASS=""
+export CODA_LIBP2P_HELPER_PATH=/coda-bin/libp2p_helper
+CODA_CONFIG_DIR=/root/.coda-config
+
+# CODA_CONFIG_DIR is exposed by the dockerfile and contains demo mode essentials
+echo "========================= STARTING DAEMON ==========================="
+/coda-bin/cli/src/coda.exe daemon \
+  -seed \
+  -demo-mode \
+  -block-producer-key "$CODA_CONFIG_DIR/wallets/store/$PK" \
+  -run-snark-worker $PK \
+  -config-file "$CODA_CONFIG_DIR/daemon.json" \
+  -config-dir "$CODA_CONFIG_DIR" \
+  -insecure-rest-server \
+  -external-ip 127.0.0.1 \
+  -archive-address 3086 \
+  -log-level fatal &
+
+# wait for it to settle
+sleep 15
+
+# rosetta
+echo "========================= STARTING ROSETTA API on PORT 3087 ==========================="
+/coda-bin/rosetta/rosetta.exe \
+  -archive-uri $PG_CONN \
+  -graphql-uri http://localhost:3085/graphql \
+  -log-level fatal \
+  -port 3087 &
+
+sleep infinity

--- a/src/app/rosetta/docker-demo-start.sh
+++ b/src/app/rosetta/docker-demo-start.sh
@@ -49,26 +49,26 @@ CODA_CONFIG_DIR=/root/.coda-config
 # CODA_CONFIG_DIR is exposed by the dockerfile and contains demo mode essentials
 echo "========================= STARTING DAEMON ==========================="
 /coda-bin/cli/src/coda.exe daemon \
-  -seed \
-  -demo-mode \
+  -archive-address 3086 \
+  -background \
   -block-producer-key "$CODA_CONFIG_DIR/wallets/store/$PK" \
-  -run-snark-worker $PK \
-  -config-file "$CODA_CONFIG_DIR/daemon.json" \
   -config-dir "$CODA_CONFIG_DIR" \
-  -insecure-rest-server \
+  -config-file "$CODA_CONFIG_DIR/daemon.json" \
+  -demo-mode \
+  -disable-telemetry \
   -external-ip 127.0.0.1 \
   -external-port "${CODA_DAEMON_PORT:-10101}" \
-  -archive-address 3086 \
-  -disable-telemetry \
+  -insecure-rest-server \
   -log-level debug \
   -log-json \
-  -background \
+  -run-snark-worker $PK \
+  -seed \
   $@
 
 # Possibly useful flags:
-#   Rosetta documentation specifies that /data/ will be a volume mount for various state
+#   Rosetta documentation specifies that /data/ will be a volume mount for various state.
 #  -working-dir /data/ \
-#   Demo mode probably doesnt need to be super strict about proving to integrate against rosetta
+#   Demo mode probably doesnt need to be super strict about proving to integrate against rosetta.
 #  -proof-level none \
 
 

--- a/src/app/rosetta/docker-demo-start.sh
+++ b/src/app/rosetta/docker-demo-start.sh
@@ -60,11 +60,17 @@ echo "========================= STARTING DAEMON ==========================="
   -external-port "${CODA_DAEMON_PORT:-10101}" \
   -archive-address 3086 \
   -disable-telemetry \
-  -working-dir /data/ \
-  -proof-level none \
-  -log-level fatal \
+  -log-level debug \
   -log-json \
-  -background
+  -background \
+  $@
+
+# Possibly useful flags:
+#   Rosetta documentation specifies that /data/ will be a volume mount for various state
+#  -working-dir /data/ \
+#   Demo mode probably doesnt need to be super strict about proving to integrate against rosetta
+#  -proof-level none \
+
 
 # wait for it to settle
 sleep 3

--- a/src/app/rosetta/docker-demo-start.sh
+++ b/src/app/rosetta/docker-demo-start.sh
@@ -24,17 +24,18 @@ echo "========================= STARTING POSTGRESQL ==========================="
 pg_ctlcluster 11 main start
 
 # wait for it to settle
-sleep 2
+sleep 3
 
 # archive
 echo "========================= STARTING ARCHIVE PROCESS ==========================="
 /coda-bin/archive/archive.exe run \
   -postgres-uri $PG_CONN \
   -server-port 3086 \
-  -log-level fatal &
+  -log-level fatal \
+  -log-json &
 
 # wait for it to settle
-sleep 2
+sleep 3
 
 # Setup and run demo-node
 PK=${PK:-B62qrPN5Y5yq8kGE3FbVKbGTdTAJNdtNtB5sNVpxyRwWGcDEhpMzc8g}
@@ -56,18 +57,24 @@ echo "========================= STARTING DAEMON ==========================="
   -config-dir "$CODA_CONFIG_DIR" \
   -insecure-rest-server \
   -external-ip 127.0.0.1 \
+  -external-port "${CODA_DAEMON_PORT:-10101}" \
   -archive-address 3086 \
-  -log-level fatal &
+  -disable-telemetry \
+  -working-dir /data/ \
+  -proof-level none \
+  -log-level fatal \
+  -log-json \
+  -background
 
 # wait for it to settle
-sleep 15
+sleep 3
 
 # rosetta
 echo "========================= STARTING ROSETTA API on PORT 3087 ==========================="
 /coda-bin/rosetta/rosetta.exe \
   -archive-uri $PG_CONN \
   -graphql-uri http://localhost:3085/graphql \
-  -log-level fatal \
+  -log-level debug \
   -port 3087 &
 
 sleep infinity


### PR DESCRIPTION
Add docker-demo-start.sh script for running in demo mode without the test agent and with less-verbose logging. For some reason the snark worker is still logging at the info level, but the goal is to make the daemon as quiet as possible so that the rosetta API can be noisier for folks trying to develop against rosetta.

Thank you for contributing to Coda! Please see `CONTRIBUTING.md` if you haven't
yet. In that doc, there are more details around how to start our CI.

Explain your changes here.

Explain how you tested your changes here.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
