### PR TITLE
add default value for BASE_BRANCH var within compare_ci_diff scripts

### DIFF
--- a/scripts/compare_ci_diff_binables.sh
+++ b/scripts/compare_ci_diff_binables.sh
@@ -15,4 +15,4 @@ rm -rf base
 # build print_binable_functors, then run Python script to compare binable functors in a pull request
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/src/print_binable_functors.exe) && \
-    ./scripts/compare_pr_diff_binables.py ${BASE_BRANCH_NAME}
+    ./scripts/compare_pr_diff_binables.py ${BASE_BRANCH_NAME:-develop}

--- a/scripts/compare_ci_diff_types.sh
+++ b/scripts/compare_ci_diff_types.sh
@@ -16,4 +16,4 @@ rm -rf base
 
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/src/print_versioned_types.exe) && \
-    ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME}
+    ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME:-develop}


### PR DESCRIPTION
Appears as though Buildkite's job-environment scoped [$BUILDKITE_PULL_REQUEST_BASE_BRANCH](https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-buildkite-pull-request-base-branch) EnvVar is not properly set when builds are triggered against the base branch itself (`develop` in this case) see: [example](https://buildkite.com/o-1-labs-2/coda/builds/1254#e399c11d-cd66-4f3e-be76-ba9e1b349b5b). This change adds a default of `develop`, which should result in a no-op, if so.

**Testing:** Buildkite CI

**Checklist:**

- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)
