### PR TITLE
trigger lint tests to force opam inits

### DIFF
--- a/buildkite/src/Jobs/ClientSdk.dhall
+++ b/buildkite/src/Jobs/ClientSdk.dhall
@@ -1,3 +1,5 @@
+-- Testing
+
 let Prelude = ../External/Prelude.dhall
 let S = ../Lib/SelectFiles.dhall
 

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -1,3 +1,5 @@
+-- testing
+
 let Prelude = ../../External/Prelude.dhall
 
 let S = ../../Lib/SelectFiles.dhall


### PR DESCRIPTION
Stress test opam initialization and dependency updates under load.

**Testing:** Buildkite CI

**Checklist:**

- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
