### PR TITLE
Rosetta, Unsigned_extended types for Yojson

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -47,8 +47,8 @@ module Internal_command_info = struct
   type t =
     { kind: Kind.t
     ; receiver: [`Pk of string]
-    ; fee: Unsigned.UInt64.t
-    ; token: Unsigned.UInt64.t
+    ; fee: Unsigned_extended.UInt64.t
+    ; token: Unsigned_extended.UInt64.t
     ; hash: string }
   [@@deriving to_yojson]
 

--- a/src/app/rosetta/lib/user_command_info.ml
+++ b/src/app/rosetta/lib/user_command_info.ml
@@ -42,8 +42,8 @@ end
 module Account_creation_fees_paid = struct
   type t =
     | By_no_one
-    | By_fee_payer of Unsigned.UInt64.t
-    | By_receiver of Unsigned.UInt64.t
+    | By_fee_payer of Unsigned_extended.UInt64.t
+    | By_receiver of Unsigned_extended.UInt64.t
   [@@deriving eq, to_yojson, sexp, compare]
 end
 
@@ -57,11 +57,11 @@ type t =
   ; fee_payer: [`Pk of string]
   ; source: [`Pk of string]
   ; receiver: [`Pk of string]
-  ; fee_token: Unsigned.UInt64.t
-  ; token: Unsigned.UInt64.t
-  ; fee: Unsigned.UInt64.t
-  ; nonce: Unsigned.UInt32.t
-  ; amount: Unsigned.UInt64.t option
+  ; fee_token: Unsigned_extended.UInt64.t
+  ; token: Unsigned_extended.UInt64.t
+  ; fee: Unsigned_extended.UInt64.t
+  ; nonce: Unsigned_extended.UInt32.t
+  ; amount: Unsigned_extended.UInt64.t option
   ; hash: string
   ; failure_status: Failure_status.t option }
 [@@deriving to_yojson, eq, sexp, compare]
@@ -72,10 +72,10 @@ module Partial = struct
     ; fee_payer: [`Pk of string]
     ; source: [`Pk of string]
     ; receiver: [`Pk of string]
-    ; fee_token: Unsigned.UInt64.t
-    ; token: Unsigned.UInt64.t
-    ; fee: Unsigned.UInt64.t
-    ; amount: Unsigned.UInt64.t option }
+    ; fee_token: Unsigned_extended.UInt64.t
+    ; token: Unsigned_extended.UInt64.t
+    ; fee: Unsigned_extended.UInt64.t
+    ; amount: Unsigned_extended.UInt64.t option }
   [@@deriving to_yojson, sexp, compare]
 
   module Reason = Errors.Partial_reason


### PR DESCRIPTION
Running `start.sh` in `src/app/rosetta` builds several pieces of code. On Linux, those builds failed because `Unsigned.UInt{32,64}` don't export Yojson functions. Using `Unsigned_extended` instead allows the builds to succeed.