### PR TITLE
Implements /con/payloads with unsigned txn coding

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -450,10 +450,7 @@ let batch_send_payments =
           let signer_pk = Public_key.compress keypair.public_key in
           User_command_input.create ~signer:signer_pk ~fee
             ~fee_token:Token_id.default (* TODO: Multiple tokens. *)
-            ~fee_payer_pk:signer_pk ~memo:User_command_memo.empty
-            ~valid_until:
-              (Option.value valid_until
-                 ~default:Coda_numbers.Global_slot.max_value)
+            ~fee_payer_pk:signer_pk ~memo:User_command_memo.empty ~valid_until
             ~body:
               (Payment
                  { source_pk= signer_pk

--- a/src/app/cli/src/init/transaction_snark_profiler.ml
+++ b/src/app/cli/src/init/transaction_snark_profiler.ml
@@ -30,7 +30,7 @@ let create_ledger_and_transactions num_transitions =
     let payload : User_command.Payload.t =
       User_command.Payload.create ~fee ~fee_token:Token_id.default
         ~fee_payer_pk:from_pk ~nonce ~memo:User_command_memo.dummy
-        ~valid_until:Coda_numbers.Global_slot.max_value
+        ~valid_until:None
         ~body:
           (Payment
              { source_pk= from_pk

--- a/src/app/cli/src/tests/coda_worker.ml
+++ b/src/app/cli/src/tests/coda_worker.ml
@@ -617,7 +617,7 @@ module T = struct
               let sender_pk = pk_of_sk sender_sk in
               User_command_input.create ~fee ~fee_token:Token_id.default
                 ~fee_payer_pk:sender_pk ~signer:sender_pk ~memo
-                ~valid_until:Coda_numbers.Global_slot.max_value
+                ~valid_until:None
                 ~body:
                   (Payment
                      { source_pk= sender_pk

--- a/src/app/cli/src/tests/coda_worker_testnet.ml
+++ b/src/app/cli/src/tests/coda_worker_testnet.ml
@@ -511,7 +511,7 @@ module Delegation : sig
 end = struct
   let delegate_stake ?acceptable_delay:(delay = 7) (testnet : Api.t) ~node
       ~delegator ~delegatee =
-    let valid_until = Coda_numbers.Global_slot.max_value in
+    let valid_until = None in
     let fee = User_command.minimum_fee in
     let worker = testnet.workers.(node) in
     let%bind _ =
@@ -566,7 +566,7 @@ end = struct
   let send_several_payments ?acceptable_delay:(delay = 7) (testnet : Api.t)
       ~node ~keypairs ~n =
     let amount = Currency.Amount.of_int 10 in
-    let valid_until = Coda_numbers.Global_slot.max_value in
+    let valid_until = None in
     let fee = User_command.minimum_fee in
     let%bind (_ : unit option list) =
       Deferred.List.init n ~f:(fun _ ->
@@ -628,7 +628,7 @@ end = struct
       ~(keypairs : Keypair.t list) ~n =
     let amount = Currency.Amount.of_int 10 in
     let fee = User_command.minimum_fee in
-    let valid_until = Coda_numbers.Global_slot.max_value in
+    let valid_until = None in
     let%bind new_payment_readers =
       Deferred.List.init (Array.length testnet.workers) ~f:(fun i ->
           let pk = Public_key.(compress @@ of_private_key_exn sender) in

--- a/src/app/cli/src/tests/full_test.ml
+++ b/src/app/cli/src/tests/full_test.ml
@@ -279,8 +279,7 @@ let run_test () : unit Deferred.t =
                 "A memo created in full-test"
             in
             User_command_input.create ?nonce ~signer ~fee ~fee_payer_pk:signer
-              ~fee_token:Token_id.default ~memo
-              ~valid_until:Coda_numbers.Global_slot.max_value
+              ~fee_token:Token_id.default ~memo ~valid_until:None
               ~body:
                 (Payment
                    { source_pk= signer

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -2,6 +2,8 @@ open Core_kernel
 open Async
 open Models
 module Public_key = Signature_lib.Public_key
+module User_command_payload = Coda_base.User_command_payload
+module User_command = Coda_base.User_command
 
 module Get_nonce =
 [%graphql
@@ -49,12 +51,21 @@ module Options = struct
            {sender; token_id= Unsigned.UInt64.of_string r.token_id} )
 end
 
+(* TODO: unify handling of json between this and Options (above) and everything else in rosetta *)
 module Metadata_data = struct
+  type t =
+    { sender: string
+    ; nonce: Unsigned_extended.UInt32.t
+    ; token_id: Unsigned_extended.UInt64.t }
+  [@@deriving yojson]
+
   let create ~nonce ~sender ~token_id =
-    `Assoc
-      [ ("sender", `String (Public_key.Compressed.to_base58_check sender))
-      ; ("nonce", `String nonce)
-      ; ("token_id", `String (Unsigned.UInt64.to_string token_id)) ]
+    {sender= Public_key.Compressed.to_base58_check sender; nonce; token_id}
+
+  let of_json r =
+    of_yojson r
+    |> Result.map_error ~f:(fun e ->
+           Errors.create ~context:"Options of_json" (`Json_parse (Some e)) )
 end
 
 module Derive = struct
@@ -150,14 +161,14 @@ module Metadata = struct
       in
       let nonce =
         Option.map
-          ~f:(fun nonce ->
-            Unsigned.UInt64.(of_string nonce |> add one |> to_string) )
+          ~f:(fun nonce -> Unsigned.UInt32.(of_string nonce |> add one))
           account#nonce
-        |> Option.value ~default:"1"
+        |> Option.value ~default:Unsigned.UInt32.one
       in
       { Construction_metadata_response.metadata=
           Metadata_data.create ~sender:options.Options.sender
-            ~token_id:options.Options.token_id ~nonce }
+            ~token_id:options.Options.token_id ~nonce
+          |> Metadata_data.to_yojson }
   end
 
   module Real = Impl (Deferred.Result)
@@ -209,6 +220,87 @@ module Preprocess = struct
   module Mock = Impl (Result)
 end
 
+module Payloads = struct
+  module Env = struct
+    module T (M : Monad_fail.S) = struct
+      type t = {lift: 'a 'e. ('a, 'e) Result.t -> ('a, 'e) M.t}
+    end
+
+    module Real = T (Deferred.Result)
+    module Mock = T (Result)
+
+    let real : Real.t = {lift= Deferred.return}
+
+    let mock : Mock.t = {lift= Fn.id}
+  end
+
+  module Impl (M : Monad_fail.S) = struct
+    let lift_reason_validation_to_errors ~(env : Env.T(M).t) t =
+      Result.map_error t ~f:(fun reasons ->
+          Errors.create (`Operations_not_valid reasons) )
+      |> env.lift
+
+    let handle ~(env : Env.T(M).t) (req : Construction_payloads_request.t) =
+      let open M.Let_syntax in
+      let%bind metadata =
+        match req.metadata with
+        | Some json ->
+            Metadata_data.of_json json |> env.lift
+        | None ->
+            M.fail
+              (Errors.create
+                 ~context:"Metadata is required for payloads request"
+                 (`Json_parse None))
+      in
+      let%bind partial_user_command =
+        User_command_info.of_operations req.operations
+        |> lift_reason_validation_to_errors ~env
+      in
+      let%bind pk =
+        let (`Pk pk) = partial_user_command.User_command_info.Partial.source in
+        Public_key.Compressed.of_base58_check pk
+        |> Result.map_error ~f:(fun _ ->
+               Errors.create ~context:"compression"
+                 `Public_key_format_not_valid )
+        |> Result.bind ~f:(fun pk ->
+               Result.of_option (Public_key.decompress pk)
+                 ~error:
+                   (Errors.create ~context:"decompression"
+                      `Public_key_format_not_valid) )
+        |> Result.map ~f:Public_key.Hex.encode
+        |> env.lift
+      in
+      let%bind user_command_payload =
+        User_command_info.Partial.to_user_command_payload ~nonce:metadata.nonce
+          partial_user_command
+        |> env.lift
+      in
+      let random_oracle_input = User_command.to_input user_command_payload in
+      let%map unsigned_transaction_string =
+        { Unsigned_transaction.random_oracle_input
+        ; command= partial_user_command
+        ; nonce= metadata.nonce }
+        |> Unsigned_transaction.render
+        |> Result.map ~f:Unsigned_transaction.Rendered.to_yojson
+        |> Result.map ~f:Yojson.Safe.to_string
+        |> env.lift
+      in
+      { Construction_payloads_response.unsigned_transaction=
+          unsigned_transaction_string
+      ; payloads=
+          [ { Signing_payload.address=
+                (let (`Pk pk) =
+                   partial_user_command.User_command_info.Partial.source
+                 in
+                 pk)
+            ; hex_bytes= pk
+            ; signature_type= Some "schnorr" } ] }
+  end
+
+  module Real = Impl (Deferred.Result)
+  module Mock = Impl (Result)
+end
+
 let router ~graphql_uri ~logger (route : string list) body =
   [%log debug] "Handling /construction/ $route"
     ~metadata:[("route", `List (List.map route ~f:(fun s -> `String s)))] ;
@@ -245,5 +337,15 @@ let router ~graphql_uri ~logger (route : string list) body =
         |> Errors.Lift.wrap
       in
       Construction_metadata_response.to_yojson res
+  | ["payloads"] ->
+      let%bind req =
+        Errors.Lift.parse ~context:"Request"
+        @@ Construction_payloads_request.of_yojson body
+        |> Errors.Lift.wrap
+      in
+      let%map res =
+        Payloads.Real.handle ~env:Payloads.Env.real req |> Errors.Lift.wrap
+      in
+      Construction_payloads_response.to_yojson res
   | _ ->
       Deferred.Result.fail `Page_not_found

--- a/src/app/rosetta/lib/errors.ml
+++ b/src/app/rosetta/lib/errors.ml
@@ -29,6 +29,7 @@ module Variant = struct
     | `Block_missing
     | `Malformed_public_key
     | `Operations_not_valid of Partial_reason.t list
+    | `Unsupported_operation_for_construction
     | `Public_key_format_not_valid ]
   [@@deriving yojson, show, eq, to_enum, to_representatives]
 end
@@ -85,6 +86,8 @@ end = struct
         "Cannot convert operations to valid transaction"
     | `Public_key_format_not_valid ->
         "Invalid public key format"
+    | `Unsupported_operation_for_construction ->
+        "Unsupported operation for construction"
 
   let context = function
     | `Sql msg ->
@@ -133,6 +136,8 @@ end = struct
              reasons)
     | `Public_key_format_not_valid ->
         None
+    | `Unsupported_operation_for_construction ->
+        None
 
   let retriable = function
     | `Sql _ ->
@@ -158,6 +163,8 @@ end = struct
     | `Operations_not_valid _ ->
         false
     | `Public_key_format_not_valid ->
+        false
+    | `Unsupported_operation_for_construction ->
         false
 
   let create ?context kind = {extra_context= context; kind}

--- a/src/app/rosetta/lib/unsigned_transaction.ml
+++ b/src/app/rosetta/lib/unsigned_transaction.ml
@@ -1,0 +1,68 @@
+open Core_kernel
+
+type t =
+  { random_oracle_input: (Snark_params.Tick0.field, bool) Random_oracle_input.t
+  ; command: User_command_info.Partial.t
+  ; nonce: Unsigned_extended.UInt32.t }
+
+module Rendered = struct
+  type public_key = string [@@deriving yojson]
+
+  module Payment = struct
+    type t =
+      { to_: public_key [@key "to"]
+      ; from: public_key
+      ; fee: Unsigned_extended.UInt64.t
+      ; nonce: Unsigned_extended.UInt32.t
+      ; memo: string option
+      ; valid_until: Unsigned_extended.UInt32.t option }
+    [@@deriving yojson]
+  end
+
+  module Delegation = struct
+    type t = Todo [@@deriving yojson]
+  end
+
+  type t =
+    { random_oracle_input: string (* serialize |> to_hex *)
+          [@key "randomOracleInput"]
+    ; payment: Payment.t option
+    ; stake_delegation: Delegation.t option [@key "stakeDelegation"] }
+  [@@deriving yojson]
+end
+
+let string_of_field field =
+  assert (Snark_params.Tick.Field.size_in_bits = 255) ;
+  Snark_params.Tick.Field.unpack field
+  |> Random_oracle_input.Coding.string_of_field
+
+let field_of_string s =
+  assert (Snark_params.Tick.Field.size_in_bits = 255) ;
+  Random_oracle_input.Coding.field_of_string s ~size_in_bits:255
+  |> Result.map ~f:(fun bits -> Snark_params.Tick.Field.project bits)
+
+let render (t : t) =
+  let open User_command_info.Partial in
+  let un_pk (`Pk pk) = pk in
+  let random_oracle_input =
+    Random_oracle_input.Coding.serialize ~string_of_field ~to_bool:Fn.id
+      ~of_bool:Fn.id t.random_oracle_input
+  in
+  match t.command.kind with
+  | `Payment ->
+      let payment =
+        { Rendered.Payment.to_= un_pk t.command.receiver
+        ; from= un_pk t.command.source
+        ; fee= t.command.fee
+        ; nonce= t.nonce
+        ; memo= None
+        ; valid_until= None }
+      in
+      Result.return
+        { Rendered.random_oracle_input
+        ; payment= Some payment
+        ; stake_delegation= None }
+  | _ ->
+      Result.fail
+        (Errors.create ~context:"Unsigned transaction rendering"
+           `Unsupported_operation_for_construction)

--- a/src/app/rosetta/lib/user_command_info.ml
+++ b/src/app/rosetta/lib/user_command_info.ml
@@ -1,5 +1,17 @@
 open Core_kernel
+module Fee_currency = Currency.Fee
+module Amount_currency = Currency.Amount
 open Models
+module User_command = Coda_base.User_command
+module Token_id = Coda_base.Token_id
+module Public_key = Signature_lib.Public_key
+module User_command_memo = Coda_base.User_command_memo
+module Payment_payload = Coda_base.Payment_payload
+
+let pk_to_public_key ~context (`Pk pk) =
+  Public_key.Compressed.of_base58_check pk
+  |> Result.map_error ~f:(fun _ ->
+         Errors.create ~context `Public_key_format_not_valid )
 
 let account_id (`Pk pk) token_id =
   { Account_identifier.address= pk
@@ -79,6 +91,46 @@ module Partial = struct
   [@@deriving to_yojson, sexp, compare]
 
   module Reason = Errors.Partial_reason
+
+  let to_user_command_payload :
+         t
+      -> nonce:Unsigned_extended.UInt32.t
+      -> (User_command.Payload.t, Errors.t) Result.t =
+   fun t ~nonce ->
+    let open Result.Let_syntax in
+    let%bind fee_payer_pk =
+      pk_to_public_key ~context:"Fee payer" t.fee_payer
+    in
+    let%bind receiver_pk = pk_to_public_key ~context:"Receiver" t.receiver in
+    let%map body =
+      match t.kind with
+      | `Payment ->
+          let%bind source_pk = pk_to_public_key ~context:"Source" t.receiver in
+          let%map amount =
+            Result.of_option t.amount
+              ~error:
+                (Errors.create
+                   (`Operations_not_valid
+                     [Errors.Partial_reason.Amount_not_some]))
+          in
+          let payload =
+            { Payment_payload.Poly.source_pk
+            ; receiver_pk
+            ; token_id= Token_id.of_uint64 t.token
+            ; amount= Amount_currency.of_uint64 amount }
+          in
+          User_command.Payload.Body.Payment payload
+      | `Delegation ->
+          (* TODO: for #5666 *)
+          Result.fail (Errors.create `Unsupported_operation_for_construction)
+      | _ ->
+          Result.fail (Errors.create `Unsupported_operation_for_construction)
+    in
+    User_command.Payload.create
+      ~fee:(Fee_currency.of_uint64 t.fee)
+      ~fee_token:(Token_id.of_uint64 t.fee_token)
+      ~fee_payer_pk ~nonce ~body ~memo:User_command_memo.empty
+      ~valid_until:None
 end
 
 let forget (t : t) : Partial.t =

--- a/src/lib/coda_base/user_command.ml
+++ b/src/lib/coda_base/user_command.ml
@@ -169,7 +169,7 @@ module Gen = struct
     let payload : Payload.t =
       Payload.create ~fee ~fee_token
         ~fee_payer_pk:(Public_key.compress signer.public_key)
-        ~nonce ~valid_until:Global_slot.max_value
+        ~nonce ~valid_until:None
         ~memo:(User_command_memo.create_by_digesting_string_exn memo)
         ~body
     in
@@ -322,8 +322,7 @@ module Gen = struct
           let payload =
             let sender_pk = Public_key.compress sender_pk.public_key in
             Payload.create ~fee ~fee_token:Token_id.default
-              ~fee_payer_pk:sender_pk ~valid_until:Global_slot.max_value ~nonce
-              ~memo
+              ~fee_payer_pk:sender_pk ~valid_until:None ~nonce ~memo
               ~body:
                 (Payment
                    { source_pk= sender_pk

--- a/src/lib/coda_base/user_command_intf.ml
+++ b/src/lib/coda_base/user_command_intf.ml
@@ -72,14 +72,14 @@ module type Gen_intf = sig
       -> unit
       -> t Quickcheck.Generator.t
 
-    (** Generate a valid sequence of payments based on the initial state of a
-        ledger. Use this together with Ledger.gen_initial_ledger_state.
-    *)
     val sequence :
          ?length:int
       -> ?sign_type:[`Fake | `Real]
       -> (Signature_lib.Keypair.t * Currency.Amount.t * Account_nonce.t) array
       -> t list Quickcheck.Generator.t
+    (** Generate a valid sequence of payments based on the initial state of a
+        ledger. Use this together with Ledger.gen_initial_ledger_state.
+    *)
   end
 end
 
@@ -133,10 +133,14 @@ module type S = sig
 
   val next_available_token : t -> Token_id.t -> Token_id.t
 
+  val to_input :
+       User_command_payload.t
+    -> (Snark_params.Tick.field, bool) Random_oracle_input.t
+
+  val check_tokens : t -> bool
   (** Check that the command is used with compatible tokens. This check is fast
       and cheap, to be used for filtering.
   *)
-  val check_tokens : t -> bool
 
   include Gen_intf with type t := t
 
@@ -180,8 +184,8 @@ module type S = sig
 
   val check : t -> With_valid_signature.t option
 
-  (** Forget the signature check. *)
   val forget_check : With_valid_signature.t -> t
+  (** Forget the signature check. *)
 
   val accounts_accessed :
     next_available_token:Token_id.t -> t -> Account_id.t list

--- a/src/lib/coda_base/user_command_payload.ml
+++ b/src/lib/coda_base/user_command_payload.ml
@@ -315,7 +315,14 @@ module Stable = struct
 end]
 
 let create ~fee ~fee_token ~fee_payer_pk ~nonce ~valid_until ~memo ~body : t =
-  {common= {fee; fee_token; fee_payer_pk; nonce; valid_until; memo}; body}
+  { common=
+      { fee
+      ; fee_token
+      ; fee_payer_pk
+      ; nonce
+      ; valid_until= Option.value valid_until ~default:Global_slot.max_value
+      ; memo }
+  ; body }
 
 let fee (t : t) = t.common.fee
 

--- a/src/lib/coda_base/user_command_payload.mli
+++ b/src/lib/coda_base/user_command_payload.mli
@@ -138,7 +138,7 @@ val create :
   -> fee_token:Token_id.t
   -> fee_payer_pk:Public_key.Compressed.t
   -> nonce:Coda_numbers.Account_nonce.t
-  -> valid_until:Coda_numbers.Global_slot.t
+  -> valid_until:Coda_numbers.Global_slot.t option
   -> memo:User_command_memo.t
   -> body:Body.t
   -> t

--- a/src/lib/coda_graphql/coda_graphql.ml
+++ b/src/lib/coda_graphql/coda_graphql.ml
@@ -1983,8 +1983,7 @@ module Mutations = struct
     let open Result.Let_syntax in
     (* TODO: We should put a more sensible default here. *)
     let valid_until =
-      Option.value_map ~default:Coda_numbers.Global_slot.max_value
-        ~f:Coda_numbers.Global_slot.of_uint32 valid_until
+      Option.map ~f:Coda_numbers.Global_slot.of_uint32 valid_until
     in
     let%bind fee =
       result_of_exn Currency.Fee.of_uint64 fee

--- a/src/lib/network_pool/transaction_pool.ml
+++ b/src/lib/network_pool/transaction_pool.ml
@@ -1306,7 +1306,7 @@ let%test_module _ =
       @@ User_command.sign test_keys.(sender_idx)
            (User_command_payload.create ~fee:(Currency.Fee.of_int fee)
               ~fee_token:Token_id.default ~fee_payer_pk:(get_pk sender_idx)
-              ~valid_until:Coda_numbers.Global_slot.max_value
+              ~valid_until:None
               ~nonce:(Account.Nonce.of_int nonce)
               ~memo:(User_command_memo.create_by_digesting_string_exn "foo")
               ~body:

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2258,7 +2258,7 @@ let%test_module "transaction_snark" =
       let payload : User_command.Payload.t =
         User_command.Payload.create ~fee ~fee_token
           ~fee_payer_pk:(Account.public_key fee_payer.account)
-          ~nonce ~memo ~valid_until:Global_slot.max_value
+          ~nonce ~memo ~valid_until:None
           ~body:
             (Payment
                { source_pk
@@ -2913,8 +2913,7 @@ let%test_module "transaction_snark" =
       Account.create (Account_id.create pk token) (Balance.of_int balance)
 
     let test_user_command_with_accounts ~constraint_constants ~ledger ~accounts
-        ~signer ~fee ~fee_payer_pk ~fee_token ?memo
-        ?(valid_until = Global_slot.max_value) ?nonce body =
+        ~signer ~fee ~fee_payer_pk ~fee_token ?memo ?valid_until ?nonce body =
       let memo =
         match memo with
         | Some memo ->

--- a/src/lib/transition_frontier/frontier_base/breadcrumb.ml
+++ b/src/lib/transition_frontier/frontier_base/breadcrumb.ml
@@ -212,8 +212,7 @@ module For_tests = struct
         let sender_pk = Account.public_key sender_account in
         let payload : User_command.Payload.t =
           User_command.Payload.create ~fee:Fee.zero ~fee_token:Token_id.default
-            ~fee_payer_pk:sender_pk ~nonce
-            ~valid_until:Coda_numbers.Global_slot.max_value
+            ~fee_payer_pk:sender_pk ~nonce ~valid_until:None
             ~memo:User_command_memo.dummy
             ~body:
               (Payment

--- a/src/lib/user_command_input/user_command_input.ml
+++ b/src/lib/user_command_input/user_command_input.ml
@@ -118,6 +118,7 @@ let fee_payer ({payload; _} : t) = Payload.fee_payer payload
 
 let create ?nonce ~fee ~fee_token ~fee_payer_pk ~valid_until ~memo ~body
     ~signer ~sign_choice () : t =
+  let valid_until = Option.value valid_until ~default:Global_slot.max_value in
   let payload =
     Payload.create ~fee ~fee_token ~fee_payer_pk ?nonce ~valid_until ~memo
       ~body

--- a/src/lib/user_command_input/user_command_input.mli
+++ b/src/lib/user_command_input/user_command_input.mli
@@ -59,7 +59,7 @@ val create :
   -> fee:Currency.Fee.t
   -> fee_token:Token_id.t
   -> fee_payer_pk:Public_key.Compressed.t
-  -> valid_until:Global_slot.t
+  -> valid_until:Global_slot.t option
   -> memo:User_command_memo.t
   -> body:User_command_payload.Body.t
   -> signer:Public_key.Compressed.t


### PR DESCRIPTION
* Pushes valid_until optionality down one more layer so consumers don't
have to remember that Global_slot.max_value is semantically equivalent
to None
* Implements unsigned-txn-coding
* Implements payloads endpoint
* Not yet tested other than compilation; this will be tested as part of #5665

Fixes #5672 and #5673