### PR TITLE
String edit for tokens CLI output

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -567,7 +567,7 @@ let create_new_token_graphql =
                   ?memo ()))
              graphql_endpoint
          in
-         printf "Dispatched create new token command with ID %s\n"
+         printf "Dispatched create new token command with TRANSACTION_ID %s\n"
            ((response#createToken)#createNewToken)#id ))
 
 let create_new_account_graphql =
@@ -634,7 +634,7 @@ let create_new_account_graphql =
                   ?memo ()))
              graphql_endpoint
          in
-         printf "Dispatched create new token command with ID %s\n"
+         printf "Dispatched create new token account command with TRANSACTION_ID %s\n"
            ((response#createTokenAccount)#createNewTokenAccount)#id ))
 
 let mint_tokens_graphql =
@@ -676,7 +676,7 @@ let mint_tokens_graphql =
                   ?memo ()))
              graphql_endpoint
          in
-         printf "Dispatched create new token command with ID %s\n"
+         printf "Dispatched mint token command with TRANSACTION_ID %s\n"
            ((response#mintTokens)#mintTokens)#id ))
 
 let cancel_transaction_graphql =


### PR DESCRIPTION
Modifies the output given to the user when issuing the CLI commands for tokens.

Currently, the output for issuing a new command whether it is creating a token, creating a token account, or minting a token is:
`Dispatched create new token command with ID`

This can be confusing to the user as they can interpret the ID to be the token ID.

The following edits are suggested:

**Creating a new token:**
`Dispatched create new token command with TRANSACTION_ID`

**Creating a new token account:**
`Dispatched create new token account command with TRANSACTION_ID`

**Minting a token:**
`Dispatched mint token command with TRANSACTION_ID`