### PR TITLE
add apt update to archive node CI postgres setup script

### DIFF
--- a/buildkite/scripts/setup-database-for-archive-node.sh
+++ b/buildkite/scripts/setup-database-for-archive-node.sh
@@ -6,7 +6,7 @@ user=$1
 password=$2
 db=$3
 
-sudo apt-get install -y postgresql
+sudo apt-get update -y && sudo apt-get install -y postgresql
 sudo service postgresql start
 sudo -u postgres psql -c "CREATE USER ${user} WITH SUPERUSER PASSWORD '${password}';"
 sudo -u postgres createdb -O $user $db


### PR DESCRIPTION
Fix the following archive unit test failures in Buildkite CI by ensuring `apt` updates prior to the *postgres* package installation.

```

Err:9 http://security.debian.org/debian-security stretch/updates/main amd64 postgresql-client-9.6 amd64 9.6.17-0+deb9u1
--
  | 404  Not Found
  | Err:10 http://security.debian.org/debian-security stretch/updates/main amd64 postgresql-9.6 amd64 9.6.17-0+deb9u1
  | 404  Not Found
  | Get:11 http://deb.debian.org/debian stretch/main amd64 libwrap0 amd64 7.6.q-26 [58.2 kB]
  | Get:12 http://deb.debian.org/debian stretch/main amd64 locales all 2.24-11+deb9u4 [3289 kB]
  | Err:13 http://security.debian.org/debian-security stretch/updates/main amd64 postgresql-contrib-9.6 amd64 9.6.17-0+deb9u1
  | 404  Not Found
```

**Testing:** Buildkite CI

**Checklist:**

- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
