### PR TITLE
add skip dhall Base Cmd config property

### DIFF
--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -1,19 +1,24 @@
 -- Commands are the individual command steps that CI runs
 
 let Prelude = ../External/Prelude.dhall
+let B = ../External/Buildkite.dhall
+
+let Map = Prelude.Map
 let List/map = Prelude.List.map
 let List/concat = Prelude.List.concat
 let Optional/map = Prelude.Optional.map
 let Optional/toList = Prelude.Optional.toList
-let B = ../External/Buildkite.dhall
+
 let B/Plugins/Partial = B.definitions/commandStep/properties/plugins/Type
 -- Retry bits
 let B/ExitStatus = B.definitions/automaticRetry/properties/exit_status/Type
 let B/AutoRetryChunk = B.definitions/automaticRetry/Type.Type
 let B/Retry = B.definitions/commandStep/properties/retry/properties/automatic/Type
 let B/Manual = B.definitions/commandStep/properties/retry/properties/manual/Type
+
+-- Job requirement/flake mgmt bits
 let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
-let Map = Prelude.Map
+let B/Skip = B.definitions/commandStep/properties/skip/Type
 
 let Cmd = ../Lib/Cmds.dhall
 let Decorate = ../Lib/Decorate.dhall
@@ -91,6 +96,7 @@ let Config =
       , summon : Optional Summon.Type
       , retries : List Retry.Type
       , soft_fail : Optional B/SoftFail
+      , skip: Optional B/Skip
       }
   , default =
     { depends_on = [] : List TaggedKey.Type
@@ -100,6 +106,7 @@ let Config =
     , artifact_paths = [] : List SelectFiles.Type
     , retries = [] : List Retry.Type
     , soft_fail = None B/SoftFail
+    , skip = None B/Skip
     }
   }
 
@@ -165,6 +172,7 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
               manual = None B/Manual
           },
     soft_fail = c.soft_fail,
+    skip = c.skip,
     plugins =
       let dockerPart =
         Optional/toList

--- a/buildkite/src/Command/Base.dhall
+++ b/buildkite/src/Command/Base.dhall
@@ -208,5 +208,5 @@ let build : Config.Type -> B/Command.Type = \(c : Config.Type) ->
       if Prelude.List.null (Map.Entry Text Plugins) allPlugins then None B/Plugins else Some (B/Plugins.Plugins/Type allPlugins)
   }
 
-in {Config = Config, build = build, Type = B/Command.Type, TaggedKey = TaggedKey, SoftFail = B/SoftFail}
+in {Config = Config, build = build, Type = B/Command.Type, TaggedKey = TaggedKey}
 

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -2,6 +2,8 @@ let Prelude = ../../External/Prelude.dhall
 let B = ../../External/Buildkite.dhall
 
 let B/Skip = B.definitions/commandStep/properties/skip/Type
+let B/SoftFail = B.definitions/commandStep/properties/soft_fail/Type
+let B/SoftFail/ExitStatus = B.definitions/commandStep/properties/soft_fail/union/properties/exit_status/Type
 
 let S = ../../Lib/SelectFiles.dhall
 
@@ -38,6 +40,7 @@ Pipeline.build
           , label = "Fast lint steps; CODEOWNERs, RFCs, Check Snarky Submodule, Preprocessor Deps"
           , key = "lint"
           , target = Size.Small
+          , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = Some Docker::{ image = (../../Constants/ContainerImages.dhall).toolchainBase }
         },
       Command.build
@@ -48,7 +51,7 @@ Pipeline.build
           , label = "Optional fast lint steps; versions compatability changes"
           , key = "lint-optional-types"
           , target = Size.Medium
-          , soft_fail = Some (Command.SoftFail.Boolean True)
+          , soft_fail = Some (B/SoftFail.ListSoft_fail/Type [{ exit_status = Some (B/SoftFail/ExitStatus.Number 1) }])
           , docker = None Docker.Type
         },
       Command.build

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -44,7 +44,7 @@ Pipeline.build
         Command.Config::{
           commands = OpamInit.andThenRunInDocker
                           (["CI=false", "BASE_BRANCH_NAME=$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ])
-                          ("./scripts/compare_ci_diff_types.sh")
+                          ("exit 1 && ./scripts/compare_ci_diff_types.sh")
           , label = "Optional fast lint steps; versions compatability changes"
           , key = "lint-optional-types"
           , target = Size.Medium

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -43,7 +43,7 @@ Pipeline.build
       Command.build
         Command.Config::{
           commands = OpamInit.andThenRunInDocker
-                          (["CI=true", "BASE_BRANCH_NAME=$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ])
+                          (["CI=false", "BASE_BRANCH_NAME=$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ])
                           ("./scripts/compare_ci_diff_types.sh")
           , label = "Optional fast lint steps; versions compatability changes"
           , key = "lint-optional-types"

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -56,7 +56,7 @@ Pipeline.build
           , label = "Optional fast lint steps; binable compatability changes"
           , key = "lint-optional-binable"
           , target = Size.Medium
-          , soft_fail = Some (Command.SoftFail.Boolean True)
+          , skip = Some (Command.Skip.String "https://github.com/CodaProtocol/coda/pull/5748")
           , docker = None Docker.Type
         }
     ]

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -1,4 +1,7 @@
 let Prelude = ../../External/Prelude.dhall
+let B = ../../External/Buildkite.dhall
+
+let B/Skip = B.definitions/commandStep/properties/skip/Type
 
 let S = ../../Lib/SelectFiles.dhall
 
@@ -56,7 +59,7 @@ Pipeline.build
           , label = "Optional fast lint steps; binable compatability changes"
           , key = "lint-optional-binable"
           , target = Size.Medium
-          , skip = Some (Command.Skip.String "https://github.com/CodaProtocol/coda/pull/5748")
+          , skip = Some (B/Skip.String "https://github.com/CodaProtocol/coda/pull/5748")
           , docker = None Docker.Type
         }
     ]


### PR DESCRIPTION
Per #4991, add dhall bindings for Buildkite's command-step `skip` property. Technically, a combination of it, `soft_fail` and `retries` could serve as a basis for Buildkite's job requirement/flake management solution with the capability to develop further (e.g. add a soft-failure message property) in tandem w/ the BK community.

`skip` + `soft-fail` View in *Buildkite UI*:
![Screenshot from 2020-08-24 20-07-32](https://user-images.githubusercontent.com/49376577/91108239-7f3c1f80-e645-11ea-9303-ebfb5081abb4.png)


View in *Github UI* (notice *skips* are NOT shown):
![Screenshot from 2020-08-24 20-02-02](https://user-images.githubusercontent.com/49376577/91108052-e60d0900-e644-11ea-9c31-5e44ad847216.png)

*Dhall* usage:

```
steps = [
      Command.build
        Command.Config::{
          commands = commands
          , ...
          # execute Job and disregard all failure status codes re: REQUIRED checks
          , soft_fail = Some (B/SoftFail.Boolean True)
          , ...
        },
      Command.build
        Command.Config::{
          commands = commands
          , ...
          # execute Job and disregard failure re: REQUIRED checks if failure status code = 1 (setting)
          , soft_fail = Some (B/SoftFail.ListSoft_fail/Type [{ exit_status = Some (B/SoftFail/ExitStatus.Number 1) }])
          , ...
        },
      Command.build
        Command.Config::{
          commands = commands
          , ...
          # ALWAYS skip Job and display message in Buildkite UI under [hidden jobs]
          , skip = Some (B/Skip.String "https://github.com/CodaProtocol/coda/pull/5748")
          , ...
        }
    ]
```

**Buildkite CI:** [test run](https://buildkite.com/o-1-labs-2/coda/builds/1557#_)

**Checklist:**

- [x] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [x] All tests pass (CI will check this if you didn't)

Closes #4991 
