### PR TITLE
remove buildkite cmd soft-fail and skip examples from fast lint jobs

### DIFF
--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -50,6 +50,7 @@ Pipeline.build
           , label = "Optional fast lint steps; versions compatability changes"
           , key = "lint-optional-types"
           , target = Size.Medium
+          , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = None Docker.Type
         },
       Command.build
@@ -60,6 +61,7 @@ Pipeline.build
           , label = "Optional fast lint steps; binable compatability changes"
           , key = "lint-optional-binable"
           , target = Size.Medium
+          , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = None Docker.Type
         }
     ]

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -40,18 +40,16 @@ Pipeline.build
           , label = "Fast lint steps; CODEOWNERs, RFCs, Check Snarky Submodule, Preprocessor Deps"
           , key = "lint"
           , target = Size.Small
-          , soft_fail = Some (B/SoftFail.Boolean True)
           , docker = Some Docker::{ image = (../../Constants/ContainerImages.dhall).toolchainBase }
         },
       Command.build
         Command.Config::{
           commands = OpamInit.andThenRunInDocker
                           (["CI=false", "BASE_BRANCH_NAME=$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ])
-                          ("exit 1 && ./scripts/compare_ci_diff_types.sh")
+                          ("./scripts/compare_ci_diff_types.sh")
           , label = "Optional fast lint steps; versions compatability changes"
           , key = "lint-optional-types"
           , target = Size.Medium
-          , soft_fail = Some (B/SoftFail.ListSoft_fail/Type [{ exit_status = Some (B/SoftFail/ExitStatus.Number 1) }])
           , docker = None Docker.Type
         },
       Command.build
@@ -62,7 +60,6 @@ Pipeline.build
           , label = "Optional fast lint steps; binable compatability changes"
           , key = "lint-optional-binable"
           , target = Size.Medium
-          , skip = Some (B/Skip.String "https://github.com/CodaProtocol/coda/pull/5748")
           , docker = None Docker.Type
         }
     ]

--- a/buildkite/src/Jobs/Lint/Fast.dhall
+++ b/buildkite/src/Jobs/Lint/Fast.dhall
@@ -45,7 +45,7 @@ Pipeline.build
       Command.build
         Command.Config::{
           commands = OpamInit.andThenRunInDocker
-                          (["CI=false", "BASE_BRANCH_NAME=$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ])
+                          (["CI=true", "BASE_BRANCH_NAME=$BUILDKITE_PULL_REQUEST_BASE_BRANCH" ])
                           ("./scripts/compare_ci_diff_types.sh")
           , label = "Optional fast lint steps; versions compatability changes"
           , key = "lint-optional-types"

--- a/scripts/compare_ci_diff_binables.sh
+++ b/scripts/compare_ci_diff_binables.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+set -eo pipefail
+
 if [ ! "$CI" = "true" ] || [ ! -f /.dockerenv ]; then
     echo `basename $0` "can run only in Circle CI"
     exit 1
 fi
-
-set -e
 
 # cleanup if needed
 

--- a/scripts/compare_ci_diff_types.sh
+++ b/scripts/compare_ci_diff_types.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+set -eo pipefail
+
 if [ ! "$CI" = "true" ] || [ ! -f /.dockerenv ]; then
     echo `basename $0` "can run only in Circle CI"
     exit 1
 fi
-
-set -e
 
 # cleanup if needed
 
@@ -13,7 +13,6 @@ git clean -dfx
 rm -rf base
 
 # build print_versioned_types, then run Python script to compare versioned types in a pull request
-
 source ~/.profile && \
     (dune build --profile=dev src/external/ppx_version/src/print_versioned_types.exe) && \
     ./scripts/compare_pr_diff_types.py ${BASE_BRANCH_NAME:-develop}


### PR DESCRIPTION
Remove soft-fails and skips accidentally left within Fast Lint Buildkite jobs.

**Checklist:**

- [x] All tests pass (CI will check this if you didn't)