### PR TITLE
Simpler signature eq test

### DIFF
--- a/src/app/rosetta/test-agent/operation_expectation.ml
+++ b/src/app/rosetta/test-agent/operation_expectation.ml
@@ -1,7 +1,6 @@
 open Core_kernel
 open Rosetta_models
 open Rosetta_lib
-open Lib
 open Async
 
 module Reason = struct

--- a/src/app/rosetta/test-agent/signer.ml
+++ b/src/app/rosetta/test-agent/signer.ml
@@ -49,11 +49,9 @@ let sign ~(keys : Keys.t) ~unsigned_transaction_string =
   let signature =
     Schnorr.sign keys.keypair.private_key
       unsigned_transaction.random_oracle_input
-    |> Signature.Raw.encode
   in
   let signature' =
     User_command.sign_payload keys.keypair.private_key user_command_payload
-    |> Signature.Raw.encode
   in
-  [%test_eq: string] signature signature' ;
-  signature
+  [%test_eq: Signature.t] signature signature' ;
+  signature |> Signature.Raw.encode


### PR DESCRIPTION
Run `test_eq` directly of signatures produced for Rosetta, rather than comparing their hex encodings.

Also removed an unused `open Lib`.

Tested by running `rosetta/start.sh` (verifying that this code was being compiled by introducing an intentional compilation error). Test ran successfully.