### PR TITLE
[Release branch] Tokens CLI changes

### DIFF
--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -234,9 +234,8 @@ let generate_receipt =
       (required public_key_compressed)
   in
   let token_flag =
-    (*flag "token" ~doc:"TOKEN_ID The token ID for the account"
-      (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)*)
-    Command.Param.return Token_id.default
+    flag "token" ~doc:"TOKEN_ID The token ID for the account"
+      (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)
   in
   Command.async ~summary:"Generate a receipt for a sent payment"
     (Cli_lib.Background_daemon.rpc_init
@@ -281,9 +280,8 @@ let verify_receipt =
       (required public_key_compressed)
   in
   let token_flag =
-    (*flag "token" ~doc:"TOKEN_ID The token ID for the account"
-      (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)*)
-    Command.Param.return Token_id.default
+    flag "token" ~doc:"TOKEN_ID The token ID for the account"
+      (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)
   in
   Command.async ~summary:"Verify a receipt of a sent payment"
     (Cli_lib.Background_daemon.rpc_init
@@ -349,9 +347,8 @@ let get_nonce_cmd =
       (required Cli_lib.Arg_type.public_key_compressed)
   in
   let token_flag =
-    (*flag "token" ~doc:"TOKEN_ID The token ID for the account"
-      (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)*)
-    Command.Param.return Token_id.default
+    flag "token" ~doc:"TOKEN_ID The token ID for the account"
+      (optional_with_default Token_id.default Cli_lib.Arg_type.token_id)
   in
   let flags = Args.zip2 address_flag token_flag in
   Command.async ~summary:"Get the current nonce for an account"

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -19,10 +19,19 @@ module Get_tracked_account =
 {|
 query ($public_key: PublicKey, $token: UInt64) {
   account(publicKey: $public_key, token: $token) {
-    public_key: publicKey @bsDecoder(fn: "Decoders.public_key")
     balance {
       total @bsDecoder(fn: "Decoders.balance")
     }
+  }
+}
+|}]
+
+module Get_all_accounts =
+[%graphql
+{|
+query ($public_key: PublicKey) {
+  accounts(publicKey: $public_key) {
+    token @bsDecoder(fn: "Decoders.token")
   }
 }
 |}]

--- a/src/app/cli/src/init/graphql_queries.ml
+++ b/src/app/cli/src/init/graphql_queries.ml
@@ -17,8 +17,8 @@ query {
 module Get_tracked_account =
 [%graphql
 {|
-query ($public_key: PublicKey) {
-  account(publicKey: $public_key) {
+query ($public_key: PublicKey, $token: UInt64) {
+  account(publicKey: $public_key, token: $token) {
     public_key: publicKey @bsDecoder(fn: "Decoders.public_key")
     balance {
       total @bsDecoder(fn: "Decoders.balance")


### PR DESCRIPTION
This is #5787 rebased onto the release branch. We want the `get-tokens` command for release so that users can access the token ID from the CLI when they create a new token.

> This PR
> * enables the token flag for receipt chain and nonce commands
> * adds the token flag to `get-balance`     
> * we only use the `coda` description for the default token (we use `coda+` in rosetta for other tokens, but it reads less well without capitalisation here)
> * adds the command `get-tokens`, to list all of the tokens associated with the give public key.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: