### PR TITLE
Nits in server config to get rosetta-cli started

### DIFF
--- a/src/app/rosetta/lib/network.ml
+++ b/src/app/rosetta/lib/network.ml
@@ -438,7 +438,7 @@ module Options = struct
           ~network_identifier:network.network_identifier
       in
       { Network_options_response.version=
-          Version.create "1.4.1" (Option.value ~default:"unknown" res#version)
+          Version.create "1.4.2" (Option.value ~default:"unknown" res#version)
       ; allow=
           { Allow.operation_statuses= Lazy.force Operation_statuses.all
           ; operation_types= Lazy.force Operation_types.all

--- a/src/app/rosetta/lib/rosetta.ml
+++ b/src/app/rosetta/lib/rosetta.ml
@@ -17,7 +17,7 @@ let router ~graphql_uri ~db ~logger route body =
   | _ ->
       Deferred.return (Error `Page_not_found)
 
-let server_handler ~db ~graphql_uri ~logger ~body _ req =
+let server_handler ~db ~graphql_uri ~logger ~body _sock req =
   let uri = Cohttp_async.Request.uri req in
   let%bind body = Cohttp_async.Body.to_string body in
   let route = List.tl_exn (String.split ~on:'/' (Uri.path uri)) in
@@ -32,13 +32,15 @@ let server_handler ~db ~graphql_uri ~logger ~body _ req =
           (`Json_parse (Some err))
         |> Deferred.Result.fail |> Errors.Lift.wrap
   in
+  let lift x = `Response x in
   match result with
   | Ok json ->
       Cohttp_async.Server.respond_string
         (Yojson.Safe.to_string json)
         ~headers:(Cohttp.Header.of_list [("Content-Type", "application/json")])
+      >>| lift
   | Error `Page_not_found ->
-      Cohttp_async.Server.respond (Cohttp.Code.status_of_code 404)
+      Cohttp_async.Server.respond (Cohttp.Code.status_of_code 404) >>| lift
   | Error (`App app_error) ->
       let error = Errors.erase app_error in
       let metadata = [("error", Rosetta_models.Error.to_yojson error)] in
@@ -47,6 +49,7 @@ let server_handler ~db ~graphql_uri ~logger ~body _ req =
         ~status:(Cohttp.Code.status_of_code 500)
         (Yojson.Safe.to_string (Rosetta_models.Error.to_yojson error))
         ~headers:(Cohttp.Header.of_list [("Content-Type", "application/json")])
+      >>| lift
 
 let command =
   let open Command.Let_syntax in
@@ -75,7 +78,15 @@ let command =
         Deferred.unit
     | Ok db ->
         let%bind server =
-          Cohttp_async.Server.create ~on_handler_error:`Raise
+          Cohttp_async.Server.create_expert ~max_connections:128
+            ~on_handler_error:
+              (`Call
+                (fun _net exn ->
+                  [%log error]
+                    "Exception while handling Rosetta server request: $error"
+                    ~metadata:
+                      [ ("error", `String (Exn.to_string_mach exn))
+                      ; ("context", `String "rest_server") ] ))
             (Async.Tcp.Where_to_listen.bind_to All_addresses (On_port port))
             (server_handler ~db ~graphql_uri ~logger)
         in

--- a/src/app/rosetta/rosetta.conf
+++ b/src/app/rosetta/rosetta.conf
@@ -1,0 +1,106 @@
+{
+ "network": {
+  "blockchain": "coda",
+  "network": "debug"
+ },
+ "online_url": "http://localhost:3087",
+ "data_directory": "",
+ "http_timeout": 10,
+ "sync_concurrency": 8,
+ "transaction_concurrency": 16,
+ "tip_delay": 300,
+ "disable_memory_limit": false,
+ "log_configuration": false,
+ "construction": {
+  "offline_url": "http://localhost:3087",
+  "currency": {
+   "symbol": "CODA",
+   "decimals": 9
+  },
+  "minimum_balance": "150000000",
+  "maximum_fee": "50000000000",
+  "curve_type": "tweedle",
+  "accounting_model": "account",
+  "scenario": [
+  {
+    "operation_identifier": {
+     "index": 0
+    },
+    "type": "fee_payer_dec",
+    "status": "",
+    "account": {
+     "address": "{{ SENDER }}",
+     "metadata": { "token_id": "1" }
+    },
+    "amount": {
+     "value": "-{{ FEE_VALUE }}",
+     "currency": {"symbol": "CODA", "decimals": 9 }
+    }
+
+  },
+   {
+    "operation_identifier": {
+     "index": 1
+    },
+    "type": "payment_source_dec",
+    "status": "",
+    "account": {
+     "address": "{{ SENDER }}",
+     "metadata": { "token_id": "1" }
+    },
+    "amount": {
+     "value": "-{{ SENDER_VALUE }}",
+     "currency": {"symbol": "CODA", "decimals": 9 }
+    }
+   },
+   {
+    "operation_identifier": {
+     "index": 2
+    },
+    "related_operations": [
+     {
+      "index": 1
+     }
+    ],
+    "type": "payment_receiver_inc",
+    "status": "",
+    "account": {
+     "address": "{{ RECIPIENT }}"
+    },
+    "amount": {
+     "value": "{{ RECIPIENT_VALUE }}",
+     "currency": null
+    }
+   }
+  ],
+  "confirmation_depth": 10,
+  "stale_depth": 30,
+  "broadcast_limit": 3,
+  "ignore_broadcast_failures": false,
+  "change_scenario": null,
+  "clear_broadcasts": false,
+  "broadcast_behind_tip": false,
+  "block_broadcast_limit": 5,
+  "rebroadcast_all": false,
+  "new_account_probability": 0.5,
+  "max_addresses": 200
+ },
+ "data": {
+  "active_reconciliation_concurrency": 16,
+  "inactive_reconciliation_concurrency": 4,
+  "inactive_reconciliation_frequency": 250,
+  "log_blocks": false,
+  "log_transactions": false,
+  "log_balance_changes": false,
+  "log_reconciliations": false,
+  "ignore_reconciliation_error": false,
+  "exempt_accounts": "",
+  "bootstrap_balances": "",
+  "historical_balance_disabled": true,
+  "interesting_accounts": "",
+  "reconciliation_disabled": false,
+  "inactive_discrepency_search_disabled": false,
+  "balance_tracking_disabled": false,
+  "coin_tracking_disabled": false
+ }
+}

--- a/src/lib/rosetta_lib/errors.ml
+++ b/src/lib/rosetta_lib/errors.ml
@@ -184,7 +184,7 @@ end = struct
     ; details=
         ( match (context t.kind, t.extra_context) with
         | None, None ->
-            Some (Variant.to_yojson t.kind)
+            Some (`Assoc [("body", Variant.to_yojson t.kind)])
         | None, Some context | Some context, None ->
             Some
               (`Assoc


### PR DESCRIPTION
* Version number bumped
* Server more robust to disconnecting clients
* Errors has consistent schema for languages lacking sum types
* Adds rosetta.conf

From the CodaProtocol/rosetta-cli fork:

`rosetta-cli --configuration-file rosetta.conf check:data`
deterministically fails after having made it through some initial validation