### PR TITLE
Serves genesis block from /block

### DIFF
--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -3,10 +3,22 @@ open Async
 open Rosetta_lib
 open Rosetta_models
 
-module Get_coinbase =
+module Get_coinbase_and_genesis =
 [%graphql
 {|
   query {
+    genesisBlock {
+      creatorAccount {
+        publicKey @bsDecoder(fn: "Decoders.public_key")
+      }
+      protocolState {
+        previousStateHash
+        blockchainState {
+          utcDate
+        }
+      }
+      stateHash
+    }
     daemonStatus {
       peers
     }
@@ -33,6 +45,17 @@ module Block_query = struct
           M.return (Some (`That (`Hash hash)))
       | Some index, Some hash ->
           M.return (Some (`Those (`Height index, `Hash hash)))
+
+    let is_genesis ~hash = function
+      | Some (`This (`Height index)) ->
+          Int64.equal index Network.genesis_block_height
+      | Some (`That (`Hash hash')) ->
+          String.equal hash hash'
+      | Some (`Those (`Height index, `Hash hash')) ->
+          Int64.equal index Network.genesis_block_height
+          && String.equal hash hash'
+      | None ->
+          false
   end
 end
 
@@ -457,7 +480,9 @@ module Specific = struct
         -> graphql_uri:Uri.t
         -> 'gql Real.t =
      fun ~logger ~db ~graphql_uri ->
-      { gql= (fun () -> Graphql.query (Get_coinbase.make ()) graphql_uri)
+      { gql=
+          (fun () ->
+            Graphql.query (Get_coinbase_and_genesis.make ()) graphql_uri )
       ; logger
       ; db_block=
           (fun query ->
@@ -471,6 +496,11 @@ module Specific = struct
           (fun () ->
             Result.return
             @@ object
+                 method genesisBlock =
+                   object
+                     method stateHash = "STATE_HASH_GENESIS"
+                   end
+
                  method genesisConstants =
                    object
                      method coinbase = Unsigned.UInt64.of_int 20_000_000_000
@@ -498,8 +528,25 @@ module Specific = struct
         env.validate_network_choice ~network_identifier:req.network_identifier
           ~gql_response:res
       in
+      let genesisBlock = res#genesisBlock in
+      let%map block_info =
+        if Query.is_genesis ~hash:genesisBlock#stateHash query then
+          M.return
+            { Block_info.block_identifier=
+                { Block_identifier.index= Network.genesis_block_height
+                ; hash= genesisBlock#stateHash }
+            ; parent_block_identifier=
+                { Block_identifier.index= Int64.zero
+                ; hash= (genesisBlock#protocolState)#previousStateHash }
+            ; creator= `Pk (genesisBlock#creatorAccount)#publicKey
+            ; timestamp=
+                Int64.of_string
+                  ((genesisBlock#protocolState)#blockchainState)#utcDate
+            ; internal_info= []
+            ; user_commands= [] }
+        else env.db_block query
+      in
       let coinbase = (res#genesisConstants)#coinbase in
-      let%map block_info = env.db_block query in
       { Block_response.block=
           Some
             { Block.block_identifier= block_info.block_identifier

--- a/src/app/rosetta/lib/decoders.ml
+++ b/src/app/rosetta/lib/decoders.ml
@@ -4,4 +4,6 @@ let uint64 json = Yojson.Basic.Util.to_string json |> Unsigned.UInt64.of_string
 
 let uint32 json = Yojson.Basic.Util.to_string json |> Unsigned.UInt32.of_string
 
+let public_key json = Yojson.Basic.Util.to_string json
+
 let optional_uint32 json = optional ~f:uint32 json

--- a/src/app/rosetta/lib/network.ml
+++ b/src/app/rosetta/lib/network.ml
@@ -3,6 +3,9 @@ open Async
 open Rosetta_lib
 open Rosetta_models
 
+(* TODO: Also change this to zero when #5361 finishes *)
+let genesis_block_height = Int64.one
+
 module Get_status =
 [%graphql
 {|
@@ -280,8 +283,7 @@ module Status = struct
       ; current_block_timestamp=
           ((latest_block#protocolState)#blockchainState)#utcDate
       ; genesis_block_identifier=
-          (* TODO: Also change this to zero when #5361 finishes *)
-          Block_identifier.create Int64.one genesis_block_state_hash
+          Block_identifier.create genesis_block_height genesis_block_state_hash
       ; oldest_block_identifier=
           ( if String.equal (snd oldest_block) genesis_block_state_hash then
             None


### PR DESCRIPTION
Test-agent still passes, and rosetta-cli can `view:block 1` successfully
now.

Fixes #5559