### PR TITLE
Add create token to Rosetta test agent

### DIFF
--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -200,13 +200,15 @@ let _ =
          | Ok
              { random_oracle_input= _
              ; payment= Some payment
-             ; stake_delegation= None } ->
+             ; stake_delegation= None
+             ; create_token= None } ->
              let command = Transaction.Unsigned.of_rendered_payment payment in
              make_signed_transaction command payment.nonce
          | Ok
              { random_oracle_input= _
              ; payment= None
-             ; stake_delegation= Some delegation } ->
+             ; stake_delegation= Some delegation
+             ; create_token= None } ->
              let command =
                Transaction.Unsigned.of_rendered_delegation delegation
              in

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -56,6 +56,24 @@ mutation ($sender: PublicKey!,
 }
 |}]
 
+module Send_create_token =
+[%graphql
+{|
+mutation ($sender: PublicKey,
+          $receiver: PublicKey!,
+          $fee: UInt64!,
+          $nonce: UInt32,
+          $memo: String,
+          $signature: String!) {
+  createToken(signature: {rawSignature: $signature}, input:
+    {feePayer: $sender, tokenOwner: $receiver, fee: $fee, nonce: $nonce, memo: $memo}) {
+    createNewToken {
+      hash
+    }
+  }
+}
+|}]
+
 module Options = struct
   type t = {sender: Public_key.Compressed.t; token_id: Unsigned.UInt64.t}
 
@@ -515,7 +533,7 @@ end
 module Submit = struct
   module Env = struct
     module T (M : Monad_fail.S) = struct
-      type ('gql_payment, 'gql_delegation) t =
+      type ('gql_payment, 'gql_delegation, 'gql_create_token) t =
         { gql_payment:
                payment:Transaction.Unsigned.Rendered.Payment.t
             -> signature:string
@@ -527,13 +545,20 @@ module Submit = struct
             -> signature:string
             -> unit
             -> ('gql_delegation, Errors.t) M.t
+        ; gql_create_token:
+               create_token:Transaction.Unsigned.Rendered.Create_token.t
+            -> signature:string
+            -> unit
+            -> ('gql_create_token, Errors.t) M.t
         ; lift: 'a 'e. ('a, 'e) Result.t -> ('a, 'e) M.t }
     end
 
     module Real = T (Deferred.Result)
     module Mock = T (Result)
 
-    let real : graphql_uri:Uri.t -> ('gql_payment, 'gql_delegation) Real.t =
+    let real :
+           graphql_uri:Uri.t
+        -> ('gql_payment, 'gql_delegation, 'gql_create_token) Real.t =
       let uint64 x = `String (Unsigned.UInt64.to_string x) in
       let uint32 x = `String (Unsigned.UInt32.to_string x) in
       fun ~graphql_uri ->
@@ -558,11 +583,21 @@ module Submit = struct
                    ?memo:delegation.memo ~nonce:(uint32 delegation.nonce)
                    ~signature ())
                 graphql_uri )
+        ; gql_create_token=
+            (fun ~create_token ~signature () ->
+              Graphql.query
+                (Send_create_token.make
+                   ~receiver:(`String create_token.receiver)
+                   ~fee:(uint64 create_token.fee) ?memo:create_token.memo
+                   ~nonce:(uint32 create_token.nonce)
+                   ~signature ())
+                graphql_uri )
         ; lift= Deferred.return }
   end
 
   module Impl (M : Monad_fail.S) = struct
-    let handle ~(env : ('gql_payment, 'gql_delegation) Env.T(M).t)
+    let handle
+        ~(env : ('gql_payment, 'gql_delegation, 'gql_create_token) Env.T(M).t)
         (req : Construction_submit_request.t) =
       let open M.Let_syntax in
       let%bind json =
@@ -577,26 +612,35 @@ module Submit = struct
       let open M.Let_syntax in
       let%map hash =
         match
-          (signed_transaction.payment, signed_transaction.stake_delegation)
+          ( signed_transaction.payment
+          , signed_transaction.stake_delegation
+          , signed_transaction.create_token )
         with
-        | Some payment, None ->
+        | Some payment, None, None ->
             let%map res =
               env.gql_payment ~payment ~signature:signed_transaction.signature
                 ()
             in
             let (`UserCommand payment) = (res#sendPayment)#payment in
             payment#hash
-        | None, Some delegation ->
+        | None, Some delegation, None ->
             let%map res =
               env.gql_delegation ~delegation
                 ~signature:signed_transaction.signature ()
             in
             let (`UserCommand delegation) = (res#sendDelegation)#delegation in
             delegation#hash
+        | None, None, Some create_token ->
+            let%map res =
+              env.gql_create_token ~create_token
+                ~signature:signed_transaction.signature ()
+            in
+            ((res#createToken)#createNewToken)#hash
         | _ ->
             M.fail
               (Errors.create
-                 ~context:"Must have one of payment or stakeDelegation"
+                 ~context:
+                   "Must have one of payment, stakeDelegation, or createToken"
                  (`Json_parse None))
       in
       { Construction_submit_response.transaction_identifier=

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -207,6 +207,32 @@ let direct_graphql_delegation_through_block ~logger ~rosetta_uri ~graphql_uri
           ; _type= "delegate_change"
           ; target= Some other_pk } ]
 
+let direct_graphql_create_token_through_block ~logger ~rosetta_uri ~graphql_uri
+    ~network_response =
+  let open Deferred.Result.Let_syntax in
+  (* Unlock the sender account *)
+  let%bind _ = Poke.Account.unlock ~graphql_uri in
+  (* create token *)
+  let%bind hash =
+    Poke.SendTransaction.create_token ~fee:(`Int 2_000_000_000)
+      ~receiver:(`String other_pk) ~graphql_uri ()
+  in
+  verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri ~txn_hash:hash
+    ~network_response
+    ~operation_expectations:
+      Operation_expectation.
+        [ { amount= Some (-2_000_000_000)
+          ; account=
+              Some {Account.pk= Poke.pk; token_id= Unsigned.UInt64.of_int 1}
+          ; status= "Pending"
+          ; _type= "fee_payer_dec"
+          ; target= None }
+        ; { amount= None
+          ; account= None
+          ; status= "Pending"
+          ; _type= "create_token"
+          ; target= None } ]
+
 let construction_api_transaction_through_mempool ~logger ~rosetta_uri
     ~graphql_uri ~network_response ~operation_expectations ~operations =
   let open Deferred.Result.Let_syntax in
@@ -340,6 +366,25 @@ let construction_api_delegation_through_mempool =
           ; _type= "delegate_change"
           ; target= Some other_pk } ]
 
+let construction_api_create_token_through_mempool =
+  construction_api_transaction_through_mempool
+    ~operations:(fun address ->
+      Poke.SendTransaction.create_token_operations ~sender:address
+        ~fee:(Unsigned.UInt64.of_int 5_000_000_000) )
+    ~operation_expectations:
+      Operation_expectation.
+        [ { amount= Some (-5_000_000_000)
+          ; account=
+              Some {Account.pk= Poke.pk; token_id= Unsigned.UInt64.of_int 1}
+          ; status= "Pending"
+          ; _type= "fee_payer_dec"
+          ; target= None }
+        ; { amount= None
+          ; account= None
+          ; status= "Pending"
+          ; _type= "create_token"
+          ; target= None } ]
+
 (* for each possible user command, run the command via GraphQL, check that
     the command is in the transaction pool
 *)
@@ -385,7 +430,7 @@ let check_new_account_user_commands ~logger ~rosetta_uri ~graphql_uri =
       ~network_response
   in
   [%log info] "Created construction payment and waited" ;
-  (* Stop staking so we can rely on things being in the mempool again *)
+  (* Stop staking *)
   let%bind _res = Poke.Staking.disable ~graphql_uri in
   let%bind () =
     direct_graphql_delegation_through_block ~logger ~rosetta_uri ~graphql_uri
@@ -399,6 +444,18 @@ let check_new_account_user_commands ~logger ~rosetta_uri ~graphql_uri =
       ~graphql_uri ~network_response
   in
   [%log info] "Created construction delegation and waited" ;
+  (* Stop staking *)
+  let%bind _res = Poke.Staking.disable ~graphql_uri in
+  let%bind () =
+    direct_graphql_create_token_through_block ~logger ~rosetta_uri ~graphql_uri
+      ~network_response
+  in
+  [%log info] "Created token via graphql and waited" ;
+  let%bind () =
+    construction_api_create_token_through_mempool ~logger ~rosetta_uri
+      ~graphql_uri ~network_response
+  in
+  [%log info] "Created token using construction and waited" ;
   (* Succeed! (for now) *)
   return ()
 

--- a/src/app/rosetta/test-agent/operation_expectation.ml
+++ b/src/app/rosetta/test-agent/operation_expectation.ml
@@ -16,7 +16,7 @@ module Reason = struct
 end
 
 module Account = struct
-  type t = {pk: string; token_id: Unsigned.UInt64.t}
+  type t = {pk: string; token_id: Unsigned.UInt64.t} [@@deriving show]
 end
 
 type t =
@@ -25,6 +25,7 @@ type t =
   ; status: string
   ; _type: string
   ; target: string option }
+[@@deriving show]
 
 (** Returns a validation of the reasons it is not similar or unit if it is *)
 let similar ~logger:_ t (op : Operation.t) =
@@ -41,10 +42,10 @@ let similar ~logger:_ t (op : Operation.t) =
         fail err
   in
   let test b err = if b then return () else fail err in
-  let%map _ =
+  let%map () =
     opt_eq t.amount op.amount ~err:Amount ~f:(fun x y ->
         test String.(equal (string_of_int x) y.Amount.value) Amount )
-  and _ =
+  and () =
     opt_eq t.account op.account ~err:Account ~f:(fun x y ->
         let%map _ =
           test
@@ -60,15 +61,15 @@ let similar ~logger:_ t (op : Operation.t) =
               fail Account_token_id
         in
         () )
-  and _ = test String.(equal t.status op.status) Status
-  and _ =
+  and () = test String.(equal t.status op.status) Status
+  and () =
     opt_eq t.target op.metadata ~err:Target ~f:(fun target metadata ->
         match metadata with
         | `Assoc [("delegate_change_target", `String y)] ->
             test String.(equal y target) Target
         | _ ->
             fail Target )
-  and _ = test String.(equal t._type op._type) Type in
+  and () = test String.(equal t._type op._type) Type in
   ()
 
 (** Result of the first expected operation that is wrong. Shows the "closest"

--- a/src/lib/rosetta_lib/transaction.ml
+++ b/src/lib/rosetta_lib/transaction.ml
@@ -54,11 +54,25 @@ module Unsigned = struct
       [@@deriving yojson]
     end
 
+    module Create_token = struct
+      type public_key = string [@@deriving yojson]
+
+      type t =
+        { receiver: public_key
+        ; disable_new_accounts: bool
+        ; fee: Unsigned_extended.UInt64.t
+        ; nonce: Unsigned_extended.UInt32.t
+        ; memo: string option
+        ; valid_until: Unsigned_extended.UInt32.t option }
+      [@@deriving yojson]
+    end
+
     type t =
       { random_oracle_input: string (* serialize |> to_hex *)
             [@key "randomOracleInput"]
       ; payment: Payment.t option
-      ; stake_delegation: Delegation.t option [@key "stakeDelegation"] }
+      ; stake_delegation: Delegation.t option [@key "stakeDelegation"]
+      ; create_token: Create_token.t option [@key "createToken"] }
     [@@deriving yojson]
   end
 
@@ -106,6 +120,16 @@ module Unsigned = struct
           ; valid_until= None }
         in
         Result.return (`Delegation delegation)
+    | `Create_token ->
+        let create_token =
+          { Rendered.Create_token.receiver= un_pk command.receiver
+          ; disable_new_accounts= false
+          ; fee= command.fee
+          ; nonce
+          ; memo= None
+          ; valid_until= None }
+        in
+        Result.return (`Create_token create_token)
     | _ ->
         Result.fail
           (Errors.create ~context:"Unsigned transaction rendering"
@@ -121,11 +145,18 @@ module Unsigned = struct
     | `Payment payment ->
         { Rendered.random_oracle_input
         ; payment= Some payment
-        ; stake_delegation= None }
+        ; stake_delegation= None
+        ; create_token= None }
     | `Delegation delegation ->
         { Rendered.random_oracle_input
         ; payment= None
-        ; stake_delegation= Some delegation }
+        ; stake_delegation= Some delegation
+        ; create_token= None }
+    | `Create_token create_token ->
+        { Rendered.random_oracle_input
+        ; payment= None
+        ; stake_delegation= None
+        ; create_token= Some create_token }
 
   let of_rendered_payment (r : Rendered.Payment.t) :
       User_command_info.Partial.t =
@@ -143,7 +174,18 @@ module Unsigned = struct
     { User_command_info.Partial.receiver= `Pk r.new_delegate
     ; source= `Pk r.delegator
     ; kind= `Delegation
-    ; fee_payer= `Pk r.delegator (* TODO: reviewer, please check! *)
+    ; fee_payer= `Pk r.delegator
+    ; fee_token= Coda_base.Token_id.(default |> to_uint64)
+    ; token= Coda_base.Token_id.(default |> to_uint64)
+    ; fee= r.fee
+    ; amount= None }
+
+  let of_rendered_create_token (r : Rendered.Create_token.t) :
+      User_command_info.Partial.t =
+    { User_command_info.Partial.receiver= `Pk r.receiver
+    ; source= `Pk r.receiver
+    ; kind= `Create_token
+    ; fee_payer= `Pk r.receiver (* TODO: reviewer, please check! *)
     ; fee_token= Coda_base.Token_id.(default |> to_uint64)
     ; token= Coda_base.Token_id.(default |> to_uint64)
     ; fee= r.fee
@@ -168,17 +210,22 @@ module Unsigned = struct
                     parse_context)
                (`Json_parse None) )
     in
-    match (r.payment, r.stake_delegation) with
-    | Some payment, None ->
+    match (r.payment, r.stake_delegation, r.create_token) with
+    | Some payment, None, None ->
         Result.return
           { command= of_rendered_payment payment
           ; random_oracle_input
           ; nonce= payment.nonce }
-    | None, Some delegation ->
+    | None, Some delegation, None ->
         Result.return
           { command= of_rendered_delegation delegation
           ; random_oracle_input
           ; nonce= delegation.nonce }
+    | None, None, Some create_token ->
+        Result.return
+          { command= of_rendered_create_token create_token
+          ; random_oracle_input
+          ; nonce= create_token.nonce }
     | _ ->
         Result.fail
           (Errors.create ~context:"Unsigned transaction un-rendering"
@@ -195,7 +242,8 @@ module Signed = struct
     type t =
       { signature: string
       ; payment: Unsigned.Rendered.Payment.t option
-      ; stake_delegation: Unsigned.Rendered.Delegation.t option }
+      ; stake_delegation: Unsigned.Rendered.Delegation.t option
+      ; create_token: Unsigned.Rendered.Create_token.t option }
     [@@deriving yojson]
   end
 
@@ -205,23 +253,35 @@ module Signed = struct
     | `Payment payment ->
         { Rendered.signature= t.signature
         ; payment= Some payment
-        ; stake_delegation= None }
+        ; stake_delegation= None
+        ; create_token= None }
     | `Delegation delegation ->
         { Rendered.signature= t.signature
         ; payment= None
-        ; stake_delegation= Some delegation }
+        ; stake_delegation= Some delegation
+        ; create_token= None }
+    | `Create_token create_token ->
+        { Rendered.signature= t.signature
+        ; payment= None
+        ; stake_delegation= None
+        ; create_token= Some create_token }
 
   let of_rendered (r : Rendered.t) : (t, Errors.t) Result.t =
-    match (r.payment, r.stake_delegation) with
-    | Some payment, None ->
+    match (r.payment, r.stake_delegation, r.create_token) with
+    | Some payment, None, None ->
         Result.return
           { command= Unsigned.of_rendered_payment payment
           ; nonce= payment.nonce
           ; signature= r.signature }
-    | None, Some delegation ->
+    | None, Some delegation, None ->
         Result.return
           { command= Unsigned.of_rendered_delegation delegation
           ; nonce= delegation.nonce
+          ; signature= r.signature }
+    | None, None, Some create_token ->
+        Result.return
+          { command= Unsigned.of_rendered_create_token create_token
+          ; nonce= create_token.nonce
           ; signature= r.signature }
     | _ ->
         Result.fail


### PR DESCRIPTION
Add `create token` to Rosetta test agent.

`src/app/rosetta/start.sh` passes locally with these changes.

Implements more of #5817; TODO: `create token account`, `mint tokens`.