### PR TITLE
Signature deriver for ppx_register_event

### DIFF
--- a/src/lib/bootstrap_controller/bootstrap_controller.mli
+++ b/src/lib/bootstrap_controller/bootstrap_controller.mli
@@ -3,6 +3,9 @@ open Coda_transition
 open Pipe_lib
 open Network_peer
 
+type Structured_log_events.t += Bootstrap_complete
+  [@@deriving register_event]
+
 val run :
      logger:Logger.t
   -> trust_system:Trust_system.t

--- a/src/lib/coda_lib/coda_lib.mli
+++ b/src/lib/coda_lib/coda_lib.mli
@@ -10,6 +10,15 @@ module Subscriptions = Coda_subscriptions
 
 type t
 
+type Structured_log_events.t +=
+  | Connecting
+  | Listening
+  | Bootstrapping
+  | Ledger_catchup
+  | Synced
+  | Rebroadcast_transition of {state_hash: State_hash.t}
+  [@@deriving register_event]
+
 exception Snark_worker_error of int
 
 exception Snark_worker_signal_interrupt of Signal.t

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -9,7 +9,7 @@ open Pipe_lib
 
 let refused_answer_query_string = "Refused to answer_query"
 
-type exn += No_initial_peers
+exception No_initial_peers
 
 type Structured_log_events.t +=
   | Block_received of {state_hash: State_hash.t; sender: Envelope.Sender.t}

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -8,6 +8,20 @@ open Network_peer
 
 exception No_initial_peers
 
+type Structured_log_events.t +=
+  | Block_received of {state_hash: State_hash.t; sender: Envelope.Sender.t}
+  | Snark_work_received of
+      { work: Snark_pool.Resource_pool.Diff.compact
+      ; sender: Envelope.Sender.t }
+  | Transactions_received of
+      { txns: Transaction_pool.Resource_pool.Diff.t
+      ; sender: Envelope.Sender.t }
+  | Gossip_new_state of {state_hash: State_hash.t}
+  | Gossip_transaction_pool_diff of
+      { txns: Transaction_pool.Resource_pool.Diff.t }
+  | Gossip_snark_pool_diff of {work: Snark_pool.Resource_pool.Diff.compact}
+  [@@deriving register_event]
+
 val refused_answer_query_string : string
 
 module Rpcs : sig

--- a/src/lib/ppx_register_event/register_event.ml
+++ b/src/lib/ppx_register_event/register_event.ml
@@ -183,6 +183,20 @@ let generate_loggers_and_parsers ~loc:_ ~path ty_ext msg_opt =
         Structured_log_events.register_constructor
           [%e evar (event_name ^ "_structured_events_repr")]] ]
 
+let generate_signature_items ~loc ~path:_ ty_ext =
+  List.concat_map ty_ext.ptyext_constructors ~f:(fun {pext_name; _} ->
+      let event_name = String.lowercase pext_name.txt in
+      let (module Ast_builder) = Ast_builder.make loc in
+      let open Ast_builder in
+      [ psig_value
+          (value_description
+             ~name:(Located.mk (event_name ^ "_structured_events_id"))
+             ~type_:[%type: Structured_log_events.id] ~prim:[])
+      ; psig_value
+          (value_description
+             ~name:(Located.mk (event_name ^ "_structured_events_repr"))
+             ~type_:[%type: Structured_log_events.repr] ~prim:[]) ] )
+
 let str_type_ext =
   let args =
     let open Ppxlib.Deriving.Args in
@@ -190,4 +204,9 @@ let str_type_ext =
   in
   Ppxlib.Deriving.Generator.make args generate_loggers_and_parsers
 
-let () = Ppxlib.Deriving.add deriver ~str_type_ext |> Ppxlib.Deriving.ignore
+let sig_type_ext =
+  Ppxlib.Deriving.Generator.make_noarg generate_signature_items
+
+let () =
+  Ppxlib.Deriving.add deriver ~str_type_ext ~sig_type_ext
+  |> Ppxlib.Deriving.ignore

--- a/src/lib/trust_system/peer_trust.ml
+++ b/src/lib/trust_system/peer_trust.ml
@@ -24,7 +24,7 @@ let max_rate secs =
 
 module type Input_intf = sig
   module Peer_id : sig
-    type t [@@deriving sexp, yojson]
+    type t [@@deriving sexp, to_yojson]
   end
 
   module Now : sig
@@ -42,37 +42,59 @@ module type Input_intf = sig
      and type config := Config.t
 
   module Action : Action_intf
+
+  type Structured_log_events.t +=
+    | Peer_banned of {peer_id: Peer_id.t; expiration: Time.t; action: string}
+    [@@deriving register_event]
 end
 
-module Make0 (Inputs : Input_intf) = struct
-  open Inputs
+module Peer_id = struct
+  include Unix.Inet_addr.Blocking_sexp
 
-  let ban_message =
-    if tmp_bans_are_disabled then
-      "Would ban peer $peer_id until $expiration due to $action, refusing due \
-       to trust system being disabled"
-    else "Banning peer $peer_id until $expiration due to $action"
+  let to_yojson x = `String (Unix.Inet_addr.to_string x)
 
+  let of_yojson = function
+    | `String addr ->
+        Result.return (Unix.Inet_addr.of_string addr)
+    | _ ->
+        Error "Trust_system.Peer_id.of_yojson"
+end
+
+module Time_with_json = struct
+  include Time
+
+  let to_yojson expiration =
+    `String (Time.to_string_abs expiration ~zone:Time.Zone.utc)
+
+  let of_yojson = function
+    | `String time ->
+        Ok
+          (Time.of_string_gen ~if_no_timezone:(`Use_this_one Time.Zone.utc)
+             time)
+    | _ ->
+        Error "Trust_system.Peer_trust: Could not parse time"
+end
+
+let ban_message =
+  if tmp_bans_are_disabled then
+    "Would ban peer $peer_id until $expiration due to $action, refusing due \
+     to trust system being disabled"
+  else "Banning peer $peer_id until $expiration due to $action"
+
+module Log_events = struct
   (* TODO: Split per action. *)
   type Structured_log_events.t +=
     | Peer_banned of
         { peer_id: Peer_id.t
-        ; expiration:
-            (Time.t[@to_yojson
-                     fun expiration ->
-                       `String
-                         (Time.to_string_abs expiration ~zone:Time.Zone.utc)]
-                   [@of_yojson
-                     function
-                     | `String time ->
-                         Ok
-                           (Time.of_string_gen
-                              ~if_no_timezone:(`Use_this_one Time.Zone.utc)
-                              time)
-                     | _ ->
-                         Error "Trust_system.Peer_trust: Could not parse time"])
+        ; expiration: Time_with_json.t
         ; action: string }
     [@@deriving register_event {msg= ban_message}]
+end
+
+include Log_events
+
+module Make0 (Inputs : Input_intf) = struct
+  open Inputs
 
   type t =
     { db: Db.t option
@@ -234,6 +256,13 @@ let%test_module "peer_trust" =
       module Config = Unit
       module Db = Db
       module Action = Action
+
+      type Structured_log_events.t +=
+        | Peer_banned of
+            { peer_id: Peer_id.t
+            ; expiration: Time_with_json.t
+            ; action: string }
+        [@@deriving register_event {msg= "Peer banned"}]
     end)
 
     (* We want to check the output of the pipe in these tests, but it's
@@ -407,17 +436,7 @@ let%test_module "peer_trust" =
   end )
 
 module Make (Action : Action_intf) = Make0 (struct
-  module Peer_id = struct
-    include Unix.Inet_addr.Blocking_sexp
-
-    let to_yojson x = `String (Unix.Inet_addr.to_string x)
-
-    let of_yojson = function
-      | `String addr ->
-          Result.return (Unix.Inet_addr.of_string addr)
-      | _ ->
-          Error "Trust_system.Peer_id.of_yojson"
-  end
+  module Peer_id = Peer_id
 
   module Now = struct
     let now = Time.now
@@ -427,4 +446,5 @@ module Make (Action : Action_intf) = Make0 (struct
   module Db =
     Rocksdb.Serializable.Make (Unix.Inet_addr.Blocking_sexp) (Record.Stable.V1)
   module Action = Action
+  include Log_events
 end)

--- a/src/lib/trust_system/peer_trust.mli
+++ b/src/lib/trust_system/peer_trust.mli
@@ -36,6 +36,13 @@ end
     peer does no good things) in actions/second. *)
 val max_rate : float -> float
 
+type Structured_log_events.t +=
+  | Peer_banned of
+      { peer_id: Unix.Inet_addr.t
+      ; expiration: Time.t
+      ; action: string }
+  [@@deriving register_event]
+
 (* FIXME The parameter docs don't render :( *)
 
 (** Instantiate the module.


### PR DESCRIPTION
This PR
* adds a signature deriver for `ppx_structure_event`
* uses it to expose the structured events and their associated derived values where they were hidden by signatures.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: