### PR TITLE
Add create token account to Rosetta test agent

### DIFF
--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -201,14 +201,16 @@ let _ =
              { random_oracle_input= _
              ; payment= Some payment
              ; stake_delegation= None
-             ; create_token= None } ->
+             ; create_token= None
+             ; create_token_account= None } ->
              let command = Transaction.Unsigned.of_rendered_payment payment in
              make_signed_transaction command payment.nonce
          | Ok
              { random_oracle_input= _
              ; payment= None
              ; stake_delegation= Some delegation
-             ; create_token= None } ->
+             ; create_token= None
+             ; create_token_account= None } ->
              let command =
                Transaction.Unsigned.of_rendered_delegation delegation
              in

--- a/src/app/rosetta/lib/block.ml
+++ b/src/app/rosetta/lib/block.ml
@@ -374,7 +374,8 @@ SELECT b.id, b.state_hash, b.parent_id, b.creator_id, b.snarked_ledger_hash_id, 
             | "create_token" ->
                 M.return `Create_token
             | "create_account" ->
-                M.return `Create_account
+                (* N.B.: not create_token_account *)
+                M.return `Create_token_account
             | "mint_tokens" ->
                 M.return `Mint_tokens
             | other ->

--- a/src/app/rosetta/lib/construction.ml
+++ b/src/app/rosetta/lib/construction.ml
@@ -74,6 +74,27 @@ mutation ($sender: PublicKey,
 }
 |}]
 
+module Send_create_token_account =
+[%graphql
+{|
+mutation ($sender: PublicKey,
+          $tokenOwner: PublicKey!,
+          $receiver: PublicKey!,
+          $token: TokenId!,
+          $fee: UInt64!,
+          $nonce: UInt32,
+          $memo: String,
+          $signature: String!
+) {
+  createTokenAccount(signature: {rawSignature: $signature}, input:
+    {feePayer: $sender, tokenOwner: $tokenOwner, receiver: $receiver, token: $token, fee: $fee, nonce: $nonce, memo: $memo}) {
+    createNewTokenAccount {
+      hash
+    }
+  }
+}
+|}]
+
 module Options = struct
   type t = {sender: Public_key.Compressed.t; token_id: Unsigned.UInt64.t}
 
@@ -533,7 +554,11 @@ end
 module Submit = struct
   module Env = struct
     module T (M : Monad_fail.S) = struct
-      type ('gql_payment, 'gql_delegation, 'gql_create_token) t =
+      type ( 'gql_payment
+           , 'gql_delegation
+           , 'gql_create_token
+           , 'gql_create_token_account )
+           t =
         { gql_payment:
                payment:Transaction.Unsigned.Rendered.Payment.t
             -> signature:string
@@ -550,6 +575,13 @@ module Submit = struct
             -> signature:string
             -> unit
             -> ('gql_create_token, Errors.t) M.t
+        ; gql_create_token_account:
+               create_token_account:Transaction.Unsigned.Rendered
+                                    .Create_token_account
+                                    .t
+            -> signature:string
+            -> unit
+            -> ('gql_create_token_account, Errors.t) M.t
         ; lift: 'a 'e. ('a, 'e) Result.t -> ('a, 'e) M.t }
     end
 
@@ -558,9 +590,14 @@ module Submit = struct
 
     let real :
            graphql_uri:Uri.t
-        -> ('gql_payment, 'gql_delegation, 'gql_create_token) Real.t =
+        -> ( 'gql_payment
+           , 'gql_delegation
+           , 'gql_create_token
+           , 'gql_create_token_account )
+           Real.t =
       let uint64 x = `String (Unsigned.UInt64.to_string x) in
       let uint32 x = `String (Unsigned.UInt32.to_string x) in
+      let token_id x = `String (Coda_base.Token_id.to_string x) in
       fun ~graphql_uri ->
         { gql_payment=
             (fun ~payment ~signature () ->
@@ -592,13 +629,29 @@ module Submit = struct
                    ~nonce:(uint32 create_token.nonce)
                    ~signature ())
                 graphql_uri )
+        ; gql_create_token_account=
+            (fun ~create_token_account ~signature () ->
+              Graphql.query
+                (Send_create_token_account.make
+                   ~tokenOwner:(`String create_token_account.token_owner)
+                   ~receiver:(`String create_token_account.receiver)
+                   ~token:(token_id create_token_account.token)
+                   ~fee:(uint64 create_token_account.fee)
+                   ?memo:create_token_account.memo
+                   ~nonce:(uint32 create_token_account.nonce)
+                   ~signature ())
+                graphql_uri )
         ; lift= Deferred.return }
   end
 
   module Impl (M : Monad_fail.S) = struct
     let handle
-        ~(env : ('gql_payment, 'gql_delegation, 'gql_create_token) Env.T(M).t)
-        (req : Construction_submit_request.t) =
+        ~(env :
+           ( 'gql_payment
+           , 'gql_delegation
+           , 'gql_create_token
+           , 'gql_create_token_account )
+           Env.T(M).t) (req : Construction_submit_request.t) =
       let open M.Let_syntax in
       let%bind json =
         try M.return (Yojson.Safe.from_string req.signed_transaction)
@@ -614,33 +667,41 @@ module Submit = struct
         match
           ( signed_transaction.payment
           , signed_transaction.stake_delegation
-          , signed_transaction.create_token )
+          , signed_transaction.create_token
+          , signed_transaction.create_token_account )
         with
-        | Some payment, None, None ->
+        | Some payment, None, None, None ->
             let%map res =
               env.gql_payment ~payment ~signature:signed_transaction.signature
                 ()
             in
             let (`UserCommand payment) = (res#sendPayment)#payment in
             payment#hash
-        | None, Some delegation, None ->
+        | None, Some delegation, None, None ->
             let%map res =
               env.gql_delegation ~delegation
                 ~signature:signed_transaction.signature ()
             in
             let (`UserCommand delegation) = (res#sendDelegation)#delegation in
             delegation#hash
-        | None, None, Some create_token ->
+        | None, None, Some create_token, None ->
             let%map res =
               env.gql_create_token ~create_token
                 ~signature:signed_transaction.signature ()
             in
             ((res#createToken)#createNewToken)#hash
+        | None, None, None, Some create_token_account ->
+            let%map res =
+              env.gql_create_token_account ~create_token_account
+                ~signature:signed_transaction.signature ()
+            in
+            ((res#createTokenAccount)#createNewTokenAccount)#hash
         | _ ->
             M.fail
               (Errors.create
                  ~context:
-                   "Must have one of payment, stakeDelegation, or createToken"
+                   "Must have one of payment, stakeDelegation, createToken, \
+                    or createTokenAccount"
                  (`Json_parse None))
       in
       { Construction_submit_response.transaction_identifier=

--- a/src/app/rosetta/lib/mempool.ml
+++ b/src/app/rosetta/lib/mempool.ml
@@ -157,7 +157,7 @@ module Transaction = struct
               `String "STAKE_DELEGATION"
           | `Create_token ->
               `String "CREATE_NEW_TOKEN"
-          | `Create_account ->
+          | `Create_token_account ->
               `String "CREATE_TOKEN_ACCOUNT"
           | `Mint_tokens ->
               `String "MINT_TOKENS"
@@ -230,7 +230,7 @@ module Transaction = struct
         | `String "CREATE_NEW_TOKEN" ->
             M.return `Create_token
         | `String "CREATE_TOKEN_ACCOUNT" ->
-            M.return `Create_account
+            M.return `Create_token_account
         | `String "MINT_TOKENS" ->
             M.return `Mint_tokens
         | kind ->

--- a/src/app/rosetta/test-agent/agent.ml
+++ b/src/app/rosetta/test-agent/agent.ml
@@ -233,6 +233,27 @@ let direct_graphql_create_token_through_block ~logger ~rosetta_uri ~graphql_uri
           ; _type= "create_token"
           ; target= None } ]
 
+let direct_graphql_create_token_account_through_block ~logger ~rosetta_uri
+    ~graphql_uri ~network_response =
+  let open Deferred.Result.Let_syntax in
+  (* Unlock the account *)
+  let%bind _ = Poke.Account.unlock ~graphql_uri in
+  (* Delegate stake *)
+  let%bind hash =
+    Poke.SendTransaction.create_token_account ~fee:(`Int 2_000_000_000)
+      ~receiver:other_pk ~token:(`String "42") ~graphql_uri ()
+  in
+  verify_in_mempool_and_block ~logger ~rosetta_uri ~graphql_uri ~txn_hash:hash
+    ~network_response
+    ~operation_expectations:
+      Operation_expectation.
+        [ { amount= Some (-2_000_000_000)
+          ; account=
+              Some {Account.pk= Poke.pk; token_id= Unsigned.UInt64.of_int 1}
+          ; status= "Pending"
+          ; _type= "fee_payer_dec"
+          ; target= None } ]
+
 let construction_api_transaction_through_mempool ~logger ~rosetta_uri
     ~graphql_uri ~network_response ~operation_expectations ~operations =
   let open Deferred.Result.Let_syntax in
@@ -385,6 +406,20 @@ let construction_api_create_token_through_mempool =
           ; _type= "create_token"
           ; target= None } ]
 
+let construction_api_create_token_account_through_mempool =
+  construction_api_transaction_through_mempool
+    ~operations:(fun address ->
+      Poke.SendTransaction.create_token_operations ~sender:address
+        ~fee:(Unsigned.UInt64.of_int 5_000_000_000) )
+    ~operation_expectations:
+      Operation_expectation.
+        [ { amount= Some (-5_000_000_000)
+          ; account=
+              Some {Account.pk= Poke.pk; token_id= Unsigned.UInt64.of_int 1}
+          ; status= "Pending"
+          ; _type= "fee_payer_dec"
+          ; target= None } ]
+
 (* for each possible user command, run the command via GraphQL, check that
     the command is in the transaction pool
 *)
@@ -456,6 +491,18 @@ let check_new_account_user_commands ~logger ~rosetta_uri ~graphql_uri =
       ~graphql_uri ~network_response
   in
   [%log info] "Created token using construction and waited" ;
+  (* Stop staking *)
+  let%bind _res = Poke.Staking.disable ~graphql_uri in
+  let%bind () =
+    direct_graphql_create_token_account_through_block ~logger ~rosetta_uri
+      ~graphql_uri ~network_response
+  in
+  [%log info] "Created token account and waited" ;
+  let%bind () =
+    construction_api_create_token_account_through_mempool ~logger ~rosetta_uri
+      ~graphql_uri ~network_response
+  in
+  [%log info] "Created token account using construction and waited" ;
   (* Succeed! (for now) *)
   return ()
 

--- a/src/app/rosetta/test-agent/poke.ml
+++ b/src/app/rosetta/test-agent/poke.ml
@@ -176,4 +176,44 @@ module SendTransaction = struct
     let json = Yojson.Safe.from_string operations in
     [%of_yojson: Rosetta_models.Operation.t list] json
     |> Result.ok |> Option.value_exn
+
+  module Create_token_account =
+  [%graphql
+  {|
+  mutation ($sender: PublicKey,
+            $tokenOwner: PublicKey!,
+            $receiver: PublicKey!,
+            $token: TokenId!,
+            $fee: UInt64!) {
+    createTokenAccount(input:
+       {feePayer: $sender, tokenOwner: $tokenOwner, receiver: $receiver, token: $token, fee: $fee}, signature: null) {
+         createNewTokenAccount {
+           hash
+         }
+       }
+     }
+   |}]
+
+  let create_token_account ~fee ~receiver ~token ~graphql_uri () =
+    let open Deferred.Result.Let_syntax in
+    let%map res =
+      Graphql.query
+        (Create_token_account.make ~sender:(`String pk)
+           ~receiver:(`String receiver) ~tokenOwner:(`String pk) ~token ~fee ())
+        graphql_uri
+    in
+    let cmd = (res#createTokenAccount)#createNewTokenAccount in
+    cmd#hash
+
+  let create_token_account_operations ~fee ~sender =
+    assert (String.equal sender pk) ;
+    let operations =
+      sprintf
+        {| [{"operation_identifier":{"index":0},"related_operations":[],"type":"fee_payer_dec","status":"Pending","account":{"address":"%s","metadata":{"token_id":"1"}},"amount":{"value":"-%s","currency":{"symbol":"CODA","decimals":9}}} |}
+        sender
+        (Unsigned.UInt64.to_string fee)
+    in
+    let json = Yojson.Safe.from_string operations in
+    [%of_yojson: Rosetta_models.Operation.t list] json
+    |> Result.ok |> Option.value_exn
 end

--- a/src/lib/rosetta_lib/user_command_info.ml
+++ b/src/lib/rosetta_lib/user_command_info.ml
@@ -62,7 +62,11 @@ end
 
 module Kind = struct
   type t =
-    [`Payment | `Delegation | `Create_token | `Create_account | `Mint_tokens]
+    [ `Payment
+    | `Delegation
+    | `Create_token
+    | `Create_token_account
+    | `Mint_tokens ]
   [@@deriving yojson, eq, sexp, compare]
 end
 
@@ -446,7 +450,7 @@ let to_operations ~failure_status (t : Partial.t) : Operation.t list =
         [{Op.label= `Delegate_change; related_to= None}]
     | `Create_token ->
         [{Op.label= `Create_token; related_to= None}]
-    | `Create_account ->
+    | `Create_token_account ->
         [] (* Covered by account creation fee *)
     | `Mint_tokens -> (
       (* When amount is not none, the amount goes to receiver's account *)
@@ -718,7 +722,7 @@ let dummies =
             (Account_creation_fees_paid.By_fee_payer
                (Unsigned.UInt64.of_int 3_000)))
     ; hash= "TXN_3b_HASH" }
-  ; { kind= `Create_account
+  ; { kind= `Create_token_account
     ; fee_payer= `Pk "Alice"
     ; source= `Pk "Alice"
     ; token= Unsigned.UInt64.of_int 1


### PR DESCRIPTION
Add user command `Create_token_account` to the Rosetta test agent.

Locally, ran `start.sh` successfully.

Implements part of #5817 (only `Mint_tokens` remains to do).