### PR TITLE
Log initialisation time when flaky tests are successful

### DIFF
--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -104,6 +104,7 @@ let stabalize_and_start_or_timeout ?(timeout_ms = 240000.) nodes =
     in
     go ()
   in
+  let before_time = Time.now () in
   match%bind
     Deferred.any
       [ (after (Time.Span.of_ms timeout_ms) >>= fun () -> return `Timeout)
@@ -112,6 +113,13 @@ let stabalize_and_start_or_timeout ?(timeout_ms = 240000.) nodes =
   | `Timeout ->
       failwith @@ sprintf "Nodes couldn't initialize within %f ms" timeout_ms
   | `Ready ->
+      let after_time = Time.now () in
+      [%log' info (Logger.create ())]
+        "Initialized nodes in $time_span_ms ms"
+        ~metadata:
+          [ ( "time_span_ms"
+            , `Float (Time.Span.to_ms (Time.abs_diff before_time after_time))
+            ) ] ;
       Deferred.List.iter nodes ~f:(fun node -> Coda_process.start_exn node)
 
 let spawn_local_processes_exn ?(first_delay = 0.0) configs =


### PR DESCRIPTION
Currently, it's hard to know whether flaky tests are failing because our timeout is too short, or whether the flakes are due to some other cause. This PR logs the initialisation time, so that we can rule out a too-short timeout, or bump the timeout if needed.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: