### PR TITLE
Add Mint_tokens user command to Rosetta test agent

### DIFF
--- a/src/app/client_sdk/client_sdk.ml
+++ b/src/app/client_sdk/client_sdk.ml
@@ -202,7 +202,8 @@ let _ =
              ; payment= Some payment
              ; stake_delegation= None
              ; create_token= None
-             ; create_token_account= None } ->
+             ; create_token_account= None
+             ; mint_tokens= None } ->
              let command = Transaction.Unsigned.of_rendered_payment payment in
              make_signed_transaction command payment.nonce
          | Ok
@@ -210,7 +211,8 @@ let _ =
              ; payment= None
              ; stake_delegation= Some delegation
              ; create_token= None
-             ; create_token_account= None } ->
+             ; create_token_account= None
+             ; mint_tokens= None } ->
              let command =
                Transaction.Unsigned.of_rendered_delegation delegation
              in

--- a/src/app/rosetta/test-agent/operation_expectation.ml
+++ b/src/app/rosetta/test-agent/operation_expectation.ml
@@ -65,7 +65,8 @@ let similar ~logger:_ t (op : Operation.t) =
   and () =
     opt_eq t.target op.metadata ~err:Target ~f:(fun target metadata ->
         match metadata with
-        | `Assoc [("delegate_change_target", `String y)] ->
+        | `Assoc [("delegate_change_target", `String y)]
+        | `Assoc [("token_owner_pk", `String y)] ->
             test String.(equal y target) Target
         | _ ->
             fail Target )

--- a/src/app/rosetta/test-agent/poke.ml
+++ b/src/app/rosetta/test-agent/poke.ml
@@ -216,4 +216,47 @@ module SendTransaction = struct
     let json = Yojson.Safe.from_string operations in
     [%of_yojson: Rosetta_models.Operation.t list] json
     |> Result.ok |> Option.value_exn
+
+  module Mint_tokens =
+  [%graphql
+  {|
+  mutation ($sender: PublicKey!,
+            $receiver: PublicKey,
+            $token: TokenId!,
+            $amount: UInt64!,
+            $fee: UInt64!) {
+    mintTokens(input: {tokenOwner: $sender, receiver: $receiver, token: $token, amount: $amount, fee: $fee},
+               signature: null) {
+        mintTokens {
+          hash
+        }
+      }
+    }
+  |}]
+
+  let mint_tokens ~fee ~receiver ~token ~amount ~graphql_uri () =
+    let open Deferred.Result.Let_syntax in
+    let%map res =
+      Graphql.query
+        (Mint_tokens.make ~sender:(`String pk) ~receiver:(`String receiver)
+           ~token ~amount ~fee ())
+        graphql_uri
+    in
+    let cmd = (res#mintTokens)#mintTokens in
+    cmd#hash
+
+  let mint_tokens_operations ~fee ~sender ~receiver ~amount =
+    assert (String.equal sender pk) ;
+    let operations =
+      sprintf
+        {| [{"operation_identifier":{"index":0},"related_operations":[],"type":"fee_payer_dec","status":"Pending","account":{"address":"%s","metadata":{"token_id":"1"}},"amount":{"value":"-%s","currency":{"symbol":"CODA","decimals":9}}},{"operation_identifier":{"index":1},"related_operations":[],"type":"mint_tokens","status":"Pending","account":{"address":"%s","metadata":{"token_id":"2"}},"amount":{"value":"%s","currency":{"symbol":"CODA+","decimals":9,"metadata":{"token_id":"2"}}}, "metadata": { "token_owner_pk": "%s"} } ] |}
+        sender
+        (Unsigned.UInt64.to_string fee)
+        receiver
+        (Unsigned.UInt64.to_string amount)
+        sender
+    in
+    let json = Yojson.Safe.from_string operations in
+    [%of_yojson: Rosetta_models.Operation.t list] json
+    |> Result.ok |> Option.value_exn
 end


### PR DESCRIPTION
Add `Mint_tokens` user command to Rosetta test agent.

Important change: for requests via the mempool, Rosetta was requesting nonces using a token id apparently from the receiver's account in the `operations` provided. Here, the token id used to get a nonce is always the default. There's a comment in the code, and the original code remains in a comment.

Also, the `Create_token_account` command was not being tested, added here.

`start.sh` sometimes fails with unexpected blocks with type `coinbase_inc`. That failure is not due to the added user command here. There is some nondeterminism that seems responsible for those errors.

Closes #5817.