### PR TITLE
[Release] Fix leaks in zexe rust bindings

### DIFF
--- a/src/cstubs_applicative.opam
+++ b/src/cstubs_applicative.opam
@@ -1,0 +1,23 @@
+opam-version: "2"
+name: "cstubs_applicative"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/CodaProtocol/coda"
+bug-reports: "https://github.com/CodaProtocol/coda/issues"
+dev-repo: "https://github.com/CodaProtocol/coda.git"
+license: "Apache"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "base"
+  "ctypes"
+  "dune"                {build & >= "2.0"}
+  "ppx_version"         {build}
+]
+synopsis: "Cstubs extended with applicative interface"
+description: "
+Cstubs interface with additional tooling and changes to support mapping over
+the results of bindings
+"
+

--- a/src/lib/cstubs_applicative/cstubs_applicative.ml
+++ b/src/lib/cstubs_applicative/cstubs_applicative.ml
@@ -1,0 +1,87 @@
+open Base
+include Cstubs
+
+module type Applicative_with_let = sig
+  include Applicative.S
+
+  include Applicative.Let_syntax with type 'a t := 'a t
+end
+
+module Make_applicative_with_let (X : Applicative.Basic) :
+  Applicative_with_let with type 'a t := 'a X.t = struct
+  module A = struct
+    type 'a t = unit
+
+    include Applicative.Make (X)
+  end
+
+  include A
+
+  include Applicative.Make_let_syntax
+            (A)
+            (struct
+              module type S = sig end
+            end)
+            ()
+end
+
+module Applicative_unit = Make_applicative_with_let (struct
+  type 'a t = unit
+
+  let apply () () = ()
+
+  let map = `Custom (fun () ~f:_ -> ())
+
+  let return _ = ()
+end)
+
+module Applicative_id = Make_applicative_with_let (struct
+  type 'a t = 'a result
+
+  let apply = Fn.id
+
+  let map = `Custom (fun x ~f -> f x)
+
+  let return = Fn.id
+end)
+
+module type Foreign_applicative = sig
+  include FOREIGN
+
+  include Applicative_with_let with type 'a t := 'a result
+end
+
+module type Bindings_with_applicative = functor
+  (F : Foreign_applicative with type 'a result = unit)
+  -> sig end
+
+module Make_applicative_unit (F : FOREIGN with type 'a result = unit) :
+  Foreign_applicative with type 'a result = unit = struct
+  include F
+  include Applicative_unit
+end
+
+module Make_applicative_id (F : FOREIGN with type 'a result = 'a) :
+  Foreign_applicative with type 'a result = 'a = struct
+  include F
+  include Applicative_id
+end
+
+module Make_cstubs_bindings
+    (B : Bindings_with_applicative)
+    (F : FOREIGN with type 'a result = unit) =
+  B (Make_applicative_unit (F))
+
+let make_bindings (module B : Bindings_with_applicative) =
+  (module Make_cstubs_bindings (B) : BINDINGS)
+
+let write_c ?concurrency ?errno fmt ~prefix b =
+  write_c ?concurrency ?errno fmt ~prefix (make_bindings b)
+
+let write_ml ?concurrency ?errno fmt ~prefix b =
+  write_ml ?concurrency ?errno fmt ~prefix (make_bindings b) ;
+  (* Append the applicative interface instance to the end of the file. *)
+  Stdlib.Format.fprintf fmt "%s@."
+    {ocaml|
+include Cstubs_applicative.Applicative_id
+|ocaml}

--- a/src/lib/cstubs_applicative/dune
+++ b/src/lib/cstubs_applicative/dune
@@ -1,0 +1,5 @@
+(library
+ (name cstubs_applicative)
+ (public_name cstubs_applicative)
+ (libraries base ctypes ctypes.stubs)
+ (preprocess (pps ppx_version)))

--- a/src/lib/zexe_backend/zexe_backend_common/dlog_based_proof.ml
+++ b/src/lib/zexe_backend/zexe_backend_common/dlog_based_proof.ml
@@ -76,27 +76,27 @@ module type Inputs_intf = sig
     type t
 
     val make :
-         Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
+         w:Scalar_field.Vector.t
+      -> za:Scalar_field.Vector.t
+      -> zb:Scalar_field.Vector.t
+      -> h1:Scalar_field.Vector.t
+      -> g1:Scalar_field.Vector.t
+      -> h2:Scalar_field.Vector.t
+      -> g2:Scalar_field.Vector.t
+      -> h3:Scalar_field.Vector.t
+      -> g3:Scalar_field.Vector.t
+      -> row_0:Scalar_field.Vector.t
+      -> row_1:Scalar_field.Vector.t
+      -> row_2:Scalar_field.Vector.t
+      -> col_0:Scalar_field.Vector.t
+      -> col_1:Scalar_field.Vector.t
+      -> col_2:Scalar_field.Vector.t
+      -> val_0:Scalar_field.Vector.t
+      -> val_1:Scalar_field.Vector.t
+      -> val_2:Scalar_field.Vector.t
+      -> rc_0:Scalar_field.Vector.t
+      -> rc_1:Scalar_field.Vector.t
+      -> rc_2:Scalar_field.Vector.t
       -> t
 
     val w : t -> Scalar_field.Vector.t
@@ -142,36 +142,36 @@ module type Inputs_intf = sig
     module Vector : Vector with type elt := t
 
     val make :
-         Scalar_field.Vector.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Poly_comm.Backend.t
-      -> Scalar_field.t
-      -> Scalar_field.t
-      -> Curve.Affine.Backend.Pair.Vector.t
-      -> Scalar_field.t
-      -> Scalar_field.t
-      -> Curve.Affine.Backend.t
-      -> Curve.Affine.Backend.t
-      -> Evaluations_backend.t
-      -> Evaluations_backend.t
-      -> Evaluations_backend.t
-      -> Scalar_field.Vector.t
-      -> Curve.Affine.Backend.Vector.t
+         primary_input:Scalar_field.Vector.t
+      -> w_comm:Poly_comm.Backend.t
+      -> za_comm:Poly_comm.Backend.t
+      -> zb_comm:Poly_comm.Backend.t
+      -> h1_comm:Poly_comm.Backend.t
+      -> g1_comm:Poly_comm.Backend.t
+      -> h2_comm:Poly_comm.Backend.t
+      -> g2_comm:Poly_comm.Backend.t
+      -> h3_comm:Poly_comm.Backend.t
+      -> g3_comm:Poly_comm.Backend.t
+      -> sigma2:Scalar_field.t
+      -> sigma3:Scalar_field.t
+      -> lr:Curve.Affine.Backend.Pair.Vector.t
+      -> z1:Scalar_field.t
+      -> z2:Scalar_field.t
+      -> delta:Curve.Affine.Backend.t
+      -> sg:Curve.Affine.Backend.t
+      -> evals0:Evaluations_backend.t
+      -> evals1:Evaluations_backend.t
+      -> evals2:Evaluations_backend.t
+      -> prev_challenges:Scalar_field.Vector.t
+      -> prev_sgs:Curve.Affine.Backend.Vector.t
       -> t
 
     val create :
-         Index.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Scalar_field.Vector.t
-      -> Curve.Affine.Backend.Vector.t
+         index:Index.t
+      -> primary_input:Scalar_field.Vector.t
+      -> auxiliary_input:Scalar_field.Vector.t
+      -> prev_challenges:Scalar_field.Vector.t
+      -> prev_sgs:Curve.Affine.Backend.Vector.t
       -> t
 
     val batch_verify : Verifier_index.t -> Vector.t -> bool


### PR DESCRIPTION
This PR updates the OCaml-rust bindings so that the OCaml garbage collector always calls the appropriate `delete` function when an object is freed. Zexe PR at o1-labs/zexe#24.

I have compiled this, but not tested it; any feedback from testing would be much appreciated.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: