### PR TITLE
The test-agent binary is no longer flaky

### DIFF
--- a/src/app/rosetta/rosetta.conf
+++ b/src/app/rosetta/rosetta.conf
@@ -5,85 +5,154 @@
  },
  "online_url": "http://localhost:3087",
  "data_directory": "",
- "http_timeout": 10,
+ "http_timeout": 500,
  "sync_concurrency": 8,
+ "retry_elapsed_time": 0,
  "transaction_concurrency": 16,
  "tip_delay": 300,
  "disable_memory_limit": false,
  "log_configuration": false,
  "construction": {
   "offline_url": "http://localhost:3087",
-  "currency": {
-   "symbol": "CODA",
-   "decimals": 9
-  },
-  "minimum_balance": "150000000",
-  "maximum_fee": "50000000000",
-  "curve_type": "tweedle",
-  "accounting_model": "account",
-  "scenario": [
-  {
-    "operation_identifier": {
-     "index": 0
-    },
-    "type": "fee_payer_dec",
-    "status": "",
-    "account": {
-     "address": "{{ SENDER }}",
-     "metadata": { "token_id": "1" }
-    },
-    "amount": {
-     "value": "-{{ FEE_VALUE }}",
-     "currency": {"symbol": "CODA", "decimals": 9 }
-    }
-
-  },
-   {
-    "operation_identifier": {
-     "index": 1
-    },
-    "type": "payment_source_dec",
-    "status": "",
-    "account": {
-     "address": "{{ SENDER }}",
-     "metadata": { "token_id": "1" }
-    },
-    "amount": {
-     "value": "-{{ SENDER_VALUE }}",
-     "currency": {"symbol": "CODA", "decimals": 9 }
-    }
-   },
-   {
-    "operation_identifier": {
-     "index": 2
-    },
-    "related_operations": [
-     {
-      "index": 1
-     }
-    ],
-    "type": "payment_receiver_inc",
-    "status": "",
-    "account": {
-     "address": "{{ RECIPIENT }}"
-    },
-    "amount": {
-     "value": "{{ RECIPIENT_VALUE }}",
-     "currency": null
-    }
-   }
-  ],
-  "confirmation_depth": 10,
-  "stale_depth": 30,
-  "broadcast_limit": 3,
+  "stale_depth": 0,
+  "broadcast_limit": 0,
   "ignore_broadcast_failures": false,
-  "change_scenario": null,
   "clear_broadcasts": false,
   "broadcast_behind_tip": false,
-  "block_broadcast_limit": 5,
+  "block_broadcast_limit": 0,
   "rebroadcast_all": false,
-  "new_account_probability": 0.5,
-  "max_addresses": 200
+  "workflows": [
+   {
+    "name": "request_funds",
+    "concurrency": 1,
+    "scenarios": [
+     {
+      "name": "find_address",
+      "actions": [
+       {
+        "input": "{\"symbol\":\"CODA\", \"decimals\":9}",
+        "type": "set_variable",
+        "output_path": "currency"
+       },
+       {
+        "input": "{\"minimum_balance\":{\"value\": \"0\", \"currency\": {{currency}}}, \"create_limit\":1}",
+        "type": "find_balance",
+        "output_path": "random_address"
+       }
+      ]
+     },
+     {
+      "name": "request",
+      "actions": [
+       {
+        "input": "{\"address\": {{random_address.account.address}}, \"minimum_balance\":{\"value\": \"10000000000000000\", \"currency\": {{currency}}}}",
+        "type": "find_balance",
+        "output_path": "loaded_address"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "name": "create_account",
+    "concurrency": 1,
+    "scenarios": [
+     {
+      "name": "create_account",
+      "actions": [
+       {
+        "input": "{\"network\":\"coda\", \"blockchain\":\"debug\"}",
+        "type": "set_variable",
+        "output_path": "network"
+       },
+       {
+        "input": "{\"curve_type\": \"secp256k1\"}",
+        "type": "generate_key",
+        "output_path": "key"
+       },
+       {
+        "input": "{\"network_identifier\": {{network}}, \"public_key\": {{key.public_key}}}",
+        "type": "derive",
+        "output_path": "address"
+       },
+       {
+        "input": "{\"address\": {{address.address}}, \"keypair\": {{key}}}",
+        "type": "save_address"
+       }
+      ]
+     }
+    ]
+   },
+   {
+    "name": "transfer",
+    "concurrency": 10,
+    "scenarios": [
+     {
+      "name": "transfer",
+      "actions": [
+       {
+        "input": "{\"network\":\"coda\", \"blockchain\":\"debug\"}",
+        "type": "set_variable",
+        "output_path": "transfer.network"
+       },
+       {
+        "input": "{\"symbol\":\"CODA\", \"decimals\":9}",
+        "type": "set_variable",
+        "output_path": "currency"
+       },
+       {
+        "input": "{\"minimum_balance\":{\"value\": \"10000000000000000\", \"currency\": {{currency}}}}",
+        "type": "find_balance",
+        "output_path": "sender"
+       },
+       {
+        "input": "\"42000000000000\"",
+        "type": "set_variable",
+        "output_path": "max_fee"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": {{sender.balance.value}}, \"right_value\": {{max_fee}}}",
+        "type": "math",
+        "output_path": "available_amount"
+       },
+       {
+        "input": "{\"minimum\": \"1\", \"maximum\": {{available_amount}}}",
+        "type": "random_number",
+        "output_path": "recipient_amount"
+       },
+       {
+        "input": "{\"recipient_amount\":{{recipient_amount}}}",
+        "type": "print_message"
+       },
+       {
+        "input": "{\"operation\":\"subtraction\", \"left_value\": \"0\", \"right_value\":{{recipient_amount}}}",
+        "type": "math",
+        "output_path": "sender_amount"
+       },
+       {
+        "input": "{\"not_address\":[{{sender.account.address}}], \"minimum_balance\":{\"value\": \"0\", \"currency\": {{currency}}}, \"create_limit\": 100, \"create_probability\": 50}",
+        "type": "find_balance",
+        "output_path": "recipient"
+       },
+       {
+        "input": "\"1\"",
+        "type": "set_variable",
+        "output_path": "transfer.confirmation_depth"
+       },
+       {
+        "input": "[{\"operation_identifier\":{\"index\":0},\"type\":\"transfer\",\"account\":{\"address\":{{sender.account.address}}},\"amount\":{\"value\":{{sender_amount}},\"currency\":{{currency}}}},{\"operation_identifier\":{\"index\":1},\"type\":\"transfer\",\"account\":{\"address\":{{recipient.account.address}}},\"amount\":{\"value\":{{recipient_amount}},\"currency\":{{currency}}}}]",
+        "type": "set_variable",
+        "output_path": "transfer.operations"
+       }
+      ]
+     }
+    ]
+   }
+  ],
+  "end_conditions": {
+   "create_account": 10,
+   "transfer": 10
+  }
  },
  "data": {
   "active_reconciliation_concurrency": 16,
@@ -101,6 +170,10 @@
   "reconciliation_disabled": false,
   "inactive_discrepency_search_disabled": false,
   "balance_tracking_disabled": false,
-  "coin_tracking_disabled": false
+  "coin_tracking_disabled": false,
+  "end_conditions": {
+   "reconciliation_coverage": 0.99
+  },
+  "results_output_file": ""
  }
 }


### PR DESCRIPTION
Plus rosetta.conf updated for new rosetta-cli

./start.sh succeeds and `./start.sh FOREVER` with rosetta-cli check:data
passes

Note: This means that rosetta-cli check:data succeeds for all types of
transactions in Coda. As the test-agent now performs every single
transaction on chain.