### PR TITLE
Prover and verifier in same process

### DIFF
--- a/src/lib/coda_lib/coda_lib.ml
+++ b/src/lib/coda_lib/coda_lib.ml
@@ -763,20 +763,37 @@ let create (config : Config.t) =
             >>| Result.ok_exn
           in
           let%bind verifier =
-            Monitor.try_with
-              ~rest:
-                (`Call
-                  (fun exn ->
-                    [%log' warn config.logger]
-                      "unhandled exception from daemon-side verifier server: \
-                       $exn"
-                      ~metadata:[("exn", `String (Exn.to_string_mach exn))] ))
-              (fun () ->
-                trace "verifier" (fun () ->
-                    Verifier.create ~logger:config.logger
-                      ~proof_level:config.precomputed_values.proof_level
-                      ~pids:config.pids ~conf_dir:(Some config.conf_dir) ) )
-            >>| Result.ok_exn
+            match
+              Type_equal.Id.same_witness Ledger_proof.id Ledger_proof.Prod.id
+            with
+            | Some T ->
+                Verifier.of_generic
+                  (object
+                     method verify_blockchain_snark chain =
+                       Prover.verify_blockchain_snark prover chain
+
+                     method verify_transaction_snarks
+                           (ts : (Ledger_proof.Prod.t * Sok_message.t) list) =
+                       Prover.verify_transaction_snarks prover ts
+                  end)
+                |> Deferred.return
+            | None ->
+                Monitor.try_with
+                  ~rest:
+                    (`Call
+                      (fun exn ->
+                        [%log' warn config.logger]
+                          "unhandled exception from daemon-side verifier \
+                           server: $exn"
+                          ~metadata:[("exn", `String (Exn.to_string_mach exn))]
+                        ))
+                  (fun () ->
+                    trace "verifier" (fun () ->
+                        Verifier.create ~logger:config.logger
+                          ~proof_level:config.precomputed_values.proof_level
+                          ~pids:config.pids ~conf_dir:(Some config.conf_dir) )
+                    )
+                >>| Result.ok_exn
           in
           let snark_worker =
             Option.value_map

--- a/src/lib/ledger_proof/ledger_proof.ml
+++ b/src/lib/ledger_proof/ledger_proof.ml
@@ -21,6 +21,9 @@ module Prod : Ledger_proof_intf.S with type t = Transaction_snark.t = struct
 
   type t = Stable.Latest.t [@@deriving compare, sexp, to_yojson]
 
+  let id : t Type_equal.Id.t =
+    Type_equal.Id.create ~name:"ledger-proof-prod" sexp_of_t
+
   let statement (t : t) = Transaction_snark.statement t
 
   let sok_digest = Transaction_snark.sok_digest
@@ -62,6 +65,9 @@ struct
   end]
 
   type t = Stable.Latest.t [@@deriving compare, sexp, yojson]
+
+  let id : t Type_equal.Id.t =
+    Type_equal.Id.create ~name:"ledger-proof-debug" sexp_of_t
 
   let statement ((t, _) : t) : Transaction_snark.Statement.t = t
 

--- a/src/lib/ledger_proof/ledger_proof_intf.ml
+++ b/src/lib/ledger_proof/ledger_proof_intf.ml
@@ -4,6 +4,8 @@ open Coda_base
 module type S = sig
   type t [@@deriving compare, sexp, to_yojson]
 
+  val id : t Type_equal.Id.t
+
   [%%versioned:
   module Stable : sig
     module V1 : sig

--- a/src/lib/prover/intf.ml
+++ b/src/lib/prover/intf.ml
@@ -43,4 +43,12 @@ module type S = sig
     -> Internal_transition.t
     -> Pending_coinbase_witness.t
     -> Proof.t Deferred.Or_error.t
+
+  val verify_blockchain_snark :
+    t -> Blockchain_snark.Blockchain.t -> bool Deferred.Or_error.t
+
+  val verify_transaction_snarks :
+       t
+    -> (Ledger_proof.Prod.t * Coda_base.Sok_message.t) list
+    -> bool Deferred.Or_error.t
 end

--- a/src/lib/verifier/dummy.ml
+++ b/src/lib/verifier/dummy.ml
@@ -26,3 +26,5 @@ let verify_transaction_snarks _ ts =
         let msg_digest = Sok_message.digest message in
         Coda_base.Sok_message.Digest.equal (snd proof) msg_digest )
   |> Deferred.Or_error.return
+
+let of_generic _ : t = ()

--- a/src/lib/verifier/generic.ml
+++ b/src/lib/verifier/generic.ml
@@ -1,0 +1,9 @@
+open Core_kernel
+open Async_kernel
+
+type 'ledger_proof t =
+  < verify_blockchain_snark:
+      Blockchain_snark.Blockchain.t -> bool Or_error.t Deferred.t
+  ; verify_transaction_snarks:
+         ('ledger_proof * Coda_base.Sok_message.t) list
+      -> bool Or_error.t Deferred.t >

--- a/src/lib/verifier/prod.ml
+++ b/src/lib/verifier/prod.ml
@@ -132,10 +132,15 @@ module Worker = struct
   include Rpc_parallel.Make (T)
 end
 
-type t = Worker.Connection.t
+type t =
+  < verify_blockchain_snark:
+      Blockchain_snark.Blockchain.t -> bool Or_error.t Deferred.t
+  ; verify_transaction_snarks:
+         (ledger_proof * Coda_base.Sok_message.t) list
+      -> bool Or_error.t Deferred.t >
 
 (* TODO: investigate why conf_dir wasn't being used *)
-let create ~logger ~proof_level ~pids ~conf_dir =
+let create ~logger ~proof_level ~pids ~conf_dir : t Deferred.t =
   let on_failure err =
     [%log error] "Verifier process failed with error $err"
       ~metadata:[("err", `String (Error.to_string_hum err))] ;
@@ -168,10 +173,21 @@ let create ~logger ~proof_level ~pids ~conf_dir =
          return
          @@ [%log error] "Verifier stderr: $stderr"
               ~metadata:[("stderr", `String stderr)] ) ;
-  connection
+  let res : t =
+    object
+      method verify_blockchain_snark chain =
+        Worker.Connection.run connection ~f:Worker.functions.verify_blockchain
+          ~arg:chain
 
-let verify_blockchain_snark t chain =
-  Worker.Connection.run t ~f:Worker.functions.verify_blockchain ~arg:chain
+      method verify_transaction_snarks ts =
+        Worker.Connection.run connection
+          ~f:Worker.functions.verify_transaction_snarks ~arg:ts
+    end
+  in
+  res
 
-let verify_transaction_snarks t ts =
-  Worker.Connection.run t ~f:Worker.functions.verify_transaction_snarks ~arg:ts
+let verify_blockchain_snark (t : t) chain = t#verify_blockchain_snark chain
+
+let verify_transaction_snarks (t : t) ts = t#verify_transaction_snarks ts
+
+let of_generic t : t = t

--- a/src/lib/verifier/verifier_intf.ml
+++ b/src/lib/verifier/verifier_intf.ml
@@ -14,6 +14,8 @@ module Base = struct
          t
       -> (ledger_proof * Coda_base.Sok_message.t) list
       -> bool Or_error.t Deferred.t
+
+    val of_generic : ledger_proof Generic.t -> t
   end
 end
 


### PR DESCRIPTION
This makes it so that for proof level = full, both prover and verifier are in the same process. This should solve an issue we're seeing in QA nets where the verifier and prover run at the same time and end up exceeding CPU limits as a result.