### PR TITLE
add explicit installation of `kubectl` tool along w/ google-cloud-sdk

### DIFF
--- a/dockerfiles/Dockerfile-toolchain
+++ b/dockerfiles/Dockerfile-toolchain
@@ -59,7 +59,7 @@ RUN VER="19.03.4" && \
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - && \
-    sudo apt-get update -y && sudo apt-get install google-cloud-sdk -y
+    sudo apt-get update -y && sudo apt-get install google-cloud-sdk kubectl -y
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rust_install.sh
 RUN chmod +x /tmp/rust_install.sh


### PR DESCRIPTION
Per google cloud sdk deb [package install docs](https://cloud.google.com/sdk/docs/downloads-apt-get#deb-extras) (to go along with the existing toolchain image setup), explicitly install `kubectl` deb package in addition to default `google-cloud-sdk` tooling package to enable *k8s* ops.

**Testing:** TBD

Checklist:

- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
