### PR TITLE
Leaderboard: Fixes to member profile backend and postgres timeout

### DIFF
--- a/frontend/leaderboard/src/Bindings.re
+++ b/frontend/leaderboard/src/Bindings.re
@@ -1,10 +1,13 @@
 module Postgres = {
   type pool;
-  type connectionString = {connectionString: string};
+  type config = {
+    connectionString: string,
+    connectionTimeoutMillis: int,
+  };
+
   type dbResult = {rows: array(Js.Json.t)};
 
-  [@bs.module "pg"] [@bs.new]
-  external makePool: connectionString => pool = "Pool";
+  [@bs.module "pg"] [@bs.new] external makePool: config => pool = "Pool";
 
   [@bs.send]
   external query:

--- a/frontend/leaderboard/src/Main.re
+++ b/frontend/leaderboard/src/Main.re
@@ -10,7 +10,7 @@
 let getEnvOrFail = name =>
   switch (Js.Dict.get(Node.Process.process##env, name)) {
   | Some(value) => value
-  | None => failwith({j|Couldn't find env var: `$name`"|j})
+  | None => failwith({j|Couldn't find env var: `$name`|j})
   };
 
 /* The Google Sheets API expects the credentials to be a local file instead of a parameter */
@@ -36,11 +36,10 @@ let main = () => {
         spreadsheetId,
         blocks |> Array.length |> string_of_int,
       );
-
-      UploadLeaderboardData.uploadUserProfileData(spreadsheetId);
     | Error(error) => Js.log(error)
     }
   });
+  UploadLeaderboardData.uploadUserProfileData(spreadsheetId);
   Postgres.endPool(pool);
 };
 

--- a/frontend/leaderboard/src/Postgres.re
+++ b/frontend/leaderboard/src/Postgres.re
@@ -18,7 +18,7 @@ LEFT JOIN public_keys AS pk4 ON uc.source_id = pk4.id
 LEFT JOIN public_keys AS pk5 ON uc.receiver_id = pk5.id";
 
 let createPool = pgConn => {
-  makePool({connectionString: pgConn});
+  makePool({connectionString: pgConn, connectionTimeoutMillis: 5000});
 };
 
 let endPool = pool => {

--- a/frontend/leaderboard/src/UploadLeaderboardData.re
+++ b/frontend/leaderboard/src/UploadLeaderboardData.re
@@ -125,7 +125,7 @@ let computeUsers = (userIndex, userData) => {
 };
 
 let computeMemberProfileData = (mainData, allTimeData, phaseData, releaseData) => {
-  let mainUserIndex = 0; /* usernames are located in the 1st column */
+  let mainUserIndex = 1; /* usernames are located in the 2nd column */
   let allTimeUserIndex = 4; /* usernames are located in the 5th column */
   let phaseUserIndex = 2; /* usernames are located in the 3rd column */
   let releaseUserIndex = 1; /* usernames are located in the 2nd column */


### PR DESCRIPTION
This PR has 2 fixes:

1. Fixes the column used for computing users in the `Main` spreadsheet. Originally, this was the first column but the second column is a list of unique usernames so that should be used instead. Additionally, moved the call to `uploadUserProfileData` to outside the Postgres query as it's not dependent on the query and we'd like to execute it no matter what.

2. Fixes the Postgres config object to accept a time out parameter. This defaults to 5 seconds. 

These fixes were tested locally. 