### PR TITLE
Restart libp2p helper

### DIFF
--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -20,6 +20,8 @@ type t =
       | `Handler of killed:bool -> Unix.Exit_or_signal.t -> unit Deferred.t
       | `Ignore ] }
 
+let pid : t -> Pid.t = fun t -> Process.pid t.process
+
 let stdout_lines : t -> string Strict_pipe.Reader.t = fun t -> t.stdout_pipe
 
 let stderr_lines : t -> string Strict_pipe.Reader.t = fun t -> t.stderr_pipe

--- a/src/lib/child_processes/child_processes.mli
+++ b/src/lib/child_processes/child_processes.mli
@@ -17,6 +17,9 @@ val stderr_lines : t -> string Strict_pipe.Reader.t
 (** Writer to process's stdin *)
 val stdin : t -> Writer.t
 
+(** Pid of process *)
+val pid : t -> Core.Pid.t
+
 (** [None] if the process is still running, [Some] when it's exited *)
 val termination_status : t -> Unix.Exit_or_signal.t option
 

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -1359,6 +1359,10 @@ let create ~logger ~conf_dir : Helper.t Deferred.Or_error.t =
           ^ Error.to_string_hum e )
     | Ok subprocess ->
         t.subprocess := Deferred.return subprocess ;
+        [%log trace]
+          ~metadata:
+            [("pid", `String (Pid.to_string (Child_processes.pid subprocess)))]
+          "Successfully spawned helper" ;
         Strict_pipe.Reader.iter (Child_processes.stderr_lines subprocess)
           ~f:(fun line ->
             ( match Go_log.record_of_yojson (Yojson.Safe.from_string line) with

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -1358,6 +1358,7 @@ let create ~logger ~conf_dir : Helper.t Deferred.Or_error.t =
              CODA_LIBP2P_HELPER_PATH=$PWD/src/app/libp2p_helper/result/bin/libp2p_helper "
           ^ Error.to_string_hum e )
     | Ok subprocess ->
+        t.subprocess := Deferred.return subprocess ;
         Strict_pipe.Reader.iter (Child_processes.stderr_lines subprocess)
           ~f:(fun line ->
             ( match Go_log.record_of_yojson (Yojson.Safe.from_string line) with


### PR DESCRIPTION
This PR addresses an issue on the QA net in which nodes terminate because their libp2p helper crashes unexpectedly. When that happens, we restart the helper.