### PR TITLE
Restart libp2p

### DIFF
--- a/dockerfiles/Dockerfile-coda-daemon
+++ b/dockerfiles/Dockerfile-coda-daemon
@@ -32,15 +32,19 @@ RUN echo '#!/bin/bash -x\n\
 mkdir -p .coda-config\n\
 touch .coda-config/coda-prover.log\n\
 touch .coda-config/coda-verifier.log\n\
-coda "$@" 2>&1 >coda.log &\n\
-coda_pid=$!\n\
-tail -q -f coda.log -f .coda-config/coda-prover.log -f .coda-config/coda-verifier.log &\n\
-tail_pid=$!\n\
-wait "$coda_pid"\n\
-echo "Coda process exited with status code $?"\n\
-sleep 10\n\
-kill "$tail_pid"\n\
-exit 0'\
+while true; do\n\
+  coda "$@" 2>&1 >coda.log &\n\
+  coda_pid=$!\n\
+  tail -q -f coda.log -f .coda-config/coda-prover.log -f .coda-config/coda-verifier.log &\n\
+  tail_pid=$!\n\
+  wait "$coda_pid"\n\
+  echo "Coda process exited with status code $?"\n\
+  sleep 10\n\
+  kill "$tail_pid"\n\
+  if [ ! -f stay_alive ]; then\n\
+    exit 0\n\
+  fi\n\
+done'\
 > init_coda.sh
 
 RUN chmod +x init_coda.sh

--- a/src/app/cli/src/init/client.ml
+++ b/src/app/cli/src/init/client.ml
@@ -1351,7 +1351,11 @@ let generate_libp2p_keypair =
       let logger = Logger.null () in
       (* Using the helper only for keypair generation requires no state. *)
       File_system.with_temp_dir "coda-generate-libp2p-keypair" ~f:(fun tmpd ->
-          match%bind Coda_net2.create ~logger ~conf_dir:tmpd with
+          match%bind
+            Coda_net2.create ~logger ~conf_dir:tmpd
+              ~on_unexpected_termination:(fun () ->
+                raise Child_processes.Child_died )
+          with
           | Ok net ->
               let%bind me = Coda_net2.Keypair.random net in
               let%bind () = Coda_net2.shutdown net in

--- a/src/app/cli/src/tests/coda_processes.ml
+++ b/src/app/cli/src/tests/coda_processes.ml
@@ -12,6 +12,8 @@ let net_configs n =
   File_system.with_temp_dir "coda-processes-generate-keys" ~f:(fun tmpd ->
       let%bind net =
         Coda_net2.create ~logger:(Logger.create ()) ~conf_dir:tmpd
+          ~on_unexpected_termination:(fun () ->
+            raise Child_processes.Child_died )
       in
       let net = Or_error.ok_exn net in
       let ips =

--- a/src/app/libp2p_helper/src/libp2p_helper/main.go
+++ b/src/app/libp2p_helper/src/libp2p_helper/main.go
@@ -1052,7 +1052,7 @@ func main() {
 	lines := bufio.NewScanner(os.Stdin)
 	// 22MiB buffer size, larger than the 21.33MB minimum for 16MiB to be b64'd
 	// 4 * (2^24/3) / 2^20 = 21.33
-	bufsize := (1024 * 1024) * 22
+	bufsize := (1024 * 1024) * 1024
 	lines.Buffer(make([]byte, bufsize), bufsize)
 	out := bufio.NewWriter(os.Stdout)
 
@@ -1101,6 +1101,7 @@ func main() {
 
 	for lines.Scan() {
 		line = lines.Text()
+		helperLog.Infof("message size is %d", len(line))
 		var raw json.RawMessage
 		env := envelope{
 			Body: &raw,

--- a/src/app/libp2p_helper/src/mplex.go
+++ b/src/app/libp2p_helper/src/mplex.go
@@ -77,7 +77,7 @@ func (t *MplexTransport) NewConn(nc net.Conn, isServer bool) (smux.Conn, error) 
 // THE SOFTWARE.
 var mplexlog = logging.Logger("mplex")
 
-var MaxMessageSize = 1 << 25
+var MaxMessageSize = 1 << 30
 
 // Max time to block waiting for a slow reader to read from a stream before
 // resetting it. Preferably, we'd have some form of back-pressure mechanism but

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -15,7 +15,7 @@
 [%%define c 8]
 [%%define delta 3]
 
-[%%define record_async_backtraces true]
+[%%define record_async_backtraces false]
 [%%define time_offsets true]
 [%%define cache_exceptions false]
 

--- a/src/config/testnet_postake_medium_curves.mlh
+++ b/src/config/testnet_postake_medium_curves.mlh
@@ -15,7 +15,7 @@
 [%%define c 8]
 [%%define delta 3]
 
-[%%define record_async_backtraces false]
+[%%define record_async_backtraces true]
 [%%define time_offsets true]
 [%%define cache_exceptions false]
 

--- a/src/lib/child_processes/child_processes.ml
+++ b/src/lib/child_processes/child_processes.ml
@@ -274,7 +274,7 @@ let start_custom :
          ; relative_to_root
          ; Some (Filename.dirname coda_binary_path ^/ name)
          ; Some ("coda-" ^ name) ])
-      ~f:(fun prog -> Process.create ~prog ~args ())
+      ~f:(fun prog -> Process.create ~stdin:"" ~prog ~args ())
   in
   let%bind () =
     Deferred.map ~f:Or_error.return

--- a/src/lib/coda_lib/coda_subscriptions.ml
+++ b/src/lib/coda_lib/coda_subscriptions.ml
@@ -68,7 +68,7 @@ let create ~logger ~constraint_constants ~wallets ~time_controller
               |> Fn.flip User_command.filter_by_participant participant
             in
             List.iter user_commands ~f:(fun user_command ->
-                Pipe.write_without_pushback writer user_command ) ) )
+                Pipe.write_without_pushback_if_open writer user_command ) ) )
   in
   let update_block_subscriptions {With_hash.data= external_transition; hash}
       transactions participants =
@@ -82,7 +82,8 @@ let create ~logger ~constraint_constants ~wallets ~time_controller
                     (`Some (Public_key.Compressed.Set.singleton participant))
                     transactions
                 in
-                Pipe.write_without_pushback writer {With_hash.data; hash} ) )
+                Pipe.write_without_pushback_if_open writer
+                  {With_hash.data; hash} ) )
           ~if_not_found:ignore ) ;
     Hashtbl.find_and_call subscribed_block_users None
       ~if_found:(fun pipes ->

--- a/src/lib/coda_net2/coda_net2.ml
+++ b/src/lib/coda_net2/coda_net2.ml
@@ -727,8 +727,15 @@ module Helper = struct
                           value here except ignore is UNSOUND because
                           write_pipe has a cast type. We don't remember
                           what the original 'return was. *)
-                  Strict_pipe.Writer.write sub.write_pipe (wrap m.sender data)
-                  |> ignore
+                  if Strict_pipe.Writer.is_closed sub.write_pipe then
+                    [%log' error t.logger]
+                      "subscription writer for $topic unexpectedly closed. \
+                       dropping message."
+                      ~metadata:[("topic", `String sub.topic)]
+                  else
+                    Strict_pipe.Writer.write sub.write_pipe
+                      (wrap m.sender data)
+                    |> ignore
               | Error e ->
                   ( match sub.on_decode_failure with
                   | `Ignore ->

--- a/src/lib/coda_net2/coda_net2.mli
+++ b/src/lib/coda_net2/coda_net2.mli
@@ -175,7 +175,11 @@ end
   *
   * This can fail for a variety of reasons related to spawning the subprocess.
 *)
-val create : logger:Logger.t -> conf_dir:string -> net Deferred.Or_error.t
+val create :
+     on_unexpected_termination:(unit -> unit Deferred.t)
+  -> logger:Logger.t
+  -> conf_dir:string
+  -> net Deferred.Or_error.t
 
 (** Configure the network connection.
   *

--- a/src/lib/coda_networking/coda_networking.ml
+++ b/src/lib/coda_networking/coda_networking.ml
@@ -1180,8 +1180,6 @@ let ban_notify t peer banned_until =
   query_peer t peer.Peer.peer_id Rpcs.Ban_notify banned_until
   >>| Fn.const (Ok ())
 
-let net2 t = Gossip_net.Any.net2 t.gossip_net
-
 let try_non_preferred_peers (type b) t input peers ~rpc :
     b Envelope.Incoming.t Deferred.Or_error.t =
   let max_current_peers = 8 in

--- a/src/lib/coda_networking/coda_networking.mli
+++ b/src/lib/coda_networking/coda_networking.mli
@@ -250,8 +250,6 @@ val ip_for_peer :
 
 val initial_peers : t -> Coda_net2.Multiaddr.t list
 
-val net2 : t -> Coda_net2.net option
-
 val ban_notification_reader :
   t -> Gossip_net.ban_notification Linear_pipe.Reader.t
 

--- a/src/lib/gossip_net/any.ml
+++ b/src/lib/gossip_net/any.ml
@@ -64,6 +64,4 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
 
   let ban_notification_reader (Any ((module M), t)) =
     M.ban_notification_reader t
-
-  let net2 (Any ((module M), t)) = M.net2 t
 end

--- a/src/lib/gossip_net/fake.ml
+++ b/src/lib/gossip_net/fake.ml
@@ -218,8 +218,6 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
 
     let ip_for_peer t peer_id =
       Deferred.return (Hashtbl.find t.peer_table peer_id)
-
-    let net2 _ = None
   end
 
   type network = Network.t

--- a/src/lib/gossip_net/intf.ml
+++ b/src/lib/gossip_net/intf.ml
@@ -46,6 +46,4 @@ module type Gossip_net_intf = sig
     -> (Message.msg Envelope.Incoming.t * (bool -> unit)) Strict_pipe.Reader.t
 
   val ban_notification_reader : t -> ban_notification Linear_pipe.Reader.t
-
-  val net2 : t -> Coda_net2.net option
 end

--- a/src/lib/gossip_net/libp2p.ml
+++ b/src/lib/gossip_net/libp2p.ml
@@ -48,14 +48,15 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
   module T = struct
     type t =
       { config: Config.t
-      ; net2: Coda_net2.net
+      ; net2: Coda_net2.net Deferred.t ref
       ; first_peer_ivar: unit Ivar.t
       ; high_connectivity_ivar: unit Ivar.t
       ; ban_reader: Intf.ban_notification Linear_pipe.Reader.t
       ; message_reader:
           (Message.msg Envelope.Incoming.t * (bool -> unit))
           Strict_pipe.Reader.t
-      ; subscription: Message.msg Coda_net2.Pubsub.Subscription.t }
+      ; subscription:
+          Message.msg Coda_net2.Pubsub.Subscription.t Deferred.t ref }
 
     let create_rpc_implementations (Rpc_handler (rpc, handler)) =
       let (module Impl) = implementation_of_rpc rpc in
@@ -86,7 +87,7 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
     (* Creates just the helper, making sure to register everything
       BEFORE we start listening/advertise ourselves for discovery. *)
     let create_libp2p (config : Config.t) rpc_handlers first_peer_ivar
-        high_connectivity_ivar =
+        high_connectivity_ivar ~on_unexpected_termination =
       let fail m =
         failwithf "Failed to connect to libp2p_helper process: %s" m ()
       in
@@ -95,7 +96,8 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
       match%bind
         Monitor.try_with ~rest:`Raise (fun () ->
             trace "coda_net2" (fun () ->
-                Coda_net2.create ~logger:config.logger ~conf_dir ) )
+                Coda_net2.create ~logger:config.logger ~conf_dir
+                  ~on_unexpected_termination ) )
       with
       | Ok (Ok net2) -> (
           let open Coda_net2 in
@@ -335,18 +337,47 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
       | Error e ->
           fail (Exn.to_string e)
 
-    let create config rpc_handlers =
+    let create (config : Config.t) rpc_handlers =
       let first_peer_ivar = Ivar.create () in
       let high_connectivity_ivar = Ivar.create () in
-      let%bind net2, subscription, message_reader =
-        create_libp2p config rpc_handlers first_peer_ivar
-          high_connectivity_ivar
+      let message_reader, message_writer =
+        Strict_pipe.create ~name:"libp2p_messages" Synchronous
+      in
+      let net2_ref = ref (Deferred.never ()) in
+      let subscription_ref = ref (Deferred.never ()) in
+      let%bind () =
+        let on_libp2p_create res =
+          net2_ref := Deferred.map res ~f:(fun (n, _, _) -> n) ;
+          subscription_ref := Deferred.map res ~f:(fun (_, s, _) -> s) ;
+          upon res (fun (_, _, m) ->
+              let logger = config.logger in
+              [%log trace] ~metadata:[] "Successfully restarted libp2p" ;
+              don't_wait_for (Strict_pipe.transfer m message_writer ~f:Fn.id)
+          )
+        in
+        let rec on_unexpected_termination () =
+          on_libp2p_create
+            (create_libp2p config rpc_handlers first_peer_ivar
+               high_connectivity_ivar ~on_unexpected_termination) ;
+          Deferred.unit
+        in
+        let res =
+          create_libp2p config rpc_handlers first_peer_ivar
+            high_connectivity_ivar ~on_unexpected_termination
+        in
+        on_libp2p_create res ;
+        let%map _ = res in
+        ()
       in
       let do_ban (addr, expiration) =
         don't_wait_for
           ( Clock.at expiration
-          >>= fun () -> Coda_net2.unban_ip net2 addr |> Deferred.ignore ) ;
-        Coda_net2.ban_ip net2 addr |> Deferred.ignore
+          >>= fun () ->
+          let%bind net2 = !net2_ref in
+          Coda_net2.unban_ip net2 addr |> Deferred.ignore ) ;
+        (let%bind net2 = !net2_ref in
+         Coda_net2.ban_ip net2 addr)
+        |> Deferred.ignore
       in
       let%map () =
         Deferred.List.iter (Trust_system.peer_statuses config.trust_system)
@@ -367,14 +398,14 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
          in
          Linear_pipe.close ban_writer) ;
       { config
-      ; net2
+      ; net2= net2_ref
       ; first_peer_ivar
       ; high_connectivity_ivar
-      ; subscription
+      ; subscription= subscription_ref
       ; message_reader
       ; ban_reader }
 
-    let peers t = Coda_net2.peers t.net2
+    let peers t = !(t.net2) >>= Coda_net2.peers
 
     let initial_peers t = t.config.initial_peers
 
@@ -477,8 +508,9 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
       try_call_rpc_with_dispatch t peer transport Impl.dispatch_multi query
 
     let query_peer t (peer_id : Peer.Id.t) rpc rpc_input =
+      let%bind net2 = !(t.net2) in
       match%bind
-        Coda_net2.open_stream t.net2 ~protocol:rpc_transport_proto peer_id
+        Coda_net2.open_stream net2 ~protocol:rpc_transport_proto peer_id
       with
       | Ok stream ->
           let peer = Coda_net2.Stream.remote_peer stream in
@@ -497,7 +529,9 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
       List.map peers ~f:(fun peer -> query_peer t peer.peer_id rpc query)
 
     let broadcast t msg =
-      don't_wait_for (Coda_net2.Pubsub.Subscription.publish t.subscription msg)
+      don't_wait_for
+        (let%bind subscription = !(t.subscription) in
+         Coda_net2.Pubsub.Subscription.publish subscription msg)
 
     let on_first_connect t ~f = Deferred.map (Ivar.read t.first_peer_ivar) ~f
 
@@ -509,10 +543,9 @@ module Make (Rpc_intf : Coda_base.Rpc_intf.Rpc_interface_intf) :
     let ban_notification_reader t = t.ban_reader
 
     let ip_for_peer t peer_id =
-      Coda_net2.lookup_peerid t.net2 peer_id
+      let%bind net2 = !(t.net2) in
+      Coda_net2.lookup_peerid net2 peer_id
       >>| function Ok p -> Some p | Error _ -> None
-
-    let net2 t = Some t.net2
   end
 
   include T

--- a/src/lib/pipe_lib/linear_pipe.ml
+++ b/src/lib/pipe_lib/linear_pipe.ml
@@ -21,7 +21,11 @@ let create_reader ~close_on_exception f =
   let r = Pipe.create_reader ~close_on_exception f in
   {Reader.pipe= r; has_reader= false}
 
-let write = Pipe.write
+let write w x =
+  ( if Pipe.is_closed w then
+    let logger = Logger.create () in
+    [%log warn] "writing to closed linear pipe" ~metadata:[] ) ;
+  Pipe.write w x
 
 let write_if_open = Pipe.write_if_open
 

--- a/src/lib/pipe_lib/strict_pipe.ml
+++ b/src/lib/pipe_lib/strict_pipe.ml
@@ -236,6 +236,14 @@ module Writer = struct
 
   let write : type type_ return. ('t, type_, return) t -> 't -> return =
    fun writer data ->
+    ( if Pipe.is_closed writer.writer then
+      let logger = Logger.create () in
+      [%log warn] "writing to closed pipe $name"
+        ~metadata:
+          [ ( "name"
+            , `String
+                (Sexplib.Sexp.to_string ([%sexp_of: string option] writer.name))
+            ) ] ) ;
     match writer.type_ with
     | Synchronous ->
         Pipe.write writer.writer data


### PR DESCRIPTION
This PR addresses an issue on the QA net in which nodes terminate because their libp2p helper crashes unexpectedly. When that happens, we restart the helper.