### PR TITLE
match out-of-snark and in-snark account-timing updates

### DIFF
--- a/src/lib/coda_base/ledger.mli
+++ b/src/lib/coda_base/ledger.mli
@@ -131,13 +131,17 @@ module Undo : sig
 
   module Fee_transfer_undo : sig
     type t = Undo.Fee_transfer_undo.t =
-      {fee_transfer: Fee_transfer.t; previous_empty_accounts: Account_id.t list}
+      { fee_transfer: Fee_transfer.t
+      ; previous_empty_accounts: Account_id.t list
+      ; receiver_timing: Account.Timing.t }
     [@@deriving sexp]
   end
 
   module Coinbase_undo : sig
     type t = Undo.Coinbase_undo.t =
-      {coinbase: Coinbase.t; previous_empty_accounts: Account_id.t list}
+      { coinbase: Coinbase.t
+      ; previous_empty_accounts: Account_id.t list
+      ; receiver_timing: Account.Timing.t }
     [@@deriving sexp]
   end
 

--- a/src/lib/coda_base/sparse_ledger.ml
+++ b/src/lib/coda_base/sparse_ledger.ml
@@ -523,41 +523,63 @@ let _apply_snapp_command_exn
   |> Or_error.ok_exn |> ignore ;
   !t
 
-let apply_fee_transfer_exn ~constraint_constants =
-  let apply_single t (ft : Fee_transfer.Single.t) =
+let update_timing_when_no_deduction ~txn_global_slot account =
+  Transaction_logic.validate_timing ~txn_amount:Currency.Amount.zero
+    ~txn_global_slot ~account
+  |> Or_error.ok_exn
+
+let apply_fee_transfer_exn ~constraint_constants ~txn_global_slot =
+  let apply_single ~update_timing t (ft : Fee_transfer.Single.t) =
     let account_id = Fee_transfer.Single.receiver ft in
     let index = find_index_exn t account_id in
     let action, account = get_or_initialize_exn account_id t index in
     let open Currency in
     let amount = Amount.of_fee ft.fee in
+    let timing =
+      if update_timing then
+        update_timing_when_no_deduction ~txn_global_slot account
+      else account.timing
+    in
     let balance =
       let amount' =
         sub_account_creation_fee ~constraint_constants action amount
       in
       Option.value_exn (Balance.add_amount account.balance amount')
     in
-    set_exn t index {account with balance}
+    set_exn t index {account with balance; timing}
   in
-  fun t transfer -> Fee_transfer.fold transfer ~f:apply_single ~init:t
+  fun t transfer ->
+    match Fee_transfer.to_singles transfer with
+    | `One s ->
+        apply_single ~update_timing:true t s
+    | `Two (s1, s2) ->
+        (*Note: Not updating the timing for s1 to avoid additional check in transactions snark (check_timing for "receiver"). This is OK because timing rules will not be violated when balance increases and will be checked whenever an amount is deducted from the account.(#5973)*)
+        let t' = apply_single ~update_timing:false t s1 in
+        apply_single ~update_timing:true t' s2
 
-let apply_coinbase_exn ~constraint_constants t
+let apply_coinbase_exn ~constraint_constants ~txn_global_slot t
     ({receiver; fee_transfer; amount= coinbase_amount} : Coinbase.t) =
   let open Currency in
-  let add_to_balance t pk amount =
+  let add_to_balance ~update_timing t pk amount =
     let idx = find_index_exn t pk in
     let action, a = get_or_initialize_exn pk t idx in
+    let timing =
+      if update_timing then update_timing_when_no_deduction ~txn_global_slot a
+      else a.timing
+    in
     let balance =
       let amount' =
         sub_account_creation_fee ~constraint_constants action amount
       in
       Option.value_exn (Balance.add_amount a.balance amount')
     in
-    set_exn t idx {a with balance}
+    set_exn t idx {a with balance; timing}
   in
-  let receiver_reward, t =
+  (* Note: Updating coinbase receiver timing only if there is no fee transfer. This is so as to not add any extra constraints in transaction snark for checking "receiver" timings. This is OK because timing rules will not be violated when balance increases and will be checked whenever an amount is deducted from the account(#5973)*)
+  let receiver_reward, t, update_coinbase_receiver_timing =
     match fee_transfer with
     | None ->
-        (coinbase_amount, t)
+        (coinbase_amount, t, true)
     | Some ({receiver_pk= _; fee} as ft) ->
         let fee = Amount.of_fee fee in
         let reward =
@@ -565,10 +587,11 @@ let apply_coinbase_exn ~constraint_constants t
           |> Option.value_exn ?here:None ?message:None ?error:None
         in
         let transferee_id = Coinbase.Fee_transfer.receiver ft in
-        (reward, add_to_balance t transferee_id fee)
+        (reward, add_to_balance ~update_timing:true t transferee_id fee, false)
   in
   let receiver_id = Account_id.create receiver Token_id.default in
-  add_to_balance t receiver_id receiver_reward
+  add_to_balance ~update_timing:update_coinbase_receiver_timing t receiver_id
+    receiver_reward
 
 let apply_transaction_exn ~constraint_constants
     ~(txn_state_view : Snapp_predicate.Protocol_state.View.t) t
@@ -576,12 +599,12 @@ let apply_transaction_exn ~constraint_constants
   let txn_global_slot = txn_state_view.curr_global_slot in
   match transition with
   | Fee_transfer tr ->
-      apply_fee_transfer_exn ~constraint_constants t tr
+      apply_fee_transfer_exn ~constraint_constants ~txn_global_slot t tr
   | User_command cmd ->
       apply_user_command_exn ~constraint_constants ~txn_global_slot t
         (cmd :> User_command.t)
   | Coinbase c ->
-      apply_coinbase_exn ~constraint_constants t c
+      apply_coinbase_exn ~constraint_constants ~txn_global_slot t c
 
 let merkle_root t =
   Ledger_hash.of_hash (merkle_root t :> Random_oracle.Digest.t)

--- a/src/lib/coda_base/transaction_logic.ml
+++ b/src/lib/coda_base/transaction_logic.ml
@@ -116,7 +116,8 @@ module Undo = struct
       module V1 = struct
         type t =
           { fee_transfer: Fee_transfer.Stable.V1.t
-          ; previous_empty_accounts: Account_id.Stable.V1.t list }
+          ; previous_empty_accounts: Account_id.Stable.V1.t list
+          ; receiver_timing: Account.Timing.Stable.V1.t }
         [@@deriving sexp]
 
         let to_latest = Fn.id
@@ -130,7 +131,8 @@ module Undo = struct
       module V1 = struct
         type t =
           { coinbase: Coinbase.Stable.V1.t
-          ; previous_empty_accounts: Account_id.Stable.V1.t list }
+          ; previous_empty_accounts: Account_id.Stable.V1.t list
+          ; receiver_timing: Account.Timing.Stable.V1.t }
         [@@deriving sexp]
 
         let to_latest = Fn.id
@@ -212,13 +214,16 @@ module type S = sig
     module Fee_transfer_undo : sig
       type t = Undo.Fee_transfer_undo.t =
         { fee_transfer: Fee_transfer.t
-        ; previous_empty_accounts: Account_id.t list }
+        ; previous_empty_accounts: Account_id.t list
+        ; receiver_timing: Account.Timing.t }
       [@@deriving sexp]
     end
 
     module Coinbase_undo : sig
       type t = Undo.Coinbase_undo.t =
-        {coinbase: Coinbase.t; previous_empty_accounts: Account_id.t list}
+        { coinbase: Coinbase.t
+        ; previous_empty_accounts: Account_id.t list
+        ; receiver_timing: Account.Timing.t }
       [@@deriving sexp]
     end
 
@@ -1363,7 +1368,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               ~account2_should_step:true )
         |> finish )
 
-  let process_fee_transfer t (transfer : Fee_transfer.t) ~modify_balance =
+  let update_timing_when_no_deduction ~txn_global_slot account =
+    validate_timing ~txn_amount:Amount.zero ~txn_global_slot ~account
+
+  let process_fee_transfer t (transfer : Fee_transfer.t) ~modify_balance
+      ~modify_timing =
     let open Or_error.Let_syntax in
     (* TODO(#4555): Allow token_id to vary from default. *)
     let%bind () =
@@ -1383,9 +1392,10 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         *)
         let action, a, loc = get_or_create t account_id in
         let emptys = previous_empty_accounts action account_id in
+        let%bind timing = modify_timing a in
         let%map balance = modify_balance action account_id a.balance ft.fee in
-        set t loc {a with balance} ;
-        emptys
+        set t loc {a with balance; timing} ;
+        (emptys, a.timing)
     | `Two (ft1, ft2) ->
         let account_id1 = Fee_transfer.Single.receiver ft1 in
         (* TODO(#4496): Do not use get_or_create here; we should not create a
@@ -1397,11 +1407,12 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
         let account_id2 = Fee_transfer.Single.receiver ft2 in
         if Account_id.equal account_id1 account_id2 then (
           let%bind fee = error_opt "overflow" (Fee.add ft1.fee ft2.fee) in
+          let%bind timing = modify_timing a1 in
           let%map balance =
             modify_balance action1 account_id1 a1.balance fee
           in
-          set t l1 {a1 with balance} ;
-          emptys1 )
+          set t l1 {a1 with balance; timing} ;
+          (emptys1, a1.timing) )
         else
           (* TODO(#4496): Do not use get_or_create here; we should not create a
              new account before we know that the transaction will go through
@@ -1412,30 +1423,38 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           let%bind balance1 =
             modify_balance action1 account_id1 a1.balance ft1.fee
           in
+          (*Note: Not updating the timing field of a1 to avoid additional check in transactions snark (check_timing for "receiver"). This is OK because timing rules will not be violated when balance increases and will be checked whenever an amount is deducted from the account. (#5973)*)
+          let%bind timing2 = modify_timing a2 in
           let%map balance2 =
             modify_balance action2 account_id2 a2.balance ft2.fee
           in
           set t l1 {a1 with balance= balance1} ;
-          set t l2 {a2 with balance= balance2} ;
-          emptys1 @ emptys2
+          set t l2 {a2 with balance= balance2; timing= timing2} ;
+          (emptys1 @ emptys2, a2.timing)
 
-  let apply_fee_transfer ~constraint_constants t transfer =
+  let apply_fee_transfer ~constraint_constants ~txn_global_slot t transfer =
     let open Or_error.Let_syntax in
-    let%map previous_empty_accounts =
-      process_fee_transfer t transfer ~modify_balance:(fun action _ b f ->
+    let%map previous_empty_accounts, receiver_timing =
+      process_fee_transfer t transfer
+        ~modify_balance:(fun action _ b f ->
           let%bind amount =
             let amount = Amount.of_fee f in
             sub_account_creation_fee ~constraint_constants action amount
           in
           add_amount b amount )
+        ~modify_timing:(fun acc ->
+          update_timing_when_no_deduction ~txn_global_slot acc )
     in
-    Undo.Fee_transfer_undo.{fee_transfer= transfer; previous_empty_accounts}
+    Undo.Fee_transfer_undo.
+      {fee_transfer= transfer; previous_empty_accounts; receiver_timing}
 
   let undo_fee_transfer ~constraint_constants t
-      ({previous_empty_accounts; fee_transfer} : Undo.Fee_transfer_undo.t) =
+      ({previous_empty_accounts; fee_transfer; receiver_timing} :
+        Undo.Fee_transfer_undo.t) =
     let open Or_error.Let_syntax in
     let%map _ =
-      process_fee_transfer t fee_transfer ~modify_balance:(fun _ aid b f ->
+      process_fee_transfer t fee_transfer
+        ~modify_balance:(fun _ aid b f ->
           let action =
             if List.mem ~equal:Account_id.equal previous_empty_accounts aid
             then `Added
@@ -1446,17 +1465,21 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               (Amount.of_fee f)
           in
           sub_amount b amount )
+        ~modify_timing:(fun _ -> Ok receiver_timing)
     in
     remove_accounts_exn t previous_empty_accounts
 
-  let apply_coinbase ~constraint_constants t
+  let apply_coinbase ~constraint_constants ~txn_global_slot t
       (* TODO: Better system needed for making atomic changes. Could use a monad. *)
       ({receiver; fee_transfer; amount= coinbase_amount} as cb : Coinbase.t) =
     let open Or_error.Let_syntax in
-    let%bind receiver_reward, emptys1, transferee_update =
+    let%bind ( receiver_reward
+             , emptys1
+             , transferee_update
+             , transferee_timing_prev ) =
       match fee_transfer with
       | None ->
-          return (coinbase_amount, [], None)
+          return (coinbase_amount, [], None, None)
       | Some ({receiver_pk= transferee; fee} as ft) ->
           assert (not @@ Public_key.Compressed.equal transferee receiver) ;
           let transferee_id = Coinbase.Fee_transfer.receiver ft in
@@ -1473,6 +1496,9 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
             get_or_create t transferee_id
           in
           let emptys = previous_empty_accounts action transferee_id in
+          let%bind timing =
+            update_timing_when_no_deduction ~txn_global_slot transferee_account
+          in
           let%map balance =
             let%bind amount =
               sub_account_creation_fee ~constraint_constants action fee
@@ -1481,7 +1507,9 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
           in
           ( receiver_reward
           , emptys
-          , Some (transferee_location, {transferee_account with balance}) )
+          , Some
+              (transferee_location, {transferee_account with balance; timing})
+          , Some transferee_account.timing )
     in
     let receiver_id = Account_id.create receiver Token_id.default in
     let action2, receiver_account, receiver_location =
@@ -1492,27 +1520,44 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       get_or_create t receiver_id
     in
     let emptys2 = previous_empty_accounts action2 receiver_id in
+    (* Note: Updating coinbase receiver timing only if there is no fee transfer. This is so as to not add any extra constraints in transaction snark for checking "receiver" timings. This is OK because timing rules will not be violated when balance increases and will be checked whenever an amount is deducted from the account(#5973)*)
+    let%bind receiver_timing_for_undo, coinbase_receiver_timing =
+      match transferee_timing_prev with
+      | None ->
+          let%map new_receiver_timing =
+            update_timing_when_no_deduction ~txn_global_slot receiver_account
+          in
+          (receiver_account.timing, new_receiver_timing)
+      | Some timing ->
+          Ok (timing, receiver_account.timing)
+    in
     let%map receiver_balance =
       let%bind amount =
         sub_account_creation_fee ~constraint_constants action2 receiver_reward
       in
       add_amount receiver_account.balance amount
     in
-    set t receiver_location {receiver_account with balance= receiver_balance} ;
+    set t receiver_location
+      { receiver_account with
+        balance= receiver_balance
+      ; timing= coinbase_receiver_timing } ;
     Option.iter transferee_update ~f:(fun (l, a) -> set t l a) ;
     Undo.Coinbase_undo.
-      {coinbase= cb; previous_empty_accounts= emptys1 @ emptys2}
+      { coinbase= cb
+      ; previous_empty_accounts= emptys1 @ emptys2
+      ; receiver_timing= receiver_timing_for_undo }
 
   (* Don't have to be atomic here because these should never fail. In fact, none of
   the undo functions should ever return an error. This should be fixed in the types. *)
   let undo_coinbase ~constraint_constants t
       Undo.Coinbase_undo.
         { coinbase= {receiver; fee_transfer; amount= coinbase_amount}
-        ; previous_empty_accounts } =
-    let receiver_reward =
+        ; previous_empty_accounts
+        ; receiver_timing } =
+    let receiver_reward, receiver_timing =
       match fee_transfer with
       | None ->
-          coinbase_amount
+          (coinbase_amount, Some receiver_timing)
       | Some ({receiver_pk= _; fee} as ft) ->
           let fee = Amount.of_fee fee in
           let transferee_id = Coinbase.Fee_transfer.receiver ft in
@@ -1538,8 +1583,10 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
               (Balance.sub_amount transferee_account.balance amount)
           in
           set t transferee_location
-            {transferee_account with balance= transferee_balance} ;
-          Option.value_exn (Amount.sub coinbase_amount fee)
+            { transferee_account with
+              balance= transferee_balance
+            ; timing= receiver_timing } ;
+          (Option.value_exn (Amount.sub coinbase_amount fee), None)
     in
     let receiver_id = Account_id.create receiver Token_id.default in
     let receiver_location =
@@ -1560,7 +1607,11 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
       in
       Option.value_exn (Balance.sub_amount receiver_account.balance amount)
     in
-    set t receiver_location {receiver_account with balance= receiver_balance} ;
+    let timing =
+      Option.value ~default:receiver_account.timing receiver_timing
+    in
+    set t receiver_location
+      {receiver_account with balance= receiver_balance; timing} ;
     remove_accounts_exn t previous_empty_accounts
 
   let undo_user_command
@@ -1793,10 +1844,12 @@ module Make (L : Ledger_intf) : S with type ledger := L.t = struct
                    ledger txn) ~f:(fun undo ->
                   Undo.Varying.Command (User_command undo) )
           | Fee_transfer t ->
-              Or_error.map (apply_fee_transfer ~constraint_constants ledger t)
-                ~f:(fun undo -> Undo.Varying.Fee_transfer undo)
+              Or_error.map
+                (apply_fee_transfer ~constraint_constants ~txn_global_slot
+                   ledger t) ~f:(fun undo -> Undo.Varying.Fee_transfer undo)
           | Coinbase t ->
-              Or_error.map (apply_coinbase ~constraint_constants ledger t)
+              Or_error.map
+                (apply_coinbase ~constraint_constants ~txn_global_slot ledger t)
                 ~f:(fun undo -> Undo.Varying.Coinbase undo) )
           ~f:(fun varying -> {Undo.previous_hash; varying}) )
 

--- a/src/lib/coda_base/transaction_union.ml
+++ b/src/lib/coda_base/transaction_union.ml
@@ -71,7 +71,7 @@ let of_transaction : Transaction.t -> t = function
                 ; valid_until= Coda_numbers.Global_slot.max_value
                 ; memo= User_command_memo.empty }
             ; body=
-                { source_pk= pk1
+                { source_pk= pk2
                 ; receiver_pk= pk1
                 ; token_id
                 ; amount= Amount.of_fee fee1

--- a/src/lib/transaction_snark/transaction_snark.ml
+++ b/src/lib/transaction_snark/transaction_snark.ml
@@ -2310,29 +2310,24 @@ module Base = struct
                     add fee_payer_amount account_creation_fee))
              in
              let txn_global_slot = current_global_slot in
-             let%bind timing =
-               let%bind `Min_balance _, new_timing =
-                 [%with_label "Check fee payer timing"]
-                   (let%bind txn_amount =
-                      Amount.Checked.if_
-                        (Sgn.Checked.is_neg amount.sgn)
-                        ~then_:amount.magnitude
-                        ~else_:Amount.(var_of_t zero)
-                    in
-                    let balance_check ok =
-                      [%with_label "Check fee payer balance"]
-                        (Boolean.Assert.is_true ok)
-                    in
-                    let timed_balance_check ok =
-                      [%with_label "Check fee payer timed balance"]
-                        (Boolean.Assert.is_true ok)
-                    in
-                    check_timing ~balance_check ~timed_balance_check ~account
-                      ~txn_amount ~txn_global_slot)
-               in
-               (* Like receiver account in payments, coinbase fee transfer account or other fee transfer account don't have the timing field updated *)
-               Account_timing.if_ is_coinbase_or_fee_transfer
-                 ~then_:account.timing ~else_:new_timing
+             let%bind `Min_balance _, timing =
+               [%with_label "Check fee payer timing"]
+                 (let%bind txn_amount =
+                    Amount.Checked.if_
+                      (Sgn.Checked.is_neg amount.sgn)
+                      ~then_:amount.magnitude
+                      ~else_:Amount.(var_of_t zero)
+                  in
+                  let balance_check ok =
+                    [%with_label "Check fee payer balance"]
+                      (Boolean.Assert.is_true ok)
+                  in
+                  let timed_balance_check ok =
+                    [%with_label "Check fee payer timed balance"]
+                      (Boolean.Assert.is_true ok)
+                  in
+                  check_timing ~balance_check ~timed_balance_check ~account
+                    ~txn_amount ~txn_global_slot)
              in
              let%bind balance =
                [%with_label "Check payer balance"]
@@ -2575,35 +2570,30 @@ module Base = struct
                  ~else_:Amount.(var_of_t zero)
              in
              let txn_global_slot = current_global_slot in
-             let%bind timing =
-               let%bind `Min_balance _, new_timing =
-                 [%with_label "Check source timing"]
-                   (let balance_check ok =
-                      [%with_label
-                        "Check source balance failure matches predicted"]
-                        (Boolean.Assert.( = ) ok
-                           (Boolean.not
-                              user_command_failure.source_insufficient_balance))
-                    in
-                    let timed_balance_check ok =
-                      [%with_label
-                        "Check source timed balance failure matches predicted"]
-                        (let%bind ok =
-                           Boolean.(
-                             ok
-                             && not
-                                  user_command_failure
-                                    .source_insufficient_balance)
-                         in
-                         Boolean.Assert.( = ) ok
-                           (Boolean.not user_command_failure.source_bad_timing))
-                    in
-                    check_timing ~balance_check ~timed_balance_check ~account
-                      ~txn_amount:amount ~txn_global_slot)
-               in
-               (* Like the receiver account in payments, coinbase fee transfer account or other fee transfer account don't have the timing field updated *)
-               Account_timing.if_ is_coinbase_or_fee_transfer
-                 ~then_:account.timing ~else_:new_timing
+             let%bind `Min_balance _, timing =
+               [%with_label "Check source timing"]
+                 (let balance_check ok =
+                    [%with_label
+                      "Check source balance failure matches predicted"]
+                      (Boolean.Assert.( = ) ok
+                         (Boolean.not
+                            user_command_failure.source_insufficient_balance))
+                  in
+                  let timed_balance_check ok =
+                    [%with_label
+                      "Check source timed balance failure matches predicted"]
+                      (let%bind ok =
+                         Boolean.(
+                           ok
+                           && not
+                                user_command_failure
+                                  .source_insufficient_balance)
+                       in
+                       Boolean.Assert.( = ) ok
+                         (Boolean.not user_command_failure.source_bad_timing))
+                  in
+                  check_timing ~balance_check ~timed_balance_check ~account
+                    ~txn_amount:amount ~txn_global_slot)
              in
              let%bind balance, `Underflow underflow =
                Balance.Checked.sub_amount_flagged account.balance amount


### PR DESCRIPTION
Outside snark,  the timing field is updated only for accounts whose  balance is deducted (when we check if the account still maintains a min balance). In transaction snark this wasn't true for coinbase and fee transfer, where the coinbase/fee receiver account's timing field was getting set to `Untimed` when the tokens were unlocked.
Changed the out-of-snark behaviour to update the timing of fee transfer/coinbase accounts that is encoded as `fee_payer` or `source` account in a transaction to avoid checks in the snark

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [X] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

