### PR TITLE
[hotfix] Look for the config file in install paths

### DIFF
--- a/scripts/rebuild-deb.sh
+++ b/scripts/rebuild-deb.sh
@@ -10,6 +10,7 @@ cd "${SCRIPTPATH}/../_build"
 GITHASH=$(git rev-parse --short=7 HEAD)
 GITBRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD |  sed 's!/!-!; s!_!-!g' )
 GITTAG=$(git describe --abbrev=0)
+GITHASH_CONFIG=$(git rev-parse --short=8 --verify HEAD)
 
 # Identify All Artifacts by Branch and Git Hash
 set +u
@@ -125,7 +126,7 @@ for f in /tmp/coda_cache_dir/genesis*; do
 done
 
 #copy config.json
-cp ../genesis_ledgers/phase_three/config.json "${BUILDDIR}/var/lib/coda/config_${VERSION}.json"
+cp ../genesis_ledgers/phase_three/config.json "${BUILDDIR}/var/lib/coda/config_${GITHASH_CONFIG}.json"
 
 # Bash autocompletion
 # NOTE: We do not list bash-completion as a required package,

--- a/src/lib/cache_dir/cache_dir.ml
+++ b/src/lib/cache_dir/cache_dir.ml
@@ -38,8 +38,12 @@ let env_path =
       manual_install_path
 
 let possible_paths base =
-  List.map [env_path; brew_install_path; s3_install_path; autogen_path]
-    ~f:(fun d -> d ^/ base)
+  List.map
+    [ env_path
+    ; brew_install_path
+    ; s3_install_path
+    ; autogen_path
+    ; manual_install_path ] ~f:(fun d -> d ^/ base)
 
 let load_from_s3 s3_bucket_prefix s3_install_path ~logger =
   Deferred.map ~f:Result.join


### PR DESCRIPTION
Runtime config file look up order
1. daemon flag `-config-file`
2. env variable `CODA_CONFIG_FILE` 
3. one of the install paths
4. config-dir/daemon.json
5. compiled configuration

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them:

Closes #0000
Closes #0000
