### PR TITLE
Website: Updating website docs with new echo bot pk

### DIFF
--- a/frontend/website/pages/docs/getting-started.mdx
+++ b/frontend/website/pages/docs/getting-started.mdx
@@ -75,9 +75,11 @@ Add the Coda Debian repo and install:
 ```
 sudo apt-get remove coda-testnet-postake-medium-curves
 sudo apt-get remove coda-kademlia
-echo "deb [trusted=yes] http://packages.o1test.net unstable main" | sudo tee /etc/apt/sources.list.d/coda.list
+echo "deb [trusted=yes] http://packages.o1test.net release main" | sudo tee /etc/apt/sources.list.d/coda.list
 sudo apt-get update
-sudo apt-get install -t unstable coda-testnet-postake-medium-curves=0.0.12-beta+406048-feature-bump-genesis-timestamp-3e9b174-PV48525e92
+sudo apt-get install coda-testnet-postake-medium-curves
+# optionally, install the archive node
+sudo apt-get install coda-archive
 ```
 
 If you already have `coda` installed from a previous release, running the above commands should automatically uninstall and reinstall the newest version. If you're installing Coda from scratch, you may see this error when you run the first command: `E: Unable to locate package coda-testnet-postake-medium-curves`. You can ignore this - it just means there wasn't a prior release installed.

--- a/frontend/website/pages/docs/my-first-transaction.mdx
+++ b/frontend/website/pages/docs/my-first-transaction.mdx
@@ -10,7 +10,7 @@ In this section, we'll make our first transaction on the Coda network. After [in
 
 Because only 200 participants can join testnet 3.2b, you'll first need to get the peer addresses of the seed nodes. The 200 participants have already been selected, but you can sign up for the waitlist [here](http://bit.ly/StakingSignup) in case a spot opens up. 
 
-Once you're in, you'll receive an email close to release 3.2b launch date with the seed node addresses and updated commands. We can start by storing the seed addresses as environment variables to help with the next steps:
+Once you're in, you'll receive an email close to release 3.3 launch date with the seed node addresses and updated commands. We can start by storing the seed addresses as environment variables to help with the next steps:
 
 ```
 export SEED1='<seed-address-1>'

--- a/frontend/website/pages/docs/my-first-transaction.mdx
+++ b/frontend/website/pages/docs/my-first-transaction.mdx
@@ -159,7 +159,7 @@ Finally we get to the good stuff, sending our first transaction! Before you send
 
 For testing purposes, there's already an echo service set up that will immediately refund your payment minus the transaction fees. You can use the following public key for the echo bot.
 ```
-4vsRCViQQRxXfkgEspR9vPWLypuSEGkZtHxjYF7srq5M1mZN4LSoX7wWCFZGitJLmdoozDXmrCugvBBKsePd6hfBAp9P3eTCHs5HwdC763A1FbjzskfrCvWMq9KXXsmFxWhYpG9nnhWzqSC1
+B62qk5jqp4nYPwDDdd9XJAV8bYQ5cSzaZ9Me7ccaMdSSJpqKasDqMx9
 ```
 
 <Alert kind="warning">
@@ -174,7 +174,7 @@ Let's send some of our newly received coda to this service to see what a payment
 
     coda client send-payment \
       -amount 0.5 \
-      -receiver 4vsRCViQQRxXfkgEspR9vPWLypuSEGkZtHxjYF7srq5M1mZN4LSoX7wWCFZGitJLmdoozDXmrCugvBBKsePd6hfBAp9P3eTCHs5HwdC763A1FbjzskfrCvWMq9KXXsmFxWhYpG9nnhWzqSC1 \
+      -receiver B62qk5jqp4nYPwDDdd9XJAV8bYQ5cSzaZ9Me7ccaMdSSJpqKasDqMx9 \
       -fee 0.1 \
       -sender $CODA_PUBLIC_KEY
 


### PR DESCRIPTION
This PR changes the old echo bot public key to use the newly generated key with the new key pair format. This change was already merged into develop but should also be pushed into master.

Previous commit: #5959