### PR TITLE
Fix CI: Manually pin ocamlgraph while ocamlgraph.lri.fr is down

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -174,7 +177,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - save_cache:
                 name: Save cache - opam
@@ -231,7 +237,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                   name: Check circle CI configuration rendering
@@ -285,7 +294,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                   name: Compare versioned types in PR
@@ -325,7 +337,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                   name: Compare test signatures for consensus, nonconsensus code
@@ -358,7 +373,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                   name: Build client SDK, run unit tests
@@ -586,7 +604,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -743,7 +764,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -789,7 +813,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -833,7 +860,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -877,7 +907,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1115,7 +1148,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1154,7 +1190,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1193,7 +1232,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1235,7 +1277,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1274,7 +1319,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1313,7 +1361,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1352,7 +1403,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1396,7 +1450,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper
@@ -1438,7 +1495,10 @@ jobs:
                     - opam-linux-v1-{{ checksum "opam_ci_cache.sig" }}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 
             - run:
                 name: Build libp2p_helper

--- a/.circleci/config.yml.jinja
+++ b/.circleci/config.yml.jinja
@@ -21,7 +21,10 @@
                     - opam-linux-v1-{{'{{'}} checksum "opam_ci_cache.sig" {{'}}'}}
             - run:
                 name: Install opam dependencies - opam -- make setup-opam
-                command: ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
+                command: |
+                    # FIXME: Remove this when it becomes unnecessary
+                    sudo apt-get install -y autoconf
+                    ./scripts/skip_if_only_frontend_or_rfcs.sh bash -c 'make setup-opam'
 {%endset%}
 
 {% set checkout_no_lfs %}

--- a/scripts/setup-opam.sh
+++ b/scripts/setup-opam.sh
@@ -41,6 +41,9 @@ else
   opam switch $SWITCH
 fi
 
+# FIXME: Manually pin ocamlgraph while their hosting is down
+opam pin https://github.com/backtracking/ocamlgraph.git#v1.8.8
+
 # All our ocaml packages
 opam switch import src/opam.export
 eval $(opam config env)

--- a/scripts/setup-opam.sh
+++ b/scripts/setup-opam.sh
@@ -42,6 +42,7 @@ else
 fi
 
 # FIXME: Manually pin ocamlgraph while their hosting is down
+opam install conf-autoconf
 opam pin ocamlgraph https://github.com/backtracking/ocamlgraph/archive/v1.8.8.tar.gz
 
 # All our ocaml packages

--- a/scripts/setup-opam.sh
+++ b/scripts/setup-opam.sh
@@ -42,7 +42,7 @@ else
 fi
 
 # FIXME: Manually pin ocamlgraph while their hosting is down
-opam pin https://github.com/backtracking/ocamlgraph.git#v1.8.8
+opam pin ocamlgraph https://github.com/backtracking/ocamlgraph/archive/v1.8.8.tar.gz
 
 # All our ocaml packages
 opam switch import src/opam.export

--- a/scripts/setup-opam.sh
+++ b/scripts/setup-opam.sh
@@ -42,7 +42,7 @@ else
 fi
 
 # FIXME: Manually pin ocamlgraph while their hosting is down
-opam install conf-autoconf
+opam install conf-autoconf # This is needed because the ocamlgraph opam file is lacking..
 opam pin ocamlgraph https://github.com/backtracking/ocamlgraph/archive/v1.8.8.tar.gz
 
 # All our ocaml packages


### PR DESCRIPTION
The hosting for the tar files is currently down. This makes CI pull the source from github instead.

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
- [ ] Serialized types are in stable-versioned modules
- [ ] Does this close issues? List them: