### PR TITLE
increase agent target sizing for docker artifact build job (medium -> xlarge)

### DIFF
--- a/buildkite/src/Command/DockerArtifact.dhall
+++ b/buildkite/src/Command/DockerArtifact.dhall
@@ -33,7 +33,7 @@ let generateStep = \(deps : List Command.TaggedKey.Type) ->
         commands  = commands,
         label = "Build and release Docker artifacts",
         key = "docker-artifact",
-        target = Size.Medium,
+        target = Size.XLarge,
         docker_login = Some DockerLogin::{=},
         depends_on = deps
       }


### PR DESCRIPTION
Increased compute resources (4vcp => ~16vcpu) should hopefully reduce the runtime from ~1hr considerably.

**Testing:** Buildkite CI

Checklist:

- [ ] Document code purpose, how to use it
  - Mention expected invariants, implicit constraints
- [ ] Tests were added for the new behavior
  - Document test purpose, significance of failures
  - Test names should reflect their purpose
- [ ] All tests pass (CI will check this if you didn't)
